### PR TITLE
Add header file to define cooperative matrices in spir-v

### DIFF
--- a/tools/clang/lib/Headers/hlsl/vk/khr/cooperative_matrix.h
+++ b/tools/clang/lib/Headers/hlsl/vk/khr/cooperative_matrix.h
@@ -7,8 +7,9 @@
 #ifndef _HLSL_VK_KHR_COOPERATIVE_MATRIX_H_
 #define _HLSL_VK_KHR_COOPERATIVE_MATRIX_H_
 
-// TODO: Add a macro to HLSL to be able to check the Vulkan version being
-// targeted.
+#if __SPIRV_MAJOR_VERSION__ == 1 && __SPIRV_MINOR_VERSION__ < 6
+#error "CooperativeMatrix requires a minimum of SPIR-V 1.6"
+#endif
 
 #include "vk/spirv.h"
 

--- a/tools/clang/lib/Headers/hlsl/vk/khr/cooperative_matrix.h
+++ b/tools/clang/lib/Headers/hlsl/vk/khr/cooperative_matrix.h
@@ -1,0 +1,274 @@
+// Copyright (c) 2024 Google LLC
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HLSL_VK_KHR_COOPERATIVE_MATRIX_H_
+#define _HLSL_VK_KHR_COOPERATIVE_MATRIX_H_
+
+// TODO: Add a macro to HLSL to be able to check the Vulkan version being
+// targeted.
+
+#include "vk/spirv.h"
+
+namespace vk {
+namespace khr {
+
+// The base cooperative matrix class. The template arguments correspond to the
+// operands in the OpTypeCooperativeMatrixKHR instruction.
+template <typename ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+class CooperativeMatrix {
+  template <class NewComponentType>
+  CooperativeMatrix<NewComponentType, scope, rows, columns, use> cast();
+
+  // Apply OpSNegate or OFNegate, depending on ComponentType, in a element by
+  // element manner.
+  CooperativeMatrix negate();
+
+  // Apply OpIAdd or OFAdd, depending on ComponentType, in a element by element
+  // manner.
+  CooperativeMatrix operator+(CooperativeMatrix other);
+
+  // Apply OpISub or OFSub, depending on ComponentType, in a element by element
+  // manner.
+  CooperativeMatrix operator-(CooperativeMatrix other);
+
+  // Apply OpIMul or OFMul, depending on ComponentType, in a element by element
+  // manner.
+  CooperativeMatrix operator*(CooperativeMatrix other);
+
+  // Apply OpSDiv, OpUDiv or OFDiv, depending on ComponentType, in a element by
+  // element manner.
+  CooperativeMatrix operator/(CooperativeMatrix other);
+
+  // Apply OpMatrixTimesScalar in a element by element manner.
+  CooperativeMatrix operator*(ComponentType scalar);
+
+  // Store the cooperative matrix using OpCooperativeMatrixStoreKHR to
+  // data using the given memory layout, stride, and memory access operands.
+  // `NonPrivatePointer` and `MakePointerAvailable` with the workgroup scope
+  // will be added to the memory access operands to make the memory coherent.
+  //
+  // This function uses a SPIR-V pointer because HLSL does not allow groupshared
+  // memory object to be passed by reference. The pointer is a hack to get
+  // around that.
+  //
+  // The layout and stride will be passed to the SPIR-V instruction as is. The
+  // precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  void Store(WorkgroupSpirvPointer<Type> data, uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access
+  // operands.
+  template <CooperativeMatrixLayout layout, class Type>
+  void Store(WorkgroupSpirvPointer<Type> data, uint32_t stride) {
+    Store<MemoryAccessMaskNone, layout>(data, stride);
+  }
+
+  // Store the cooperative matrix using OpCooperativeMatrixStoreKHR to
+  // data[index] using the given memory layout, stride, and memory access
+  // operands. The layout and stride will be passed to the SPIR-V instruction as
+  // is. The precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  void Store(RWStructuredBuffer<Type> data, uint32_t index, uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access
+  // operands.
+  template <CooperativeMatrixLayout layout, class Type>
+  void Store(RWStructuredBuffer<Type> data, uint32_t index, uint32_t stride) {
+    Store<MemoryAccessMaskNone, layout>(data, index, stride);
+  }
+
+  // Store the cooperative matrix using OpCooperativeMatrixStoreKHR to
+  // data[index] using the given memory layout, stride, and memory access
+  // operands. `NonPrivatePointer` and `MakePointerAvailable` with the
+  // QueueFamily scope will be added to the memory access operands to make the
+  // memory coherent.
+  //
+  // The layout and stride will be passed to the SPIR-V instruction as is. The
+  // precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  void CoherentStore(globallycoherent RWStructuredBuffer<Type> data,
+                     uint32_t index, uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access operands
+  // template argument.
+  template <CooperativeMatrixLayout layout, class Type>
+  void CoherentStore(globallycoherent RWStructuredBuffer<Type> data,
+                     uint32_t index, uint32_t stride) {
+    CoherentStore<MemoryAccessMaskNone, layout>(data, index, stride);
+  }
+
+  // Loads a cooperative matrix using OpCooperativeMatrixLoadKHR from
+  // data using the given memory layout, stride, and memory access operands.
+  // `NonPrivatePointer` and `MakePointerVisible` with the workgroup scope
+  // will be added to the memory access operands to make the memory coherent.
+  //
+  // This function uses a SPIR-V pointer because HLSL does not allow groupshared
+  // memory object to be passed by reference. The pointer is a hack to get
+  // around that.
+  //
+  // The layout and stride will be passed to the SPIR-V instruction as is. The
+  // precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  static CooperativeMatrix Load(WorkgroupSpirvPointer<Type> data,
+                                uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access
+  // operands.
+  template <CooperativeMatrixLayout layout, class Type>
+  static CooperativeMatrix Load(WorkgroupSpirvPointer<Type> data,
+                                uint32_t stride) {
+    return Load<MemoryAccessMaskNone, layout>(data, stride);
+  }
+
+  // Loads a cooperative matrix using OpCooperativeMatrixLoadKHR from
+  // data[index] using the given memory layout, stride, and memory access
+  // operands.
+  //
+  // The layout and stride will be passed to the SPIR-V instruction as is. The
+  // precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  static CooperativeMatrix Load(RWStructuredBuffer<Type> data, uint32_t index,
+                                uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access
+  // operands.
+  template <CooperativeMatrixLayout layout, class Type>
+  static CooperativeMatrix Load(RWStructuredBuffer<Type> data, uint32_t index,
+                                uint32_t stride) {
+    return Load<MemoryAccessMaskNone, layout>(data, index, stride);
+  }
+
+  // Loads a cooperative matrix using OpCooperativeMatrixLoadKHR from
+  // data[index] using the given memory layout, stride, and memory access
+  // operands. `NonPrivatePointer` and `MakePointerVisible` with the QueueFamily
+  // scope will be added to the memory access operands to make the memory
+  // coherent.
+  //
+  //
+  // The layout and stride will be passed to the SPIR-V instruction as is. The
+  // precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  static CooperativeMatrix
+  CoherentLoad(globallycoherent RWStructuredBuffer<Type> data, uint32_t index,
+               uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access operands
+  // template argument.
+  template <CooperativeMatrixLayout layout, class Type>
+  static CooperativeMatrix
+  CoherentLoad(globallycoherent RWStructuredBuffer<Type> data, uint32_t index,
+               uint32_t stride) {
+    return CoherentLoad<MemoryAccessMaskNone, layout>(data, index, stride);
+  }
+
+  // Loads a cooperative matrix using OpCooperativeMatrixLoadKHR from
+  // data[index] using the given memory layout, stride, and memory access
+  // operands. No memory access bits are added to the operands. Since the memory
+  // is readonly, there should be no need.
+  //
+  // The layout and stride will be passed to the SPIR-V instruction as is. The
+  // precise meaning can be found in the specification for
+  // SPV_KHR_cooperative_matrix.
+  template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+            class Type>
+  static CooperativeMatrix Load(StructuredBuffer<Type> data, uint32_t index,
+                                uint32_t stride);
+
+  // Same as above, but uses MemoryAccessMaskNone for the memory access
+  // operands.
+  template <CooperativeMatrixLayout layout, class Type>
+  static CooperativeMatrix Load(StructuredBuffer<Type> data, uint32_t index,
+                                uint32_t stride) {
+    return Load<MemoryAccessMaskNone, layout>(data, index, stride);
+  }
+
+  // Constructs a cooperative matrix with all values initialized to v. Note that
+  // all threads in scope must have the same value for v.
+  static CooperativeMatrix Splat(ComponentType v);
+
+  // Returns the result of OpCooperativeMatrixLengthKHR on the current type.￼
+  static uint32_t GetLength();
+
+  // Functions to access the elements of the cooperative matrix. The index must
+  // be less than GetLength().
+  void Set(ComponentType value, uint32_t index);
+  ComponentType Get(uint32_t index);
+
+  static const bool hasSignedIntegerComponentType =
+      (ComponentType(0) - ComponentType(1) < ComponentType(0));
+
+  // clang-format off
+  using SpirvMatrixType = vk::SpirvOpaqueType<
+      /* OpTypeCooperativeMatrixKHR */ 4456, ComponentType,
+      vk::integral_constant<uint, scope>, vk::integral_constant<uint, rows>,
+      vk::integral_constant<uint, columns>, vk::integral_constant<uint, use> >;
+
+  [[vk::ext_extension("SPV_KHR_cooperative_matrix")]]
+  [[vk::ext_capability(/* CooperativeMatrixKHRCapability */ 6022)]]
+  [[vk::ext_capability(/* VulkanMemoryModel */ 5345)]]
+  SpirvMatrixType _matrix;
+  // clang-format on
+};
+
+// Cooperative matrix that can be used in the "a" position of a multiply add
+// instruction (r = (a * b) + c).
+template <typename ComponentType, Scope scope, uint rows, uint columns>
+using CooperativeMatrixA =
+    CooperativeMatrix<ComponentType, scope, rows, columns,
+                      CooperativeMatrixUseMatrixAKHR>;
+
+// Cooperative matrix that can be used in the "b" position of a multiply add
+// instruction (r = (a * b) + c).
+template <typename ComponentType, Scope scope, uint rows, uint columns>
+using CooperativeMatrixB =
+    CooperativeMatrix<ComponentType, scope, rows, columns,
+                      CooperativeMatrixUseMatrixBKHR>;
+
+// Cooperative matrix that can be used in the "r" and "c" position of a multiply
+// add instruction (r = (a * b) + c).
+template <typename ComponentType, Scope scope, uint rows, uint columns>
+using CooperativeMatrixAccumulator =
+    CooperativeMatrix<ComponentType, scope, rows, columns,
+                      CooperativeMatrixUseMatrixAccumulatorKHR>;
+
+// Returns the result of OpCooperativeMatrixMulAddKHR when applied to a, b, and
+// c. The cooperative matrix operands are inferred, with the
+// SaturatingAccumulationKHR bit not set.
+template <typename ComponentType, Scope scope, uint rows, uint columns, uint K>
+CooperativeMatrixAccumulator<ComponentType, scope, rows, columns>
+cooperativeMatrixMultiplyAdd(
+    CooperativeMatrixA<ComponentType, scope, rows, K> a,
+    CooperativeMatrixB<ComponentType, scope, K, columns> b,
+    CooperativeMatrixAccumulator<ComponentType, scope, rows, columns> c);
+
+// Returns the result of OpCooperativeMatrixMulAddKHR when applied to a, b, and
+// c. The cooperative matrix operands are inferred, with the
+// SaturatingAccumulationKHR bit set.
+template <typename ComponentType, Scope scope, uint rows, uint columns, uint K>
+CooperativeMatrixAccumulator<ComponentType, scope, rows, columns>
+cooperativeMatrixSaturatingMultiplyAdd(
+    CooperativeMatrixA<ComponentType, scope, rows, K> a,
+    CooperativeMatrixB<ComponentType, scope, K, columns> b,
+    CooperativeMatrixAccumulator<ComponentType, scope, rows, columns> c);
+
+} // namespace khr
+} // namespace vk
+
+#include "cooperative_matrix.impl"
+#endif // _HLSL_VK_KHR_COOPERATIVE_MATRIX_H_

--- a/tools/clang/lib/Headers/hlsl/vk/khr/cooperative_matrix.impl
+++ b/tools/clang/lib/Headers/hlsl/vk/khr/cooperative_matrix.impl
@@ -1,0 +1,377 @@
+// Copyright (c) 2024 Google LLC
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "vk/opcode_selector.h"
+
+template <typename ResultType, typename ComponentType>
+[[vk::ext_instruction(/* OpMatrixTimesScalar */ 143)]] ResultType
+__builtin_spv_MatrixTimesScalar(ResultType a, ComponentType b);
+
+template <typename ComponentType, vk::Scope scope, uint rows, uint columns,
+          vk::CooperativeMatrixUse use>
+[[vk::ext_instruction(/* OpCompositeExtract */ 81)]] ComponentType
+__builtin_spv_ExtractFromCooperativeMatrix(
+    typename vk::khr::CooperativeMatrix<ComponentType, scope, rows, columns,
+                                        use>::SpirvMatrixType matrix,
+    uint32_t index);
+
+template <typename CoopMatrixType, typename ComponentType>
+[[vk::ext_instruction(/* OpCompositeConstruct */ 80)]] CoopMatrixType
+__builtin_spv_ConstructCooperativeMatrix(ComponentType value);
+
+template <class ResultPointerType, class BaseType>
+[[vk::ext_instruction(/* OpAccessChain */ 65)]] ResultPointerType
+__builtin_spv_AccessChain([[vk::ext_reference]] BaseType base, uint32_t index);
+
+template <class ObjectType, class PointerType>
+[[vk::ext_instruction(/* OpLoad */ 61)]] ObjectType
+__builtin_spv_LoadPointer(PointerType base);
+
+template <class PointerType, class ObjectType>
+[[vk::ext_instruction(/* OpLoad */ 62)]] void
+__builtin_spv_StorePointer(PointerType base, ObjectType object);
+
+template <typename ComponentType, vk::Scope scope, uint rows, uint columns,
+          vk::CooperativeMatrixUse use>
+[[vk::ext_instruction(/* OpCompositeInsert */ 82)]]
+typename vk::khr::CooperativeMatrix<ComponentType, scope, rows, columns,
+                                    use>::SpirvMatrixType
+__builtin_spv_InsertIntoCooperativeMatrix(
+    ComponentType value,
+    typename vk::khr::CooperativeMatrix<ComponentType, scope, rows, columns,
+                                        use>::SpirvMatrixType matrix,
+    uint32_t index);
+
+// Define the load and store instructions
+template <typename ResultType, typename PointerType>
+[[vk::ext_instruction(/* OpCooperativeMatrixLoadKHR */ 4457)]] ResultType
+__builtin_spv_CooperativeMatrixLoadKHR(
+    [[vk::ext_reference]] PointerType pointer,
+    vk::CooperativeMatrixLayout memory_layout, uint stride,
+    [[vk::ext_literal]] uint32_t memory_operand);
+
+template <typename ResultType, typename PointerType>
+[[vk::ext_instruction(/* OpCooperativeMatrixLoadKHR */ 4457)]] ResultType
+__builtin_spv_CooperativeMatrixLoadKHR(
+    [[vk::ext_reference]] PointerType pointer,
+    vk::CooperativeMatrixLayout memory_layout, uint stride,
+    [[vk::ext_literal]] uint32_t memory_operand, vk::Scope scope);
+
+template <typename ResultType, typename PointerType>
+[[vk::ext_instruction(/* OpCooperativeMatrixLoadKHR */ 4457)]] ResultType
+__builtin_spv_CooperativeMatrixWorkgroupLoadKHR(
+    vk::WorkgroupSpirvPointer<PointerType> pointer,
+    vk::CooperativeMatrixLayout memory_layout, uint stride,
+    [[vk::ext_literal]] uint32_t memory_operand, vk::Scope scope);
+
+template <typename ObjectType, typename PointerType>
+[[vk::ext_instruction(/* OpCooperativeMatrixStoreKHR */ 4458)]] void
+__builtin_spv_CooperativeMatrixStoreKHR(
+    [[vk::ext_reference]] PointerType pointer, ObjectType object,
+    vk::CooperativeMatrixLayout memory_layout, uint stride,
+    [[vk::ext_literal]] uint32_t memory_operand, vk::Scope scope);
+
+template <typename ObjectType, typename PointerType>
+[[vk::ext_instruction(/* OpCooperativeMatrixStoreKHR */ 4458)]] void
+__builtin_spv_CooperativeMatrixStoreKHR(
+    [[vk::ext_reference]] PointerType pointer, ObjectType object,
+    vk::CooperativeMatrixLayout memory_layout, uint stride,
+    [[vk::ext_literal]] uint32_t memory_operand);
+
+template <typename ObjectType, typename PointerType>
+[[vk::ext_instruction(/* OpCooperativeMatrixStoreKHR */ 4458)]] void
+__builtin_spv_CooperativeMatrixWorkgroupStoreKHR(
+    vk::WorkgroupSpirvPointer<PointerType> pointer, ObjectType object,
+    vk::CooperativeMatrixLayout memory_layout, uint stride,
+    [[vk::ext_literal]] uint32_t memory_operand, vk::Scope scope);
+
+// We cannot define `OpCooperativeMatrixLengthKHR` using ext_instruction because
+// one of the operands is a type id. This builtin will have specific code in the
+// compiler to expand it.
+template <class MatrixType> uint __builtin_spv_CooperativeMatrixLengthKHR();
+
+// Arithmetic Instructions
+template <typename ResultType, typename MatrixTypeA, typename MatrixTypeB,
+          typename MatrixTypeC>
+[[vk::ext_instruction(/* OpCooperativeMatrixMulAddKHR */ 4459)]] ResultType
+__builtin_spv_CooperativeMatrixMulAddKHR(MatrixTypeA a, MatrixTypeB b,
+                                         MatrixTypeC c,
+                                         [[vk::ext_literal]] int operands);
+namespace vk {
+namespace khr {
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <class NewComponentType>
+CooperativeMatrix<NewComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::cast() {
+  using ResultType =
+      CooperativeMatrix<NewComponentType, scope, rows, columns, use>;
+  ResultType result;
+  result._matrix = util::ConversionSelector<ComponentType, NewComponentType>::
+      template Convert<typename ResultType::SpirvMatrixType>(_matrix);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::negate() {
+  CooperativeMatrix result;
+  result._matrix = util::ArithmeticSelector<ComponentType>::Negate(_matrix);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::operator+(
+    CooperativeMatrix other) {
+  CooperativeMatrix result;
+  result._matrix =
+      util::ArithmeticSelector<ComponentType>::Add(_matrix, other._matrix);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::operator-(
+    CooperativeMatrix other) {
+  CooperativeMatrix result;
+  result._matrix =
+      util::ArithmeticSelector<ComponentType>::Sub(_matrix, other._matrix);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::operator*(
+    CooperativeMatrix other) {
+  CooperativeMatrix result;
+  result._matrix =
+      util::ArithmeticSelector<ComponentType>::Mul(_matrix, other._matrix);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::operator/(
+    CooperativeMatrix other) {
+  CooperativeMatrix result;
+  result._matrix =
+      util::ArithmeticSelector<ComponentType>::Div(_matrix, other._matrix);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::operator*(
+    ComponentType scalar) {
+  CooperativeMatrix result;
+  result._matrix = __builtin_spv_MatrixTimesScalar(_matrix, scalar);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+void CooperativeMatrix<ComponentType, scope, rows, columns, use>::Store(
+    WorkgroupSpirvPointer<Type> data, uint32_t stride) {
+  __builtin_spv_CooperativeMatrixWorkgroupStoreKHR(
+      data, _matrix, layout, stride,
+      memoryAccessOperands | MemoryAccessNonPrivatePointerMask |
+          MemoryAccessMakePointerAvailableMask,
+      ScopeWorkgroup);
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+void CooperativeMatrix<ComponentType, scope, rows, columns, use>::Store(
+    RWStructuredBuffer<Type> data, uint32_t index, uint32_t stride) {
+  __builtin_spv_CooperativeMatrixStoreKHR(data[index], _matrix, layout, stride,
+                                          memoryAccessOperands);
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+void CooperativeMatrix<ComponentType, scope, rows, columns, use>::CoherentStore(
+    globallycoherent RWStructuredBuffer<Type> data, uint32_t index,
+    uint32_t stride) {
+  __builtin_spv_CooperativeMatrixStoreKHR(
+      data[index], _matrix, layout, stride,
+      memoryAccessOperands | MemoryAccessNonPrivatePointerMask |
+          MemoryAccessMakePointerAvailableMask,
+      ScopeQueueFamily);
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::Load(
+    vk::WorkgroupSpirvPointer<Type> buffer, uint32_t stride) {
+  CooperativeMatrix result;
+  result._matrix =
+      __builtin_spv_CooperativeMatrixWorkgroupLoadKHR<SpirvMatrixType>(
+          buffer, layout, stride,
+          memoryAccessOperands | MemoryAccessNonPrivatePointerMask |
+              MemoryAccessMakePointerVisibleMask,
+          ScopeWorkgroup);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::Load(
+    RWStructuredBuffer<Type> buffer, uint32_t index, uint32_t stride) {
+  CooperativeMatrix result;
+  result._matrix = __builtin_spv_CooperativeMatrixLoadKHR<SpirvMatrixType>(
+      buffer[index], layout, stride, memoryAccessOperands);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::CoherentLoad(
+    RWStructuredBuffer<Type> buffer, uint32_t index, uint32_t stride) {
+  CooperativeMatrix result;
+  result._matrix = __builtin_spv_CooperativeMatrixLoadKHR<SpirvMatrixType>(
+      buffer[index], layout, stride,
+      memoryAccessOperands | MemoryAccessNonPrivatePointerMask |
+          MemoryAccessMakePointerVisibleMask,
+      ScopeQueueFamily);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+template <uint32_t memoryAccessOperands, CooperativeMatrixLayout layout,
+          class Type>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::Load(
+    StructuredBuffer<Type> buffer, uint32_t index, uint32_t stride) {
+  CooperativeMatrix result;
+  result._matrix = __builtin_spv_CooperativeMatrixLoadKHR<SpirvMatrixType>(
+      buffer[index], layout, stride, MemoryAccessMaskNone);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>
+CooperativeMatrix<ComponentType, scope, rows, columns, use>::Splat(
+    ComponentType v) {
+  CooperativeMatrix result;
+  result._matrix = __builtin_spv_ConstructCooperativeMatrix<SpirvMatrixType>(v);
+  return result;
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+uint CooperativeMatrix<ComponentType, scope, rows, columns, use>::GetLength() {
+  return __builtin_spv_CooperativeMatrixLengthKHR<SpirvMatrixType>();
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+ComponentType CooperativeMatrix<ComponentType, scope, rows, columns, use>::Get(
+    uint32_t index) {
+  // clang-format off
+  using ComponentPtr = vk::SpirvOpaqueType<
+      /* OpTypePointer */ 32,
+      /* function storage class */ vk::Literal<vk::integral_constant<uint, 7> >,
+      ComponentType>;
+  // clang-format on
+  ComponentPtr ptr = __builtin_spv_AccessChain<ComponentPtr>(_matrix, index);
+  return __builtin_spv_LoadPointer<ComponentType>(ptr);
+}
+
+template <class ComponentType, Scope scope, uint rows, uint columns,
+          CooperativeMatrixUse use>
+void CooperativeMatrix<ComponentType, scope, rows, columns, use>::Set(
+    ComponentType value, uint32_t index) {
+  // clang-format off
+  using ComponentPtr = vk::SpirvOpaqueType<
+      /* OpTypePointer */ 32,
+      /* function storage class */ vk::Literal<vk::integral_constant<uint, 7> >,
+      ComponentType>;
+  // clang-format on
+  ComponentPtr ptr = __builtin_spv_AccessChain<ComponentPtr>(_matrix, index);
+  return __builtin_spv_StorePointer(ptr, value);
+}
+
+template <typename ComponentType, Scope scope, uint rows, uint columns, uint K>
+CooperativeMatrixAccumulator<ComponentType, scope, rows, columns>
+cooperativeMatrixMultiplyAdd(
+    CooperativeMatrixA<ComponentType, scope, rows, K> a,
+    CooperativeMatrixB<ComponentType, scope, K, columns> b,
+    CooperativeMatrixAccumulator<ComponentType, scope, rows, columns> c) {
+
+  const vk::CooperativeMatrixOperandsMask allSignedComponents =
+      vk::CooperativeMatrixOperandsMatrixASignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsMatrixBSignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsMatrixCSignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsMatrixResultSignedComponentsKHRMask;
+
+  const vk::CooperativeMatrixOperandsMask operands =
+      (vk::CooperativeMatrixOperandsMask)(
+          a.hasSignedIntegerComponentType
+              ? allSignedComponents
+              : vk::CooperativeMatrixOperandsMaskNone);
+
+  CooperativeMatrixAccumulator<ComponentType, scope, rows, columns> result;
+  result._matrix = __builtin_spv_CooperativeMatrixMulAddKHR<
+      typename CooperativeMatrixAccumulator<ComponentType, scope, rows,
+                                            columns>::SpirvMatrixType>(
+      a._matrix, b._matrix, c._matrix, operands);
+  return result;
+}
+
+template <typename ComponentType, Scope scope, uint rows, uint columns, uint K>
+CooperativeMatrixAccumulator<ComponentType, scope, rows, columns>
+cooperativeMatrixSaturatingMultiplyAdd(
+    CooperativeMatrixA<ComponentType, scope, rows, K> a,
+    CooperativeMatrixB<ComponentType, scope, K, columns> b,
+    CooperativeMatrixAccumulator<ComponentType, scope, rows, columns> c) {
+
+  const vk::CooperativeMatrixOperandsMask allSignedComponents =
+      vk::CooperativeMatrixOperandsMatrixASignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsMatrixBSignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsMatrixCSignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsMatrixResultSignedComponentsKHRMask |
+      vk::CooperativeMatrixOperandsSaturatingAccumulationKHRMask;
+
+  const vk::CooperativeMatrixOperandsMask operands =
+      (vk::CooperativeMatrixOperandsMask)(
+          a.hasSignedIntegerComponentType
+              ? allSignedComponents
+              : vk::CooperativeMatrixOperandsSaturatingAccumulationKHRMask);
+  CooperativeMatrixAccumulator<ComponentType, scope, rows, columns> result;
+  result._matrix = __builtin_spv_CooperativeMatrixMulAddKHR<
+      typename CooperativeMatrixAccumulator<ComponentType, scope, rows,
+                                            columns>::SpirvMatrixType>(
+      a._matrix, b._matrix, c._matrix, operands);
+  return result;
+}
+
+} // namespace khr
+} // namespace vk

--- a/tools/clang/lib/Headers/hlsl/vk/opcode_selector.h
+++ b/tools/clang/lib/Headers/hlsl/vk/opcode_selector.h
@@ -1,0 +1,227 @@
+// Copyright (c) 2024 Google LLC
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _HLSL_VK_KHR_OPCODE_SELECTOR_H_
+#define _HLSL_VK_KHR_OPCODE_SELECTOR_H_
+
+#define DECLARE_UNARY_OP(name, opcode)                                         \
+  template <typename ResultType>                                               \
+  [[vk::ext_instruction(opcode)]] ResultType __builtin_spv_##name(             \
+      ResultType a)
+
+DECLARE_UNARY_OP(CopyObj, 83);
+DECLARE_UNARY_OP(SNegate, 126);
+DECLARE_UNARY_OP(FNegate, 127);
+
+#define DECLARE_CONVERSION_OP(name, opcode)                                    \
+  template <typename ResultType, typename OperandType>                         \
+  [[vk::ext_instruction(opcode)]] ResultType __builtin_spv_##name(             \
+      OperandType a)
+
+DECLARE_CONVERSION_OP(ConvertFtoU, 109);
+DECLARE_CONVERSION_OP(ConvertFtoS, 110);
+DECLARE_CONVERSION_OP(ConvertSToF, 111);
+DECLARE_CONVERSION_OP(ConvertUToF, 112);
+DECLARE_CONVERSION_OP(UConvert, 113);
+DECLARE_CONVERSION_OP(SConvert, 114);
+DECLARE_CONVERSION_OP(FConvert, 115);
+DECLARE_CONVERSION_OP(Bitcast, 124);
+
+#undef DECLARY_UNARY_OP
+
+#define DECLARE_BINOP(name, opcode)                                            \
+  template <typename ResultType>                                               \
+  [[vk::ext_instruction(opcode)]] ResultType __builtin_spv_##name(             \
+      ResultType a, ResultType b)
+
+DECLARE_BINOP(IAdd, 128);
+DECLARE_BINOP(FAdd, 129);
+DECLARE_BINOP(ISub, 130);
+DECLARE_BINOP(FSub, 131);
+DECLARE_BINOP(IMul, 132);
+DECLARE_BINOP(FMul, 133);
+DECLARE_BINOP(UDiv, 134);
+DECLARE_BINOP(SDiv, 135);
+DECLARE_BINOP(FDiv, 136);
+
+#undef DECLARE_BINOP
+namespace vk {
+namespace util {
+
+template <class ComponentType> class ArithmeticSelector;
+
+#define ARITHMETIC_SELECTOR(BaseType, OpNegate, OpAdd, OpSub, OpMul, OpDiv,    \
+                            SIGNED_INTEGER_TYPE)                               \
+  template <> class ArithmeticSelector<BaseType> {                             \
+    template <class T> static T Negate(T a) { return OpNegate(a); }            \
+    template <class T> static T Add(T a, T b) { return OpAdd(a, b); }          \
+    template <class T> static T Sub(T a, T b) { return OpSub(a, b); }          \
+    template <class T> static T Mul(T a, T b) { return OpMul(a, b); }          \
+    template <class T> static T Div(T a, T b) { return OpDiv(a, b); }          \
+  };
+
+ARITHMETIC_SELECTOR(half, __builtin_spv_FNegate, __builtin_spv_FAdd,
+                    __builtin_spv_FSub, __builtin_spv_FMul, __builtin_spv_FDiv,
+                    false);
+ARITHMETIC_SELECTOR(float, __builtin_spv_FNegate, __builtin_spv_FAdd,
+                    __builtin_spv_FSub, __builtin_spv_FMul, __builtin_spv_FDiv,
+                    false);
+ARITHMETIC_SELECTOR(double, __builtin_spv_FNegate, __builtin_spv_FAdd,
+                    __builtin_spv_FSub, __builtin_spv_FMul, __builtin_spv_FDiv,
+                    false);
+
+#if __HLSL_ENABLE_16_BIT
+ARITHMETIC_SELECTOR(int16_t, __builtin_spv_SNegate, __builtin_spv_IAdd,
+                    __builtin_spv_ISub, __builtin_spv_IMul, __builtin_spv_SDiv,
+                    true);
+ARITHMETIC_SELECTOR(uint16_t, __builtin_spv_SNegate, __builtin_spv_IAdd,
+                    __builtin_spv_ISub, __builtin_spv_IMul, __builtin_spv_UDiv,
+                    false);
+#endif // __HLSL_ENABLE_16_BIT
+
+ARITHMETIC_SELECTOR(int32_t, __builtin_spv_SNegate, __builtin_spv_IAdd,
+                    __builtin_spv_ISub, __builtin_spv_IMul, __builtin_spv_SDiv,
+                    true);
+ARITHMETIC_SELECTOR(int64_t, __builtin_spv_SNegate, __builtin_spv_IAdd,
+                    __builtin_spv_ISub, __builtin_spv_IMul, __builtin_spv_SDiv,
+                    true);
+ARITHMETIC_SELECTOR(uint32_t, __builtin_spv_SNegate, __builtin_spv_IAdd,
+                    __builtin_spv_ISub, __builtin_spv_IMul, __builtin_spv_UDiv,
+                    false);
+ARITHMETIC_SELECTOR(uint64_t, __builtin_spv_SNegate, __builtin_spv_IAdd,
+                    __builtin_spv_ISub, __builtin_spv_IMul, __builtin_spv_UDiv,
+                    false);
+
+// The conversion selector is will be used to convert one type to another
+// using the SPIR-V conversion instructions. See
+// https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_conversion_instructions.
+// SourceType and TargetType must be integer or floating point scalar type.
+
+// ConversionSelector::Convert converts an object of type S to an object of type
+// T. S must be SourceType, a vector of SourceType, or a cooperative matrix of
+// SourceType. T must be TargetType, a vector of TargetType, or a cooperative
+// matrix of TargetType. T must have the same number of components as S. T is a
+// cooperative matrix if and only if S is a cooperative matrix.
+template <class SourceType, class TargetType> class ConversionSelector;
+
+#define CONVERSION_SELECTOR(SourceType, TargetType, OpConvert)                 \
+  template <> class ConversionSelector<SourceType, TargetType> {               \
+    template <class T, class S> static T Convert(S a) {                        \
+      return OpConvert<T>(a);                                                  \
+    }                                                                          \
+  };
+
+#if __HLSL_ENABLE_16_BIT
+CONVERSION_SELECTOR(uint16_t, uint16_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(uint16_t, int16_t, __builtin_spv_Bitcast);
+CONVERSION_SELECTOR(uint16_t, uint32_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(uint16_t, int32_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(uint16_t, uint64_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(uint16_t, int64_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(uint16_t, half, __builtin_spv_ConvertUToF);
+CONVERSION_SELECTOR(uint16_t, float, __builtin_spv_ConvertUToF);
+CONVERSION_SELECTOR(uint16_t, double, __builtin_spv_ConvertUToF);
+
+CONVERSION_SELECTOR(int16_t, uint16_t, __builtin_spv_Bitcast);
+CONVERSION_SELECTOR(int16_t, int16_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(int16_t, uint32_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(int16_t, int32_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(int16_t, uint64_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(int16_t, int64_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(int16_t, half, __builtin_spv_ConvertSToF);
+CONVERSION_SELECTOR(int16_t, float, __builtin_spv_ConvertSToF);
+CONVERSION_SELECTOR(int16_t, double, __builtin_spv_ConvertSToF);
+
+CONVERSION_SELECTOR(uint32_t, uint16_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(uint32_t, int16_t, __builtin_spv_SConvert);
+
+CONVERSION_SELECTOR(int32_t, uint16_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(int32_t, int16_t, __builtin_spv_SConvert);
+
+CONVERSION_SELECTOR(uint64_t, uint16_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(uint64_t, int16_t, __builtin_spv_SConvert);
+
+CONVERSION_SELECTOR(int64_t, uint16_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(int64_t, int16_t, __builtin_spv_SConvert);
+
+CONVERSION_SELECTOR(half, uint16_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(half, int16_t, __builtin_spv_ConvertFtoS);
+
+CONVERSION_SELECTOR(float, uint16_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(float, int16_t, __builtin_spv_ConvertFtoS);
+
+CONVERSION_SELECTOR(double, uint16_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(double, int16_t, __builtin_spv_ConvertFtoS);
+#endif
+
+CONVERSION_SELECTOR(uint32_t, uint32_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(uint32_t, int32_t, __builtin_spv_Bitcast);
+CONVERSION_SELECTOR(uint32_t, uint64_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(uint32_t, int64_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(uint32_t, half, __builtin_spv_ConvertUToF);
+CONVERSION_SELECTOR(uint32_t, float, __builtin_spv_ConvertUToF);
+CONVERSION_SELECTOR(uint32_t, double, __builtin_spv_ConvertUToF);
+
+CONVERSION_SELECTOR(int32_t, uint32_t, __builtin_spv_Bitcast);
+CONVERSION_SELECTOR(int32_t, int32_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(int32_t, uint64_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(int32_t, int64_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(int32_t, half, __builtin_spv_ConvertSToF);
+CONVERSION_SELECTOR(int32_t, float, __builtin_spv_ConvertSToF);
+CONVERSION_SELECTOR(int32_t, double, __builtin_spv_ConvertSToF);
+
+CONVERSION_SELECTOR(uint64_t, uint32_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(uint64_t, int32_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(uint64_t, uint64_t, __builtin_spv_Bitcast);
+CONVERSION_SELECTOR(uint64_t, int64_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(uint64_t, half, __builtin_spv_ConvertUToF);
+CONVERSION_SELECTOR(uint64_t, float, __builtin_spv_ConvertUToF);
+CONVERSION_SELECTOR(uint64_t, double, __builtin_spv_ConvertUToF);
+
+CONVERSION_SELECTOR(int64_t, uint32_t, __builtin_spv_UConvert);
+CONVERSION_SELECTOR(int64_t, int32_t, __builtin_spv_SConvert);
+CONVERSION_SELECTOR(int64_t, uint64_t, __builtin_spv_Bitcast);
+CONVERSION_SELECTOR(int64_t, int64_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(int64_t, half, __builtin_spv_ConvertSToF);
+CONVERSION_SELECTOR(int64_t, float, __builtin_spv_ConvertSToF);
+CONVERSION_SELECTOR(int64_t, double, __builtin_spv_ConvertSToF);
+
+CONVERSION_SELECTOR(half, uint32_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(half, int32_t, __builtin_spv_ConvertFtoS);
+CONVERSION_SELECTOR(half, uint64_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(half, int64_t, __builtin_spv_ConvertFtoS);
+CONVERSION_SELECTOR(half, half, __builtin_spv_CopyObj);
+#if __HLSL_ENABLE_16_BIT
+CONVERSION_SELECTOR(half, float, __builtin_spv_FConvert);
+#else
+CONVERSION_SELECTOR(half, float, __builtin_spv_CopyObj);
+#endif
+
+CONVERSION_SELECTOR(half, double, __builtin_spv_FConvert);
+
+CONVERSION_SELECTOR(float, uint32_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(float, int32_t, __builtin_spv_ConvertFtoS);
+CONVERSION_SELECTOR(float, uint64_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(float, int64_t, __builtin_spv_ConvertFtoS);
+#if __HLSL_ENABLE_16_BIT
+CONVERSION_SELECTOR(float, half, __builtin_spv_FConvert);
+#else
+CONVERSION_SELECTOR(float, half, __builtin_spv_CopyObj);
+#endif
+CONVERSION_SELECTOR(float, float, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(float, double, __builtin_spv_FConvert);
+
+CONVERSION_SELECTOR(double, uint32_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(double, int32_t, __builtin_spv_ConvertFtoS);
+CONVERSION_SELECTOR(double, uint64_t, __builtin_spv_ConvertFtoU);
+CONVERSION_SELECTOR(double, int64_t, __builtin_spv_ConvertFtoS);
+CONVERSION_SELECTOR(double, half, __builtin_spv_FConvert);
+CONVERSION_SELECTOR(double, float, __builtin_spv_FConvert);
+CONVERSION_SELECTOR(double, double, __builtin_spv_CopyObj);
+}; // namespace util
+} // namespace vk
+
+#endif // _HLSL_VK_KHR_OPCODE_SELECTOR_H_

--- a/tools/clang/lib/Headers/hlsl/vk/opcode_selector.h
+++ b/tools/clang/lib/Headers/hlsl/vk/opcode_selector.h
@@ -12,7 +12,7 @@
   [[vk::ext_instruction(opcode)]] ResultType __builtin_spv_##name(             \
       ResultType a)
 
-DECLARE_UNARY_OP(CopyObj, 83);
+DECLARE_UNARY_OP(CopyObject, 83);
 DECLARE_UNARY_OP(SNegate, 126);
 DECLARE_UNARY_OP(FNegate, 127);
 
@@ -115,7 +115,7 @@ template <class SourceType, class TargetType> class ConversionSelector;
   };
 
 #if __HLSL_ENABLE_16_BIT
-CONVERSION_SELECTOR(uint16_t, uint16_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(uint16_t, uint16_t, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(uint16_t, int16_t, __builtin_spv_Bitcast);
 CONVERSION_SELECTOR(uint16_t, uint32_t, __builtin_spv_UConvert);
 CONVERSION_SELECTOR(uint16_t, int32_t, __builtin_spv_SConvert);
@@ -126,7 +126,7 @@ CONVERSION_SELECTOR(uint16_t, float, __builtin_spv_ConvertUToF);
 CONVERSION_SELECTOR(uint16_t, double, __builtin_spv_ConvertUToF);
 
 CONVERSION_SELECTOR(int16_t, uint16_t, __builtin_spv_Bitcast);
-CONVERSION_SELECTOR(int16_t, int16_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(int16_t, int16_t, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(int16_t, uint32_t, __builtin_spv_UConvert);
 CONVERSION_SELECTOR(int16_t, int32_t, __builtin_spv_SConvert);
 CONVERSION_SELECTOR(int16_t, uint64_t, __builtin_spv_UConvert);
@@ -157,7 +157,7 @@ CONVERSION_SELECTOR(double, uint16_t, __builtin_spv_ConvertFtoU);
 CONVERSION_SELECTOR(double, int16_t, __builtin_spv_ConvertFtoS);
 #endif
 
-CONVERSION_SELECTOR(uint32_t, uint32_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(uint32_t, uint32_t, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(uint32_t, int32_t, __builtin_spv_Bitcast);
 CONVERSION_SELECTOR(uint32_t, uint64_t, __builtin_spv_UConvert);
 CONVERSION_SELECTOR(uint32_t, int64_t, __builtin_spv_SConvert);
@@ -166,7 +166,7 @@ CONVERSION_SELECTOR(uint32_t, float, __builtin_spv_ConvertUToF);
 CONVERSION_SELECTOR(uint32_t, double, __builtin_spv_ConvertUToF);
 
 CONVERSION_SELECTOR(int32_t, uint32_t, __builtin_spv_Bitcast);
-CONVERSION_SELECTOR(int32_t, int32_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(int32_t, int32_t, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(int32_t, uint64_t, __builtin_spv_UConvert);
 CONVERSION_SELECTOR(int32_t, int64_t, __builtin_spv_SConvert);
 CONVERSION_SELECTOR(int32_t, half, __builtin_spv_ConvertSToF);
@@ -176,7 +176,7 @@ CONVERSION_SELECTOR(int32_t, double, __builtin_spv_ConvertSToF);
 CONVERSION_SELECTOR(uint64_t, uint32_t, __builtin_spv_UConvert);
 CONVERSION_SELECTOR(uint64_t, int32_t, __builtin_spv_SConvert);
 CONVERSION_SELECTOR(uint64_t, uint64_t, __builtin_spv_Bitcast);
-CONVERSION_SELECTOR(uint64_t, int64_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(uint64_t, int64_t, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(uint64_t, half, __builtin_spv_ConvertUToF);
 CONVERSION_SELECTOR(uint64_t, float, __builtin_spv_ConvertUToF);
 CONVERSION_SELECTOR(uint64_t, double, __builtin_spv_ConvertUToF);
@@ -184,7 +184,7 @@ CONVERSION_SELECTOR(uint64_t, double, __builtin_spv_ConvertUToF);
 CONVERSION_SELECTOR(int64_t, uint32_t, __builtin_spv_UConvert);
 CONVERSION_SELECTOR(int64_t, int32_t, __builtin_spv_SConvert);
 CONVERSION_SELECTOR(int64_t, uint64_t, __builtin_spv_Bitcast);
-CONVERSION_SELECTOR(int64_t, int64_t, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(int64_t, int64_t, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(int64_t, half, __builtin_spv_ConvertSToF);
 CONVERSION_SELECTOR(int64_t, float, __builtin_spv_ConvertSToF);
 CONVERSION_SELECTOR(int64_t, double, __builtin_spv_ConvertSToF);
@@ -193,11 +193,11 @@ CONVERSION_SELECTOR(half, uint32_t, __builtin_spv_ConvertFtoU);
 CONVERSION_SELECTOR(half, int32_t, __builtin_spv_ConvertFtoS);
 CONVERSION_SELECTOR(half, uint64_t, __builtin_spv_ConvertFtoU);
 CONVERSION_SELECTOR(half, int64_t, __builtin_spv_ConvertFtoS);
-CONVERSION_SELECTOR(half, half, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(half, half, __builtin_spv_CopyObject);
 #if __HLSL_ENABLE_16_BIT
 CONVERSION_SELECTOR(half, float, __builtin_spv_FConvert);
 #else
-CONVERSION_SELECTOR(half, float, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(half, float, __builtin_spv_CopyObject);
 #endif
 
 CONVERSION_SELECTOR(half, double, __builtin_spv_FConvert);
@@ -209,9 +209,9 @@ CONVERSION_SELECTOR(float, int64_t, __builtin_spv_ConvertFtoS);
 #if __HLSL_ENABLE_16_BIT
 CONVERSION_SELECTOR(float, half, __builtin_spv_FConvert);
 #else
-CONVERSION_SELECTOR(float, half, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(float, half, __builtin_spv_CopyObject);
 #endif
-CONVERSION_SELECTOR(float, float, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(float, float, __builtin_spv_CopyObject);
 CONVERSION_SELECTOR(float, double, __builtin_spv_FConvert);
 
 CONVERSION_SELECTOR(double, uint32_t, __builtin_spv_ConvertFtoU);
@@ -220,7 +220,7 @@ CONVERSION_SELECTOR(double, uint64_t, __builtin_spv_ConvertFtoU);
 CONVERSION_SELECTOR(double, int64_t, __builtin_spv_ConvertFtoS);
 CONVERSION_SELECTOR(double, half, __builtin_spv_FConvert);
 CONVERSION_SELECTOR(double, float, __builtin_spv_FConvert);
-CONVERSION_SELECTOR(double, double, __builtin_spv_CopyObj);
+CONVERSION_SELECTOR(double, double, __builtin_spv_CopyObject);
 }; // namespace util
 } // namespace vk
 

--- a/tools/clang/lib/Headers/hlsl/vk/spirv.h
+++ b/tools/clang/lib/Headers/hlsl/vk/spirv.h
@@ -9,6 +9,57 @@
 
 namespace vk {
 
+enum CooperativeMatrixUse {
+  CooperativeMatrixUseMatrixAKHR = 0,
+  CooperativeMatrixUseMatrixBKHR = 1,
+  CooperativeMatrixUseMatrixAccumulatorKHR = 2,
+  CooperativeMatrixUseMax = 0x7fffffff,
+};
+
+enum CooperativeMatrixLayout {
+  CooperativeMatrixLayoutRowMajorKHR = 0,
+  CooperativeMatrixLayoutColumnMajorKHR = 1,
+  CooperativeMatrixLayoutRowBlockedInterleavedARM = 4202,
+  CooperativeMatrixLayoutColumnBlockedInterleavedARM = 4203,
+  CooperativeMatrixLayoutMax = 0x7fffffff,
+};
+
+enum CooperativeMatrixOperandsMask {
+  CooperativeMatrixOperandsMaskNone = 0,
+  CooperativeMatrixOperandsMatrixASignedComponentsKHRMask = 0x00000001,
+  CooperativeMatrixOperandsMatrixBSignedComponentsKHRMask = 0x00000002,
+  CooperativeMatrixOperandsMatrixCSignedComponentsKHRMask = 0x00000004,
+  CooperativeMatrixOperandsMatrixResultSignedComponentsKHRMask = 0x00000008,
+  CooperativeMatrixOperandsSaturatingAccumulationKHRMask = 0x00000010,
+};
+
+enum MemoryAccessMask {
+  MemoryAccessMaskNone = 0,
+  MemoryAccessVolatileMask = 0x00000001,
+  MemoryAccessAlignedMask = 0x00000002,
+  MemoryAccessNontemporalMask = 0x00000004,
+  MemoryAccessMakePointerAvailableMask = 0x00000008,
+  MemoryAccessMakePointerAvailableKHRMask = 0x00000008,
+  MemoryAccessMakePointerVisibleMask = 0x00000010,
+  MemoryAccessMakePointerVisibleKHRMask = 0x00000010,
+  MemoryAccessNonPrivatePointerMask = 0x00000020,
+  MemoryAccessNonPrivatePointerKHRMask = 0x00000020,
+  MemoryAccessAliasScopeINTELMaskMask = 0x00010000,
+  MemoryAccessNoAliasINTELMaskMask = 0x00020000,
+};
+
+enum Scope {
+  ScopeCrossDevice = 0,
+  ScopeDevice = 1,
+  ScopeWorkgroup = 2,
+  ScopeSubgroup = 3,
+  ScopeInvocation = 4,
+  ScopeQueueFamily = 5,
+  ScopeQueueFamilyKHR = 5,
+  ScopeShaderCallKHR = 6,
+  ScopeMax = 0x7fffffff,
+};
+
 enum StorageClass {
   StorageClassWorkgroup = 4,
 };

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -413,6 +413,17 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
   section->insert(section->end(), curInst.begin(), curInst.end());
 }
 
+bool EmitVisitor::emitCooperativeMatrixLength(SpirvUnaryOp *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  const uint32_t operandResultTypeId =
+      typeHandler.emitType(inst->getOperand()->getResultType());
+  curInst.push_back(operandResultTypeId);
+  finalizeInstruction(&mainBinary);
+  return true;
+}
+
 void EmitVisitor::initInstruction(SpirvInstruction *inst) {
   // Emit the result type if the instruction has a result type.
   if (inst->hasResultType()) {
@@ -1318,6 +1329,10 @@ bool EmitVisitor::visit(SpirvNullaryOp *inst) {
 }
 
 bool EmitVisitor::visit(SpirvUnaryOp *inst) {
+  if (inst->getopcode() == spv::Op::OpCooperativeMatrixLengthKHR) {
+    return emitCooperativeMatrixLength(inst);
+  }
+
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -399,6 +399,11 @@ private:
     emittedSource[fileId] = dbg_src_id;
   }
 
+  // Emits an OpCooperativeMatrixLength instruction into the main binary
+  // section. It will replace the operand with the id of the type of the
+  // operand.
+  bool emitCooperativeMatrixLength(SpirvUnaryOp *inst);
+
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
   template <unsigned N>

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -223,10 +223,11 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
   // Access chains must have a pointer type. The storage class for the pointer
   // is the same as the storage class of the access base.
   case spv::Op::OpAccessChain: {
-    const auto *pointerType = spvContext.getPointerType(
-        resultType,
-        cast<SpirvAccessChain>(instr)->getBase()->getStorageClass());
-    instr->setResultType(pointerType);
+    if (auto *acInst = dyn_cast<SpirvAccessChain>(instr)) {
+      const auto *pointerType = spvContext.getPointerType(
+          resultType, acInst->getBase()->getStorageClass());
+      instr->setResultType(pointerType);
+    }
     break;
   }
   // OpImageTexelPointer's result type must be a pointer with image storage

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -752,6 +752,10 @@ private:
   /// `vk::RawBufferStore()`.
   uint32_t getRawBufferAlignment(const Expr *expr);
 
+  /// Returns a spirv OpCooperativeMatrixLengthKHR instruction generated from a
+  /// call to __builtin_spv_CooperativeMatrixLengthKHR.
+  SpirvInstruction *processCooperativeMatrixGetLength(const CallExpr *call);
+
   /// Process vk::ext_execution_mode intrinsic
   SpirvInstruction *processIntrinsicExecutionMode(const CallExpr *expr,
                                                   bool useIdParams);

--- a/tools/clang/test/CodeGenSPIRV/convert.selector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/convert.selector.hlsl
@@ -1,0 +1,139 @@
+// Convert to half
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+
+// Convert to float
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+
+// Convert to double
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+
+// int type to int16_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+
+// float type to int16_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+
+// int type to int32_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+
+// float type to int32_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+
+// int type to int64_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+
+// float type to int64_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+
+// int type to uint16_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+
+// float type to uint16_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+
+// int type to uint32_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+
+// float type to uint32_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+
+// int type to uint64_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+
+// float type to uint64_t
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+
+#include "vk/opcode_selector.h"
+
+#define VEC_TYPE_INT(TYPE) TYPE##4
+#define VEC_TYPE(t) VEC_TYPE_INT(t)
+
+RWStructuredBuffer<VEC_TYPE(SOURCE_TYPE)> source;
+RWStructuredBuffer<VEC_TYPE(TARGET_TYPE)> target;
+
+[numthreads(64, 1, 1)] void main() {
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain {{%_ptr_StorageBuffer_.*}} %source %int_0 %uint_0
+// CHECK: [[ld:%[0-9]+]] = OpLoad {{%.*}} [[ac]]
+// STOF: [[result:%[0-9]+]] = OpConvertSToF {{%.*}} [[ld]]
+// FTOS: [[result:%[0-9]+]] = OpConvertFToS {{%.*}} [[ld]]
+// UTOF: [[result:%[0-9]+]] = OpConvertUToF {{%.*}} [[ld]]
+// FTOU: [[result:%[0-9]+]] = OpConvertFToU {{%.*}} [[ld]]
+// FCONVERT: [[result:%[0-9]+]] = OpFConvert {{%.*}} [[ld]]
+// UCONVERT: [[result:%[0-9]+]] = OpUConvert {{%.*}} [[ld]]
+// SCONVERT: [[result:%[0-9]+]] = OpSConvert {{%.*}} [[ld]]
+// BITCAST: [[result:%[0-9]+]] = OpBitcast {{%.*}} [[ld]]
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain {{%_ptr_StorageBuffer_.*}} %target %int_0 %uint_0
+// CHECK: OpStore [[ac]] [[result]]
+  target[0] = vk::util::ConversionSelector<SOURCE_TYPE, TARGET_TYPE>::Convert<VEC_TYPE(TARGET_TYPE)>(source[0]);
+
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain {{%_ptr_StorageBuffer_.*}} %source %int_0 %uint_0 %int_0
+// CHECK: [[ld:%[0-9]+]] = OpLoad {{%.*}} [[ac]]
+// STOF: [[result:%[0-9]+]] = OpConvertSToF {{%.*}} [[ld]]
+// FTOS: [[result:%[0-9]+]] = OpConvertFToS {{%.*}} [[ld]]
+// UTOF: [[result:%[0-9]+]] = OpConvertUToF {{%.*}} [[ld]]
+// FTOU: [[result:%[0-9]+]] = OpConvertFToU {{%.*}} [[ld]]
+// FCONVERT: [[result:%[0-9]+]] = OpFConvert {{%.*}} [[ld]]
+// UCONVERT: [[result:%[0-9]+]] = OpUConvert {{%.*}} [[ld]]
+// SCONVERT: [[result:%[0-9]+]] = OpSConvert {{%.*}} [[ld]]
+// BITCAST: [[result:%[0-9]+]] = OpBitcast {{%.*}} [[ld]]
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain {{%_ptr_StorageBuffer_.*}} %target %int_0 %uint_0 %int_0
+// CHECK: OpStore [[ac]] [[result]]
+  target[0].x = vk::util::ConversionSelector<SOURCE_TYPE, TARGET_TYPE>::Convert<TARGET_TYPE>(source[0].x);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.arithmetic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.arithmetic.hlsl
@@ -1,0 +1,95 @@
+// RUN: dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int16_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT16
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT32
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int64_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT64
+// RUN: dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint16_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT16
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT32
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint64_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT64
+// RUN: dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=half %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=HALF-ENABLED
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=half %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=HALF-DISABLED
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=float %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=FLOAT
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=double %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=DOUBLE
+
+#include "vk/khr/cooperative_matrix.h"
+
+StructuredBuffer<float> structured_buffer;
+
+RWStructuredBuffer<TYPE> data;
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+
+// Check that the type is correctly created.
+// INT16: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %short %uint_3 %uint_16 %uint_8 %uint_0
+// INT32: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %int %uint_3 %uint_16 %uint_8 %uint_0
+// INT64: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %long %uint_3 %uint_16 %uint_8 %uint_0
+// UINT16: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %ushort %uint_3 %uint_16 %uint_8 %uint_0
+// UINT32: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %uint %uint_3 %uint_16 %uint_8 %uint_0
+// UINT64: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %ulong %uint_3 %uint_16 %uint_8 %uint_0
+
+// When 16bit types are not enabled, HALF is a float
+// HALF-DISABLED: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %float %uint_3 %uint_16 %uint_8 %uint_0
+// HALF-ENABLED: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %half %uint_3 %uint_16 %uint_8 %uint_0
+// FLOAT: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %float %uint_3 %uint_16 %uint_8 %uint_0
+// DOUBLE: %spirvIntrinsicType = OpTypeCooperativeMatrixKHR %double %uint_3 %uint_16 %uint_8 %uint_0
+
+[numthreads(64, 1, 1)] void main() {
+  using CoopMat = vk::khr::CooperativeMatrixA<
+      TYPE, vk::ScopeSubgroup, 16, 8>;
+
+  // CHECK: [[ac1:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_{{.*}} %data %int_0 %uint_0
+  // CHECK: [[m:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac1]] %int_1 %uint_64 None
+  CoopMat m = CoopMat::Load<vk::CooperativeMatrixLayoutColumnMajorKHR>(data, 0, 64);
+
+  // CHECK: [[len:%[0-9]+]] = OpCooperativeMatrixLengthKHR %uint %spirvIntrinsicType
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_{{.*}} %structured_buffer %int_0 [[len]]
+  // CHECK: [[n:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac]] %int_0 %uint_64 None
+  uint32_t length = CoopMat::GetLength();
+  CoopMat n = CoopMat::Load<vk::CooperativeMatrixLayoutRowMajorKHR>(structured_buffer, length, 64);
+
+  // INTEGERS: [[r:%[0-9]+]] = OpIAdd %spirvIntrinsicType [[m]] [[n]]
+  // FLOATS: [[r:%[0-9]+]] = OpFAdd %spirvIntrinsicType [[m]] [[n]]
+  CoopMat r = m + n;
+
+  // INTEGERS: [[n:%[0-9]+]] = OpISub %spirvIntrinsicType [[m]] [[r]]
+  // FLOATS: [[n:%[0-9]+]] = OpFSub %spirvIntrinsicType [[m]] [[r]]
+  n = m - r;
+
+  // INTEGERS: [[m:%[0-9]+]] = OpSNegate %spirvIntrinsicType [[n]]
+  // FLOATS: [[m:%[0-9]+]] = OpFNegate %spirvIntrinsicType [[n]]
+  m = n.negate();
+
+  // INT16: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %short_2
+  // INT32: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %int_2
+  // INT64: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %long_2
+  // UINT16: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %ushort_2
+  // UINT32: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %uint_2
+  // UINT64: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %ulong_2
+  // HALF-DISABLED: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %float_2
+  // HALF-ENABLED: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %half_0x1p_1
+  // FLOAT: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %float_2
+  // DOUBLE: [[r:%[0-9]+]] = OpMatrixTimesScalar %spirvIntrinsicType [[m]] %double_2
+  r = m * 2.0;
+
+  // INT16: [[n:%[0-9]+]] = OpSDiv %spirvIntrinsicType [[r]] [[m]]
+  // INT32: [[n:%[0-9]+]] = OpSDiv %spirvIntrinsicType [[r]] [[m]]
+  // INT64: [[n:%[0-9]+]] = OpSDiv %spirvIntrinsicType [[r]] [[m]]
+  // UINT16: [[n:%[0-9]+]] = OpUDiv %spirvIntrinsicType [[r]] [[m]]
+  // UINT32: [[n:%[0-9]+]] = OpUDiv %spirvIntrinsicType [[r]] [[m]]
+  // UINT64: [[n:%[0-9]+]] = OpUDiv %spirvIntrinsicType [[r]] [[m]]
+  // HALF-DISABLED: [[n:%[0-9]+]] = OpFDiv %spirvIntrinsicType [[r]] [[m]]
+  // HALF-ENABLED: [[n:%[0-9]+]] = OpFDiv %spirvIntrinsicType [[r]] [[m]]
+  // FLOAT: [[n:%[0-9]+]] = OpFDiv %spirvIntrinsicType [[r]] [[m]]
+  // DOUBLE: [[n:%[0-9]+]] = OpFDiv %spirvIntrinsicType [[r]] [[m]]
+  n = r / m;
+
+  // INTEGERS: [[r:%[0-9]+]] = OpIMul %spirvIntrinsicType [[n]] [[m]]
+  // FLOATS: [[r:%[0-9]+]] = OpFMul %spirvIntrinsicType [[n]] [[m]]
+  r = n * m;
+
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac1]] [[r]] %int_0 %uint_64 None
+  r.Store<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 0, 64);
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_{{.*}} %data %int_0 %uint_16
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac]] [[r]] %int_1 %uint_64 None
+  r.Store<vk::CooperativeMatrixLayoutColumnMajorKHR>(data, 16, 64);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.convert.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.convert.hlsl
@@ -1,0 +1,25 @@
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+RWStructuredBuffer<int> data;
+int stride;
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+
+[numthreads(64, 1, 1)] void main() {
+  using IntMatA = vk::khr::CooperativeMatrixA<int, vk::ScopeSubgroup, 16, 4>;
+  using FloatMatA = vk::khr::CooperativeMatrixA<float, vk::ScopeSubgroup, 16, 4>;
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_0
+  // CHECK: [[ld:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac]] %int_1
+  IntMatA int_matrix = IntMatA::Load<vk::CooperativeMatrixLayoutColumnMajorKHR>(data, 0, stride);
+
+  // CHECK: [[result:%[0-9]+]] = OpConvertSToF %spirvIntrinsicType_0 [[ld]]
+  FloatMatA float_matrix = int_matrix.cast<float>();
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_64
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac]] [[result]] %int_0
+  float_matrix.Store<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 64, stride);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.element.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.element.access.hlsl
@@ -1,0 +1,33 @@
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+RWStructuredBuffer<int> data;
+int stride;
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+
+// CHECK-DAG: [[typeA:%spirvIntrinsicType[_0-9]*]] = OpTypeCooperativeMatrixKHR %int %uint_3 %uint_16 %uint_4 %uint_0
+
+[numthreads(64, 1, 1)] void main() {
+  using IntMatA = vk::khr::CooperativeMatrixA<int, vk::ScopeSubgroup, 16, 4>;
+
+  // CHECK: [[a:%[0-9]+]] = OpVariable %_ptr_Function_spirvIntrinsicType Function
+  // CHECK: [[v:%[0-9]+]] = OpCompositeConstruct %spirvIntrinsicType %int_10
+  // CHECK: OpStore [[a]] [[v]]
+  IntMatA a = IntMatA::Splat(10);
+
+  uint32_t length = a.GetLength();
+  // CHECK: OpLoopMerge [[mbb:%[0-9]+]]
+  for (int i = 0; i < length; ++i) {
+    // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Function_int [[a]]
+    // CHECK: [[get:%[0-9]+]] = OpLoad %int [[ac]]
+    // CHECK: [[add:%[0-9]+]] = OpIAdd %int [[get]] %int_1
+    // CHECK: OpStore [[ac]] [[add]]
+    int v = a.Get(i);
+    a.Set(v + 1, i);
+  }
+  // CHECK: [[mbb]] = OpLabel
+  a.Store<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 64, stride);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.globallycoherent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.globallycoherent.hlsl
@@ -1,0 +1,19 @@
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+globallycoherent RWStructuredBuffer<int> data;
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+[numthreads(64, 1, 1)] void main() {
+  using FloatMatA = vk::khr::CooperativeMatrixA<float, vk::ScopeSubgroup, 16, 4>;
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_0
+  // CHECK: [[ld:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac]] %int_1 %uint_256 MakePointerVisible|NonPrivatePointer %int_5
+  FloatMatA m = FloatMatA::CoherentLoad<vk::CooperativeMatrixLayoutColumnMajorKHR>(data, 0, 256);
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_64
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac]] [[ld]] %int_0 %uint_8 MakePointerAvailable|NonPrivatePointer %int_5
+  m.CoherentStore<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 64, 8);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.groupshared.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.groupshared.hlsl
@@ -1,0 +1,30 @@
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+RWStructuredBuffer<int> data;
+
+groupshared float shared_data[64];
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+[numthreads(64, 1, 1)] void main() {
+  using FloatMatA = vk::khr::CooperativeMatrixA<float, vk::ScopeSubgroup, 16, 4>;
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_0
+  // CHECK: [[ld:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac]] %int_1 %uint_256 None
+  FloatMatA m = FloatMatA::Load<vk::CooperativeMatrixLayoutColumnMajorKHR>(data, 0, 256);
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Workgroup_float %shared_data %int_0
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac]] [[ld]] %int_1 %uint_64 MakePointerAvailable|NonPrivatePointer %int_2
+  m.Store<vk::CooperativeMatrixLayoutColumnMajorKHR>(vk::GetGroupSharedAddress(shared_data[0]), 64);
+
+  FloatMatA m2;
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Workgroup_float %shared_data %int_10
+  // CHECK: [[ld:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac]] %int_1 %uint_128 MakePointerVisible|NonPrivatePointer %int_2
+  m2 = FloatMatA::Load<vk::CooperativeMatrixLayoutColumnMajorKHR>(vk::GetGroupSharedAddress(shared_data[10]), 128);
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_64
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac]] [[ld]] %int_0 %uint_8 None
+  m2.Store<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 64, 8);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.memory.operand.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.memory.operand.hlsl
@@ -1,0 +1,22 @@
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+RWStructuredBuffer<int> data;
+
+groupshared float shared_data[64];
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+[numthreads(64, 1, 1)] void main() {
+  using FloatMatA = vk::khr::CooperativeMatrixA<float, vk::ScopeSubgroup, 16, 4>;
+
+  FloatMatA m;
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Workgroup_float %shared_data %int_0
+  // CHECK: [[ld:%[0-9]+]] = OpCooperativeMatrixLoadKHR %spirvIntrinsicType [[ac]] %int_1 %uint_128 Nontemporal
+  m = FloatMatA::Load<vk::MemoryAccessNontemporalMask, vk::CooperativeMatrixLayoutColumnMajorKHR>(vk::GetGroupSharedAddress(shared_data[0]), 128);
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_int %data %int_0 %uint_64
+  // CHECK: OpCooperativeMatrixStoreKHR [[ac]] [[ld]] %int_0 %uint_8 Nontemporal
+  m.Store<vk::MemoryAccessNontemporalMask, vk::CooperativeMatrixLayoutRowMajorKHR>(data, 64, 8);
+}

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.old.spirv.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.old.spirv.hlsl
@@ -1,0 +1,8 @@
+// RUN: not dxc -fspv-target-env=vulkan1.1 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT32
+
+#include "vk/khr/cooperative_matrix.h"
+
+[numthreads(64, 1, 1)] void main() {
+}
+
+// CHECK: error: "CooperativeMatrix requires a minimum of SPIR-V 1.6"

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix_muladd_test.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix_muladd_test.hlsl
@@ -1,0 +1,41 @@
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+RWStructuredBuffer<int> data;
+uint stride;
+
+// CHECK: OpCapability CooperativeMatrixKHR
+// CHECK: OpExtension "SPV_KHR_cooperative_matrix"
+
+// CHECK-DAG: [[typeA:%spirvIntrinsicType[_0-9]*]] = OpTypeCooperativeMatrixKHR %int %uint_3 %uint_16 %uint_4 %uint_0
+// CHECK-DAG: [[typeB:%spirvIntrinsicType[_0-9]*]] = OpTypeCooperativeMatrixKHR %int %uint_3 %uint_4 %uint_8 %uint_1
+// CHECK-DAG: [[typeAc:%spirvIntrinsicType[_0-9]*]] = OpTypeCooperativeMatrixKHR %int %uint_3 %uint_16 %uint_8 %uint_2
+
+// CHECK: [[r:%[0-9]+]] = OpUndef [[typeAc]]
+[numthreads(64, 1, 1)] void main() {
+  using IntMatA = vk::khr::CooperativeMatrixA<int, vk::ScopeSubgroup, 16, 4>;
+  using IntMatB = vk::khr::CooperativeMatrixB<int, vk::ScopeSubgroup, 4, 8>;
+  using IntMatAc = vk::khr::CooperativeMatrixAccumulator<int, vk::ScopeSubgroup, 16, 8>;
+
+  // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %_Globals %int_0
+  // CHECK: [[stride:%[0-9]+]] = OpLoad %uint [[ac]]
+
+  // CHECK: [[a:%[0-9]+]] = OpCooperativeMatrixLoadKHR [[typeA]] {{%[0-9]*}} %int_1 [[stride]] None
+  IntMatA a = IntMatA::Load<vk::CooperativeMatrixLayoutColumnMajorKHR>(data, 0, stride);
+
+  // CHECK: [[b:%[0-9]+]] = OpCooperativeMatrixLoadKHR [[typeB]] {{%[0-9]*}} %int_0 [[stride]] None
+  IntMatB b = IntMatB::Load<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 32, stride);
+
+  // TODO: Is default initialization meaningful?
+  IntMatAc r;
+
+  // CHECK: [[r2:%[0-9]+]] = OpCooperativeMatrixMulAddKHR [[typeAc]] [[a]] [[b]] [[r]] MatrixASignedComponentsKHR|MatrixBSignedComponentsKHR|MatrixCSignedComponentsKHR|MatrixResultSignedComponentsKHR
+  r = cooperativeMatrixMultiplyAdd(a, b, r);
+
+  // CHECK: [[r:%[0-9]+]] = OpCooperativeMatrixMulAddKHR [[typeAc]] [[a]] [[b]] [[r2]] MatrixASignedComponentsKHR|MatrixBSignedComponentsKHR|MatrixCSignedComponentsKHR|MatrixResultSignedComponentsKHR|SaturatingAccumulationKHR
+  r = cooperativeMatrixSaturatingMultiplyAdd(a, b, r);
+
+  // CHECK: OpCooperativeMatrixStoreKHR {{.*}} [[r]] %int_0 [[stride]] None
+  r.Store<vk::CooperativeMatrixLayoutRowMajorKHR>(data, 64, stride);
+}

--- a/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.const.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.const.hlsl
@@ -1,0 +1,16 @@
+// RUN: not dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
+
+#include "vk/khr/cooperative_matrix.h"
+
+RWStructuredBuffer<int> data;
+
+groupshared int shared_data[64];
+
+[numthreads(64, 1, 1)] void main() {
+  vk::WorkgroupSpirvPointer<int> p = vk::GetGroupSharedAddress(shared_data[0]);
+  if (data[0] > 10 ) {
+    p = vk::GetGroupSharedAddress(shared_data[0]);
+  }
+}
+
+// CHECK:  cannot assign to variable 'p' with const-qualified type


### PR DESCRIPTION
This pr will introduce the HLSL standard header files. This will become the a
way to add new extensions to HLSL without having to make modifications to the
compiler.

This first example is a fairly complex example that demonstrates how to do a few
different things:

1. Trying to create a simple class interface that allows the compiler to
   naturally enforce the validation rules. In this case, we might be more strict
than the spir-v validation, but I believe this is still usable.
2. How to create a builtin that can be expanded by the spir-v backend. The 
OpCooperativeMatrixLengthKHR instruction does not have an interface that is
natural in a language like HLSL. However, we can define a function that is, and
have the backend, make small adjustments. These cases should be avoided as much
as possible.


