### PR TITLE
Add local lit config to re-enable reassociate tests

### DIFF
--- a/test/Transforms/Reassociate/lit.local.cfg
+++ b/test/Transforms/Reassociate/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.ll'] # HLSL Change


### PR DESCRIPTION
This change adds a local lit configuration file to re-enable the reassociate pass tests. 