### PR TITLE
Remove nameless struct in ShaderBinary COperandBase class

### DIFF
--- a/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
+++ b/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
@@ -379,11 +379,8 @@ public: // esp in the unions...it's just redundant to not directly access things
     double m_Valued[2];
   };
 
-#pragma warning(suppress : 4201) // Warning about nameless structure.
-  struct {
-    D3D10_SB_OPERAND_INDEX_REPRESENTATION m_IndexType[3];
-    D3D10_SB_OPERAND_INDEX_DIMENSION m_IndexDimension;
-  };
+  D3D10_SB_OPERAND_INDEX_REPRESENTATION m_IndexType[3];
+  D3D10_SB_OPERAND_INDEX_DIMENSION m_IndexDimension;
 
   friend class CShaderAsm;
   friend class CShaderCodeParser;


### PR DESCRIPTION
The nameless struct is triggering C4201 warning in internal build config in VS v17.10.3 despite the #pragma that should disable it.

The preceding class field is an unnamed union that contains double (64-bit), so the field alignment of `m_IndexType` and `m_IndexDimension` after the change should be identical as before.