### PR TITLE
[NFC] Remove implicit `this` capture in lambdas

### DIFF
--- a/tools/clang/lib/AST/ASTDumper.cpp
+++ b/tools/clang/lib/AST/ASTDumper.cpp
@@ -341,7 +341,7 @@ namespace  {
       for (QualType PT : T->getParamTypes())
         dumpTypeAsChild(PT);
       if (EPI.Variadic)
-        dumpChild([=] { OS << "..."; });
+        dumpChild([=, this] { OS << "..."; });
     }
     void VisitUnresolvedUsingType(const UnresolvedUsingType *T) {
       dumpDeclRef(T->getDecl());
@@ -646,7 +646,7 @@ void ASTDumper::dumpTypeAsChild(QualType T) {
   if (!SQT.Quals.hasQualifiers())
     return dumpTypeAsChild(SQT.Ty);
 
-  dumpChild([=] {
+  dumpChild([=, this] {
     OS << "QualType";
     dumpPointer(T.getAsOpaquePtr());
     OS << " ";
@@ -657,7 +657,7 @@ void ASTDumper::dumpTypeAsChild(QualType T) {
 }
 
 void ASTDumper::dumpTypeAsChild(const Type *T) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     if (!T) {
       ColorScope Color(*this, NullColor);
       OS << "<<<NULL>>>";
@@ -714,7 +714,7 @@ void ASTDumper::dumpDeclRef(const Decl *D, const char *Label) {
   if (!D)
     return;
 
-  dumpChild([=]{
+  dumpChild([=, this]{
     if (Label)
       OS << Label << ' ';
     dumpBareDeclRef(D);
@@ -748,7 +748,7 @@ void ASTDumper::dumpDeclContext(const DeclContext *DC) {
   // HLSL Change Ends
 
   if (DC->hasExternalLexicalStorage()) {
-    dumpChild([=]{
+    dumpChild([=, this]{
       ColorScope Color(*this, UndeserializedColor);
       OS << "<undeserialized declarations>";
     });
@@ -756,7 +756,7 @@ void ASTDumper::dumpDeclContext(const DeclContext *DC) {
 }
 
 void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     OS << "StoredDeclsMap ";
     dumpBareDeclRef(cast<Decl>(DC));
 
@@ -774,7 +774,7 @@ void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
       DeclarationName Name = I.getLookupName();
       DeclContextLookupResult R = *I++;
 
-      dumpChild([=] {
+      dumpChild([=, this] {
         OS << "DeclarationName ";
         {
           ColorScope Color(*this, DeclNameColor);
@@ -783,7 +783,7 @@ void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
 
         for (DeclContextLookupResult::iterator RI = R.begin(), RE = R.end();
              RI != RE; ++RI) {
-          dumpChild([=] {
+          dumpChild([=, this] {
             dumpBareDeclRef(*RI);
 
             if ((*RI)->isHidden())
@@ -805,7 +805,7 @@ void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
     }
 
     if (HasUndeserializedLookups) {
-      dumpChild([=] {
+      dumpChild([=, this] {
         ColorScope Color(*this, UndeserializedColor);
         OS << "<undeserialized lookups>";
       });
@@ -814,7 +814,7 @@ void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
 }
 
 void ASTDumper::dumpAttr(const Attr *A) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     {
       ColorScope Color(*this, AttrColor);
 
@@ -886,7 +886,7 @@ void ASTDumper::dumpAccessSpecifier(AccessSpecifier AS) {
 }
 
 void ASTDumper::dumpCXXCtorInitializer(const CXXCtorInitializer *Init) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     OS << "CXXCtorInitializer";
     if (Init->isAnyMemberInitializer()) {
       OS << ' ';
@@ -927,7 +927,7 @@ void ASTDumper::dumpTemplateArgumentList(const TemplateArgumentList &TAL) {
 }
 
 void ASTDumper::dumpTemplateArgument(const TemplateArgument &A, SourceRange R) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     OS << "TemplateArgument";
     if (R.isValid())
       dumpSourceRange(R);
@@ -993,7 +993,7 @@ void ASTDumper::dumpHLSLUnusualAnnotations(const ArrayRef<hlsl::UnusualAnnotatio
 {
   for (auto It = UA.begin(), E = UA.end(); It != E; ++It)
   {
-    dumpChild([=] {
+    dumpChild([=, this] {
       {
         ColorScope Color(*this, AttrColor);
         switch ((*It)->getKind())
@@ -1081,7 +1081,7 @@ void ASTDumper::dumpHLSLUnusualAnnotations(const ArrayRef<hlsl::UnusualAnnotatio
 // HLSL Change Ends
 
 void ASTDumper::dumpDecl(const Decl *D) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     if (!D) {
       ColorScope Color(*this, NullColor);
       OS << "<<<NULL>>>";
@@ -1113,7 +1113,7 @@ void ASTDumper::dumpDecl(const Decl *D) {
     if (auto *ND = dyn_cast<NamedDecl>(D))
       for (Module *M : D->getASTContext().getModulesWithMergedDefinition(
                const_cast<NamedDecl *>(ND)))
-        dumpChild([=] { OS << "also in " << M->getFullModuleName(); });
+        dumpChild([=, this] { OS << "also in " << M->getFullModuleName(); });
     if (const NamedDecl *ND = dyn_cast<NamedDecl>(D))
       if (ND->isHidden())
         OS << " hidden";
@@ -1253,7 +1253,7 @@ void ASTDumper::VisitFunctionDecl(const FunctionDecl *D) {
     dumpDecl(*I);
 
   if (!D->param_begin() && D->getNumParams())
-    dumpChild([=] { OS << "<<NULL params x " << D->getNumParams() << ">>"; });
+    dumpChild([=, this] { OS << "<<NULL params x " << D->getNumParams() << ">>"; });
   else
     for (FunctionDecl::param_const_iterator I = D->param_begin(),
                                             E = D->param_end();
@@ -1356,7 +1356,7 @@ void ASTDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
     return;
 
   for (const auto &I : D->bases()) {
-    dumpChild([=] {
+    dumpChild([=, this] {
       if (I.isVirtual())
         OS << "virtual ";
       dumpAccessSpecifier(I.getAccessSpecifier());
@@ -1595,7 +1595,7 @@ void ASTDumper::VisitObjCMethodDecl(const ObjCMethodDecl *D) {
   }
 
   if (D->isVariadic())
-    dumpChild([=] { OS << "..."; });
+    dumpChild([=, this] { OS << "..."; });
 
   if (D->hasBody())
     dumpStmt(D->getBody());
@@ -1723,13 +1723,13 @@ void ASTDumper::VisitBlockDecl(const BlockDecl *D) {
     dumpDecl(I);
 
   if (D->isVariadic())
-    dumpChild([=]{ OS << "..."; });
+    dumpChild([=, this]{ OS << "..."; });
 
   if (D->capturesCXXThis())
-    dumpChild([=]{ OS << "capture this"; });
+    dumpChild([=, this]{ OS << "capture this"; });
 
   for (const auto &I : D->captures()) {
-    dumpChild([=] {
+    dumpChild([=, this] {
       OS << "capture";
       if (I.isByRef())
         OS << " byref";
@@ -1751,7 +1751,7 @@ void ASTDumper::VisitBlockDecl(const BlockDecl *D) {
 //===----------------------------------------------------------------------===//
 
 void ASTDumper::dumpStmt(const Stmt *S) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     if (!S) {
       ColorScope Color(*this, NullColor);
       OS << "<<<NULL>>>";
@@ -1965,7 +1965,7 @@ void ASTDumper::VisitStringLiteral(const StringLiteral *Str) {
 void ASTDumper::VisitInitListExpr(const InitListExpr *ILE) {
   VisitExpr(ILE);
   if (auto *Filler = ILE->getArrayFiller()) {
-    dumpChild([=] {
+    dumpChild([=, this] {
       OS << "array filler";
       dumpStmt(Filler);
     });
@@ -2302,7 +2302,7 @@ void ASTDumper::dumpFullComment(const FullComment *C) {
 }
 
 void ASTDumper::dumpComment(const Comment *C) {
-  dumpChild([=] {
+  dumpChild([=, this] {
     if (!C) {
       ColorScope Color(*this, NullColor);
       OS << "<<<NULL>>>";

--- a/tools/clang/lib/AST/ASTDumper.cpp
+++ b/tools/clang/lib/AST/ASTDumper.cpp
@@ -714,7 +714,7 @@ void ASTDumper::dumpDeclRef(const Decl *D, const char *Label) {
   if (!D)
     return;
 
-  dumpChild([=, this]{
+  dumpChild([=, this] {
     if (Label)
       OS << Label << ' ';
     dumpBareDeclRef(D);
@@ -748,7 +748,7 @@ void ASTDumper::dumpDeclContext(const DeclContext *DC) {
   // HLSL Change Ends
 
   if (DC->hasExternalLexicalStorage()) {
-    dumpChild([=, this]{
+    dumpChild([=, this] {
       ColorScope Color(*this, UndeserializedColor);
       OS << "<undeserialized declarations>";
     });
@@ -998,14 +998,18 @@ void ASTDumper::dumpHLSLUnusualAnnotations(const ArrayRef<hlsl::UnusualAnnotatio
         ColorScope Color(*this, AttrColor);
         switch ((*It)->getKind())
         {
-          case hlsl::UnusualAnnotation::UA_ConstantPacking:
-            OS << "ConstantPacking"; break;
-          case hlsl::UnusualAnnotation::UA_RegisterAssignment:
-            OS << "RegisterAssignment"; break;
-          case hlsl::UnusualAnnotation::UA_SemanticDecl:
-            OS << "SemanticDecl"; break;
-          case hlsl::UnusualAnnotation::UA_PayloadAccessQualifier:
-            OS << "PayloadAccessQualifier"; break;
+        case hlsl::UnusualAnnotation::UA_ConstantPacking:
+          OS << "ConstantPacking";
+          break;
+        case hlsl::UnusualAnnotation::UA_RegisterAssignment:
+          OS << "RegisterAssignment";
+          break;
+        case hlsl::UnusualAnnotation::UA_SemanticDecl:
+          OS << "SemanticDecl";
+          break;
+        case hlsl::UnusualAnnotation::UA_PayloadAccessQualifier:
+          OS << "PayloadAccessQualifier";
+          break;
         }
       }
       dumpPointer(It);
@@ -1014,48 +1018,52 @@ void ASTDumper::dumpHLSLUnusualAnnotations(const ArrayRef<hlsl::UnusualAnnotatio
       switch ((*It)->getKind())
       {
       case hlsl::UnusualAnnotation::UA_ConstantPacking: {
-          const hlsl::ConstantPacking* constantPacking = cast<hlsl::ConstantPacking>(*It);
-          OS << " packoffset(c";
-          OS << constantPacking->Subcomponent;
-          OS << ".";
-          const char *xyzw[4] = { "x", "y", "z", "w" };
-          if(constantPacking->ComponentOffset < 4)
-            OS << xyzw[constantPacking->ComponentOffset];
-          else
-            OS << "<invalid>";
-          OS << ")";
-          if (!constantPacking->IsValid)
-            OS << " invalid";
-          break;
-        }
+        const hlsl::ConstantPacking *constantPacking =
+            cast<hlsl::ConstantPacking>(*It);
+        OS << " packoffset(c";
+        OS << constantPacking->Subcomponent;
+        OS << ".";
+        const char *xyzw[4] = {"x", "y", "z", "w"};
+        if (constantPacking->ComponentOffset < 4)
+          OS << xyzw[constantPacking->ComponentOffset];
+        else
+          OS << "<invalid>";
+        OS << ")";
+        if (!constantPacking->IsValid)
+          OS << " invalid";
+        break;
+      }
       case hlsl::UnusualAnnotation::UA_RegisterAssignment: {
-          const hlsl::RegisterAssignment* registerAssignment = cast<hlsl::RegisterAssignment>(*It);
-          OS << " register(";
-          if (!registerAssignment->ShaderProfile.empty())
-            OS << registerAssignment->ShaderProfile << ", ";
-          bool needsComma = false;
-          if (!registerAssignment->isSpaceOnly()) {
-            if (!registerAssignment->RegisterType)
-              OS << "invalid";
-            else
-              OS << StringRef(&registerAssignment->RegisterType, 1);
-            OS << registerAssignment->RegisterNumber + registerAssignment->RegisterOffset;
-            needsComma = true;
-          }
-          if (registerAssignment->RegisterSpace.hasValue()) {
-            if (needsComma) OS << ", ";
-            OS << "space" << registerAssignment->RegisterSpace.getValue();
-          }
-          OS << ")";
-          if (!registerAssignment->IsValid)
-            OS << " invalid";
-          break;
+        const hlsl::RegisterAssignment *registerAssignment =
+            cast<hlsl::RegisterAssignment>(*It);
+        OS << " register(";
+        if (!registerAssignment->ShaderProfile.empty())
+          OS << registerAssignment->ShaderProfile << ", ";
+        bool needsComma = false;
+        if (!registerAssignment->isSpaceOnly()) {
+          if (!registerAssignment->RegisterType)
+            OS << "invalid";
+          else
+            OS << StringRef(&registerAssignment->RegisterType, 1);
+          OS << registerAssignment->RegisterNumber +
+                    registerAssignment->RegisterOffset;
+          needsComma = true;
         }
+        if (registerAssignment->RegisterSpace.hasValue()) {
+          if (needsComma)
+            OS << ", ";
+          OS << "space" << registerAssignment->RegisterSpace.getValue();
+        }
+        OS << ")";
+        if (!registerAssignment->IsValid)
+          OS << " invalid";
+        break;
+      }
       case hlsl::UnusualAnnotation::UA_SemanticDecl: {
-          const hlsl::SemanticDecl* semanticDecl = cast<hlsl::SemanticDecl>(*It);
-          OS << " \"" << semanticDecl->SemanticName << "\"";
-          break;
-        }      
+        const hlsl::SemanticDecl *semanticDecl = cast<hlsl::SemanticDecl>(*It);
+        OS << " \"" << semanticDecl->SemanticName << "\"";
+        break;
+      }
       case hlsl::UnusualAnnotation::UA_PayloadAccessQualifier: {
         const hlsl::PayloadAccessAnnotation *annotation =
             cast<hlsl::PayloadAccessAnnotation>(*It);
@@ -1253,7 +1261,8 @@ void ASTDumper::VisitFunctionDecl(const FunctionDecl *D) {
     dumpDecl(*I);
 
   if (!D->param_begin() && D->getNumParams())
-    dumpChild([=, this] { OS << "<<NULL params x " << D->getNumParams() << ">>"; });
+    dumpChild(
+        [=, this] { OS << "<<NULL params x " << D->getNumParams() << ">>"; });
   else
     for (FunctionDecl::param_const_iterator I = D->param_begin(),
                                             E = D->param_end();
@@ -1723,10 +1732,10 @@ void ASTDumper::VisitBlockDecl(const BlockDecl *D) {
     dumpDecl(I);
 
   if (D->isVariadic())
-    dumpChild([=, this]{ OS << "..."; });
+    dumpChild([=, this] { OS << "..."; });
 
   if (D->capturesCXXThis())
-    dumpChild([=, this]{ OS << "capture this"; });
+    dumpChild([=, this] { OS << "capture this"; });
 
   for (const auto &I : D->captures()) {
     dumpChild([=, this] {

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -171,7 +171,7 @@ namespace clang {
       if (LinkModule) {
         if (Linker::LinkModules(
                 M, LinkModule.get(),
-                [=](const DiagnosticInfo &DI) { linkerDiagnosticHandler(DI); }))
+                [=, this](const DiagnosticInfo &DI) { linkerDiagnosticHandler(DI); }))
           return;
       }
 

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -169,9 +169,10 @@ namespace clang {
 
       // Link LinkModule into this module if present, preserving its validity.
       if (LinkModule) {
-        if (Linker::LinkModules(
-                M, LinkModule.get(),
-                [=, this](const DiagnosticInfo &DI) { linkerDiagnosticHandler(DI); }))
+        if (Linker::LinkModules(M, LinkModule.get(),
+                                [=, this](const DiagnosticInfo &DI) {
+                                  linkerDiagnosticHandler(DI);
+                                }))
           return;
       }
 

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -170,7 +170,7 @@ namespace clang {
       // Link LinkModule into this module if present, preserving its validity.
       if (LinkModule) {
         if (Linker::LinkModules(M, LinkModule.get(),
-                                [=, this](const DiagnosticInfo &DI) {
+                                [this](const DiagnosticInfo &DI) {
                                   linkerDiagnosticHandler(DI);
                                 }))
           return;

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -1964,7 +1964,8 @@ Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
            "Diagnosing an empty lookup with explicit template args!");
     *Out = CorrectTypoDelayed(
         R.getLookupNameInfo(), R.getLookupKind(), S, &SS, std::move(CCC),
-        [=, this](const TypoCorrection &TC) {
+        [this, SS, Name, TypoLoc, Args, diagnostic,
+         diagnostic_suggest](const TypoCorrection &TC) {
           emitEmptyLookupTypoDiagnostic(TC, *this, SS, Name, TypoLoc, Args,
                                         diagnostic, diagnostic_suggest);
         },

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -1964,7 +1964,7 @@ Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
            "Diagnosing an empty lookup with explicit template args!");
     *Out = CorrectTypoDelayed(
         R.getLookupNameInfo(), R.getLookupKind(), S, &SS, std::move(CCC),
-        [=](const TypoCorrection &TC) {
+        [=, this](const TypoCorrection &TC) {
           emitEmptyLookupTypoDiagnostic(TC, *this, SS, Name, TypoLoc, Args,
                                         diagnostic, diagnostic_suggest);
         },


### PR DESCRIPTION
When declaring a lambda with a value-capture default [=, ...], the this pointer is implicitly captured by value as well. This results in potentially-unintuitive behavior and has been deprecated in C++20. It produces a warning in newer versions of clang (https://reviews.llvm.org/D142639).

This PR makes the implicit captures explicit, preventing the warning. It does not change the compiled code at all, since it's just removing some syntactic sugar.