### PR TITLE
Use a real instruction for the sentinel in the Instruction intrusive …

### DIFF
--- a/lib/IR/BasicBlock.cpp
+++ b/lib/IR/BasicBlock.cpp
@@ -37,10 +37,17 @@ LLVMContext &BasicBlock::getContext() const {
 // are not in the public header file...
 template class llvm::SymbolTableListTraits<Instruction, BasicBlock>;
 
-
 BasicBlock::BasicBlock(LLVMContext &C, const Twine &Name, Function *NewParent,
                        BasicBlock *InsertBefore)
-  : Value(Type::getLabelTy(C), Value::BasicBlockVal), Parent(nullptr) {
+    : Value(Type::getLabelTy(C), Value::BasicBlockVal),
+      // HLSL Change Starts
+      // Use a real instruction as the sentinel. Transfer ownership to InstList.
+      // The sentinel only needs to participate in the intrusive list of
+      // instructions. Any instruction kind will do, but UnreachableInst is
+      // small and simple.
+      InstList(std::unique_ptr<Instruction>(new UnreachableInst(C))),
+      // HLSL Change Ends
+      Parent(nullptr) {
 
   // HLSL Change Begin
   // Do everything that can throw before inserting into the


### PR DESCRIPTION
…list

Instructions in a BasicBlock are maintained in a doubly-linked list. The links are "instrusive" in the sense that with inheritance tricks the Next and Prev nodes are embedded in the Instruction object itself.

The linked list uses a sentinel object to mark the tail of the list.

Previously, the sentinel was an ilist_half_node<Instruction> which just consists of a 'Instruction* Prev', but then it was cast to Instruction*. This is flagged by the undefined behaviour sanitizer in some cases. Also, it's weird and wrong.

Upstream LLVM has entirely reimplimented the intrusive list to avoid such problems.  But that's a massive change.

This change uses a real Instruction object as the sentinel. The instruction is only used for its Next and Prev properties. I used an UnreachableInst becuase it's small and simple.

Issue: #6446