### PR TITLE
[CMake] Add an option to disable source generation

### DIFF
--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -1,4 +1,6 @@
 option(HLSL_COPY_GENERATED_SOURCES "Copy generated sources if different" Off)
+option(HLSL_DISABLE_SOURCE_GENERATION "Disable generation of in-tree sources" Off)
+mark_as_advanced(HLSL_DISABLE_SOURCE_GENERATION)
 
 add_custom_target(HCTGen)
 
@@ -42,6 +44,10 @@ function(add_hlsl_hctgen mode)
 
   if (NOT ARG_OUTPUT)
     message(FATAL_ERROR "add_hlsl_hctgen requires OUTPUT argument")
+  endif()
+
+  if (HLSL_DISABLE_SOURCE_GENERATION AND NOT ARG_BUILD_DIR)
+    return()
   endif()
  
   set(temp_output ${CMAKE_CURRENT_BINARY_DIR}/tmp/${ARG_OUTPUT})
@@ -101,7 +107,7 @@ function(add_hlsl_hctgen mode)
   endif()
 
   add_custom_command(OUTPUT ${temp_output}
-                     COMMAND ${Python3_EXECUTABLE}
+                     COMMAND ${PYTHON_EXECUTABLE}
                              ${hctgen} ${force_lf}
                              ${mode} --output ${temp_output} ${input_flag}
                      ${format_cmd}

--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -107,7 +107,7 @@ function(add_hlsl_hctgen mode)
   endif()
 
   add_custom_command(OUTPUT ${temp_output}
-                     COMMAND ${PYTHON_EXECUTABLE}
+                     COMMAND ${Python3_EXECUTABLE}
                              ${hctgen} ${force_lf}
                              ${mode} --output ${temp_output} ${input_flag}
                      ${format_cmd}


### PR DESCRIPTION
This change adds a new CMake configuration option
`HLSL_DISABLE_SOURCE_GENERATION` which allows a user to disable generating the in-tree sources which contributte to DXC's source releases. This option should only be used by users building DXC and not modifying it.

Resolves #6728