### PR TITLE
Rename WeakVH to WeakTrackingVH; NFC

### DIFF
--- a/docs/ProgrammersManual.rst
+++ b/docs/ProgrammersManual.rst
@@ -1416,9 +1416,9 @@ llvm/IR/ValueMap.h
 ValueMap is a wrapper around a :ref:`DenseMap <dss_densemap>` mapping
 ``Value*``\ s (or subclasses) to another type.  When a Value is deleted or
 RAUW'ed, ValueMap will update itself so the new version of the key is mapped to
-the same value, just as if the key were a WeakVH.  You can configure exactly how
-this happens, and what else happens on these two events, by passing a ``Config``
-parameter to the ValueMap template.
+the same value, just as if the key were a WeakTrackingVH.  You can configure
+exactly how this happens, and what else happens on these two events, by passing
+a ``Config`` parameter to the ValueMap template.
 
 .. _dss_intervalmap:
 

--- a/include/llvm/Analysis/AssumptionCache.h
+++ b/include/llvm/Analysis/AssumptionCache.h
@@ -48,7 +48,7 @@ class AssumptionCache {
 
   /// \brief Vector of weak value handles to calls of the @llvm.assume
   /// intrinsic.
-  SmallVector<WeakVH, 4> AssumeHandles;
+  SmallVector<WeakTrackingVH, 4> AssumeHandles;
 
   /// \brief Flag tracking whether we have scanned the function yet.
   ///
@@ -86,7 +86,7 @@ public:
   /// FIXME: We should replace this with pointee_iterator<filter_iterator<...>>
   /// when we can write that to filter out the null values. Then caller code
   /// will become simpler.
-  MutableArrayRef<WeakVH> assumptions() {
+  MutableArrayRef<WeakTrackingVH> assumptions() {
     if (!Scanned)
       scanFunction();
     return AssumeHandles;

--- a/include/llvm/Analysis/CallGraph.h
+++ b/include/llvm/Analysis/CallGraph.h
@@ -169,7 +169,7 @@ class CallGraphNode {
 public:
   /// \brief A pair of the calling instruction (a call or invoke)
   /// and the call graph node being called.
-  typedef std::pair<WeakVH, CallGraphNode *> CallRecord;
+  typedef std::pair<WeakTrackingVH, CallGraphNode *> CallRecord;
 
 public:
   typedef std::vector<CallRecord> CalledFunctionsVector;

--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -31,7 +31,7 @@ struct DxilValueCache : public ImmutablePass {
       void allUsesReplacedWith(Value *) override { setValPtr(nullptr); }
     };
     struct ValueEntry {
-      WeakVH Value;
+      WeakTrackingVH Value;
       ValueVH Self;
       ValueEntry() : Value(nullptr), Self(nullptr) {}
       inline void Set(llvm::Value *Key, llvm::Value *V) {

--- a/include/llvm/Analysis/IVUsers.h
+++ b/include/llvm/Analysis/IVUsers.h
@@ -79,7 +79,7 @@ private:
 
   /// OperandValToReplace - The Value of the operand in the user instruction
   /// that this IVStrideUse is representing.
-  WeakVH OperandValToReplace;
+  WeakTrackingVH OperandValToReplace;
 
   /// PostIncLoops - The set of loops for which Expr has been adjusted to
   /// use post-inc mode. This corresponds with SCEVExpander's post-inc concept.

--- a/include/llvm/Analysis/MemoryBuiltins.h
+++ b/include/llvm/Analysis/MemoryBuiltins.h
@@ -208,7 +208,7 @@ class ObjectSizeOffsetEvaluator
   : public InstVisitor<ObjectSizeOffsetEvaluator, SizeOffsetEvalType> {
 
   typedef IRBuilder<true, TargetFolder> BuilderTy;
-  typedef std::pair<WeakVH, WeakVH> WeakEvalType;
+  typedef std::pair<WeakTrackingVH, WeakTrackingVH> WeakEvalType;
   typedef DenseMap<const Value*, WeakEvalType> CacheMapTy;
   typedef SmallPtrSet<const Value*, 8> PtrSetTy;
 

--- a/include/llvm/Analysis/ScalarEvolutionExpander.h
+++ b/include/llvm/Analysis/ScalarEvolutionExpander.h
@@ -138,7 +138,7 @@ namespace llvm {
     /// \brief replace congruent phis with their most canonical
     /// representative. Return the number of phis eliminated.
     unsigned replaceCongruentIVs(Loop *L, const DominatorTree *DT,
-                                 SmallVectorImpl<WeakVH> &DeadInsts,
+                                 SmallVectorImpl<WeakTrackingVH> &DeadInsts,
                                  const TargetTransformInfo *TTI = nullptr);
 
     /// \brief Insert code to directly compute the specified SCEV expression

--- a/include/llvm/IR/ValueHandle.h
+++ b/include/llvm/IR/ValueHandle.h
@@ -45,7 +45,7 @@ protected:
   ///
   /// This is to avoid having a vtable for the light-weight handle pointers. The
   /// fully general Callback version does have a vtable.
-  enum HandleBaseKind { Assert, Callback, Weak };
+  enum HandleBaseKind { Assert, Callback, WeakTracking };
 
 private:
   PointerIntPair<ValueHandleBase**, 2, HandleBaseKind> PrevPair;
@@ -141,14 +141,14 @@ private:
 /// is useful for advisory sorts of information, but should not be used as the
 /// key of a map (since the map would have to rearrange itself when the pointer
 /// changes).
-class WeakVH : public ValueHandleBase {
+class WeakTrackingVH : public ValueHandleBase {
 public:
-  WeakVH() : ValueHandleBase(Weak) {}
-  WeakVH(Value *P) : ValueHandleBase(Weak, P) {}
-  WeakVH(const WeakVH &RHS)
-    : ValueHandleBase(Weak, RHS) {}
+  WeakTrackingVH() : ValueHandleBase(WeakTracking) {}
+  WeakTrackingVH(Value *P) : ValueHandleBase(WeakTracking, P) {}
+  WeakTrackingVH(const WeakTrackingVH &RHS)
+      : ValueHandleBase(WeakTracking, RHS) {}
 
-  WeakVH &operator=(const WeakVH &RHS) = default;
+  WeakTrackingVH &operator=(const WeakTrackingVH &RHS) = default;
 
   Value *operator=(Value *RHS) {
     return ValueHandleBase::operator=(RHS);
@@ -166,15 +166,17 @@ public:
   }
 };
 
-// Specialize simplify_type to allow WeakVH to participate in
+// Specialize simplify_type to allow WeakTrackingVH to participate in
 // dyn_cast, isa, etc.
-template <> struct simplify_type<WeakVH> {
+template <> struct simplify_type<WeakTrackingVH> {
   typedef Value *SimpleType;
-  static SimpleType getSimplifiedValue(WeakVH &WVH) { return WVH; }
+  static SimpleType getSimplifiedValue(WeakTrackingVH &WVH) { return WVH; }
 };
-template <> struct simplify_type<const WeakVH> {
+template <> struct simplify_type<const WeakTrackingVH> {
   typedef Value *SimpleType;
-  static SimpleType getSimplifiedValue(const WeakVH &WVH) { return WVH; }
+  static SimpleType getSimplifiedValue(const WeakTrackingVH &WVH) {
+    return WVH;
+  }
 };
 
 /// \brief Value handle that asserts if the Value is deleted.
@@ -291,7 +293,7 @@ struct isPodLike<AssertingVH<T> > {
 /// Assigning a value to a TrackingVH is always allowed, even if said TrackingVH
 /// no longer points to a valid value.
 template <typename ValueTy> class TrackingVH {
-  WeakVH InnerHandle;
+  WeakTrackingVH InnerHandle;
 
 public:
   ValueTy *getValPtr() const {
@@ -396,7 +398,8 @@ public:
   ///
   /// Called when this->getValPtr() is destroyed, inside ~Value(), so you
   /// may call any non-virtual Value method on getValPtr(), but no subclass
-  /// methods.  If WeakVH were implemented as a CallbackVH, it would use this
+  /// methods.  If WeakTrackingVH were implemented as a CallbackVH, it would use
+  /// this
   /// method to call setValPtr(NULL).  AssertingVH would use this method to
   /// cause an assertion failure.
   ///
@@ -407,7 +410,8 @@ public:
   /// \brief Callback for Value RAUW.
   ///
   /// Called when this->getValPtr()->replaceAllUsesWith(new_value) is called,
-  /// _before_ any of the uses have actually been replaced.  If WeakVH were
+  /// _before_ any of the uses have actually been replaced.  If WeakTrackingVH
+  /// were
   /// implemented as a CallbackVH, it would use this method to call
   /// setValPtr(new_value).  AssertingVH would do nothing in this method.
   virtual void allUsesReplacedWith(Value *) {}

--- a/include/llvm/Transforms/Utils/Cloning.h
+++ b/include/llvm/Transforms/Utils/Cloning.h
@@ -209,7 +209,7 @@ public:
 
   /// InlinedCalls - InlineFunction fills this in with callsites that were
   /// inlined from the callee.  This is only filled in if CG is non-null.
-  SmallVector<WeakVH, 8> InlinedCalls;
+  SmallVector<WeakTrackingVH, 8> InlinedCalls;
 
   void reset() {
     StaticAllocas.clear();

--- a/include/llvm/Transforms/Utils/SimplifyIndVar.h
+++ b/include/llvm/Transforms/Utils/SimplifyIndVar.h
@@ -58,12 +58,13 @@ public:
 /// simplifyUsersOfIV - Simplify instructions that use this induction variable
 /// by using ScalarEvolution to analyze the IV's recurrence.
 bool simplifyUsersOfIV(PHINode *CurrIV, ScalarEvolution *SE, LPPassManager *LPM,
-                       SmallVectorImpl<WeakVH> &Dead, IVVisitor *V = nullptr);
+                       SmallVectorImpl<WeakTrackingVH> &Dead,
+                       IVVisitor *V = nullptr);
 
 /// SimplifyLoopIVs - Simplify users of induction variables within this
 /// loop. This does not actually change or add IVs.
 bool simplifyLoopIVs(Loop *L, ScalarEvolution *SE, LPPassManager *LPM,
-                     SmallVectorImpl<WeakVH> &Dead);
+                     SmallVectorImpl<WeakTrackingVH> &Dead);
 
 } // namespace llvm
 

--- a/include/llvm/Transforms/Utils/ValueMapper.h
+++ b/include/llvm/Transforms/Utils/ValueMapper.h
@@ -20,7 +20,7 @@
 namespace llvm {
   class Value;
   class Instruction;
-  typedef ValueMap<const Value *, WeakVH> ValueToValueMapTy;
+  typedef ValueMap<const Value *, WeakTrackingVH> ValueToValueMapTy;
 
   /// ValueMapTypeRemapper - This is a class that can be implemented by clients
   /// to remap types when cloning constants and instructions.

--- a/lib/Analysis/IPA/CallGraphSCCPass.cpp
+++ b/lib/Analysis/IPA/CallGraphSCCPass.cpp
@@ -219,7 +219,7 @@ bool CGPassManager::RefreshCallGraph(CallGraphSCC &CurSCC,
     // Get the set of call sites currently in the function.
     for (CallGraphNode::iterator I = CGN->begin(), E = CGN->end(); I != E; ) {
       // If this call site is null, then the function pass deleted the call
-      // entirely and the WeakVH nulled it out.  
+      // entirely and the WeakTrackingVH nulled it out.  
       if (!I->first ||
           // If we've already seen this call site, then the FunctionPass RAUW'd
           // one call with another, which resulted in two "uses" in the edge
@@ -362,7 +362,8 @@ bool CGPassManager::RefreshCallGraph(CallGraphSCC &CurSCC,
       DevirtualizedCall = true;
     
     // After scanning this function, if we still have entries in callsites, then
-    // they are dangling pointers.  WeakVH should save us for this, so abort if
+    // they are dangling pointers.  WeakTrackingVH should save us for this, so
+    // abort if
     // this happens.
     assert(CallSites.empty() && "Dangling pointers found in call sites map");
     

--- a/lib/Analysis/IPA/CallGraphSCCPass.cpp
+++ b/lib/Analysis/IPA/CallGraphSCCPass.cpp
@@ -219,7 +219,7 @@ bool CGPassManager::RefreshCallGraph(CallGraphSCC &CurSCC,
     // Get the set of call sites currently in the function.
     for (CallGraphNode::iterator I = CGN->begin(), E = CGN->end(); I != E; ) {
       // If this call site is null, then the function pass deleted the call
-      // entirely and the WeakTrackingVH nulled it out.  
+      // entirely and the WeakTrackingVH nulled it out.
       if (!I->first ||
           // If we've already seen this call site, then the FunctionPass RAUW'd
           // one call with another, which resulted in two "uses" in the edge
@@ -360,7 +360,7 @@ bool CGPassManager::RefreshCallGraph(CallGraphSCC &CurSCC,
     if (NumIndirectRemoved > NumIndirectAdded &&
         NumDirectRemoved < NumDirectAdded)
       DevirtualizedCall = true;
-    
+
     // After scanning this function, if we still have entries in callsites, then
     // they are dangling pointers.  WeakTrackingVH should save us for this, so
     // abort if

--- a/lib/Analysis/ScalarEvolutionExpander.cpp
+++ b/lib/Analysis/ScalarEvolutionExpander.cpp
@@ -1689,9 +1689,10 @@ SCEVExpander::getOrInsertCanonicalInductionVariable(const Loop *L,
 ///
 /// This does not depend on any SCEVExpander state but should be used in
 /// the same context that SCEVExpander is used.
-unsigned SCEVExpander::replaceCongruentIVs(Loop *L, const DominatorTree *DT,
-                                           SmallVectorImpl<WeakVH> &DeadInsts,
-                                           const TargetTransformInfo *TTI) {
+unsigned
+SCEVExpander::replaceCongruentIVs(Loop *L, const DominatorTree *DT,
+                                  SmallVectorImpl<WeakTrackingVH> &DeadInsts,
+                                  const TargetTransformInfo *TTI) {
   // Find integer phis in order of increasing width.
   SmallVector<PHINode*, 8> Phis;
   for (BasicBlock::iterator I = L->getHeader()->begin();

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -44,7 +44,7 @@ enum {
 };
 
 class BitcodeReaderValueList {
-  std::vector<WeakVH> ValuePtrs;
+  std::vector<WeakTrackingVH> ValuePtrs;
 
   /// As we resolve forward-referenced constants, we add information about them
   /// to this vector.  This allows us to resolve them in bulk instead of
@@ -786,7 +786,7 @@ void BitcodeReaderValueList::assignValue(Value *V, unsigned Idx) {
   if (Idx >= size())
     resize(Idx+1);
 
-  WeakVH &OldV = ValuePtrs[Idx];
+  WeakTrackingVH &OldV = ValuePtrs[Idx];
   if (!OldV) {
     OldV = V;
     return;

--- a/lib/CodeGen/CodeGenPrepare.cpp
+++ b/lib/CodeGen/CodeGenPrepare.cpp
@@ -1370,9 +1370,9 @@ bool CodeGenPrepare::OptimizeCallInst(CallInst *CI, bool& ModifiedDT) {
       Constant *RetVal = ConstantInt::get(ReturnTy, Min ? 0 : -1ULL);
 
       // Substituting this can cause recursive simplifications, which can
-      // invalidate our iterator.  Use a WeakVH to hold onto it in case this
+      // invalidate our iterator.  Use WeakTrackingVH to hold onto it in case this
       // happens.
-      WeakVH IterHandle(CurInstIterator);
+      WeakTrackingVH IterHandle(CurInstIterator);
 
       replaceAndRecursivelySimplify(CI, RetVal,
                                     TLInfo, nullptr);
@@ -3531,8 +3531,8 @@ bool CodeGenPrepare::OptimizeMemoryInst(Instruction *MemoryInst, Value *Addr,
   // using it.
   if (Repl->use_empty()) {
     // This can cause recursive deletion, which can invalidate our iterator.
-    // Use a WeakVH to hold onto it in case this happens.
-    WeakVH IterHandle(CurInstIterator);
+    // Use a WeakTrackingVH to hold onto it in case this happens.
+    WeakTrackingVH IterHandle(CurInstIterator);
     BasicBlock *BB = CurInstIterator->getParent();
 
     RecursivelyDeleteTriviallyDeadInstructions(Repl, TLInfo);

--- a/lib/CodeGen/CodeGenPrepare.cpp
+++ b/lib/CodeGen/CodeGenPrepare.cpp
@@ -1370,8 +1370,8 @@ bool CodeGenPrepare::OptimizeCallInst(CallInst *CI, bool& ModifiedDT) {
       Constant *RetVal = ConstantInt::get(ReturnTy, Min ? 0 : -1ULL);
 
       // Substituting this can cause recursive simplifications, which can
-      // invalidate our iterator.  Use WeakTrackingVH to hold onto it in case this
-      // happens.
+      // invalidate our iterator.  Use WeakTrackingVH to hold onto it in case
+      // this happens.
       WeakTrackingVH IterHandle(CurInstIterator);
 
       replaceAndRecursivelySimplify(CI, RetVal,

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -1410,7 +1410,7 @@ bool CleanupSharedMemoryAddrSpaceCast(Module &M) {
   }
 
   // Cleanup unused replacement instructions
-  SmallVector<WeakVH, 8> cleanupInsts;
+  SmallVector<WeakTrackingVH, 8> cleanupInsts;
   for (auto it : valueMap) {
     if (isa<Instruction>(it.first))
       cleanupInsts.push_back(it.first);

--- a/lib/IR/Value.cpp
+++ b/lib/IR/Value.cpp
@@ -672,8 +672,8 @@ void ValueHandleBase::ValueIsDeleted(Value *V) {
     switch (Entry->getKind()) {
     case Assert:
       break;
-    case Weak:
-      // Weak just goes to null, which will unlink it from the list.
+    case WeakTracking:
+      // WeakTracking just goes to null, which will unlink it from the list.
       Entry->operator=(nullptr);
       break;
     case Callback:
@@ -724,7 +724,7 @@ void ValueHandleBase::ValueIsRAUWd(Value *Old, Value *New) {
     case Assert:
       // Asserting handle does not follow RAUW implicitly.
       break;
-    case Weak:
+    case WeakTracking:
       // Weak goes to the new value, which will unlink it from Old's list.
       Entry->operator=(New);
       break;
@@ -741,12 +741,12 @@ void ValueHandleBase::ValueIsRAUWd(Value *Old, Value *New) {
   if (Old->HasValueHandle)
     for (Entry = pImpl->ValueHandles[Old]; Entry; Entry = Entry->Next)
       switch (Entry->getKind()) {
-      case Weak:
+      case WeakTracking:
         dbgs() << "After RAUW from " << *Old->getType() << " %"
                << Old->getName() << " to " << *New->getType() << " %"
                << New->getName() << "\n";
         llvm_unreachable(
-            "A weak value handle still pointed to the  old value!\n");
+            "A weak tracking value handle still pointed to the  old value!\n");
       default:
         break;
       }

--- a/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/lib/Transforms/IPO/GlobalOpt.cpp
@@ -276,7 +276,7 @@ static bool CleanupConstantGlobalUsers(Value *V, Constant *Init,
   // we delete a constant array, we may also be holding pointer to one of its
   // elements (or an element of one of its elements if we're dealing with an
   // array of arrays) in the worklist.
-  SmallVector<WeakVH, 8> WorkList(V->user_begin(), V->user_end());
+  SmallVector<WeakTrackingVH, 8> WorkList(V->user_begin(), V->user_end());
   while (!WorkList.empty()) {
     Value *UV = WorkList.pop_back_val();
     if (!UV)

--- a/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/lib/Transforms/IPO/MergeFunctions.cpp
@@ -1248,7 +1248,8 @@ bool MergeFunctions::runOnModule(Module &M) {
     // Insert only strong functions and merge them. Strong function merging
     // always deletes one of them.
     for (std::vector<WeakTrackingVH>::iterator I = Worklist.begin(),
-           E = Worklist.end(); I != E; ++I) {
+                                               E = Worklist.end();
+         I != E; ++I) {
       if (!*I) continue;
       Function *F = cast<Function>(*I);
       if (!F->isDeclaration() && !F->hasAvailableExternallyLinkage() &&
@@ -1262,7 +1263,8 @@ bool MergeFunctions::runOnModule(Module &M) {
     // functions are identical, we create a new strong function with two weak
     // weak thunks to it which are identical but not mergable.
     for (std::vector<WeakTrackingVH>::iterator I = Worklist.begin(),
-           E = Worklist.end(); I != E; ++I) {
+                                               E = Worklist.end();
+         I != E; ++I) {
       if (!*I) continue;
       Function *F = cast<Function>(*I);
       if (!F->isDeclaration() && !F->hasAvailableExternallyLinkage() &&

--- a/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/lib/Transforms/IPO/MergeFunctions.cpp
@@ -1097,11 +1097,11 @@ private:
 
   /// A work queue of functions that may have been modified and should be
   /// analyzed again.
-  std::vector<WeakVH> Deferred;
+  std::vector<WeakTrackingVH> Deferred;
 
   /// Checks the rules of order relation introduced among functions set.
   /// Returns true, if sanity check has been passed, and false if failed.
-  bool doSanityCheck(std::vector<WeakVH> &Worklist);
+  bool doSanityCheck(std::vector<WeakTrackingVH> &Worklist);
 
   /// Insert a ComparableFunction into the FnTree, or merge it away if it's
   /// equal to one that's already present.
@@ -1154,7 +1154,7 @@ ModulePass *llvm::createMergeFunctionsPass() {
   return new MergeFunctions();
 }
 
-bool MergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
+bool MergeFunctions::doSanityCheck(std::vector<WeakTrackingVH> &Worklist) {
 #if 0 // Begin HLSL Change (NumFunctionsForSanityCheck is always zero)
   if (const unsigned Max = NumFunctionsForSanityCheck) {
     unsigned TripleNumber = 0;
@@ -1163,10 +1163,10 @@ bool MergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
     dbgs() << "MERGEFUNC-SANITY: Started for first " << Max << " functions.\n";
 
     unsigned i = 0;
-    for (std::vector<WeakVH>::iterator I = Worklist.begin(), E = Worklist.end();
+    for (std::vector<WeakTrackingVH>::iterator I = Worklist.begin(), E = Worklist.end();
          I != E && i < Max; ++I, ++i) {
       unsigned j = i;
-      for (std::vector<WeakVH>::iterator J = I; J != E && j < Max; ++J, ++j) {
+      for (std::vector<WeakTrackingVH>::iterator J = I; J != E && j < Max; ++J, ++j) {
         Function *F1 = cast<Function>(*I);
         Function *F2 = cast<Function>(*J);
         int Res1 = FunctionComparator(F1, F2).compare();
@@ -1185,7 +1185,7 @@ bool MergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
           continue;
 
         unsigned k = j;
-        for (std::vector<WeakVH>::iterator K = J; K != E && k < Max;
+        for (std::vector<WeakTrackingVH>::iterator K = J; K != E && k < Max;
              ++k, ++K, ++TripleNumber) {
           if (K == J)
             continue;
@@ -1233,11 +1233,11 @@ bool MergeFunctions::runOnModule(Module &M) {
 
   for (Module::iterator I = M.begin(), E = M.end(); I != E; ++I) {
     if (!I->isDeclaration() && !I->hasAvailableExternallyLinkage())
-      Deferred.push_back(WeakVH(I));
+      Deferred.push_back(WeakTrackingVH(I));
   }
 
   do {
-    std::vector<WeakVH> Worklist;
+    std::vector<WeakTrackingVH> Worklist;
     Deferred.swap(Worklist);
 
     DEBUG(doSanityCheck(Worklist));
@@ -1247,7 +1247,7 @@ bool MergeFunctions::runOnModule(Module &M) {
 
     // Insert only strong functions and merge them. Strong function merging
     // always deletes one of them.
-    for (std::vector<WeakVH>::iterator I = Worklist.begin(),
+    for (std::vector<WeakTrackingVH>::iterator I = Worklist.begin(),
            E = Worklist.end(); I != E; ++I) {
       if (!*I) continue;
       Function *F = cast<Function>(*I);
@@ -1261,7 +1261,7 @@ bool MergeFunctions::runOnModule(Module &M) {
     // create thunks to the strong function when possible. When two weak
     // functions are identical, we create a new strong function with two weak
     // weak thunks to it which are identical but not mergable.
-    for (std::vector<WeakVH>::iterator I = Worklist.begin(),
+    for (std::vector<WeakTrackingVH>::iterator I = Worklist.begin(),
            E = Worklist.end(); I != E; ++I) {
       if (!*I) continue;
       Function *F = cast<Function>(*I);

--- a/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1843,7 +1843,7 @@ Instruction *InstCombiner::visitGetElementPtrInst(GetElementPtrInst &GEP) {
 
 static bool isAllocSiteRemovable(Instruction *AI,
                                  SmallVectorImpl<WeakTrackingVH> &Users,
-                     const TargetLibraryInfo *TLI) {
+                                 const TargetLibraryInfo *TLI) {
   SmallVector<Instruction*, 4> Worklist;
   Worklist.push_back(AI);
 

--- a/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1841,8 +1841,8 @@ Instruction *InstCombiner::visitGetElementPtrInst(GetElementPtrInst &GEP) {
   return nullptr;
 }
 
-static bool
-isAllocSiteRemovable(Instruction *AI, SmallVectorImpl<WeakVH> &Users,
+static bool isAllocSiteRemovable(Instruction *AI,
+                                 SmallVectorImpl<WeakTrackingVH> &Users,
                      const TargetLibraryInfo *TLI) {
   SmallVector<Instruction*, 4> Worklist;
   Worklist.push_back(AI);
@@ -1922,7 +1922,7 @@ Instruction *InstCombiner::visitAllocSite(Instruction &MI) {
   // If we have a malloc call which is only used in any amount of comparisons
   // to null and free calls, delete the calls and replace the comparisons with
   // true or false as appropriate.
-  SmallVector<WeakVH, 64> Users;
+  SmallVector<WeakTrackingVH, 64> Users;
   if (isAllocSiteRemovable(&MI, Users, TLI)) {
     for (unsigned i = 0, e = Users.size(); i != e; ++i) {
       Instruction *I = cast_or_null<Instruction>(&*Users[i]);

--- a/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -511,7 +511,7 @@ bool DSE::runOnBasicBlock(BasicBlock &BB) {
 
           // DeleteDeadInstruction can delete the current instruction.  Save BBI
           // in case we need it.
-          WeakVH NextInst(BBI);
+          WeakTrackingVH NextInst(BBI);
 
           DeleteDeadInstruction(SI, *MD, TLI);
 

--- a/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -903,20 +903,13 @@ class WidenIV {
   SmallVector<NarrowIVDefUse, 8> NarrowIVUsers;
 
 public:
-  WidenIV(const WideIVInfo &WI, LoopInfo *LInfo,
-          ScalarEvolution *SEv, DominatorTree *DTree, SmallVectorImpl<WeakTrackingVH> &DI)
-      :
-    OrigPhi(WI.NarrowIV),
-    WideType(WI.WidestNativeType),
-    IsSigned(WI.IsSigned),
-    LI(LInfo),
-    L(LI->getLoopFor(OrigPhi->getParent())),
-    SE(SEv),
-    DT(DTree),
-    WidePhi(nullptr),
-    WideInc(nullptr),
-    WideIncExpr(nullptr),
-    DeadInsts(DI) {
+  WidenIV(const WideIVInfo &WI, LoopInfo *LInfo, ScalarEvolution *SEv,
+          DominatorTree *DTree, SmallVectorImpl<WeakTrackingVH> &DI)
+      : OrigPhi(WI.NarrowIV), WideType(WI.WidestNativeType),
+        IsSigned(WI.IsSigned), LI(LInfo),
+        L(LI->getLoopFor(OrigPhi->getParent())), SE(SEv), DT(DTree),
+        WidePhi(nullptr), WideInc(nullptr), WideIncExpr(nullptr),
+        DeadInsts(DI) {
     assert(L->getHeader() == OrigPhi->getParent() && "Phi must be an IV");
   }
 

--- a/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -100,7 +100,7 @@ namespace {
     TargetLibraryInfo         *TLI;
     const TargetTransformInfo *TTI;
 
-    SmallVector<WeakVH, 16> DeadInsts;
+    SmallVector<WeakTrackingVH, 16> DeadInsts;
     bool Changed;
   public:
 
@@ -441,8 +441,8 @@ void IndVarSimplify::HandleFloatingPointIV(Loop *L, PHINode *PN) {
                                       Compare->getName());
 
   // In the following deletions, PN may become dead and may be deleted.
-  // Use a WeakVH to observe whether this happens.
-  WeakVH WeakPH = PN;
+  // Use a WeakTrackingVH to observe whether this happens.
+  WeakTrackingVH WeakPH = PN;
 
   // Delete the old floating point exit comparison.  The branch starts using the
   // new comparison.
@@ -477,7 +477,7 @@ void IndVarSimplify::RewriteNonIntegerIVs(Loop *L) {
   //
   BasicBlock *Header = L->getHeader();
 
-  SmallVector<WeakVH, 8> PHIs;
+  SmallVector<WeakTrackingVH, 8> PHIs;
   for (BasicBlock::iterator I = Header->begin();
        PHINode *PN = dyn_cast<PHINode>(I); ++I)
     PHIs.push_back(PN);
@@ -897,15 +897,15 @@ class WidenIV {
   PHINode *WidePhi;
   Instruction *WideInc;
   const SCEV *WideIncExpr;
-  SmallVectorImpl<WeakVH> &DeadInsts;
+  SmallVectorImpl<WeakTrackingVH> &DeadInsts;
 
   SmallPtrSet<Instruction*,16> Widened;
   SmallVector<NarrowIVDefUse, 8> NarrowIVUsers;
 
 public:
   WidenIV(const WideIVInfo &WI, LoopInfo *LInfo,
-          ScalarEvolution *SEv, DominatorTree *DTree,
-          SmallVectorImpl<WeakVH> &DI) :
+          ScalarEvolution *SEv, DominatorTree *DTree, SmallVectorImpl<WeakTrackingVH> &DI)
+      :
     OrigPhi(WI.NarrowIV),
     WideType(WI.WidestNativeType),
     IsSigned(WI.IsSigned),

--- a/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -696,7 +696,7 @@ bool LoopIdiomRecognize::runOnLoopBlock(BasicBlock *BB, const SCEV *BECount,
     Instruction *Inst = I++;
     // Look for store instructions, which may be optimized to memset/memcpy.
     if (StoreInst *SI = dyn_cast<StoreInst>(Inst))  {
-      WeakVH InstPtr(I);
+      WeakTrackingVH InstPtr(I);
       if (!processLoopStore(SI, BECount)) continue;
       MadeChange = true;
 
@@ -709,7 +709,7 @@ bool LoopIdiomRecognize::runOnLoopBlock(BasicBlock *BB, const SCEV *BECount,
 
     // Look for memset instructions, which may be optimized to a larger memset.
     if (MemSetInst *MSI = dyn_cast<MemSetInst>(Inst))  {
-      WeakVH InstPtr(I);
+      WeakTrackingVH InstPtr(I);
       if (!processLoopMemSet(MSI, BECount)) continue;
       MadeChange = true;
 

--- a/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -1766,21 +1766,14 @@ class LSRInstance {
                                   const LSRUse &LU,
                                   SCEVExpander &Rewriter) const;
 
-  Value *Expand(const LSRFixup &LF,
-                const Formula &F,
-                BasicBlock::iterator IP,
+  Value *Expand(const LSRFixup &LF, const Formula &F, BasicBlock::iterator IP,
                 SCEVExpander &Rewriter,
                 SmallVectorImpl<WeakTrackingVH> &DeadInsts) const;
-  void RewriteForPHI(PHINode *PN, const LSRFixup &LF,
-                     const Formula &F,
+  void RewriteForPHI(PHINode *PN, const LSRFixup &LF, const Formula &F,
                      SCEVExpander &Rewriter,
-                     SmallVectorImpl<WeakTrackingVH> &DeadInsts,
-                     Pass *P) const;
-  void Rewrite(const LSRFixup &LF,
-               const Formula &F,
-               SCEVExpander &Rewriter,
-               SmallVectorImpl<WeakTrackingVH> &DeadInsts,
-               Pass *P) const;
+                     SmallVectorImpl<WeakTrackingVH> &DeadInsts, Pass *P) const;
+  void Rewrite(const LSRFixup &LF, const Formula &F, SCEVExpander &Rewriter,
+               SmallVectorImpl<WeakTrackingVH> &DeadInsts, Pass *P) const;
   void ImplementSolution(const SmallVectorImpl<const Formula *> &Solution,
                          Pass *P);
 
@@ -4449,10 +4442,8 @@ LSRInstance::AdjustInsertPositionForExpand(BasicBlock::iterator LowestIP,
 
 /// Expand - Emit instructions for the leading candidate expression for this
 /// LSRUse (this is called "expanding").
-Value *LSRInstance::Expand(const LSRFixup &LF,
-                           const Formula &F,
-                           BasicBlock::iterator IP,
-                           SCEVExpander &Rewriter,
+Value *LSRInstance::Expand(const LSRFixup &LF, const Formula &F,
+                           BasicBlock::iterator IP, SCEVExpander &Rewriter,
                            SmallVectorImpl<WeakTrackingVH> &DeadInsts) const {
   const LSRUse &LU = Uses[LF.LUIdx];
   if (LU.RigidFormula)
@@ -4634,10 +4625,8 @@ Value *LSRInstance::Expand(const LSRFixup &LF,
 /// RewriteForPHI - Helper for Rewrite. PHI nodes are special because the use
 /// of their operands effectively happens in their predecessor blocks, so the
 /// expression may need to be expanded in multiple places.
-void LSRInstance::RewriteForPHI(PHINode *PN,
-                                const LSRFixup &LF,
-                                const Formula &F,
-                                SCEVExpander &Rewriter,
+void LSRInstance::RewriteForPHI(PHINode *PN, const LSRFixup &LF,
+                                const Formula &F, SCEVExpander &Rewriter,
                                 SmallVectorImpl<WeakTrackingVH> &DeadInsts,
                                 Pass *P) const {
   DenseMap<BasicBlock *, Value *> Inserted;
@@ -4710,8 +4699,7 @@ void LSRInstance::RewriteForPHI(PHINode *PN,
 /// Rewrite - Emit instructions for the leading candidate expression for this
 /// LSRUse (this is called "expanding"), and update the UserInst to reference
 /// the newly expanded value.
-void LSRInstance::Rewrite(const LSRFixup &LF,
-                          const Formula &F,
+void LSRInstance::Rewrite(const LSRFixup &LF, const Formula &F,
                           SCEVExpander &Rewriter,
                           SmallVectorImpl<WeakTrackingVH> &DeadInsts,
                           Pass *P) const {

--- a/lib/Transforms/Scalar/LoopUnswitch.cpp
+++ b/lib/Transforms/Scalar/LoopUnswitch.cpp
@@ -980,11 +980,11 @@ void LoopUnswitch::UnswitchNontrivialCondition(Value *LIC, Constant *Val,
   LoopProcessWorklist.push_back(NewLoop);
   redoLoop = true;
 
-  // Keep a WeakVH holding onto LIC.  If the first call to RewriteLoopBody
+  // Keep a WeakTrackingVH holding onto LIC.  If the first call to RewriteLoopBody
   // deletes the instruction (for example by simplifying a PHI that feeds into
   // the condition that we're unswitching on), we don't rewrite the second
   // iteration.
-  WeakVH LICHandle(LIC);
+  WeakTrackingVH LICHandle(LIC);
 
   // Now we rewrite the original code to know that the condition is true and the
   // new code to know that the condition is false.

--- a/lib/Transforms/Scalar/LoopUnswitch.cpp
+++ b/lib/Transforms/Scalar/LoopUnswitch.cpp
@@ -980,10 +980,10 @@ void LoopUnswitch::UnswitchNontrivialCondition(Value *LIC, Constant *Val,
   LoopProcessWorklist.push_back(NewLoop);
   redoLoop = true;
 
-  // Keep a WeakTrackingVH holding onto LIC.  If the first call to RewriteLoopBody
-  // deletes the instruction (for example by simplifying a PHI that feeds into
-  // the condition that we're unswitching on), we don't rewrite the second
-  // iteration.
+  // Keep a WeakTrackingVH holding onto LIC.  If the first call to
+  // RewriteLoopBody deletes the instruction (for example by simplifying a PHI
+  // that feeds into the condition that we're unswitching on), we don't rewrite
+  // the second iteration.
   WeakTrackingVH LICHandle(LIC);
 
   // Now we rewrite the original code to know that the condition is true and the

--- a/lib/Transforms/Scalar/Reassociate.cpp
+++ b/lib/Transforms/Scalar/Reassociate.cpp
@@ -1134,7 +1134,7 @@ static unsigned FindInOperandList(SmallVectorImpl<ValueEntry> &Ops, unsigned i,
 /// Emit a tree of add instructions, summing Ops together
 /// and returning the result.  Insert the tree before I.
 static Value *EmitAddTreeOfValues(Instruction *I,
-                                  SmallVectorImpl<WeakVH> &Ops){
+                                  SmallVectorImpl<WeakTrackingVH> &Ops) {
   if (Ops.size() == 1) return Ops.back();
 
   Value *V1 = Ops.back();
@@ -1699,7 +1699,7 @@ Value *Reassociate::OptimizeAdd(Instruction *I,
             ? BinaryOperator::CreateAdd(MaxOccVal, MaxOccVal)
             : BinaryOperator::CreateFAdd(MaxOccVal, MaxOccVal);
 
-    SmallVector<WeakVH, 4> NewMulOps;
+    SmallVector<WeakTrackingVH, 4> NewMulOps;
     for (unsigned i = 0; i != Ops.size(); ++i) {
       // Only try to remove factors from expressions we're allowed to.
       BinaryOperator *BOp =

--- a/lib/Transforms/Utils/BasicBlockUtils.cpp
+++ b/lib/Transforms/Utils/BasicBlockUtils.cpp
@@ -91,8 +91,8 @@ void llvm::FoldSingleEntryPHINodes(BasicBlock *BB, AliasAnalysis *AA,
 /// it is ultimately unused or if it reaches an unused cycle.
 bool llvm::DeleteDeadPHIs(BasicBlock *BB, const TargetLibraryInfo *TLI) {
   // Recursively deleting a PHI may cause multiple PHIs to be deleted
-  // or RAUW'd undef, so use an array of WeakVH for the PHIs to delete.
-  SmallVector<WeakVH, 8> PHIs;
+  // or RAUW'd undef, so use an array of WeakTrackingVH for the PHIs to delete.
+  SmallVector<WeakTrackingVH, 8> PHIs;
   for (BasicBlock::iterator I = BB->begin();
        PHINode *PN = dyn_cast<PHINode>(I); ++I)
     PHIs.push_back(PN);

--- a/lib/Transforms/Utils/CloneFunction.cpp
+++ b/lib/Transforms/Utils/CloneFunction.cpp
@@ -297,7 +297,7 @@ namespace {
 void PruningFunctionCloner::CloneBlock(const BasicBlock *BB,
                                        BasicBlock::const_iterator StartingInst,
                                        std::vector<const BasicBlock*> &ToClone){
-  WeakVH &BBEntry = VMap[BB];
+  WeakTrackingVH &BBEntry = VMap[BB];
 
   // Have we already cloned this block?
   if (BBEntry) return;
@@ -632,7 +632,7 @@ void llvm::CloneAndPruneIntoFromInst(Function *NewFunc, const Function *OldFunc,
   // Make a second pass over the PHINodes now that all of them have been
   // remapped into the new function, simplifying the PHINode and performing any
   // recursive simplifications exposed. This will transparently update the
-  // WeakVH in the VMap. Notably, we rely on that so that if we coalesce
+  // WeakTrackingVH in the VMap. Notably, we rely on that so that if we coalesce
   // two PHINodes, the iteration over the old PHIs remains valid, and the
   // mapping will just map us to the new node (which may not even be a PHI
   // node).

--- a/lib/Transforms/Utils/InlineFunction.cpp
+++ b/lib/Transforms/Utils/InlineFunction.cpp
@@ -219,7 +219,7 @@ static void HandleCallsInBlockInlinedThroughInvoke(BasicBlock *BB,
     II->setAttributes(CI->getAttributes());
     
     // Make sure that anything using the call now uses the invoke!  This also
-    // updates the CallGraph if present, because it uses a WeakVH.
+    // updates the CallGraph if present, because it uses a WeakTrackingVH.
     CI->replaceAllUsesWith(II);
 
     // Delete the original call

--- a/lib/Transforms/Utils/InlineFunction.cpp
+++ b/lib/Transforms/Utils/InlineFunction.cpp
@@ -217,7 +217,7 @@ static void HandleCallsInBlockInlinedThroughInvoke(BasicBlock *BB,
     II->setDebugLoc(CI->getDebugLoc());
     II->setCallingConv(CI->getCallingConv());
     II->setAttributes(CI->getAttributes());
-    
+
     // Make sure that anything using the call now uses the invoke!  This also
     // updates the CallGraph if present, because it uses a WeakTrackingVH.
     CI->replaceAllUsesWith(II);

--- a/lib/Transforms/Utils/Local.cpp
+++ b/lib/Transforms/Utils/Local.cpp
@@ -447,7 +447,7 @@ bool llvm::SimplifyInstructionsInBlock(BasicBlock *BB,
     assert(!BI->isTerminator());
     Instruction *Inst = BI++;
 
-    WeakVH BIHandle(BI);
+    WeakTrackingVH BIHandle(BI);
     if (recursivelySimplifyInstruction(Inst, TLI)) {
       MadeChange = true;
       if (BIHandle != BI)
@@ -488,7 +488,7 @@ void llvm::RemovePredecessorAndSimplify(BasicBlock *BB, BasicBlock *Pred) {
   // that can be removed.
   BB->removePredecessor(Pred, true);
 
-  WeakVH PhiIt = &BB->front();
+  WeakTrackingVH PhiIt = &BB->front();
   while (PHINode *PN = dyn_cast<PHINode>(PhiIt)) {
     PhiIt = &*++BasicBlock::iterator(cast<Instruction>(PhiIt));
     Value *OldPhiIt = PhiIt;

--- a/lib/Transforms/Utils/LoopUnroll.cpp
+++ b/lib/Transforms/Utils/LoopUnroll.cpp
@@ -495,7 +495,7 @@ bool llvm::UnrollLoop(Loop *L, unsigned Count, unsigned TripCount,
 
     // Simplify any new induction variables in the partially unrolled loop.
     if (SE && !CompletelyUnroll) {
-      SmallVector<WeakVH, 16> DeadInsts;
+      SmallVector<WeakTrackingVH, 16> DeadInsts;
       simplifyLoopIVs(L, SE, LPM, DeadInsts);
 
       // Aggressively clean up dead instructions that simplifyLoopIVs already

--- a/lib/Transforms/Utils/SimplifyIndVar.cpp
+++ b/lib/Transforms/Utils/SimplifyIndVar.cpp
@@ -48,13 +48,13 @@ namespace {
     LoopInfo         *LI;
     ScalarEvolution  *SE;
 
-    SmallVectorImpl<WeakVH> &DeadInsts;
+    SmallVectorImpl<WeakTrackingVH> &DeadInsts;
 
     bool Changed;
 
   public:
     SimplifyIndvar(Loop *Loop, ScalarEvolution *SE, LoopInfo *LI,
-                   SmallVectorImpl<WeakVH> &Dead)
+                   SmallVectorImpl<WeakTrackingVH> &Dead)
         : L(Loop), LI(LI), SE(SE), DeadInsts(Dead), Changed(false) {
       assert(LI && "IV simplification requires LoopInfo");
     }
@@ -514,8 +514,7 @@ void IVVisitor::anchor() { }
 /// Simplify instructions that use this induction variable
 /// by using ScalarEvolution to analyze the IV's recurrence.
 bool simplifyUsersOfIV(PHINode *CurrIV, ScalarEvolution *SE, LPPassManager *LPM,
-                       SmallVectorImpl<WeakVH> &Dead, IVVisitor *V)
-{
+                       SmallVectorImpl<WeakTrackingVH> &Dead, IVVisitor *V) {
   LoopInfo *LI = &LPM->getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
   SimplifyIndvar SIV(LI->getLoopFor(CurrIV->getParent()), SE, LI, Dead);
   SIV.simplifyUsers(CurrIV, V);
@@ -525,7 +524,7 @@ bool simplifyUsersOfIV(PHINode *CurrIV, ScalarEvolution *SE, LPPassManager *LPM,
 /// Simplify users of induction variables within this
 /// loop. This does not actually change or add IVs.
 bool simplifyLoopIVs(Loop *L, ScalarEvolution *SE, LPPassManager *LPM,
-                     SmallVectorImpl<WeakVH> &Dead) {
+                     SmallVectorImpl<WeakTrackingVH> &Dead) {
   bool Changed = false;
   for (BasicBlock::iterator I = L->getHeader()->begin(); isa<PHINode>(I); ++I) {
     Changed |= simplifyUsersOfIV(cast<PHINode>(I), SE, LPM, Dead);

--- a/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -3195,9 +3195,11 @@ private:
 /// \brief Check that the Values in the slice in VL array are still existent in
 /// the WeakTrackingVH array.
 /// Vectorization of part of the VL array may cause later values in the VL array
-/// to become invalid. We track when this has happened in the WeakTrackingVH array.
-static bool hasValueBeenRAUWed(ArrayRef<Value *> VL, ArrayRef<WeakTrackingVH> VH,
-                               unsigned SliceBegin, unsigned SliceSize) {
+/// to become invalid. We track when this has happened in the WeakTrackingVH
+/// array.
+static bool hasValueBeenRAUWed(ArrayRef<Value *> VL,
+                               ArrayRef<WeakTrackingVH> VH, unsigned SliceBegin,
+                               unsigned SliceSize) {
   VL = VL.slice(SliceBegin, SliceSize);
   VH = VH.slice(SliceBegin, SliceSize);
   return !std::equal(VL.begin(), VL.end(), VH.begin());

--- a/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -3193,10 +3193,10 @@ private:
 };
 
 /// \brief Check that the Values in the slice in VL array are still existent in
-/// the WeakVH array.
+/// the WeakTrackingVH array.
 /// Vectorization of part of the VL array may cause later values in the VL array
-/// to become invalid. We track when this has happened in the WeakVH array.
-static bool hasValueBeenRAUWed(ArrayRef<Value *> VL, ArrayRef<WeakVH> VH,
+/// to become invalid. We track when this has happened in the WeakTrackingVH array.
+static bool hasValueBeenRAUWed(ArrayRef<Value *> VL, ArrayRef<WeakTrackingVH> VH,
                                unsigned SliceBegin, unsigned SliceSize) {
   VL = VL.slice(SliceBegin, SliceSize);
   VH = VH.slice(SliceBegin, SliceSize);
@@ -3218,7 +3218,7 @@ bool SLPVectorizer::vectorizeStoreChain(ArrayRef<Value *> Chain,
     return false;
 
   // Keep track of values that were deleted by vectorizing in the loop below.
-  SmallVector<WeakVH, 8> TrackValues(Chain.begin(), Chain.end());
+  SmallVector<WeakTrackingVH, 8> TrackValues(Chain.begin(), Chain.end());
 
   bool Changed = false;
   // Look for profitable vectorizable trees at all offsets, starting at zero.
@@ -3381,7 +3381,7 @@ bool SLPVectorizer::tryToVectorizeList(ArrayRef<Value *> VL, BoUpSLP &R,
   bool Changed = false;
 
   // Keep track of values that were deleted by vectorizing in the loop below.
-  SmallVector<WeakVH, 8> TrackValues(VL.begin(), VL.end());
+  SmallVector<WeakTrackingVH, 8> TrackValues(VL.begin(), VL.end());
 
   for (unsigned i = 0, e = VL.size(); i < e; ++i) {
     unsigned OpsWidth = 0;

--- a/tools/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/tools/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -556,9 +556,10 @@ CodeGenFunction::GenerateCXXGlobalInitFunc(llvm::Function *Fn,
   FinishFunction();
 }
 
-void CodeGenFunction::GenerateCXXGlobalDtorsFunc(llvm::Function *Fn,
+void CodeGenFunction::GenerateCXXGlobalDtorsFunc(
+    llvm::Function *Fn,
     const std::vector<std::pair<llvm::WeakTrackingVH, llvm::Constant *>>
-                                                &DtorsAndObjects) {
+        &DtorsAndObjects) {
   {
     auto NL = ApplyDebugLocation::CreateEmpty(*this);
     StartFunction(GlobalDecl(), getContext().VoidTy, Fn,

--- a/tools/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/tools/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -557,7 +557,7 @@ CodeGenFunction::GenerateCXXGlobalInitFunc(llvm::Function *Fn,
 }
 
 void CodeGenFunction::GenerateCXXGlobalDtorsFunc(llvm::Function *Fn,
-                  const std::vector<std::pair<llvm::WeakVH, llvm::Constant*> >
+    const std::vector<std::pair<llvm::WeakTrackingVH, llvm::Constant *>>
                                                 &DtorsAndObjects) {
   {
     auto NL = ApplyDebugLocation::CreateEmpty(*this);

--- a/tools/clang/lib/CodeGen/CodeGenFunction.h
+++ b/tools/clang/lib/CodeGen/CodeGenFunction.h
@@ -2849,7 +2849,7 @@ public:
   /// GenerateCXXGlobalDtorsFunc - Generates code for destroying global
   /// variables.
   void GenerateCXXGlobalDtorsFunc(llvm::Function *Fn,
-                                  const std::vector<std::pair<llvm::WeakVH,
+      const std::vector<std::pair<llvm::WeakTrackingVH,
                                   llvm::Constant*> > &DtorsAndObjects);
 
   void GenerateCXXGlobalVarDeclInitFunc(llvm::Function *Fn,

--- a/tools/clang/lib/CodeGen/CodeGenFunction.h
+++ b/tools/clang/lib/CodeGen/CodeGenFunction.h
@@ -2848,9 +2848,10 @@ public:
 
   /// GenerateCXXGlobalDtorsFunc - Generates code for destroying global
   /// variables.
-  void GenerateCXXGlobalDtorsFunc(llvm::Function *Fn,
-      const std::vector<std::pair<llvm::WeakTrackingVH,
-                                  llvm::Constant*> > &DtorsAndObjects);
+  void GenerateCXXGlobalDtorsFunc(
+      llvm::Function *Fn,
+      const std::vector<std::pair<llvm::WeakTrackingVH, llvm::Constant *>>
+          &DtorsAndObjects);
 
   void GenerateCXXGlobalVarDeclInitFunc(llvm::Function *Fn,
                                         const VarDecl *D,

--- a/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -990,7 +990,7 @@ void CodeGenModule::addCompilerUsedGlobal(llvm::GlobalValue *GV) {
 }
 
 static void emitUsed(CodeGenModule &CGM, StringRef Name,
-                     std::vector<llvm::WeakVH> &List) {
+                     std::vector<llvm::WeakTrackingVH> &List) {
   // Don't create llvm.used if there is no need.
   if (List.empty())
     return;

--- a/tools/clang/lib/CodeGen/CodeGenModule.h
+++ b/tools/clang/lib/CodeGen/CodeGenModule.h
@@ -351,8 +351,8 @@ private:
   /// List of global values which are required to be present in the object file;
   /// bitcast to i8*. This is used for forcing visibility of symbols which may
   /// otherwise be optimized out.
-  std::vector<llvm::WeakVH> LLVMUsed;
-  std::vector<llvm::WeakVH> LLVMCompilerUsed;
+  std::vector<llvm::WeakTrackingVH> LLVMUsed;
+  std::vector<llvm::WeakTrackingVH> LLVMCompilerUsed;
 
   /// Store the list of global constructors and their respective priorities to
   /// be emitted when the translation unit is complete.
@@ -424,7 +424,7 @@ private:
   SmallVector<GlobalInitData, 8> PrioritizedCXXGlobalInits;
 
   /// Global destructor functions and arguments that need to run on termination.
-  std::vector<std::pair<llvm::WeakVH,llvm::Constant*> > CXXGlobalDtors;
+  std::vector<std::pair<llvm::WeakTrackingVH, llvm::Constant *>> CXXGlobalDtors;
 
   /// \brief The complete set of modules that has been imported.
   llvm::SetVector<clang::Module *> ImportedModules;
@@ -437,11 +437,11 @@ private:
 
   /// Cached reference to the class for constant strings. This value has type
   /// int * but is actually an Obj-C class pointer.
-  llvm::WeakVH CFConstantStringClassRef;
+  llvm::WeakTrackingVH CFConstantStringClassRef;
 
   /// Cached reference to the class for constant strings. This value has type
   /// int * but is actually an Obj-C class pointer.
-  llvm::WeakVH ConstantStringClassRef;
+  llvm::WeakTrackingVH ConstantStringClassRef;
 
   /// \brief The LLVM type corresponding to NSConstantString.
   llvm::StructType *NSConstantStringType;

--- a/unittests/IR/ValueHandleTest.cpp
+++ b/unittests/IR/ValueHandleTest.cpp
@@ -100,7 +100,6 @@ TEST_F(ValueHandle, WeakTrackingVH_NullOnDeletion) {
   EXPECT_EQ(null_value, WVH_Recreated);
 }
 
-
 TEST_F(ValueHandle, AssertingVH_BasicOperation) {
   AssertingVH<CastInst> AVH(BitcastV.get());
   CastInst *implicit_to_exact_type = AVH;

--- a/unittests/IR/ValueHandleTest.cpp
+++ b/unittests/IR/ValueHandleTest.cpp
@@ -34,8 +34,8 @@ public:
   ConcreteCallbackVH(Value *V) : CallbackVH(V) {}
 };
 
-TEST_F(ValueHandle, WeakVH_BasicOperation) {
-  WeakVH WVH(BitcastV.get());
+TEST_F(ValueHandle, WeakTrackingVH_BasicOperation) {
+  WeakTrackingVH WVH(BitcastV.get());
   EXPECT_EQ(BitcastV.get(), WVH);
   WVH = ConstantV;
   EXPECT_EQ(ConstantV, WVH);
@@ -46,9 +46,9 @@ TEST_F(ValueHandle, WeakVH_BasicOperation) {
   EXPECT_EQ(Type::getInt32Ty(getGlobalContext()), (*WVH).getType());
 }
 
-TEST_F(ValueHandle, WeakVH_Comparisons) {
-  WeakVH BitcastWVH(BitcastV.get());
-  WeakVH ConstantWVH(ConstantV);
+TEST_F(ValueHandle, WeakTrackingVH_Comparisons) {
+  WeakTrackingVH BitcastWVH(BitcastV.get());
+  WeakTrackingVH ConstantWVH(ConstantV);
 
   EXPECT_TRUE(BitcastWVH == BitcastWVH);
   EXPECT_TRUE(BitcastV.get() == BitcastWVH);
@@ -79,20 +79,20 @@ TEST_F(ValueHandle, WeakVH_Comparisons) {
   EXPECT_EQ(BV >= CV, BitcastWVH >= ConstantV);
 }
 
-TEST_F(ValueHandle, WeakVH_FollowsRAUW) {
-  WeakVH WVH(BitcastV.get());
-  WeakVH WVH_Copy(WVH);
-  WeakVH WVH_Recreated(BitcastV.get());
+TEST_F(ValueHandle, WeakTrackingVH_FollowsRAUW) {
+  WeakTrackingVH WVH(BitcastV.get());
+  WeakTrackingVH WVH_Copy(WVH);
+  WeakTrackingVH WVH_Recreated(BitcastV.get());
   BitcastV->replaceAllUsesWith(ConstantV);
   EXPECT_EQ(ConstantV, WVH);
   EXPECT_EQ(ConstantV, WVH_Copy);
   EXPECT_EQ(ConstantV, WVH_Recreated);
 }
 
-TEST_F(ValueHandle, WeakVH_NullOnDeletion) {
-  WeakVH WVH(BitcastV.get());
-  WeakVH WVH_Copy(WVH);
-  WeakVH WVH_Recreated(BitcastV.get());
+TEST_F(ValueHandle, WeakTrackingVH_NullOnDeletion) {
+  WeakTrackingVH WVH(BitcastV.get());
+  WeakTrackingVH WVH_Copy(WVH);
+  WeakTrackingVH WVH_Recreated(BitcastV.get());
   BitcastV.reset();
   Value *null_value = nullptr;
   EXPECT_EQ(null_value, WVH);
@@ -374,11 +374,11 @@ TEST_F(ValueHandle, DestroyingOtherVHOnSameValueDoesntBreakIteration) {
 
   class DestroyingVH : public CallbackVH {
   public:
-    std::unique_ptr<WeakVH> ToClear[2];
+    std::unique_ptr<WeakTrackingVH> ToClear[2];
     DestroyingVH(Value *V) {
-      ToClear[0].reset(new WeakVH(V));
+      ToClear[0].reset(new WeakTrackingVH(V));
       setValPtr(V);
-      ToClear[1].reset(new WeakVH(V));
+      ToClear[1].reset(new WeakTrackingVH(V));
     }
     void deleted() override {
       ToClear[0].reset();
@@ -392,9 +392,9 @@ TEST_F(ValueHandle, DestroyingOtherVHOnSameValueDoesntBreakIteration) {
   };
 
   {
-    WeakVH ShouldBeVisited1(BitcastV.get());
+    WeakTrackingVH ShouldBeVisited1(BitcastV.get());
     DestroyingVH C(BitcastV.get());
-    WeakVH ShouldBeVisited2(BitcastV.get());
+    WeakTrackingVH ShouldBeVisited2(BitcastV.get());
 
     BitcastV->replaceAllUsesWith(ConstantV);
     EXPECT_EQ(ConstantV, static_cast<Value*>(ShouldBeVisited1));
@@ -402,9 +402,9 @@ TEST_F(ValueHandle, DestroyingOtherVHOnSameValueDoesntBreakIteration) {
   }
 
   {
-    WeakVH ShouldBeVisited1(BitcastV.get());
+    WeakTrackingVH ShouldBeVisited1(BitcastV.get());
     DestroyingVH C(BitcastV.get());
-    WeakVH ShouldBeVisited2(BitcastV.get());
+    WeakTrackingVH ShouldBeVisited2(BitcastV.get());
 
     BitcastV.reset();
     EXPECT_EQ(nullptr, static_cast<Value*>(ShouldBeVisited1));


### PR DESCRIPTION
This PR pulls the upstream change, Rename WeakVH to WeakTrackingVH; NFC (https://github.com/llvm/llvm-project/commit/e6bca0eecbd31d9dd65040b212326330c9cf2655), into DXC.

Here's the summary of the change:

>   I plan to use WeakVH to mean "nulls itself out on deletion, but does not track RAUW" in a subsequent commit.
> 
>   Reviewers: dblaikie, davide
> 
>   Reviewed By: davide
> 
>   Subscribers: arsenm, mehdi_amini, mcrosier, mzolotukhin, jfb, llvm-commits, nhaehnle
> 
>   Differential Revision: https://reviews.llvm.org/D32266

This is part 3 of the fix for #6659.