### PR TITLE
[SPIR-V] Fix firstbit{high,low} elem check

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8979,8 +8979,10 @@ SpirvEmitter::processIntrinsicFirstbit(const CallExpr *callExpr,
   const SourceRange srcRange = callExpr->getSourceRange();
   const QualType argType = callExpr->getArg(0)->getType();
 
-  if (astContext.getTypeSize(argType) == 64) {
-    emitError("%0 is not yet implemented for 64-bit width components when "
+  const uint32_t bitwidth = getElementSpirvBitwidth(
+      astContext, argType, spirvOptions.enable16BitTypes);
+  if (bitwidth != 32) {
+    emitError("%0 is currently limited to 32-bit width components when "
               "targetting SPIR-V",
               srcLoc)
         << getFunctionOrOperatorName(callee, true);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
@@ -2,7 +2,9 @@
 
 void main() {
   uint64_t   uint_1;
+  int64_t2   int_2;
+// CHECK: error: firstbithigh is currently limited to 32-bit width components when targetting SPIR-V
   int fbh = firstbithigh(uint_1);
+// CHECK: error: firstbithigh is currently limited to 32-bit width components when targetting SPIR-V
+  int64_t2 fbh2 = firstbithigh(int_2);
 }
-
-// CHECK: error: firstbithigh is not yet implemented for 64-bit width components when targetting SPIR-V

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.hlsl
@@ -6,6 +6,7 @@ void main() {
   int   sint_1;
   int4  sint_4;
   uint  uint_1;
+  uint2 uint_2;
   uint4 uint_4;
 
 // CHECK: [[sint_1:%[0-9]+]] = OpLoad %int %sint_1
@@ -24,6 +25,11 @@ void main() {
 // CHECK:    [[msb:%[0-9]+]] = OpExtInst %uint [[glsl]] FindUMsb [[uint_1]]
 // CHECK:                   OpStore %ufbh [[msb]]
   uint ufbh = firstbithigh(uint_1);
+
+// CHECK: [[uint_2:%[0-9]+]] = OpLoad %v2uint %uint_2
+// CHECK:    [[msb:%[0-9]+]] = OpExtInst %v2uint [[glsl]] FindUMsb [[uint_2]]
+// CHECK:                   OpStore %ufbh2 [[msb]]
+  uint2 ufbh2 = firstbithigh(uint_2);
 
 // CHECK: [[uint_4:%[0-9]+]] = OpLoad %v4uint %uint_4
 // CHECK:    [[msb:%[0-9]+]] = OpExtInst %v4uint [[glsl]] FindUMsb [[uint_4]]

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
@@ -2,7 +2,6 @@
 
 void main() {
   uint64_t   uint_1;
+// CHECK: error: firstbitlow is currently limited to 32-bit width components when targetting SPIR-V
   int fbl = firstbitlow(uint_1);
 }
-
-// CHECK: error: firstbitlow is not yet implemented for 64-bit width components when targetting SPIR-V


### PR DESCRIPTION
The code gen for firstbithigh and -low was incorrectly checking the size of the full (possibly composite) type rather than the element size. This is now fixed, and I've also switch the error check from whether the element type is == 64-bit to != 32-bit, so that it matches the current limitations of the GLSL extended instructions.

https://registry.khronos.org/SPIR-V/specs/unified1/GLSL.std.450.html#:~:text=%3Cid%3E%0AValue-,FindSMsb,-Signed%2Dinteger%20most

Related to #4702