### PR TITLE
Avoid NOMINMAX redefinition warnings

### DIFF
--- a/tools/clang/utils/TableGen/TableGen.cpp
+++ b/tools/clang/utils/TableGen/TableGen.cpp
@@ -21,7 +21,9 @@
 
 // HLSL Change Starts
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 

--- a/utils/TableGen/TableGen.cpp
+++ b/utils/TableGen/TableGen.cpp
@@ -22,7 +22,9 @@
 
 // HLSL Change Starts
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
On MinGW, NOMINMAX is defined by default, so guard it to avoid redefinition warnings.