### PR TITLE
[NFC]: Rename a template parameter conflict with CALLBACK macro

### DIFF
--- a/tools/clang/include/clang/Analysis/CFG.h
+++ b/tools/clang/include/clang/Analysis/CFG.h
@@ -913,8 +913,7 @@ public:
   // Member templates useful for various batch operations over CFGs.
   //===--------------------------------------------------------------------===//
 
-  template <typename CALLBACK>
-  void VisitBlockStmts(CALLBACK& O) const {
+  template <typename Callback> void VisitBlockStmts(Callback &O) const {
     for (const_iterator I=begin(), E=end(); I != E; ++I)
       for (CFGBlock::const_iterator BI=(*I)->begin(), BE=(*I)->end();
            BI != BE; ++BI) {


### PR DESCRIPTION

    This imports upstream commit
    https://github.com/llvm/llvm-project/commit/54bff1522fc863329894d875d54c2fe4cd1b4f3f
    
    This fixes the following compiler error with clang 18.1.8 with mingw-w64 toolchain.
    
    CFG.h:916:22: error: expected a qualified name after 'typename'
      916 |   template <typename CALLBACK>
          |                      ^
    minwindef.h:90:18: note: expanded from macro 'CALLBACK'
       90 | #define CALLBACK __stdcall
          |                  ^
