### PR TITLE
fix compile error for newer VS toolchain

### DIFF
--- a/utils/TableGen/AsmWriterEmitter.cpp
+++ b/utils/TableGen/AsmWriterEmitter.cpp
@@ -736,13 +736,14 @@ public:
     O.indent(4) << '}';
   }
 
-  bool operator==(const IAPrinter &RHS) {
+  bool operator==(const IAPrinter &RHS) const {
     if (Conds.size() != RHS.Conds.size())
       return false;
 
     unsigned Idx = 0;
-    for (std::vector<std::string>::iterator
-           I = Conds.begin(), E = Conds.end(); I != E; ++I)
+    for (std::vector<std::string>::const_iterator I = Conds.begin(),
+                                                  E = Conds.end();
+         I != E; ++I)
       if (*I != RHS.Conds[Idx++])
         return false;
 
@@ -1073,7 +1074,7 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
         << "    break;\n";
     }
     O << "  }\n";
-  }    
+  }
   O << "}\n\n";
 
   if (!MCOpPredicates.empty()) {

--- a/utils/TableGen/AsmWriterEmitter.cpp
+++ b/utils/TableGen/AsmWriterEmitter.cpp
@@ -736,6 +736,7 @@ public:
     O.indent(4) << '}';
   }
 
+  // HLSL Change begin
   bool operator==(const IAPrinter &RHS) const {
     if (Conds.size() != RHS.Conds.size())
       return false;
@@ -749,6 +750,7 @@ public:
 
     return true;
   }
+  // HLSL Change end
 };
 
 } // end anonymous namespace

--- a/utils/TableGen/AsmWriterEmitter.cpp
+++ b/utils/TableGen/AsmWriterEmitter.cpp
@@ -736,21 +736,17 @@ public:
     O.indent(4) << '}';
   }
 
-  // HLSL Change begin
   bool operator==(const IAPrinter &RHS) const {
     if (Conds.size() != RHS.Conds.size())
       return false;
 
     unsigned Idx = 0;
-    for (std::vector<std::string>::const_iterator I = Conds.begin(),
-                                                  E = Conds.end();
-         I != E; ++I)
-      if (*I != RHS.Conds[Idx++])
+    for (const auto &str : Conds)
+      if (str != RHS.Conds[Idx++])
         return false;
 
     return true;
   }
-  // HLSL Change end
 };
 
 } // end anonymous namespace


### PR DESCRIPTION
This is to fix compile error like

```
../../third_party/dxc/utils/TableGen/AsmWriterEmitter.cpp(974): error C2666: '`anonymous-namespace'::IAPrinter::operator ==': overloaded functions have similar conversions
../../third_party/dxc/utils/TableGen/AsmWriterEmitter.cpp(739): note: could be 'bool `anonymous-namespace'::IAPrinter::operator ==(const `anonymous-namespace'::IAPrinter &)'
../../third_party/dxc/utils/TableGen/AsmWriterEmitter.cpp(739): note: or 'bool `anonymous-namespace'::IAPrinter::operator ==(const `anonymous-namespace'::IAPrinter &)' [synthesized expression 'y == x']
../../third_party/dxc/utils/TableGen/AsmWriterEmitter.cpp(974): note: while trying to match the argument list '(`anonymous-namespace'::IAPrinter, `anonymous-namespace'::IAPrinter)'
```
in dawn project which is updating to newer VS toolchain.

This imports fix from https://github.com/llvm/llvm-project/commit/4ab57cd9abb9535149e62c18461b56b94b09285a.

more context is in https://issues.chromium.org/issues/341890053#comment2