### PR TITLE
[SPIR-V] Best effort const eval of vk::ext_literal

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicLiteralVariable.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicLiteralVariable.error.hlsl
@@ -1,0 +1,13 @@
+// RUN: not %dxc -T cs_6_6 -spirv -fspv-target-env=vulkan1.3 -fcgl %s 2>&1 | FileCheck %s
+
+static uint Reduce;
+
+[[vk::ext_instruction(/* OpGroupNonUniformBallotBitCount */ 342)]]
+uint OpGroupNonUniformBallotBitCount(uint scope, [[vk::ext_literal]] uint groupOperation, uint4 ballot);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+// CHECK: error: vk::ext_literal may only be applied to parameters that can be evaluated to a literal value
+	OpGroupNonUniformBallotBitCount(vk::SubgroupScope, Reduce, 0);
+}

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicLiteralVariable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicLiteralVariable.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -T cs_6_6 -spirv -fspv-target-env=vulkan1.3 -fcgl %s | FileCheck %s
+
+static const uint Reduce = 0;
+
+#define InclusiveScan 1
+
+enum
+{
+    ExclusiveScan = 2,
+};
+
+[[vk::ext_instruction(/* OpGroupNonUniformBallotBitCount */ 342)]]
+uint OpGroupNonUniformBallotBitCount(uint scope, [[vk::ext_literal]] uint groupOperation, uint4 ballot);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+// CHECK: [[ballot:%[0-9]+]] = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+
+// CHECK: {{%[0-9]+}} = OpGroupNonUniformBallotBitCount %uint %uint_3 Reduce [[ballot]]
+	OpGroupNonUniformBallotBitCount(vk::SubgroupScope, Reduce, 0);
+// CHECK: {{%[0-9]+}} = OpGroupNonUniformBallotBitCount %uint %uint_3 InclusiveScan [[ballot]]
+	OpGroupNonUniformBallotBitCount(vk::SubgroupScope, InclusiveScan, 0);
+// CHECK: {{%[0-9]+}} = OpGroupNonUniformBallotBitCount %uint %uint_3 ExclusiveScan [[ballot]]
+	OpGroupNonUniformBallotBitCount(vk::SubgroupScope, ExclusiveScan, 0);
+}


### PR DESCRIPTION
If a parameter annotated with `[[vk::ext_literal]]` is not lowered to a SpirvConstant, make a best-effort attempt to evaluate it to a constant literal value. If unsuccessful, fail gracefully rather than crash.

Fixes #6586