### PR TITLE
[SPIR-V] Lower templated enums correctly.

### DIFF
--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -619,6 +619,14 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     return spvContext.getSIntType(32);
   }
 
+  // Templated types.
+  if (const auto *spec = type->getAs<TemplateSpecializationType>()) {
+    return lowerType(spec->desugar(), rule, isRowMajor, srcLoc);
+  }
+  if (const auto *spec = type->getAs<SubstTemplateTypeParmType>()) {
+    return lowerType(spec->desugar(), rule, isRowMajor, srcLoc);
+  }
+
   emitError("lower type %0 unimplemented", srcLoc) << type->getTypeClassName();
   type->dump();
   return 0;

--- a/tools/clang/test/CodeGenSPIRV/type.enum.templated.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.enum.templated.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T cs_6_6 -E main -spirv %s -fcgl | FileCheck %s
+
+template<typename T>
+void templated_func() {
+  T tmp;
+}
+
+template<typename T>
+void templated_func_deduced(T tmp) {
+}
+
+enum MyEnum { };
+
+template<typename T>
+using TemplatedType = MyEnum;
+
+[numthreads(1, 1, 1)]
+void main() {
+// CHECK: %a = OpVariable %_ptr_Function_int Function
+  TemplatedType<MyEnum> a;
+
+// CHECK: OpFunctionCall %void %templated_func
+  templated_func<MyEnum>();
+
+// CHECK: [[a:%[0-9]+]] = OpLoad %int %a
+// CHECK:                 OpStore %param_var_tmp [[a]]
+// CHECK:                 OpFunctionCall %void %templated_func_deduced %param_var_tmp
+  templated_func_deduced(a);
+}


### PR DESCRIPTION
Templated enums lowering was not supported. This commit fixes those cases.

Fixes #6753