### PR TITLE
Disassembler: Remove duplicated "signature" in output

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -1681,7 +1681,7 @@ HRESULT Disassemble(IDxcBlob *pProgram, raw_string_ostream &Stream) {
                       DxilPartIsType(DFCC_PatchConstantSignature));
     if (it != end(pContainer)) {
       PrintSignature(
-          "Patch Constant signature",
+          "Patch Constant",
           reinterpret_cast<const DxilProgramSignature *>(GetDxilPartData(*it)),
           false, Stream, /*comment*/ ";");
     }


### PR DESCRIPTION
There is an extra "signature" in the Patch Constant signature part of the disassembler output, causing the "Patch Constant signature signature" to appear. This PR removes the extra "signature" from the output.

Example HLSL input:

```hlsl
struct OutputConstantData {
    float tessFactor[4] : SV_TessFactor;
    float insideTessFactor[2] : SV_InsideTessFactor;
};

OutputConstantData HSConstant() {
    OutputConstantData output;
    return output;
}

[domain("quad")]
[partitioning("integer")]
[outputtopology("triangle_cw")]
[outputcontrolpoints(1)]
[patchconstantfunc("HSConstant")]
void HSMain() {}
```

Example Disassembler output:

```diff
  ...
  ;
- ; Patch Constant signature signature:
+ ; Patch Constant signature:
  ;
  ; Name                 Index   Mask Register SysValue  Format   Used
  ; -------------------- ----- ------ -------- -------- ------- ------
  ; SV_TessFactor            0      w        0 QUADEDGE   float      w
  ; SV_TessFactor            1      w        1 QUADEDGE   float      w
  ; SV_TessFactor            2      w        2 QUADEDGE   float      w
  ; SV_TessFactor            3      w        3 QUADEDGE   float      w
  ; SV_InsideTessFactor      0      w        4  QUADINT   float      w
  ; SV_InsideTessFactor      1      w        5  QUADINT   float      w
  ;
  ...
```