### PR TITLE
[SPIR-V] Fix crash when using entrypoint prototype

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -770,7 +770,8 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
                                  funcDecl, /*isEntryFunction*/ false);
         }
       } else {
-        if (funcDecl->getName() == hlslEntryFunctionName) {
+        const bool isPrototype = !funcDecl->isThisDeclarationADefinition();
+        if (funcDecl->getName() == hlslEntryFunctionName && !isPrototype) {
           addFunctionToWorkQueue(spvContext.getCurrentShaderModelKind(),
                                  funcDecl, /*isEntryFunction*/ true);
           numEntryPoints++;

--- a/tools/clang/test/CodeGenSPIRV/spirv.entry-function.prototype.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.entry-function.prototype.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T cs_6_6 -E main -spirv %s | FileCheck %s
+
+void main();
+
+// CHECK:     OpEntryPoint GLCompute %main "main"
+[numthreads(1, 1, 1)]
+void main() {
+}


### PR DESCRIPTION
When the prototype of an entrypoint was defined, the codegen crashed because it failed to filter this partial declaration when adding functions to the work-queue.

Fixes #6750