### PR TITLE
[SPIR-V] Fix GroupNonUniform capabilities+ext 

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/intrinsics.nonuniform.arithmetic.extension.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.nonuniform.arithmetic.extension.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 | FileCheck %s
+
+// CHECK-NOT: OpCapability GroupNonUniformPartitionedNV
+// CHECK-NOT: OpExtension "SPV_NV_shader_subgroup_partitioned"
+// CHECK:     OpCapability GroupNonUniformArithmetic
+
+RWBuffer<int> value;
+
+[numthreads(4, 1, 1)]
+void main(uint3 threadID : SV_DispatchThreadID) {
+  uint sum = 0;
+  switch (value[threadID.x]) {
+    case 0:
+// CHECK: OpGroupNonUniformIAdd {{.*}} {{.*}} Reduce {{.*}}
+      sum += WaveActiveSum(1);
+    default:
+// CHECK: OpGroupNonUniformIAdd {{.*}} {{.*}} Reduce {{.*}}
+      sum += WaveActiveSum(10);
+      break;
+  }
+  value[threadID.x] = sum;
+}

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.cullprimative.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.cullprimative.hlsl
@@ -8,7 +8,7 @@ struct MeshletPrimitiveOut
 // m_cullPrimitive will have to be turned into a uint because of the Vulkan
 // specification says that externally visible variables cannot be bool.
 // CHECK: OpDecorate [[var:%[0-9]+]] BuiltIn CullPrimitiveEXT
-// CHECK: OpDecorate [[var]] PerPrimitiveNV
+// CHECK: OpDecorate [[var]] PerPrimitiveEXT
 // CHECK: [[var]] = OpVariable %_ptr_Output__arr_uint_uint_2 Output
 
 struct VertOut

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
@@ -3,9 +3,9 @@
 // CHECK:  OpExtension "SPV_EXT_mesh_shader"
 // CHECK:  OpEntryPoint MeshEXT %main "main" %gl_Position [[primind:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 64 1 1
-// CHECK:  OpExecutionMode %main OutputTrianglesNV
+// CHECK:  OpExecutionMode %main OutputTrianglesEXT
 // CHECK:  OpExecutionMode %main OutputVertices 81
-// CHECK:  OpExecutionMode %main OutputPrimitivesNV 128
+// CHECK:  OpExecutionMode %main OutputPrimitivesEXT 128
 
 // CHECK:  OpDecorate %gl_Position BuiltIn Position
 // CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveTriangleIndicesEXT

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.triangle.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.triangle.mesh.hlsl
@@ -3,9 +3,9 @@
 // CHECK:  OpExtension "SPV_EXT_mesh_shader"
 // CHECK:  OpEntryPoint MeshEXT %main "main" %gl_ClipDistance %gl_CullDistance %in_var_pld [[drawid:%[0-9]+]] %gl_LocalInvocationID %gl_WorkGroupID %gl_GlobalInvocationID %gl_LocalInvocationIndex %gl_Position %gl_PointSize %out_var_USER %out_var_USER_ARR %out_var_USER_MAT [[primindices:%[0-9]+]] %gl_PrimitiveID %gl_Layer %gl_ViewportIndex [[cullprim:%[0-9]+]] [[primshadingrate:%[0-9]+]] %out_var_PRIM_USER %out_var_PRIM_USER_ARR
 // CHECK:  OpExecutionMode %main LocalSize 128 1 1
-// CHECK:  OpExecutionMode %main OutputTrianglesNV
+// CHECK:  OpExecutionMode %main OutputTrianglesEXT
 // CHECK:  OpExecutionMode %main OutputVertices 64
-// CHECK:  OpExecutionMode %main OutputPrimitivesNV 81
+// CHECK:  OpExecutionMode %main OutputPrimitivesEXT 81
 
 // CHECK:  OpDecorate %gl_ClipDistance BuiltIn ClipDistance
 // CHECK:  OpDecorate %gl_CullDistance BuiltIn CullDistance
@@ -18,17 +18,17 @@
 // CHECK:  OpDecorate %gl_PointSize BuiltIn PointSize
 // CHECK:  OpDecorate [[primindices]] BuiltIn PrimitiveTriangleIndicesEXT
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate %gl_PrimitiveID PerPrimitiveNV
+// CHECK:  OpDecorate %gl_PrimitiveID PerPrimitiveEXT
 // CHECK:  OpDecorate %gl_Layer BuiltIn Layer
-// CHECK:  OpDecorate %gl_Layer PerPrimitiveNV
+// CHECK:  OpDecorate %gl_Layer PerPrimitiveEXT
 // CHECK:  OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
-// CHECK:  OpDecorate %gl_ViewportIndex PerPrimitiveNV
+// CHECK:  OpDecorate %gl_ViewportIndex PerPrimitiveEXT
 // CHECK:  OpDecorate [[cullprim]] BuiltIn CullPrimitiveEXT
-// CHECK:  OpDecorate [[cullprim]] PerPrimitiveNV
+// CHECK:  OpDecorate [[cullprim]] PerPrimitiveEXT
 // CHECK:  OpDecorate [[primshadingrate]] BuiltIn PrimitiveShadingRateKHR
-// CHECK:  OpDecorate [[primshadingrate]] PerPrimitiveNV
-// CHECK:  OpDecorate %out_var_PRIM_USER PerPrimitiveNV
-// CHECK:  OpDecorate %out_var_PRIM_USER_ARR PerPrimitiveNV
+// CHECK:  OpDecorate [[primshadingrate]] PerPrimitiveEXT
+// CHECK:  OpDecorate %out_var_PRIM_USER PerPrimitiveEXT
+// CHECK:  OpDecorate %out_var_PRIM_USER_ARR PerPrimitiveEXT
 // CHECK:  OpDecorate %out_var_USER Location 0
 // CHECK:  OpDecorate %out_var_USER_ARR Location 1
 // CHECK:  OpDecorate %out_var_USER_MAT Location 3

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.line.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.line.mesh.hlsl
@@ -3,9 +3,9 @@
 // CHECK:  OpExtension "SPV_NV_mesh_shader"
 // CHECK:  OpEntryPoint MeshNV %main "main" %gl_GlobalInvocationID %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 128 1 1
-// CHECK:  OpExecutionMode %main OutputLinesNV
+// CHECK:  OpExecutionMode %main OutputLinesEXT
 // CHECK:  OpExecutionMode %main OutputVertices 256
-// CHECK:  OpExecutionMode %main OutputPrimitivesNV 256
+// CHECK:  OpExecutionMode %main OutputPrimitivesEXT 256
 
 // CHECK:  OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
 // CHECK:  OpDecorate %gl_Position BuiltIn Position

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.point.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.point.mesh.hlsl
@@ -5,7 +5,7 @@
 // CHECK:  OpExecutionMode %main LocalSize 128 1 1
 // CHECK:  OpExecutionMode %main OutputPoints
 // CHECK:  OpExecutionMode %main OutputVertices 256
-// CHECK:  OpExecutionMode %main OutputPrimitivesNV 256
+// CHECK:  OpExecutionMode %main OutputPrimitivesEXT 256
 
 // CHECK:  OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
 // CHECK:  OpDecorate %gl_Position BuiltIn Position

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
@@ -3,9 +3,9 @@
 // CHECK:  OpExtension "SPV_NV_mesh_shader"
 // CHECK:  OpEntryPoint MeshNV %main "main" %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 32 1 1
-// CHECK:  OpExecutionMode %main OutputTrianglesNV
+// CHECK:  OpExecutionMode %main OutputTrianglesEXT
 // CHECK:  OpExecutionMode %main OutputVertices 81
-// CHECK:  OpExecutionMode %main OutputPrimitivesNV 128
+// CHECK:  OpExecutionMode %main OutputPrimitivesEXT 128
 
 // CHECK:  OpDecorate %gl_Position BuiltIn Position
 // CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveIndicesNV

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.triangle.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.triangle.mesh.hlsl
@@ -3,9 +3,9 @@
 // CHECK:  OpExtension "SPV_NV_mesh_shader"
 // CHECK:  OpEntryPoint MeshNV %main "main" %gl_ClipDistance %gl_CullDistance %in_var_dummy %in_var_pos [[drawid:%[0-9]+]] %gl_LocalInvocationID %gl_WorkGroupID %gl_GlobalInvocationID %gl_LocalInvocationIndex %gl_Position %gl_PointSize %out_var_USER %out_var_USER_ARR %out_var_USER_MAT [[primind:%[0-9]+]] %gl_PrimitiveID %gl_Layer %gl_ViewportIndex [[vmask:%[0-9]+]] %out_var_PRIM_USER %out_var_PRIM_USER_ARR [[primcount:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 128 1 1
-// CHECK:  OpExecutionMode %main OutputTrianglesNV
+// CHECK:  OpExecutionMode %main OutputTrianglesEXT
 // CHECK:  OpExecutionMode %main OutputVertices 64
-// CHECK:  OpExecutionMode %main OutputPrimitivesNV 81
+// CHECK:  OpExecutionMode %main OutputPrimitivesEXT 81
 
 // CHECK:  OpDecorate %gl_ClipDistance BuiltIn ClipDistance
 // CHECK:  OpDecorate %gl_CullDistance BuiltIn CullDistance
@@ -22,15 +22,15 @@
 // CHECK:  OpDecorate %gl_PointSize BuiltIn PointSize
 // CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveIndicesNV
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate %gl_PrimitiveID PerPrimitiveNV
+// CHECK:  OpDecorate %gl_PrimitiveID PerPrimitiveEXT
 // CHECK:  OpDecorate %gl_Layer BuiltIn Layer
-// CHECK:  OpDecorate %gl_Layer PerPrimitiveNV
+// CHECK:  OpDecorate %gl_Layer PerPrimitiveEXT
 // CHECK:  OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
-// CHECK:  OpDecorate %gl_ViewportIndex PerPrimitiveNV
+// CHECK:  OpDecorate %gl_ViewportIndex PerPrimitiveEXT
 // CHECK:  OpDecorate [[vmask]] BuiltIn ViewportMaskNV
-// CHECK:  OpDecorate [[vmask]] PerPrimitiveNV
-// CHECK:  OpDecorate %out_var_PRIM_USER PerPrimitiveNV
-// CHECK:  OpDecorate %out_var_PRIM_USER_ARR PerPrimitiveNV
+// CHECK:  OpDecorate [[vmask]] PerPrimitiveEXT
+// CHECK:  OpDecorate %out_var_PRIM_USER PerPrimitiveEXT
+// CHECK:  OpDecorate %out_var_PRIM_USER_ARR PerPrimitiveEXT
 // CHECK:  OpDecorate [[primcount]] BuiltIn PrimitiveCountNV
 // CHECK:  OpDecorate %out_var_USER Location 0
 // CHECK:  OpDecorate %out_var_USER_ARR Location 1

--- a/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.hlsl
@@ -1,27 +1,27 @@
 // RUN: %dxc -T lib_6_3 -fspv-target-env=vulkan1.2 -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingKHR
 // CHECK:  OpExtension "SPV_KHR_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 // CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexKHR
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginNV
-// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionNV
-// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldNV
-// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
-// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginKHR
+// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionKHR
+// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldKHR
+// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectKHR
+// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindKHR
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn RayGeometryIndexKHR
-// CHECK:  OpDecorate [[n:%[0-9]+]] BuiltIn RayTmaxNV
+// CHECK:  OpDecorate [[n:%[0-9]+]] BuiltIn RayTmaxKHR
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
 // CHECK-NOT: OpTypeAccelerationStructureKHR
 
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;
@@ -31,7 +31,7 @@ struct CallData
 {
   float4 data;
 };
-// CHECK:  OpTypePointer HitAttributeNV %Attribute
+// CHECK:  OpTypePointer HitAttributeKHR %Attribute
 struct Attribute
 {
   float2 bary;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.vulkan1.1spirv1.4.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.vulkan1.1spirv1.4.hlsl
@@ -4,27 +4,27 @@
 // CHECK-NEXT: ; Version: 1.4
 // CHECK:  OpCapability RayTracingKHR
 // CHECK:  OpExtension "SPV_KHR_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 // CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexKHR
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginNV
-// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionNV
-// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldNV
-// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
-// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginKHR
+// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionKHR
+// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldKHR
+// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectKHR
+// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindKHR
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn RayGeometryIndexKHR
-// CHECK:  OpDecorate [[n:%[0-9]+]] BuiltIn RayTmaxNV
+// CHECK:  OpDecorate [[n:%[0-9]+]] BuiltIn RayTmaxKHR
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
 // CHECK-NOT: OpTypeAccelerationStructureKHR
 
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;
@@ -34,7 +34,7 @@ struct CallData
 {
   float4 data;
 };
-// CHECK:  OpTypePointer HitAttributeNV %Attribute
+// CHECK:  OpTypePointer HitAttributeKHR %Attribute
 struct Attribute
 {
   float2 bary;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.khr.terminate.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.khr.terminate.hlsl
@@ -2,14 +2,14 @@
 // CHECK:  OpCapability RayTracingKHR
 // CHECK:  OpExtension "SPV_KHR_ray_tracing"
 
-// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindKHR
 
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;
 };
-// CHECK:  OpTypePointer HitAttributeNV %Attribute
+// CHECK:  OpTypePointer HitAttributeKHR %Attribute
 struct Attribute
 {
   float2 bary;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.anyhit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.anyhit.hlsl
@@ -1,31 +1,31 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 // CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexKHR
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginNV
-// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionNV
-// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldNV
-// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
-// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginKHR
+// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionKHR
+// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldKHR
+// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectKHR
+// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindKHR
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn HitTNV
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
 // CHECK-NOT: OpTypeAccelerationStructureKHR
 
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;
 };
-// CHECK:  OpTypePointer HitAttributeNV %Attribute
+// CHECK:  OpTypePointer HitAttributeKHR %Attribute
 struct Attribute
 {
   float2 bary;
@@ -76,7 +76,7 @@ void main(inout Payload MyPayload, in Attribute MyAttr) {
   if (_16 == 1U) {
 // CHECK:  [[payloadread0:%[0-9]+]] = OpLoad %Payload %MyPayload_0
 // CHECK-NEXT : OpStore %MyPayload [[payloadread0]]
-// CHECK-NEXT : OpIgnoreIntersectionNV
+// CHECK-NEXT : OpIgnoreIntersectionKHR
     IgnoreHit();
   } else {
 // CHECK:  [[payloadread1:%[0-9]+]] = OpLoad %Payload %MyPayload_0

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.callable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.callable.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
 
-// CHECK:  OpTypePointer IncomingCallableDataNV %CallData
+// CHECK:  OpTypePointer IncomingCallableDataKHR %CallData
 struct CallData
 {
   float4 data;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.closesthit.hlsl
@@ -1,31 +1,31 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 // CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexKHR
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginNV
-// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionNV
-// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldNV
-// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
-// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginKHR
+// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionKHR
+// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldKHR
+// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectKHR
+// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindKHR
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn HitTNV
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
 // CHECK-NOT: OpTypeAccelerationStructureKHR
 
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;
 };
-// CHECK:  OpTypePointer HitAttributeNV %Attribute
+// CHECK:  OpTypePointer HitAttributeKHR %Attribute
 struct Attribute
 {
   float2 bary;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.enum.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
 // CHECK-NOT: OpTypeAccelerationStructureKHR

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.intersection.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.intersection.hlsl
@@ -1,19 +1,19 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 // CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexKHR
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginNV
-// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionNV
-// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldNV
-// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
+// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginKHR
+// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionKHR
+// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldKHR
+// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectKHR
 
 struct Attribute
 {

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.library.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.library.hlsl
@@ -1,47 +1,47 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpEntryPoint RayGenerationNV %MyRayGenMain "MyRayGenMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint RayGenerationNV %MyRayGenMain2 "MyRayGenMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint MissNV %MyMissMain "MyMissMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint MissNV %MyMissMain2 "MyMissMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint IntersectionNV %MyISecMain "MyISecMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint IntersectionNV %MyISecMain2 "MyISecMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint AnyHitNV %MyAHitMain "MyAHitMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint AnyHitNV %MyAHitMain2 "MyAHitMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint ClosestHitNV %MyCHitMain "MyCHitMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint ClosestHitNV %MyCHitMain2 "MyCHitMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint CallableNV %MyCallMain "MyCallMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpEntryPoint CallableNV %MyCallMain2 "MyCallMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpEntryPoint RayGenerationKHR %MyRayGenMain "MyRayGenMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint RayGenerationKHR %MyRayGenMain2 "MyRayGenMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint MissKHR %MyMissMain "MyMissMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint MissKHR %MyMissMain2 "MyMissMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint IntersectionKHR %MyISecMain "MyISecMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint IntersectionKHR %MyISecMain2 "MyISecMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint AnyHitKHR %MyAHitMain "MyAHitMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint AnyHitKHR %MyAHitMain2 "MyAHitMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint ClosestHitKHR %MyCHitMain "MyCHitMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint ClosestHitKHR %MyCHitMain2 "MyCHitMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint CallableKHR %MyCallMain "MyCallMain" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpEntryPoint CallableKHR %MyCallMain2 "MyCallMain2" {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} %gl_InstanceID {{%[0-9]+}} %gl_PrimitiveID {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 // CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
-// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate [[g:%[0-9]+]] BuiltIn InstanceCustomIndexKHR
 // CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
-// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginNV
-// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionNV
-// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldNV
-// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
-// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[h:%[0-9]+]] BuiltIn ObjectRayOriginKHR
+// CHECK:  OpDecorate [[i:%[0-9]+]] BuiltIn ObjectRayDirectionKHR
+// CHECK:  OpDecorate [[j:%[0-9]+]] BuiltIn ObjectToWorldKHR
+// CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectKHR
+// CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindKHR
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
-// CHECK-NOT: OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureNV
 
-// CHECK: OpTypePointer CallableDataNV %CallData
+// CHECK: OpTypePointer CallableDataKHR %CallData
 struct CallData
 {
   float4 data;
 };
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;
 };
-// CHECK:  OpTypePointer HitAttributeNV %Attribute
+// CHECK:  OpTypePointer HitAttributeKHR %Attribute
 struct Attribute
 {
   float2 bary;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.miss.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.miss.hlsl
@@ -1,14 +1,14 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
-// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginNV
-// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionNV
-// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminNV
-// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
+// CHECK:  OpDecorate [[c:%[0-9]+]] BuiltIn WorldRayOriginKHR
+// CHECK:  OpDecorate [[d:%[0-9]+]] BuiltIn WorldRayDirectionKHR
+// CHECK:  OpDecorate [[e:%[0-9]+]] BuiltIn RayTminKHR
+// CHECK:  OpDecorate [[f:%[0-9]+]] BuiltIn IncomingRayFlagsKHR
 
-// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+// CHECK:  OpTypePointer IncomingRayPayloadKHR %Payload
 struct Payload
 {
   float4 color;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.raygen.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.raygen.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fcgl  %s -spirv | FileCheck %s
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
-// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
-// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
+// CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdKHR
+// CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeKHR
 
 // CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
 // CHECK-NOT: OpTypeAccelerationStructureKHR

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicStorageClass.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicStorageClass.hlsl
@@ -1,12 +1,12 @@
 // RUN: %dxc -T ps_6_0 -E main -spirv -Vd -fcgl  %s -spirv | FileCheck %s
 
 //CHECK: [[payloadTy:%[a-zA-Z0-9_]+]] = OpTypeStruct %v4float
-//CHECK-NEXT: [[payloadTyPtr:%[a-zA-Z0-9_]+]] = OpTypePointer RayPayloadNV [[payloadTy]]
+//CHECK-NEXT: [[payloadTyPtr:%[a-zA-Z0-9_]+]] = OpTypePointer RayPayloadKHR [[payloadTy]]
 //CHECK: [[crossTy:%[a-zA-Z0-9_]+]] = OpTypePointer CrossWorkgroup %int
-//CHECK: {{%[a-zA-Z0-9_]+}} = OpVariable [[payloadTyPtr]] RayPayloadNV
+//CHECK: {{%[a-zA-Z0-9_]+}} = OpVariable [[payloadTyPtr]] RayPayloadKHR
 //CHECK: {{%[a-zA-Z0-9_]+}} = OpVariable [[crossTy]] CrossWorkgroup
 
-[[vk::ext_storage_class(/*RayPayloadNV*/5338)]]
+[[vk::ext_storage_class(/*RayPayloadKHR*/5338)]]
 float4 payload;
 
 int main() : SV_Target0 {

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.shader-record-ext.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.shader-record-ext.std430.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -fspv-target-env=vulkan1.2 -fvk-use-gl-layout -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: OpEntryPoint ClosestHitNV %chs1 "chs1" %cbuf %block %P %A
-// CHECK: OpEntryPoint ClosestHitNV %chs2 "chs2" %cbuf %block %P_0 %A_0
+// CHECK: OpEntryPoint ClosestHitKHR %chs1 "chs1" %cbuf %block %P %A
+// CHECK: OpEntryPoint ClosestHitKHR %chs2 "chs2" %cbuf %block %P_0 %A_0
 
 // CHECK: OpDecorate %_arr_v2float_uint_3 ArrayStride 8
 // CHECK: OpDecorate %_arr_mat3v2float_uint_2 ArrayStride 32
@@ -70,8 +70,8 @@ cbuffer block {
 struct Payload { float p; };
 struct Attr    { float a; };
 
-// CHECK: %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferNV %type_ConstantBuffer_S
-// CHECK: %cbuf = OpVariable %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S ShaderRecordBufferNV
+// CHECK: %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferKHR %type_ConstantBuffer_S
+// CHECK: %cbuf = OpVariable %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S ShaderRecordBufferKHR
 
 [shader("closesthit")]
 void chs1(inout Payload P, in Attr A) {

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.shader-record-nv.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.shader-record-nv.std430.hlsl
@@ -67,8 +67,8 @@ cbuffer block {
 struct Payload { float p; };
 struct Attr    { float a; };
 
-// CHECK: %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferNV %type_ConstantBuffer_S
-// CHECK: %cbuf = OpVariable %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S ShaderRecordBufferNV
+// CHECK: %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferKHR %type_ConstantBuffer_S
+// CHECK: %cbuf = OpVariable %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S ShaderRecordBufferKHR
 
 [shader("closesthit")]
 void chs1(inout Payload P, in Attr A) {

--- a/tools/clang/test/CodeGenSPIRV/vk.shader-record-ext.constantbuffer.assign.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.shader-record-ext.constantbuffer.assign.hlsl
@@ -9,7 +9,7 @@ struct Foo
     float m_x;
 };
 
-// CHECK: %g_pc = OpVariable %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_Foo ShaderRecordBufferNV
+// CHECK: %g_pc = OpVariable %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_Foo ShaderRecordBufferKHR
 [[vk::shader_record_ext]] ConstantBuffer<Foo> g_pc;
 RWStructuredBuffer<float> g_buff;
 

--- a/tools/clang/test/CodeGenSPIRV/vk.shader-record-ext.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.shader-record-ext.hlsl
@@ -19,9 +19,9 @@ struct S {
     float2x3 f3;
     T        f4;
 };
-// CHECK: %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferNV %type_ConstantBuffer_S
+// CHECK: %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferKHR %type_ConstantBuffer_S
 
-// CHECK: %srb = OpVariable %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S ShaderRecordBufferNV
+// CHECK: %srb = OpVariable %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S ShaderRecordBufferKHR
 [[vk::shader_record_ext]]
 ConstantBuffer<S> srb;
 
@@ -32,15 +32,15 @@ struct Attribute { float a; };
 void main(inout Payload P)
 {
    P.p =
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %srb %int_0
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float %srb %int_0
         srb.f1 +
-// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v3float %srb %int_1
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float [[ptr]] %int_2
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferKHR_v3float %srb %int_1
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float [[ptr]] %int_2
         srb.f2.z +
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %srb %int_2 %uint_1 %uint_2
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float %srb %int_2 %uint_1 %uint_2
         srb.f3[1][2] +
-// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV__arr_v2float_uint_3 %srb %int_3 %int_0
-// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v2float [[base]] %int_2
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float [[ptr_0]] %int_1
+// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferKHR__arr_v2float_uint_3 %srb %int_3 %int_0
+// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferKHR_v2float [[base]] %int_2
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float [[ptr_0]] %int_1
         srb.f4.val[2].y;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.shader-record-nv.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.shader-record-nv.hlsl
@@ -19,9 +19,9 @@ struct S {
     float2x3 f3;
     T        f4;
 };
-// CHECK: %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferNV %type_ConstantBuffer_S
+// CHECK: %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S = OpTypePointer ShaderRecordBufferKHR %type_ConstantBuffer_S
 
-// CHECK: %srb = OpVariable %_ptr_ShaderRecordBufferNV_type_ConstantBuffer_S ShaderRecordBufferNV
+// CHECK: %srb = OpVariable %_ptr_ShaderRecordBufferKHR_type_ConstantBuffer_S ShaderRecordBufferKHR
 [[vk::shader_record_nv]]
 ConstantBuffer<S> srb;
 
@@ -32,15 +32,15 @@ struct Attribute { float a; };
 void main(inout Payload P)
 {
    P.p =
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %srb %int_0
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float %srb %int_0
         srb.f1 +
-// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v3float %srb %int_1
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float [[ptr]] %int_2
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferKHR_v3float %srb %int_1
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float [[ptr]] %int_2
         srb.f2.z +
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %srb %int_2 %uint_1 %uint_2
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float %srb %int_2 %uint_1 %uint_2
         srb.f3[1][2] +
-// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV__arr_v2float_uint_3 %srb %int_3 %int_0
-// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v2float [[base]] %int_2
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float [[ptr_0]] %int_1
+// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferKHR__arr_v2float_uint_3 %srb %int_3 %int_0
+// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferKHR_v2float [[base]] %int_2
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferKHR_float [[ptr_0]] %int_1
         srb.f4.val[2].y;
 }


### PR DESCRIPTION
[SPIR-V] Fix GroupNonUniform capabilities+ext

Fixes emission of GroupNonUniform capabilities and related extensions,
in particular SPV_NV_shader_subgroup_partitioned.

Since this PR bumps SPIR-V headers + tools, some test changes are required due to opcode changes. Those are in a separate commit, but same PR.

Fixes #6672