### PR TITLE
Remove all WARP skips

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -14750,11 +14750,6 @@ TEST_F(ExecutionTest, QuadAnyAll) {
       continue;
     }
 
-    if (IsDeviceBasicAdapter(pDevice)) {
-      WEX::Logging::Log::Comment(L"QuadAny/All fails on basic render driver.");
-      continue;
-    }
-
     if (!DoesDeviceSupportWaveOps(pDevice)) {
       LogCommentFmt(
           L"Device does not support wave operations in shader model 6.%1u",

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -224,37 +224,6 @@ static void SavePixelsToFile(LPCVOID pPixels, DXGI_FORMAT format,
   VERIFY_SUCCEEDED(pStream->Commit(STGC_DEFAULT));
 }
 
-// Checks if the given warp version supports the given operation.
-bool IsValidWarpDllVersion(unsigned int minBuildNumber) {
-  HMODULE pLibrary = LoadLibrary("D3D10Warp.dll");
-  if (pLibrary) {
-    char path[MAX_PATH];
-    DWORD length = GetModuleFileName(pLibrary, path, MAX_PATH);
-    if (length) {
-      DWORD dwVerHnd = 0;
-      DWORD dwVersionInfoSize = GetFileVersionInfoSize(path, &dwVerHnd);
-      std::unique_ptr<int[]> VffInfo(new int[dwVersionInfoSize]);
-      if (GetFileVersionInfo(path, NULL, dwVersionInfoSize, VffInfo.get())) {
-        LPVOID versionInfo;
-        UINT size;
-        if (VerQueryValue(VffInfo.get(), "\\", &versionInfo, &size)) {
-          if (size) {
-            VS_FIXEDFILEINFO *verInfo = (VS_FIXEDFILEINFO *)versionInfo;
-            unsigned int warpBuildNumber =
-                verInfo->dwFileVersionLS >> 16 & 0xffff;
-            if (verInfo->dwSignature == 0xFEEF04BD &&
-                warpBuildNumber >= minBuildNumber) {
-              return true;
-            }
-          }
-        }
-      }
-    }
-    FreeLibrary(pLibrary);
-  }
-  return false;
-}
-
 #if WDK_NTDDI_VERSION <= NTDDI_WIN10_RS2
 #define D3D12_FEATURE_D3D12_OPTIONS3 ((D3D12_FEATURE)21)
 #define NTDDI_WIN10_RS3 0x0A000004 /* ABRACADABRA_WIN10_RS2 */
@@ -2458,14 +2427,6 @@ TEST_F(ExecutionTest, LifetimeIntrinsicTest) {
   bool bDXRSupported =
       bSM_6_3_Supported && DoesDeviceSupportRayTracing(pDevice);
 
-  if (GetTestParamUseWARP(UseWarpByDefault()) ||
-      IsDeviceBasicAdapter(pDevice)) {
-    WEX::Logging::Log::Comment(
-        L"WARP has a known issue with LifetimeIntrinsicTest.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
-
   if (!bSM_6_6_Supported) {
     WEX::Logging::Log::Comment(
         L"Native lifetime markers skipped, device does not support SM 6.6");
@@ -4087,14 +4048,6 @@ TEST_F(ExecutionTest, QuadReadTest) {
   CComPtr<ID3D12Device> pDevice;
   if (!CreateDevice(&pDevice))
     return;
-
-  if (GetTestParamUseWARP(UseWarpByDefault()) ||
-      IsDeviceBasicAdapter(pDevice)) {
-    WEX::Logging::Log::Comment(
-        L"WARP does not support QuadRead in compute shaders.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
 
   if (!DoesDeviceSupportWaveOps(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support wave operations.");
@@ -7162,12 +7115,6 @@ TEST_F(ExecutionTest, UnaryFloatOpTest) {
   CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);
   CW2A Text(handler.GetTableParamByName(L"ShaderOp.Text")->m_str);
 
-  unsigned int WarpVersion =
-      handler.GetTableParamByName(L"Warp.Version")->m_uint;
-  if (GetTestParamUseWARP(true) && !IsValidWarpDllVersion(WarpVersion)) {
-    return;
-  }
-
   std::vector<float> *Validation_Input =
       &(handler.GetTableParamByName(L"Validation.Input1")->m_floatTable);
   std::vector<float> *Validation_Expected =
@@ -7402,12 +7349,6 @@ TEST_F(ExecutionTest, UnaryHalfOpTest) {
   CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);
   CW2A Text(handler.GetTableParamByName(L"ShaderOp.Text")->m_str);
   CW2A Arguments(handler.GetTableParamByName(L"ShaderOp.Arguments")->m_str);
-
-  unsigned int WarpVersion =
-      handler.GetTableParamByName(L"Warp.Version")->m_uint;
-  if (GetTestParamUseWARP(true) && !IsValidWarpDllVersion(WarpVersion)) {
-    return;
-  }
 
   std::vector<uint16_t> *Validation_Input =
       &(handler.GetTableParamByName(L"Validation.Input1")->m_halfTable);
@@ -10982,18 +10923,6 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
              "must have same number of expected values");
   }
 
-#if defined(_M_ARM64) || defined(_M_ARM64EC)
-  if ((GetTestParamUseWARP(UseWarpByDefault()) ||
-       IsDeviceBasicAdapter(pDevice)) &&
-      mode == Float32DenormMode::Preserve) {
-    WEX::Logging::Log::Comment(
-        L"WARP has an issue with DenormBinaryFloatOpTest with '-denorm "
-        L"preserve' on ARM64.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
-#endif // defined(_M_ARM64) || defined(_M_ARM64EC)
-
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
       pDevice, m_support, pStream, "BinaryFPOp",
       // this callbacked is called when the test
@@ -11106,18 +11035,6 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
     DXASSERT(Validation_Expected2->size() == Validation_Expected1->size(),
              "must have same number of expected values");
   }
-
-#if defined(_M_ARM64) || defined(_M_ARM64EC)
-  if ((GetTestParamUseWARP(UseWarpByDefault()) ||
-       IsDeviceBasicAdapter(pDevice)) &&
-      mode == Float32DenormMode::Preserve) {
-    WEX::Logging::Log::Comment(
-        L"WARP has an issue with DenormTertiaryFloatOpTest with '-denorm "
-        L"preserve' on ARM64.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
-#endif // defined(_M_ARM64) || defined(_M_ARM64EC)
 
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
       pDevice, m_support, pStream, "TertiaryFPOp",
@@ -11666,13 +11583,7 @@ void ExecutionTest::WaveIntrinsicsActivePrefixTest(
   }
 }
 
-static const unsigned int MinWarpVersionForWaveIntrinsics = 16202;
-
 TEST_F(ExecutionTest, WaveIntrinsicsActiveIntTest) {
-  if (GetTestParamUseWARP(true) &&
-      !IsValidWarpDllVersion(MinWarpVersionForWaveIntrinsics)) {
-    return;
-  }
   WaveIntrinsicsActivePrefixTest<int, int>(
       WaveIntrinsicsActiveIntParameters,
       sizeof(WaveIntrinsicsActiveIntParameters) / sizeof(TableParameter),
@@ -11680,10 +11591,6 @@ TEST_F(ExecutionTest, WaveIntrinsicsActiveIntTest) {
 }
 
 TEST_F(ExecutionTest, WaveIntrinsicsActiveUintTest) {
-  if (GetTestParamUseWARP(true) &&
-      !IsValidWarpDllVersion(MinWarpVersionForWaveIntrinsics)) {
-    return;
-  }
   WaveIntrinsicsActivePrefixTest<unsigned int, unsigned int>(
       WaveIntrinsicsActiveUintParameters,
       sizeof(WaveIntrinsicsActiveUintParameters) / sizeof(TableParameter),
@@ -11691,10 +11598,6 @@ TEST_F(ExecutionTest, WaveIntrinsicsActiveUintTest) {
 }
 
 TEST_F(ExecutionTest, WaveIntrinsicsPrefixIntTest) {
-  if (GetTestParamUseWARP(true) &&
-      !IsValidWarpDllVersion(MinWarpVersionForWaveIntrinsics)) {
-    return;
-  }
   WaveIntrinsicsActivePrefixTest<int, int>(
       WaveIntrinsicsPrefixIntParameters,
       sizeof(WaveIntrinsicsPrefixIntParameters) / sizeof(TableParameter),
@@ -11702,10 +11605,6 @@ TEST_F(ExecutionTest, WaveIntrinsicsPrefixIntTest) {
 }
 
 TEST_F(ExecutionTest, WaveIntrinsicsPrefixUintTest) {
-  if (GetTestParamUseWARP(true) &&
-      !IsValidWarpDllVersion(MinWarpVersionForWaveIntrinsics)) {
-    return;
-  }
   WaveIntrinsicsActivePrefixTest<unsigned int, unsigned int>(
       WaveIntrinsicsPrefixUintParameters,
       sizeof(WaveIntrinsicsPrefixUintParameters) / sizeof(TableParameter),
@@ -14698,14 +14597,6 @@ TEST_F(ExecutionTest, HelperLaneTestWave) {
       continue;
     }
 
-    if (GetTestParamUseWARP(UseWarpByDefault()) ||
-        IsDeviceBasicAdapter(pDevice)) {
-      WEX::Logging::Log::Comment(
-          L"WARP has a known issue with HelperLaneTestWave.");
-      WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-      return;
-    }
-
     if (!DoesDeviceSupportWaveOps(pDevice)) {
       LogCommentFmt(
           L"Device does not support wave operations in shader model 6.%1u",
@@ -15036,13 +14927,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
   CComPtr<ID3D12Device> pDevice;
   VERIFY_IS_TRUE(CreateDevice(&pDevice, D3D_SHADER_MODEL_6_0,
                               false /* skipUnsupported */));
-
-  if (GetTestParamUseWARP(UseWarpByDefault()) ||
-      IsDeviceBasicAdapter(pDevice)) {
-    WEX::Logging::Log::Comment(L"WARP has a known issue with IsNormalTest.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
 
   // The input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN,
   // Nan, and then 4 normal float numbers. Only the last 4 floats are normal, so


### PR DESCRIPTION
Now that WARP is actually getting bugfixes and features, and has a way for folks to get new versions without waiting years for an OS update, stop hiding the places where it's failing. Having these hardcoded skips in place makes it impossible to run the tests to see if it's still failing. If we really need these skips, we at least need some kind of command line option to override them for debugging and fixing the failures.