### PR TITLE
Workaround broken GitHub runner images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ if(WIN32 AND NOT (CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "ARM.*"))
   add_link_options(/CETCOMPAT)
 endif()
 
+# This is a hack workaround for the broken azure runner images:
+# https://github.com/actions/runner-images/issues/10004
+if(WIN32)
+  add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 # HLSL Change Ends
 
 # HLSL Change Starts - set flag for Appveyor CI

--- a/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
+++ b/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
@@ -378,10 +378,11 @@ public: // esp in the unions...it's just redundant to not directly access things
     INT64 m_Value64[2];
     double m_Valued[2];
   };
+
+#pragma warning(suppress : 4201) // Warning about nameless structure.
   struct {
     D3D10_SB_OPERAND_INDEX_REPRESENTATION m_IndexType[3];
     D3D10_SB_OPERAND_INDEX_DIMENSION m_IndexDimension;
-#pragma warning(suppress : 4201) // Warning about nameless structure.
   };
 
   friend class CShaderAsm;


### PR DESCRIPTION
This PR contains two changes:
1) Moves a pragma to disable a warning, which seems to be required by the new compiler.
2) Adds a preprocessor define to workaround the crashes caused by the runner image mismatching C++ runtime versions.

The second change we will want to revert once the runner images are fixed. The issue tracking the runner images is:

https://github.com/actions/runner-images/issues/10004

Related #6668