### PR TITLE
Allow cap and extention attribute on member variables and type aliases

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1317,7 +1317,7 @@ def VKBinding : InheritableAttr {
 
 def VKCapabilityExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_capability">];
-  let Subjects = SubjectList<[Function, Var], ErrorDiag>;
+  let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
   let Args = [IntArgument<"capability">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
@@ -1357,7 +1357,7 @@ def VKDecorateStringExt : InheritableAttr {
 
 def VKExtensionExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_extension">];
-  let Subjects = SubjectList<[Function, Var], ErrorDiag>;
+  let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
   let Args = [StringArgument<"name">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -76,7 +76,7 @@ public:
   /// Allows all extensions to be used in CodeGen.
   void allowAllKnownExtensions();
 
-  /// Rqeusts the given extension for translating the given target feature at
+  /// Requests the given extension for translating the given target feature at
   /// the given source location. Emits an error if the given extension is not
   /// permitted to use.
   bool requestExtension(Extension, llvm::StringRef target, SourceLocation);

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -764,12 +764,7 @@ public:
                                         SpirvInstruction *v);
   SpirvInstruction *getPerVertexStgInput(SpirvInstruction *k);
 
-public:
   std::vector<uint32_t> takeModule();
-
-protected:
-  /// Only friend classes are allowed to add capability/extension to the module
-  /// under construction.
 
   /// \brief Adds the given capability to the module under construction due to
   /// the feature used at the given source location.

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -4785,7 +4785,6 @@ void DeclResultIdMapper::registerCapabilitiesAndExtensionsForType(
     const TypedefType *type) {
   for (const auto *decl : typeAliasesWithAttributes) {
     if (type == decl->getTypeForDecl()) {
-      assert(decl->hasAttrs());
       for (auto *attribute : decl->specific_attrs<VKExtensionExtAttr>()) {
         clang::StringRef extensionName = attribute->getName();
         spvBuilder.requireExtension(extensionName, decl->getLocation());

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -968,13 +968,6 @@ DeclResultIdMapper::getDeclSpirvInfo(const ValueDecl *decl) const {
 SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
                                                       SourceLocation loc,
                                                       SourceRange range) {
-  if (decl->hasAttr<VKExtensionExtAttr>() ||
-      decl->hasAttr<VKCapabilityExtAttr>()) {
-    theEmitter.createSpirvIntrInstExt(decl->getAttrs(), QualType(),
-                                      /* spvArgs */ {}, /* isInst */ false,
-                                      loc);
-  }
-
   if (auto *builtinAttr = decl->getAttr<VKExtBuiltinInputAttr>()) {
     return getBuiltinVar(spv::BuiltIn(builtinAttr->getBuiltInID()),
                          decl->getType(), spv::StorageClass::Input, loc);
@@ -1638,6 +1631,18 @@ DeclResultIdMapper::createShaderRecordBuffer(const HLSLBufferDecl *decl,
     astDecls[varDecl] = createDeclSpirvInfo(bufferVar, index++);
   }
   return bufferVar;
+}
+
+void DeclResultIdMapper::recordsSpirvTypeAlias(const Decl *decl) {
+  auto *typedefDecl = dyn_cast<TypedefNameDecl>(decl);
+  if (!typedefDecl)
+    return;
+
+  if (!typedefDecl->hasAttr<VKCapabilityExtAttr>() &&
+      !typedefDecl->hasAttr<VKExtensionExtAttr>())
+    return;
+
+  typeAliasesWithAttributes.push_back(typedefDecl);
 }
 
 void DeclResultIdMapper::createGlobalsCBuffer(const VarDecl *var) {
@@ -4773,6 +4778,23 @@ void DeclResultIdMapper::storeOutStageVarsToStorage(
     storeOutStageVarsToStorage(cast<DeclaratorDecl>(field), ctrlPointID,
                                field->getType(), tempLocation);
     ++index;
+  }
+}
+
+void DeclResultIdMapper::registerCapabilitiesAndExtensionsForType(
+    const TypedefType *type) {
+  for (const auto *decl : typeAliasesWithAttributes) {
+    if (type == decl->getTypeForDecl()) {
+      assert(decl->hasAttrs());
+      for (auto *attribute : decl->specific_attrs<VKExtensionExtAttr>()) {
+        clang::StringRef extensionName = attribute->getName();
+        spvBuilder.requireExtension(extensionName, decl->getLocation());
+      }
+      for (auto *attribute : decl->specific_attrs<VKCapabilityExtAttr>()) {
+        spv::Capability cap = spv::Capability(attribute->getCapability());
+        spvBuilder.requireCapability(cap, decl->getLocation());
+      }
+    }
   }
 }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -376,6 +376,10 @@ public:
   SpirvVariable *createShaderRecordBuffer(const HLSLBufferDecl *decl,
                                           ContextUsageKind kind);
 
+  // Records the TypedefDecl or TypeAliasDecl of vk::SpirvType so that any
+  // required capabilities and extensions can be added if the type is used.
+  void recordsSpirvTypeAlias(const Decl *decl);
+
 private:
   /// The struct containing SPIR-V information of a AST Decl.
   struct DeclSpirvInfo {
@@ -568,6 +572,12 @@ public:
                                   SpirvInstruction *ptr);
 
   spv::ExecutionMode getInterlockExecutionMode();
+
+  /// Records any Spir-V capabilities and extensions for the given type so
+  /// they will be added to the SPIR-V module. The capabilities and extension
+  /// required for the type will be sourced from the decls that were recorded
+  /// using `recordSpirvTypeAlias`.
+  void registerCapabilitiesAndExtensionsForType(const TypedefType *type);
 
 private:
   /// \brief Wrapper method to create a fatal error message and report it
@@ -1057,6 +1067,8 @@ private:
   bool needsFlatteningCompositeResources;
 
   uint32_t perspBaryCentricsIndex, noPerspBaryCentricsIndex;
+
+  llvm::SmallVector<const TypedefNameDecl *, 4> typeAliasesWithAttributes;
 
 public:
   /// The gl_PerVertex structs for both input and output

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -1085,6 +1085,19 @@ LowerTypeVisitor::lowerStructFields(const RecordDecl *decl,
           field->getBitWidthValue(field->getASTContext());
     }
 
+    if (field->hasAttrs()) {
+      for (auto &attr : field->getAttrs()) {
+        if (auto capAttr = dyn_cast<VKCapabilityExtAttr>(attr)) {
+          spvBuilder.requireCapability(
+              static_cast<spv::Capability>(capAttr->getCapability()),
+              capAttr->getLocation());
+        } else if (auto extAttr = dyn_cast<VKExtensionExtAttr>(attr)) {
+          spvBuilder.requireExtension(extAttr->getName(),
+                                      extAttr->getLocation());
+        }
+      }
+    }
+
     fields.push_back(HybridStructType::FieldInfo(
         field->getType(), field->getName(),
         /*vkoffset*/ field->getAttr<VKOffsetAttr>(),

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -986,8 +986,7 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
 }
 
 void SpirvEmitter::doDecl(const Decl *decl) {
-  if (isa<EmptyDecl>(decl) || isa<TypedefDecl>(decl) ||
-      isa<TypeAliasDecl>(decl) || isa<TypeAliasTemplateDecl>(decl) ||
+  if (isa<EmptyDecl>(decl) || isa<TypeAliasTemplateDecl>(decl) ||
       isa<VarTemplateDecl>(decl))
     return;
 
@@ -1016,6 +1015,8 @@ void SpirvEmitter::doDecl(const Decl *decl) {
   } else if (const auto *classTemplateDecl =
                  dyn_cast<ClassTemplateDecl>(decl)) {
     doClassTemplateDecl(classTemplateDecl);
+  } else if (isa<TypedefNameDecl>(decl)) {
+    declIdMapper.recordsSpirvTypeAlias(decl);
   } else if (isa<FunctionTemplateDecl>(decl)) {
     // nothing to do.
   } else if (isa<UsingDecl>(decl)) {
@@ -1696,6 +1697,26 @@ bool SpirvEmitter::validateVKAttributes(const NamedDecl *decl) {
   return success;
 }
 
+void SpirvEmitter::registerCapabilitiesAndExtensionsForVarDecl(
+    const VarDecl *varDecl) {
+  // First record any extensions that part of the actual variable declaration.
+  for (auto *attribute : varDecl->specific_attrs<VKExtensionExtAttr>()) {
+    clang::StringRef extensionName = attribute->getName();
+    spvBuilder.requireExtension(extensionName, varDecl->getLocation());
+  }
+  for (auto *attribute : varDecl->specific_attrs<VKCapabilityExtAttr>()) {
+    spv::Capability cap = spv::Capability(attribute->getCapability());
+    spvBuilder.requireCapability(cap, varDecl->getLocation());
+  }
+
+  // Now check for any capabilities or extensions that are part of the type.
+  const TypedefType *type = dyn_cast<TypedefType>(varDecl->getType());
+  if (!type)
+    return;
+
+  declIdMapper.registerCapabilitiesAndExtensionsForType(type);
+}
+
 void SpirvEmitter::doHLSLBufferDecl(const HLSLBufferDecl *bufferDecl) {
   // This is a cbuffer/tbuffer decl.
   // Check and emit warnings for member intializers which are not
@@ -1846,6 +1867,8 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
         decl, DeclResultIdMapper::ContextUsageKind::ShaderRecordBufferKHR);
     return;
   }
+
+  registerCapabilitiesAndExtensionsForVarDecl(decl);
 
   // Handle vk::ext_builtin_input and vk::ext_builtin_input by using
   // getBuiltinVar to create the builtin and validate the storage class

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1699,7 +1699,8 @@ bool SpirvEmitter::validateVKAttributes(const NamedDecl *decl) {
 
 void SpirvEmitter::registerCapabilitiesAndExtensionsForVarDecl(
     const VarDecl *varDecl) {
-  // First record any extensions that are part of the actual variable declaration.
+  // First record any extensions that are part of the actual variable
+  // declaration.
   for (auto *attribute : varDecl->specific_attrs<VKExtensionExtAttr>()) {
     clang::StringRef extensionName = attribute->getName();
     spvBuilder.requireExtension(extensionName, varDecl->getLocation());

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1699,7 +1699,7 @@ bool SpirvEmitter::validateVKAttributes(const NamedDecl *decl) {
 
 void SpirvEmitter::registerCapabilitiesAndExtensionsForVarDecl(
     const VarDecl *varDecl) {
-  // First record any extensions that part of the actual variable declaration.
+  // First record any extensions that are part of the actual variable declaration.
   for (auto *attribute : varDecl->specific_attrs<VKExtensionExtAttr>()) {
     clang::StringRef extensionName = attribute->getName();
     spvBuilder.requireExtension(extensionName, varDecl->getLocation());

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -412,6 +412,10 @@ private:
   /// errors are found.
   bool validateVKAttributes(const NamedDecl *decl);
 
+  /// Records any Spir-V capabilities and extensions for the given varDecl so
+  /// they will be added to the SPIR-V module.
+  void registerCapabilitiesAndExtensionsForVarDecl(const VarDecl *varDecl);
+
 private:
   /// Converts the given value from the bitwidth of 'fromType' to the bitwidth
   /// of 'toType'. If the two have the same bitwidth, returns the value itself.

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.capability.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.capability.hlsl
@@ -1,12 +1,19 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl -Vd %s -spirv | FileCheck %s
 
-// CHECK: OpCapability Int8
-// CHECK: OpCapability SampleMaskPostDepthCoverage
+// CHECK-DAG: OpCapability Int8
+// CHECK-DAG: OpCapability SampleMaskPostDepthCoverage
+// CHECK-DAG: OpCapability WorkgroupMemoryExplicitLayoutKHR
 
-[[vk::ext_capability(/* SampleMaskPostDepthCoverageCapability */ 4447)]]
-int val;
 
+// Test that the capability on a typedef is added to the module.
 [[vk::ext_capability(/* Int8 */ 39)]]
+typedef vk::SpirvType</* OpTypeInt */ 21, 8, 8, vk::Literal<vk::integral_constant<uint, 8> >, vk::Literal<vk::integral_constant<bool, false> > > uint8_t;
+
+// Test that the capability on a variable is added to the module.
+[[vk::ext_capability(/* SampleMaskPostDepthCoverageCapability */ 4447)]]
+uint8_t val;
+
+// Test that the capability on the entry point is added to the module.
+[[vk::ext_capability(/* WorkgroupMemoryExplicitLayoutKHR */ 4428)]]
 void main() {
-  int local = val;
 }

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.extension.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.extension.hlsl
@@ -1,13 +1,22 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
 
-// CHECK: OpExtension "entry_point_extension"
-// CHECK: OpExtension "another_extension"
-// CHECK: OpExtension "some_extension"
+// CHECK-DAG: OpExtension "entry_point_extension"
+// CHECK-DAG: OpExtension "another_extension"
+// CHECK-DAG: OpExtension "some_extension"
+// CHECK-DAG: OpExtension "ext_on_field1"
+// CHECK-DAG: OpExtension "ext_on_field2"
 
 [[vk::ext_extension("some_extension"), vk::ext_extension("another_extension")]]
 int val;
 
+struct T
+{
+  [[vk::ext_extension("ext_on_field1"), vk::ext_extension("ext_on_field2")]]
+  int val;
+};
+
 [[vk::ext_extension("entry_point_extension")]]
 void main() {
-  int local = val;
+  T t;
+  int local = val+t.val;
 }

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.extension.unused.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.extension.unused.hlsl
@@ -1,11 +1,21 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
 
-// CHECK-NOT: OpExtension "some_extension"
-// CHECK-NOT: OpCapability SampleMaskPostDepthCoverage
+// CHECK-NOT: OpExtension "ext_on_type"
+// CHECK-NOT: OpCapability Int8
+// CHECK-NOT: OpExtension "ext_on_field"
+// CHECK-NOT: OpCapability StorageBuffer8BitAccess
 
-[[vk::ext_extension("some_extension")]]
-[[vk::ext_capability(/* SampleMaskPostDepthCoverageCapability */ 4447)]]
-int val;
+// Test that the capabilities and extensions on an unused type are not added
+// to the Spir-V module.
+using uint8_t [[vk::ext_capability(/* Int8 */ 39), vk::ext_extension("ext_on_type")]] = vk::SpirvType</* OpTypeInt */ 21, 8, 8, vk::Literal<vk::integral_constant<uint, 8> >, vk::Literal<vk::integral_constant<bool, false> > >;
+
+// Test that the capabilities and extensions on a field in an unused struct are
+// not added to the Spir-V module.
+struct T {
+  [[vk::ext_extension("ext_on_field")]]
+  [[vk::ext_capability(/* StorageBuffer8BitAccess */ 4448)]]
+  int v;
+};
 
 void main() {
 }

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.type.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.type.hlsl
@@ -9,12 +9,10 @@
 typedef vk::SpirvOpaqueType</* OpTypeArray */ 28, Texture2D, vk::integral_constant<uint, 4> > ArrayTex2D;
 
 // CHECK: %spirvIntrinsicType_0 = OpTypeInt 8 0
-typedef vk::SpirvOpaqueType</* OpTypeInt */ 21, vk::Literal<vk::integral_constant<uint, 8> >, vk::Literal<vk::integral_constant<bool, false> > > uint8_t;
+using uint8_t [[vk::ext_capability(/* Int8 */ 39)]] = vk::SpirvType</* OpTypeInt */ 21, 8, 8, vk::Literal<vk::integral_constant<uint, 8> >, vk::Literal<vk::integral_constant<bool, false> > >;
 
 // CHECK: %_arr_spirvIntrinsicType_0_uint_4 = OpTypeArray %spirvIntrinsicType_0 %uint_4
 
-// TODO: maybe I've checked this before, but can we add this to uint8_t instead?
-[[vk::ext_capability(/* Int8 */ 39)]]
 void main() {
   // CHECK: %image = OpVariable %_ptr_Function_spirvIntrinsicType Function
   // Array<Texture2D> image;


### PR DESCRIPTION
This implements the changes proposed in
https://github.com/microsoft/hlsl-specs/pull/270.
