### PR TITLE
Add a new WeakVH value handle; NFC

### DIFF
--- a/lib/IR/Value.cpp
+++ b/lib/IR/Value.cpp
@@ -672,6 +672,7 @@ void ValueHandleBase::ValueIsDeleted(Value *V) {
     switch (Entry->getKind()) {
     case Assert:
       break;
+    case Weak:
     case WeakTracking:
       // WeakTracking just goes to null, which will unlink it from the list.
       Entry->operator=(nullptr);
@@ -722,7 +723,8 @@ void ValueHandleBase::ValueIsRAUWd(Value *Old, Value *New) {
 
     switch (Entry->getKind()) {
     case Assert:
-      // Asserting handle does not follow RAUW implicitly.
+    case Weak:
+      // Asserting and Weak handles do not follow RAUW implicitly.
       break;
     case WeakTracking:
       // Weak goes to the new value, which will unlink it from Old's list.

--- a/unittests/IR/ValueHandleTest.cpp
+++ b/unittests/IR/ValueHandleTest.cpp
@@ -34,6 +34,24 @@ public:
   ConcreteCallbackVH(Value *V) : CallbackVH(V) {}
 };
 
+TEST_F(ValueHandle, WeakVH_BasicOperation) {
+  WeakVH WVH(BitcastV.get());
+  EXPECT_EQ(BitcastV.get(), WVH);
+  WVH = ConstantV;
+  EXPECT_EQ(ConstantV, WVH);
+
+  // Make sure I can call a method on the underlying Value.  It
+  // doesn't matter which method.
+  EXPECT_EQ(Type::getInt32Ty(getGlobalContext()), WVH->getType());
+  EXPECT_EQ(Type::getInt32Ty(getGlobalContext()), (*WVH).getType());
+
+  WVH = BitcastV.get();
+  BitcastV->replaceAllUsesWith(ConstantV);
+  EXPECT_EQ(WVH, BitcastV.get());
+  BitcastV.reset();
+  EXPECT_EQ(WVH, nullptr);
+}
+
 TEST_F(ValueHandle, WeakTrackingVH_BasicOperation) {
   WeakTrackingVH WVH(BitcastV.get());
   EXPECT_EQ(BitcastV.get(), WVH);


### PR DESCRIPTION
Originally @lizhengxing's PR. Retargeting main.

This PR pulls 2 upstream changes, Add a new WeakVH value handle; NFC (https://github.com/llvm/llvm-project/commit/f1c0eafd5b10d33d957457ef292c56e6bab17938) and Use a 2 bit pointer in ValueHandleBase::PrevPair; NFC (https://github.com/llvm/llvm-project/commit/b297bff1cc974023a49d6ad898badf78a08692c3), into DXC.

Here's the summary of the changes:

Add a new WeakVH value handle; NFC 
>       WeakVH nulls itself out if the value it was tracking gets deleted, but it does not track RAUW.
> 
>       Reviewers: dblaikie, davide
> 
>       Subscribers: mcrosier, llvm-commits
> 
>       Differential Revision: https://reviews.llvm.org/D32267

Use a 2 bit pointer in ValueHandleBase::PrevPair; NFC

> This was an omission in r301813.  I had made the supporting changes to make this happen, but I forgot to actually update the 
> 
> PrevPair declaration.

This is part 4 and 5 of the fix for #6659.