### PR TITLE
[SPIRV] Fix documentation for RayTCurrent

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -3588,7 +3588,7 @@ Intrinsics
 ``WorldRayOrigin()``            ``WorldRayOrigin{NV/KHR}``                 ✓             ✓          ✓       ✓
 ``WorldRayDirection()``         ``WorldRayDirection{NV/KHR}``              ✓             ✓          ✓       ✓
 ``RayTMin()``                   ``RayTmin{NV/KHR}``                        ✓             ✓          ✓       ✓
-``RayTCurrent()``               ``HitT{NV/KHR}``                           ✓             ✓          ✓       ✓
+``RayTCurrent()``               ``RayTmax{NV/KHR}``                        ✓             ✓          ✓       ✓
 ``RayFlags()``                  ``IncomingRayFlags{NV/KHR}``               ✓             ✓          ✓       ✓
 ``InstanceIndex()``             ``InstanceId``                             ✓             ✓          ✓
 ``GeometryIndex()``             ``RayGeometryIndexKHR``                    ✓             ✓          ✓


### PR DESCRIPTION
The documentation says that we use the HitTKHR builtin to implement
RayTCurrent. However, HitTKHR was renamed to RayTMaxKHR. We update
the documentation to represent that change.

Fixes #6739
