### PR TITLE
[NFC] Use full qualified name with std::nullptr_t type

### DIFF
--- a/include/dxc/Support/microcom.h
+++ b/include/dxc/Support/microcom.h
@@ -187,7 +187,7 @@ template <typename T> HRESULT AssignToOut(T value, T *pResult) {
   *pResult = value;
   return S_OK;
 }
-template <typename T> HRESULT AssignToOut(nullptr_t value, T *pResult) {
+template <typename T> HRESULT AssignToOut(std::nullptr_t value, T *pResult) {
   if (pResult == nullptr)
     return E_POINTER;
   *pResult = value;
@@ -204,7 +204,7 @@ template <typename T> void AssignToOutOpt(T value, T *pResult) {
   if (pResult != nullptr)
     *pResult = value;
 }
-template <typename T> void AssignToOutOpt(nullptr_t value, T *pResult) {
+template <typename T> void AssignToOutOpt(std::nullptr_t value, T *pResult) {
   if (pResult != nullptr)
     *pResult = value;
 }


### PR DESCRIPTION

    
    This fixes the following compiler error with clang 18.1.6 with mingw-w64 toolchain.
    
    microcom.h:190:43: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
      190 | template <typename T> HRESULT AssignToOut(nullptr_t value, T *pResult) {
          |                                           ^~~~~~~~~
          |                                           std::nullptr_t
    microcom.h:207:43: error: unknown type name 'nullptr_t'; did you mean 'std::nullptr_t'?
      207 | template <typename T> void AssignToOutOpt(nullptr_t value, T *pResult) {
          |                                           ^~~~~~~~~
          |                                           std::nullptr_t
