### PR TITLE
Release Note for OS-normalized include paths (#6789)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -69,6 +69,8 @@ DX Compiler release for March 2024
   - Validation errors more accurately determine usage by the entry point
 - Improve debug info generation
 - Further improvements to Linux build quality
+- File paths arguments for `IDxcIncludeHandler::LoadSource` will now be normalized to use OS specific slashes
+  (`\` for windows, `/` for *nix) and no longer have double slashes except for UNC paths (`\\my\unc\path`).”
 
 ### Version 1.7.2308
 


### PR DESCRIPTION
The behavior was changed with #6317 so that regardless of spelling in the shader, the include path will conform to the host OS style for the purposes of the include handler. This just adds a release note for that new behavior.

Fixes #6669

(cherry picked from commit 9fa4618de91a0d80168a13cf71e1fc0355001b7c)