### PR TITLE
[SPIR-V] Add error message for SamplerFeedback

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1240,6 +1240,15 @@ SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
     spvContext.registerVkImageFeaturesForSpvVariable(varInstr, vkImgFeatures);
   }
 
+  if (const auto *recordType = type->getAs<RecordType>()) {
+    StringRef typeName = recordType->getDecl()->getName();
+    if (typeName.startswith("FeedbackTexture")) {
+      emitError("Texture resource type '%0' is not supported with -spirv", loc)
+          << typeName;
+      return nullptr;
+    }
+  }
+
   if (hlsl::IsHLSLResourceType(type)) {
     if (!areFormatAndTypeCompatible(vkImgFeatures.format,
                                     hlsl::GetHLSLResourceResultType(type))) {

--- a/tools/clang/test/CodeGenSPIRV/sm6_5.sampler_feedback.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6_5.sampler_feedback.hlsl
@@ -1,0 +1,27 @@
+// RUN: not %dxc -DTEST0 -T ps_6_5 -fcgl -spirv %s 2>&1 | FileCheck %s --check-prefix=CHECK0
+// RUN: not %dxc -DTEST1 -T ps_6_5 -fcgl -spirv %s 2>&1 | FileCheck %s --check-prefix=CHECK1
+// RUN: not %dxc -DTEST2 -T ps_6_5 -fcgl -spirv %s 2>&1 | FileCheck %s --check-prefix=CHECK2
+// RUN: not %dxc -DTEST3 -T ps_6_5 -fcgl -spirv %s 2>&1 | FileCheck %s --check-prefix=CHECK3
+
+#ifdef TEST0
+// CHECK0: error: Texture resource type 'FeedbackTexture2D' is not supported with -spirv
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> feedbackMinMip;
+
+#elif TEST1
+// CHECK1: error: Texture resource type 'FeedbackTexture2D' is not supported with -spirv
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIP_REGION_USED> feedbackMipRegionUsed;
+
+#elif TEST2
+// CHECK2: error: Texture resource type 'FeedbackTexture2DArray' is not supported with -spirv
+FeedbackTexture2DArray<SAMPLER_FEEDBACK_MIN_MIP> feedbackMinMipArray;
+
+#elif TEST3
+// CHECK3: error: Texture resource type 'FeedbackTexture2DArray' is not supported with -spirv
+FeedbackTexture2DArray<SAMPLER_FEEDBACK_MIP_REGION_USED> feebackMipRegionUsedArray;
+
+#endif
+
+float main() : SV_Target
+{
+    return 0;
+}


### PR DESCRIPTION
Sampler feedback resource types are not supported by the SPIR-V backend, but they would previously fail silently until a function was called on them. This change makes the error message more explicit on the type.

Related to #6614