### PR TITLE
Add CMake option DXC_CODEGEN_EXCEPTIONS_TRAP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ endif()
 option(DXC_DISABLE_ALLOCATOR_OVERRIDES "Disable usage of allocator overrides" OFF)
 mark_as_advanced(DXC_DISABLE_ALLOCATOR_OVERRIDES)
 
+option(DXC_CODEGEN_EXCEPTIONS_TRAP "An exception in code generation generates a trap, ending the compiler process" OFF)
+mark_as_advanced(DXC_CODEGEN_EXCEPTIONS_TRAP)
+
 # adjust link option to enable debugging from kernel mode; not compatible with incremental linking
 if(NOT CMAKE_VERSION VERSION_LESS "3.13" AND MSVC AND NOT CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64EC")
   add_link_options(/DEBUGTYPE:CV,FIXUP,PDATA /INCREMENTAL:NO)

--- a/include/dxc/config.h.cmake
+++ b/include/dxc/config.h.cmake
@@ -1,2 +1,4 @@
 /* Disable overriding memory allocators. */
 #cmakedefine DXC_DISABLE_ALLOCATOR_OVERRIDES
+/* Generate a trap if an hlsl::Exception is thrown during code generation */
+#cmakedefine DXC_CODEGEN_EXCEPTIONS_TRAP

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -8,6 +8,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/CodeGen/BackendUtil.h"
+#include "dxc/HLSL/DxilGenerationPass.h" // HLSL Change
+#include "dxc/HLSL/HLMatrixLowerPass.h"  // HLSL Change
+#include "dxc/Support/Global.h"          // HLSL Change
+#include "dxc/config.h"                  // HLSL Change
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/TargetOptions.h"
@@ -41,10 +45,8 @@
 #include "llvm/Transforms/ObjCARC.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/SymbolRewriter.h"
+#include <cstdio>
 #include <memory>
-#include "dxc/HLSL/DxilGenerationPass.h" // HLSL Change
-#include "dxc/HLSL/HLMatrixLowerPass.h"  // HLSL Change
-#include "dxc/Support/Global.h" // HLSL Change
 
 using namespace clang;
 using namespace llvm;
@@ -782,6 +784,13 @@ void clang::EmitBackendOutput(DiagnosticsEngine &Diags,
   } catch (const ::hlsl::Exception &hlslException) {
     Diags.Report(Diags.getCustomDiagID(DiagnosticsEngine::Error, "%0\n"))
         << StringRef(hlslException.what());
+#if defined(DXC_CODEGEN_EXCEPTIONS_TRAP)
+    // llvm::errs() doesn't work in release builds on Linux.
+    // Use C-style fprintf because it works everywhere.
+    fprintf(stderr, "internal codegen error: %s\n", hlslException.what());
+    fflush(stderr);
+    LLVM_BUILTIN_TRAP;
+#endif
   } // HLSL Change Ends
 
   // If an optional clang TargetInfo description string was passed in, use it to


### PR DESCRIPTION
When enabled, any hlsl::Exception thrown during code generation and optimization will cause the process to trap.


---
edit: I've changed the implementation to generate a trap, instead of std::abort