### PR TITLE
[Action] Use pull_request_target

### DIFF
--- a/.github/workflows/pr-description-checker.yml
+++ b/.github/workflows/pr-description-checker.yml
@@ -1,6 +1,6 @@
 name: 'PR description checker'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
We should use the pull_request_target option here so that the PR runs from the pipeline in the target rather than the PR source branch. This allows the action to run with reduced security implications.