### PR TITLE
Fix aligment for empty structs

### DIFF
--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -66,15 +66,7 @@ void AlignmentSizeCalculator::alignUsingHLSLRelaxedLayout(
 std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
     QualType type, const RecordType *structType, SpirvLayoutRule rule,
     llvm::Optional<bool> isRowMajor, uint32_t *stride) const {
-  bool hasBaseStructs = type->getAsCXXRecordDecl() &&
-                        type->getAsCXXRecordDecl()->getNumBases() > 0;
-
-  // Special case for handling empty structs, whose size is 0 and has no
-  // requirement over alignment (thus 1).
-  if (structType->getDecl()->field_empty() && !hasBaseStructs)
-    return {1, 0};
-
-  uint32_t maxAlignment = 0;
+  uint32_t maxAlignment = 1;
   uint32_t structSize = 0;
 
   // If this struct is derived from some other structs, place an implicit

--- a/tools/clang/test/CodeGenSPIRV/empty_struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/empty_struct.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s -check-prefix=RELAXED
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv -fvk-use-gl-layout | FileCheck %s -check-prefix=RELAXED
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv -fvk-use-scalar-layout | FileCheck %s -check-prefix=SCALAR
+
+struct empty_struct { };
+
+
+// RELAXED: OpMemberDecorate %type_cb 0 Offset 0
+// RELAXED: OpMemberDecorate %type_cb 1 Offset 16
+// RELAXED: OpMemberDecorate %type_cb 2 Offset 16
+// RELAXED: OpMemberDecorate %type_cb 3 Offset 32
+
+// SCALAR: OpMemberDecorate %type_cb 0 Offset 0
+// SCALAR: OpMemberDecorate %type_cb 1 Offset 12
+// SCALAR: OpMemberDecorate %type_cb 2 Offset 12
+// SCALAR: OpMemberDecorate %type_cb 3 Offset 20
+
+cbuffer cb
+{
+	float3 a;
+	empty_struct b;
+	float2 c;
+
+	float4 test;
+};
+
+float4 main() : SV_TARGET
+{
+	return test;
+}


### PR DESCRIPTION
We have a special case to that the the size and alignment for an empty
struct is `{1,0}`. However that is not correct. See
https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-alignment-requirements.

> An empty structure has a base alignment equal to the size of the smallest
scalar type permitted by the capabilities declared in the SPIR-V module. (e.g.,
for a 1 byte aligned empty struct in the StorageBuffer storage class,
StorageBuffer8BitAccess or UniformAndStorageBuffer8BitAccess must be declared
in the SPIR-V module.

I'm not 100% sure how DXC handle this minimum alignment, but I figured I
would inialize the alignment to 1. If there are not members, then it
will remain 1, and I would let the rest of the logic happen. No special
case.

Fixes #2882