### PR TITLE
[llc/opt] Add an option to run all passes twice

### DIFF
--- a/test/MC/ELF/empty-twice.ll
+++ b/test/MC/ELF/empty-twice.ll
@@ -1,0 +1,6 @@
+; Check that there is no persistent state in the ELF emitter that crashes us
+; when we try to reuse the pass manager
+; RUN: llc -compile-twice -filetype=obj %s -o -
+
+target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:32:32-n8:16:32"
+target triple = "i386-pc-linux-gnu"

--- a/test/Object/opt-twice.ll
+++ b/test/Object/opt-twice.ll
@@ -1,0 +1,14 @@
+; The pass here doesn't matter (we use deadargelim), but test
+; that the -run-twice options exists, generates output, and
+; doesn't crash
+; RUN: opt -run-twice -deadargelim -S < %s | FileCheck %s
+
+; CHECK: define internal void @test
+define internal {} @test() {
+  ret {} undef
+}
+
+define void @caller() {
+  call {} @test()
+  ret void
+}

--- a/tools/llc/llc.cpp
+++ b/tools/llc/llc.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetSubtargetInfo.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 #include <memory>
 using namespace llvm;
 
@@ -94,6 +95,12 @@ static cl::opt<bool> EnableDwarfDirectory(
 static cl::opt<bool> AsmVerbose("asm-verbose",
                                 cl::desc("Add comments to directives."),
                                 cl::init(true));
+
+static cl::opt<bool>
+    CompileTwice("compile-twice", cl::Hidden,
+                 cl::desc("Run everything twice, re-using the same pass "
+                          "manager and verify the the result is the same."),
+                 cl::init(false));
 
 static int compileModule(char **, LLVMContext &);
 
@@ -326,10 +333,15 @@ static int compileModule(char **argv, LLVMContext &Context) {
 
   {
     raw_pwrite_stream *OS = &Out->os();
-    std::unique_ptr<buffer_ostream> BOS;
-    if (FileType != TargetMachine::CGFT_AssemblyFile &&
-        !Out->os().supportsSeeking()) {
-      BOS = make_unique<buffer_ostream>(*OS);
+
+    // Manually do the buffering rather than using buffer_ostream,
+    // so we can memcmp the contents in CompileTwice mode
+    SmallVector<char, 0> Buffer;
+    std::unique_ptr<raw_svector_ostream> BOS;
+    if ((FileType != TargetMachine::CGFT_AssemblyFile &&
+         !Out->os().supportsSeeking()) ||
+        CompileTwice) {
+      BOS = make_unique<raw_svector_ostream>(Buffer);
       OS = BOS.get();
     }
 
@@ -379,7 +391,39 @@ static int compileModule(char **argv, LLVMContext &Context) {
     // Before executing passes, print the final values of the LLVM options.
     cl::PrintOptionValues();
 
+    // If requested, run the pass manager over the same module again,
+    // to catch any bugs due to persistent state in the passes. Note that
+    // opt has the same functionality, so it may be worth abstracting this out
+    // in the future.
+    SmallVector<char, 0> CompileTwiceBuffer;
+    if (CompileTwice) {
+      std::unique_ptr<Module> M2(llvm::CloneModule(M.get()));
+      PM.run(*M2);
+      CompileTwiceBuffer = Buffer;
+      Buffer.clear();
+    }
+
     PM.run(*M);
+
+    // Compare the two outputs and make sure they're the same
+    if (CompileTwice) {
+      if (Buffer.size() != CompileTwiceBuffer.size() ||
+          (memcmp(Buffer.data(), CompileTwiceBuffer.data(), Buffer.size()) !=
+           0)) {
+        errs()
+            << "Running the pass manager twice changed the output.\n"
+               "Writing the result of the second run to the specified output\n"
+               "To generate the one-run comparison binary, just run without\n"
+               "the compile-twice option\n";
+        Out->os() << Buffer;
+        Out->keep();
+        return 1;
+      }
+    }
+
+    if (BOS) {
+      Out->os() << Buffer;
+    }
   }
 
   // Declare success.

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -14,7 +14,6 @@
 
 #include "BreakpointPrinter.h"
 #include "NewPMDriver.h"
-#include "llvm/PassPrinters/PassPrinters.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Analysis/CallGraphSCCPass.h"
@@ -37,6 +36,7 @@
 #include "llvm/LinkAllIR.h"
 #include "llvm/LinkAllPasses.h"
 #include "llvm/MC/SubtargetFeature.h"
+#include "llvm/PassPrinters/PassPrinters.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -28,6 +28,7 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/LegacyPassNameParser.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
@@ -36,7 +37,6 @@
 #include "llvm/LinkAllIR.h"
 #include "llvm/LinkAllPasses.h"
 #include "llvm/MC/SubtargetFeature.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"
@@ -51,6 +51,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 
 // HLSL Change Starts
 #include "dxc/HLSL/ComputeViewIdState.h"
@@ -201,6 +202,11 @@ static cl::opt<bool> PreserveAssemblyUseListOrder(
     "preserve-ll-uselistorder",
     cl::desc("Preserve use-list order when writing LLVM assembly."),
     cl::init(false), cl::Hidden);
+
+static cl::opt<bool>
+    RunTwice("run-twice",
+             cl::desc("Run all passes twice, re-using the same pass manager."),
+             cl::init(false), cl::Hidden);
 
 static inline void addPass(legacy::PassManagerBase &PM, Pass *P) {
   // Add the pass to the pass manager...
@@ -632,14 +638,25 @@ int __cdecl main(int argc, char **argv) {
   if (!NoVerify && !VerifyEach)
     Passes.add(createVerifierPass());
 
+  // In run twice mode, we want to make sure the output is bit-by-bit
+  // equivalent if we run the pass manager again, so setup two buffers and
+  // a stream to write to them. Note that llc does something similar and it
+  // may be worth to abstract this out in the future.
+  SmallVector<char, 0> Buffer;
+  SmallVector<char, 0> CompileTwiceBuffer;
+  std::unique_ptr<raw_svector_ostream> BOS;
+  raw_ostream *OS = &Out->os();
+  if (RunTwice) {
+    BOS = make_unique<raw_svector_ostream>(Buffer);
+    OS = BOS.get();
+  }
+
   // Write bitcode or assembly to the output as the last step...
   if (!NoOutput && !AnalyzeOnly) {
     if (OutputAssembly)
-      Passes.add(
-          createPrintModulePass(Out->os(), "", PreserveAssemblyUseListOrder));
+      Passes.add(createPrintModulePass(*OS, "", PreserveAssemblyUseListOrder));
     else
-      Passes.add(
-          createBitcodeWriterPass(Out->os(), PreserveBitcodeUseListOrder));
+      Passes.add(createBitcodeWriterPass(*OS, PreserveBitcodeUseListOrder));
   }
 
   // Before executing passes, print the final values of the LLVM options.
@@ -654,6 +671,27 @@ int __cdecl main(int argc, char **argv) {
     exit(1);
   }
   // HLSL Change Ends
+
+  // If requested, run all passes again with the same pass manager to catch
+  // bugs caused by persistent state in the passes
+  if (RunTwice) {
+    CompileTwiceBuffer = Buffer;
+    Buffer.clear();
+    std::unique_ptr<Module> M2(CloneModule(M.get()));
+    Passes.run(*M2);
+    if (Buffer.size() != CompileTwiceBuffer.size() ||
+        (memcmp(Buffer.data(), CompileTwiceBuffer.data(), Buffer.size()) !=
+         0)) {
+      errs() << "Running the pass manager twice changed the output.\n"
+                "Writing the result of the second run to the specified output."
+                "To generate the one-run comparison binary, just run without\n"
+                "the compile-twice option\n";
+      Out->os() << BOS->str();
+      Out->keep();
+      return 1;
+    }
+    Out->os() << BOS->str();
+  }
 
   // Declare success.
   if (!NoOutput || PrintBreakpoints)

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -677,6 +677,7 @@ int __cdecl main(int argc, char **argv) {
   // If requested, run all passes again with the same pass manager to catch
   // bugs caused by persistent state in the passes
   if (RunTwice) {
+    assert(Out);
     CompileTwiceBuffer = Buffer;
     Buffer.clear();
     std::unique_ptr<Module> M2(CloneModule(M.get()));

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -416,23 +416,21 @@ int __cdecl main(int argc, char **argv) {
   if (!TargetTriple.empty())
     M->setTargetTriple(Triple::normalize(TargetTriple));
 
-  // Figure out what stream we are supposed to write to...
-  std::unique_ptr<tool_output_file> Out;
   if (NoOutput) {
     if (!OutputFilename.empty())
       errs() << "WARNING: The -o (output filename) option is ignored when\n"
                 "the --disable-output option is used.\n";
-  } else {
-    // Default to standard output.
-    if (OutputFilename.empty())
-      OutputFilename = "-";
+  }
 
-    std::error_code EC;
-    Out.reset(new tool_output_file(OutputFilename, EC, sys::fs::F_None));
-    if (EC) {
-      errs() << EC.message() << '\n';
-      return 1;
-    }
+  if (OutputFilename.empty())
+    OutputFilename = "-";
+
+  std::unique_ptr<tool_output_file> Out;
+  std::error_code EC;
+  Out.reset(new tool_output_file(OutputFilename, EC, sys::fs::F_None));
+  if (EC) {
+    errs() << EC.message() << '\n';
+    return 1;
   }
 
   Triple ModuleTriple(M->getTargetTriple());
@@ -511,19 +509,6 @@ int __cdecl main(int argc, char **argv) {
   }
 
   if (PrintBreakpoints) {
-    // Default to standard output.
-    if (!Out) {
-      if (OutputFilename.empty())
-        OutputFilename = "-";
-
-      std::error_code EC;
-      Out = llvm::make_unique<tool_output_file>(OutputFilename, EC,
-                                                sys::fs::F_None);
-      if (EC) {
-        errs() << EC.message() << '\n';
-        return 1;
-      }
-    }
     Passes.add(createBreakpointPrinter(Out->os()));
     NoOutput = true;
   }
@@ -652,7 +637,7 @@ int __cdecl main(int argc, char **argv) {
   }
 
   // Write bitcode or assembly to the output as the last step...
-  if (!NoOutput && !AnalyzeOnly) {
+  if ((!NoOutput && !AnalyzeOnly) || RunTwice) {
     if (OutputAssembly)
       Passes.add(createPrintModulePass(*OS, "", PreserveAssemblyUseListOrder));
     else

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -645,14 +645,16 @@ int __cdecl main(int argc, char **argv) {
   SmallVector<char, 0> Buffer;
   SmallVector<char, 0> CompileTwiceBuffer;
   std::unique_ptr<raw_svector_ostream> BOS;
-  raw_ostream *OS = &Out->os();
-  if (RunTwice) {
-    BOS = make_unique<raw_svector_ostream>(Buffer);
-    OS = BOS.get();
-  }
+  raw_ostream *OS = nullptr;
 
   // Write bitcode or assembly to the output as the last step...
   if (!NoOutput && !AnalyzeOnly) {
+    assert(Out);
+    OS = &Out->os();
+    if (RunTwice) {
+      BOS = make_unique<raw_svector_ostream>(Buffer);
+      OS = BOS.get();
+    }
     if (OutputAssembly)
       Passes.add(createPrintModulePass(*OS, "", PreserveAssemblyUseListOrder));
     else


### PR DESCRIPTION
This PR pulls the following upstream changes into DXC:

[llc/opt] Add an option to run all passes twice (https://github.com/llvm/llvm-project/commit/04464cf7313a7c2873f2b8a9011a19f1685b44c1)
>   Lately, I have submitted a number of patches to fix bugs that only occurred when using the same pass manager to compile
>   multiple modules (generally these bugs are failure to reset some persistent state).
> 
>   Unfortunately I don't think there is currently a way to test that from the command line. This adds a very simple flag to both
>   llc and opt, under which the tools will simply re-run their respective
>   pass pipelines using the same pass manager on (a clone of the same module). Additionally, we verify that both outputs are
>   bitwise the same.
> 
>   Reviewers: yaron.keren

[opt] Fix sanitizer complaints about r254774 (https://github.com/llvm/llvm-project/commit/38707c45be6ea1c6f3d382efbee960151d7301c8)
> `Out` can be null if no output is requested, so move any access
> to it inside the conditional. Thanks to Justin Bogner for finding
> this.

This is for the test of this change (https://github.com/llvm/llvm-project/commit/ef8761fd3b0f0b24b7e9347ad4ae686fc9ed8f94) to fix #6659.