### PR TITLE
HLSLTestLib: Support xfailcat: acts like xfail but propagates stdin,stdout     

### DIFF
--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -143,6 +143,7 @@ private:
                                const FileRunCommandResult *Prior);
   FileRunCommandResult RunTee(const FileRunCommandResult *Prior);
   FileRunCommandResult RunXFail(const FileRunCommandResult *Prior);
+  FileRunCommandResult RunXFailCat(const FileRunCommandResult *Prior);
   FileRunCommandResult RunDxilVer(dxc::DxcDllSupport &DllSupport,
                                   const FileRunCommandResult *Prior);
   FileRunCommandResult RunDxcHashTest(dxc::DxcDllSupport &DllSupport);

--- a/tools/clang/test/HLSLFileCheck/passes/hl/hl_matrix_lower/dont_crash_on_invalid_cast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/hl_matrix_lower/dont_crash_on_invalid_cast.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 %s | xfail
+// RUN: %dxc -T cs_6_0 %s | xfailcat | FileCheck %s -input-file=stderr
 
 // The HL matrix lowering pass can sometimes throw an exception
 // due to an invalid LLVM-level cast<Ty> call.  Make sure that
@@ -7,10 +7,8 @@
 // Note: There is still a bug in the compiler here.  Not all matrix
 // lowerings are covered by the pass.
 
-// (I would like to use a FileCheck %s but that does not work.
-// Alternately, I could use 'not dxc...' but 'not' is unsupported.)
 
-//     CHECK: error: cast<X>() argument of incompatible type
+//   CHECK: error: cast<X>() argument of incompatible type
 
 struct a {
   float b;

--- a/tools/clang/test/HLSLFileCheck/passes/hl/hl_matrix_lower/dont_crash_on_invalid_cast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/hl_matrix_lower/dont_crash_on_invalid_cast.hlsl
@@ -1,0 +1,34 @@
+// RUN: %dxc -T cs_6_0 %s | xfail
+
+// The HL matrix lowering pass can sometimes throw an exception
+// due to an invalid LLVM-level cast<Ty> call.  Make sure that
+// propagates out to a user-level error.
+
+// Note: There is still a bug in the compiler here.  Not all matrix
+// lowerings are covered by the pass.
+
+// (I would like to use a FileCheck %s but that does not work.
+// Alternately, I could use 'not dxc...' but 'not' is unsupported.)
+
+//     CHECK: error: cast<X>() argument of incompatible type
+
+struct a {
+  float b;
+  float2x4 c;
+};
+struct d {
+  a c;
+};
+struct e {
+  d c[1];
+  d f[1];
+};
+
+static e g = (e)0;
+
+[numthreads(1, 1, 1)]
+void main() {
+  d h = g.f[0];
+  return;
+}
+


### PR DESCRIPTION
Add support for 'xfailcat' in RUN: commands.
It requires the prior command to fail, and also propagates
stdout and stderr.

This is useful for cases for parsing error messages, example
    
       // RUN: %dxc -T cs_6_0 will_fail.hlsl %s | xfailcat | FileCheck %s
       // CHECK: error: something blah blah

This is an alternative to supporting 'not'.
    
Builds on #6710.
Also, modify the test from #6710 to check the error message