### PR TITLE
Add duplicate pragma

### DIFF
--- a/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
+++ b/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
@@ -383,6 +383,7 @@ public: // esp in the unions...it's just redundant to not directly access things
   struct {
     D3D10_SB_OPERAND_INDEX_REPRESENTATION m_IndexType[3];
     D3D10_SB_OPERAND_INDEX_DIMENSION m_IndexDimension;
+#pragma warning(suppress : 4201) // Warning about nameless structure.
   };
 
   friend class CShaderAsm;


### PR DESCRIPTION
Internal build that has DXC as a submodule and that is built with a different VC toolset version started failing after the pragma got moved up in commit 0b9acdb75. Adding a duplicate pragma back at the original location makes both compiler versions happy.