### PR TITLE
Add error for invalid arguments to GetDimension

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4014,6 +4014,15 @@ SpirvEmitter::processBufferTextureGetDimensions(const CXXMemberCallExpr *expr) {
     numSamples = expr->getArg(numArgs - 1);
   }
 
+  // Make sure that all output args are an l-value.
+  for (uint32_t argIdx = (mipLevel ? 1 : 0); argIdx < numArgs; ++argIdx) {
+    if (!expr->getArg(argIdx)->isLValue()) {
+      emitError("Output argument must be an l-value",
+                expr->getArg(argIdx)->getExprLoc());
+      return nullptr;
+    }
+  }
+
   uint32_t querySize = numArgs;
   // If numLevels arg is present, mipLevel must also be present. These are not
   // queried via ImageQuerySizeLod.

--- a/tools/clang/test/CodeGenSPIRV/texture.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.get-dimensions.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: not %dxc -T ps_6_0 -E main -fcgl  %s -spirv -DERROR 2>&1 | FileCheck %s --check-prefix=ERROR
 
 // CHECK: OpCapability ImageQuery
 
@@ -360,4 +361,12 @@ void main() {
 // CHECK-NEXT:  [[query_levels_int:%[0-9]+]] = OpBitcast %int [[query_levels_uint]]
 // CHECK-NEXT:                              OpStore %signedNumLevels [[query_levels_int]]
   t3.GetDimensions(signedMipLevel, signedWidth, signedHeight, signedNumLevels);
+
+#ifdef ERROR
+// ERROR: 367:30: error: Output argument must be an l-value
+  t9.GetDimensions(mipLevel, 0, height, elements, numLevels);
+
+// ERROR: 370:35: error: Output argument must be an l-value
+  t9.GetDimensions(width, height, 20);
+#endif
 }


### PR DESCRIPTION
When processing the GetDimension member function for textures, we do not
emit an error if the output variable is not an l-value. This change will
add this error.

Fixes #6689