### PR TITLE
Add upcoming release section to release notes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,6 +18,10 @@ The included licenses apply to the following files:
 
 ## Changelog
 
+### Upcoming Release
+
+Place release notes for the upcoming release below this line and remove this line upon naming this release.
+
 ### Version 1.8.2407
 
 This cumulative release contains numerous bug fixes and stability improvments.


### PR DESCRIPTION
This is the section where the next release notes will be inserted. It's just a placeholder instruction for now.

Fixes #6697