### PR TITLE
Fix a PIX pass's attempt to set the validator version

### DIFF
--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -123,8 +123,8 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
   }
   unsigned int Major = 0;
   unsigned int Minor = 0;
-  m_DM->GetDxilVersion(Major, Minor);
-  if (Major < 6 || (Major == 6 && Minor <= 4)) {
+  m_DM->GetValidatorVersion(Major, Minor);
+  if (Major < 1 || (Major == 1 && Minor < 4)) {
     m_DM->SetValidatorVersion(1, 4);
   }
 
@@ -149,7 +149,7 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
     }
   }
 
-  for (auto *F : instrumentableFunctions) {
+  for (auto* F : instrumentableFunctions) {
     int InstructionRangeStart = InstNum;
     int InstructionRangeEnd = InstNum;
     for (auto &block : F->getBasicBlockList()) {
@@ -177,7 +177,6 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
                   << printableNameSubset << "\n";
     }
   }
-
   if (OSOverride != nullptr) {
     // Print a set of strings of the exemplary form "InstructionCount: <n>
     // <fnName>"

--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -124,7 +124,7 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
   unsigned int Major = 0;
   unsigned int Minor = 0;
   m_DM->GetValidatorVersion(Major, Minor);
-  if (Major < 1 || (Major == 1 && Minor < 4)) {
+  if (hlsl::DXIL::CompareVersions(Major, Minor, 1, 4) < 0) {
     m_DM->SetValidatorVersion(1, 4);
   }
 
@@ -177,6 +177,7 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
                   << printableNameSubset << "\n";
     }
   }
+
   if (OSOverride != nullptr) {
     // Print a set of strings of the exemplary form "InstructionCount: <n>
     // <fnName>"

--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -149,7 +149,7 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
     }
   }
 
-  for (auto* F : instrumentableFunctions) {
+  for (auto *F : instrumentableFunctions) {
     int InstructionRangeStart = InstNum;
     int InstructionRangeEnd = InstNum;
     for (auto &block : F->getBasicBlockList()) {

--- a/tools/clang/test/DXC/Passes/PIX/validatorNoDowngrade.ll
+++ b/tools/clang/test/DXC/Passes/PIX/validatorNoDowngrade.ll
@@ -1,3 +1,6 @@
+; This test tests that a shader with current dxil validator version does not downgrade to 1.4. 
+; (The annotate-with-virtual-register pass was erroneously doing just this)
+
 ; RUN: %dxopt %s -dxil-annotate-with-virtual-regs -hlsl-dxilemit -S | FileCheck %s
 
 ; CHECK: !dx.valver = !{![[VALVER:.*]]}

--- a/tools/clang/test/DXC/Passes/PIX/validatorNoDowngrade.ll
+++ b/tools/clang/test/DXC/Passes/PIX/validatorNoDowngrade.ll
@@ -1,15 +1,16 @@
 ; RUN: %dxopt %s -dxil-annotate-with-virtual-regs -hlsl-dxilemit -S | FileCheck %s
 
 ; CHECK: !dx.valver = !{![[VALVER:.*]]}
-; CHECK: ![[VALVER]] = !{i32 1, i32 4}
+; CHECK-NOT: ![[VALVER]] = !{i32 1, i32 4}
 
 
 ; GENERATED FROM:
 ; dxc -Emain -Tcs_6_1
+
+
 ; void main()
 ; {
 ; }
-; AND THEN MANUALLY EDITNG valver to 1.3.
 
 
 
@@ -56,7 +57,7 @@ define void @main() {
 
 !0 = !{!"dxc(private) 1.8.0.4583 (PIX_MemberFunctions, 2f4a01af1-dirty)"}
 !1 = !{i32 1, i32 1}
-!2 = !{i32 1, i32 3}
+!2 = !{i32 1, i32 8}
 !3 = !{!"cs", i32 6, i32 1}
 !4 = !{void ()* @main, !"main", null, null, !5}
 !5 = !{i32 4, !6}

--- a/tools/clang/test/DXC/Passes/PIX/validatorUpgrade.ll
+++ b/tools/clang/test/DXC/Passes/PIX/validatorUpgrade.ll
@@ -1,0 +1,64 @@
+; RUN: %dxopt %s -dxil-annotate-with-virtual-regs -hlsl-dxilemit -S | FileCheck %s
+
+; CHECK: !dx.valver = !{![[VALVER:.*]]}
+; CHECK-NOT: ![[VALVER]] = !{i32 1, i32 4}
+
+
+; GENERATED FROM:
+; dxc -Emain -Tcs_6_1
+
+
+; void main()
+; {
+; }
+
+
+
+;
+; Input signature:
+;
+; Name                 Index   Mask Register SysValue  Format   Used
+; -------------------- ----- ------ -------- -------- ------- ------
+; no parameters
+;
+; Output signature:
+;
+; Name                 Index   Mask Register SysValue  Format   Used
+; -------------------- ----- ------ -------- -------- ------- ------
+; no parameters
+; shader hash: bcdf90f13d29df9ebdc77539089a75a6
+;
+; Pipeline Runtime Information:
+;
+; Compute Shader
+; NumThreads=(1,1,1)
+;
+;
+; Buffer Definitions:
+;
+;
+; Resource Bindings:
+;
+; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
+; ------------------------------ ---------- ------- ----------- ------- -------------- ------
+;
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @main() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!2}
+!dx.shaderModel = !{!3}
+!dx.entryPoints = !{!4}
+
+!0 = !{!"dxc(private) 1.8.0.4583 (PIX_MemberFunctions, 2f4a01af1-dirty)"}
+!1 = !{i32 1, i32 1}
+!2 = !{i32 1, i32 8}
+!3 = !{!"cs", i32 6, i32 1}
+!4 = !{void ()* @main, !"main", null, null, !5}
+!5 = !{i32 4, !6}
+!6 = !{i32 1, i32 1, i32 1}

--- a/tools/clang/test/DXC/Passes/PIX/validatorUpgrade.ll
+++ b/tools/clang/test/DXC/Passes/PIX/validatorUpgrade.ll
@@ -1,3 +1,5 @@
+; This test tests that a shader with dxil validator version of 1.3 gets upgraded to 1.4 after the annotate with virtual regs pass
+
 ; RUN: %dxopt %s -dxil-annotate-with-virtual-regs -hlsl-dxilemit -S | FileCheck %s
 
 ; CHECK: !dx.valver = !{![[VALVER:.*]]}


### PR DESCRIPTION
This pass was attempting to compare different things. The return values of GetDxilVersion are not shader models, but... dxil version. Since the code is trying to upgrade the validator version, I changed this to GetValidatorVersion, to pair with SetValidatorVersion.
The previous code was breaking the nvidia driver on workgraphs.
