### PR TITLE
[Metal] Add experimental Metal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Development kits containing only the dxc.exe driver app, the dxcompiler.dll, and
 
 As an example of community contribution, this project can also target the [SPIR-V](https://www.khronos.org/registry/spir-v/) intermediate representation. Please see the [doc](docs/SPIR-V.rst) for how HLSL features are mapped to SPIR-V, and the [wiki](https://github.com/microsoft/DirectXShaderCompiler/wiki/SPIR%E2%80%90V-CodeGen) page for how to build, use, and contribute to the SPIR-V CodeGen.
 
+### Metal CodeGen
+
+When built from source DXC can utilize the [Metal Shader
+Converter](https://developer.apple.com/metal/shader-converter/) if it is
+available during build and configuration time. This allows DXC to generate Metal
+shader libraries directly using the `-metal` flag.
+
+Note: DXC cannot currently disassemble Metal shaders so the `-Fc` flag cannot be
+used in conjunction with the `-Fo` flag.
+
 ## Building Sources
 
 See the full documentation for [Building and testing DXC](docs/BuildingAndTestingDXC.rst) for detailed instructions.

--- a/cmake/config-ix.cmake
+++ b/cmake/config-ix.cmake
@@ -568,3 +568,12 @@ else()
 endif()
 
 string(REPLACE " " ";" LLVM_BINDINGS_LIST "${LLVM_BINDINGS}")
+
+# HLSL Change Begin - Metal IR Converter
+find_package(MetalIRConverter)
+if (METAL_IRCONVERTER_FOUND)
+  set(ENABLE_METAL_CODEGEN On)
+  message(STATUS "Enabling Metal Support")
+  add_definitions(-DENABLE_METAL_CODEGEN)
+endif()
+# HLSL Change End - Metal IR Converter

--- a/cmake/modules/FindMetalIRConverter.cmake
+++ b/cmake/modules/FindMetalIRConverter.cmake
@@ -1,0 +1,16 @@
+find_path(METAL_IRCONVERTER_INCLUDE_DIR metal_irconverter.h
+          HINTS /usr/local/include/metal_irconverter
+          DOC "Path to metal IR converter headers"
+          )
+
+find_library(METAL_IRCONVERTER_LIB NAMES metalirconverter
+  PATH_SUFFIXES lib
+  )
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(METAL_IRCONVERTER
+                                    REQUIRED_VARS METAL_IRCONVERTER_LIB METAL_IRCONVERTER_INCLUDE_DIR)
+
+message(STATUS "Metal IR Converter Include Dir: ${METAL_IRCONVERTER_INCLUDE_DIR}")
+message(STATUS "Metal IR Converter Library: ${METAL_IRCONVERTER_LIB}")
+mark_as_advanced(METAL_IRCONVERTER_LIB METAL_IRCONVERTER_INCLUDE_DIR)

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -274,6 +274,8 @@ public:
       SpirvOptions; // All SPIR-V CodeGen-related options
 #endif
   // SPIRV Change Ends
+
+  bool GenMetal = false; // OPT_metal
 };
 
 /// Use this class to capture, convert and handle the lifetime for the

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -346,8 +346,10 @@ def disable_exception_handling : Flag<["-", "/"], "disable-exception-handling">,
 def skip_serialization : Flag<["-", "/"], "skip-serialization">, Group<hlslcore_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Return a module interface instead of serialized output">;
 
-def metal : Flag<["-"], "metal">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Generate Metal code">;
+def metal : Flag<["-"], "metal">,
+            Group<spirv_Group>,
+            Flags<[CoreOption, DriverOption]>,
+            HelpText<"Generate Metal code">;
 
 // SPIRV Change Starts
 def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -346,6 +346,9 @@ def disable_exception_handling : Flag<["-", "/"], "disable-exception-handling">,
 def skip_serialization : Flag<["-", "/"], "skip-serialization">, Group<hlslcore_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Return a module interface instead of serialized output">;
 
+def metal : Flag<["-"], "metal">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Generate Metal code">;
+
 // SPIRV Change Starts
 def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Generate SPIR-V code">;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1089,6 +1089,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 
   addDiagnosticArgs(Args, OPT_W_Group, OPT_W_value_Group, opts.Warnings);
 
+  opts.GenMetal = Args.hasFlag(OPT_metal, OPT_INVALID, false);
+
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN
   opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
@@ -1312,6 +1314,21 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   }
 #endif // ENABLE_SPIRV_CODEGEN
   // SPIRV Change Ends
+
+#ifndef ENABLE_METAL_CODEGEN
+  if (opts.GenMetal) {
+    errors << "Metal CodeGen not available. "
+              "Please rebuild with Metal IR Converter installed.";
+    return 1;
+  }
+#endif
+
+  if (opts.GenMetal) {
+    if (!opts.AssemblyCode.empty() || opts.OutputObject.empty()) {
+      errors << "Disassembly of Metal IR not supported (yet).";
+      return 1;
+    }
+  }
 
   // Validation for DebugInfo here because spirv uses same DebugInfo opt,
   // and legacy wrappers will add EmbedDebug in this case, leading to this

--- a/tools/clang/test/DXC/metal.test
+++ b/tools/clang/test/DXC/metal.test
@@ -1,0 +1,7 @@
+// REQUIRES: metal
+
+// Metal libraries are LLVM bitcode. This check inspects the magic number from
+// the metal library output.
+// RUN: %dxc %S/Inputs/smoke.hlsl  /T ps_6_0 -metal -Fo Tmp.metal
+// RUN: head -c 4 Tmp.metal | FileCheck -check-prefix=MTL %s
+// MTL: {{^MTLB}}

--- a/tools/clang/test/DXC/no_metal.test
+++ b/tools/clang/test/DXC/no_metal.test
@@ -1,0 +1,4 @@
+// UNSUPPORTED: metal
+
+// RUN:not %dxc %S/Inputs/smoke.hlsl  /T ps_6_0 -metal 2>&1 | FileCheck %s
+// CHECK:Metal CodeGen not available

--- a/tools/clang/test/DXC/no_metal_disassembly.test
+++ b/tools/clang/test/DXC/no_metal_disassembly.test
@@ -1,0 +1,7 @@
+// REQUIRES: metal
+
+// These cases both fail because the shader converter library cannot emit
+// textual IR.
+// RUN: not %dxc %S/Inputs/smoke.hlsl  /T ps_6_0 -metal -Fo Tmp.metal -Fc Tmp.air 2>&1 | FileCheck %s
+// RUN: not %dxc %S/Inputs/smoke.hlsl  /T ps_6_0 -metal 2>&1 | FileCheck %s
+// CHECK: Disassembly of Metal IR not supported (yet).

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -504,6 +504,9 @@ if config.enable_backtrace == "1":
 if config.spirv:
     config.available_features.add("spirv")
 
+if config.metal:
+    config.available_features.add("metal")
+
 # Check supported dxil version
 def get_dxil_version():
     result = subprocess.run([lit.util.which('dxc', llvm_tools_dir), "--version"], stdout=subprocess.PIPE)

--- a/tools/clang/test/lit.site.cfg.in
+++ b/tools/clang/test/lit.site.cfg.in
@@ -22,6 +22,7 @@ config.enable_backtrace = "@ENABLE_BACKTRACES@"
 config.host_arch = "@HOST_ARCH@"
 config.spirv = "@ENABLE_SPIRV_CODEGEN@" =="ON"
 config.hlsl_headers_dir = "@HLSL_HEADERS_DIR@" # HLSL change
+config.metal = "@ENABLE_METAL_CODEGEN@".upper() == "ON" # HLSL change
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -136,6 +136,14 @@ target_link_libraries(dxcompiler PRIVATE ${LIBRARIES})
 if (ENABLE_SPIRV_CODEGEN)
   target_link_libraries(dxcompiler PRIVATE clangSPIRV)
 endif (ENABLE_SPIRV_CODEGEN)
+if (ENABLE_METAL_CODEGEN)
+  target_link_libraries(dxcompiler PRIVATE ${METAL_IRCONVERTER_LIB})
+  target_include_directories(dxcompiler PRIVATE ${METAL_IRCONVERTER_INCLUDE_DIR})
+
+  get_filename_component(METAL_IRCONVERTER_LIB_DIR ${METAL_IRCONVERTER_LIB} DIRECTORY CACHE)
+  set_property(TARGET dxcompiler APPEND_STRING
+               PROPERTY LINK_FLAGS " -Wl,-rpath,${METAL_IRCONVERTER_LIB_DIR}")
+endif (ENABLE_METAL_CODEGEN)
 include_directories(AFTER ${LLVM_INCLUDE_DIR}/dxc/Tracing ${DIASDK_INCLUDE_DIRS} ${HLSL_VERSION_LOCATION})
 include_directories(${LLVM_SOURCE_DIR}/tools/clang/tools/dxcvalidator)
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1176,18 +1176,18 @@ public:
                    "Library targets not supported for Metal (yet).");
             IRObjectGetMetalLibBinary(AIR, Stage, MetalLib);
             size_t MetalLibSize = IRMetalLibGetBytecodeSize(MetalLib);
-            uint8_t *MetalLibBytes = new uint8_t[MetalLibSize];
-            IRMetalLibGetBytecode(MetalLib, MetalLibBytes);
+            std::unique_ptr<uint8_t[]> MetalLibBytes =
+                std::unique_ptr<uint8_t[]>(new uint8_t[MetalLibSize]);
+            IRMetalLibGetBytecode(MetalLib, MetalLibBytes.get());
 
             // Store the metallib to custom format or disk, or use to create a
             // MTLLibrary.
 
             CComPtr<IDxcBlob> MetalBlob;
             IFT(hlsl::DxcCreateBlobOnHeapCopy(
-                MetalLibBytes, (uint32_t)MetalLibSize, &MetalBlob));
+                MetalLibBytes.get(), (uint32_t)MetalLibSize, &MetalBlob));
             std::swap(pOutputBlob, MetalBlob);
 
-            delete[] MetalLibBytes;
             IRMetalLibBinaryDestroy(MetalLib);
             IRObjectDestroy(DXILObj);
             IRObjectDestroy(AIR);


### PR DESCRIPTION
This adds a new `-metal` flag to DXC which can be used to generate Metal's IR directly from DXC after compilation. There are some limitations in this flag which are worth noting:

1) It does not support library shaders (yet)
2) It does not support disassembly (yet)
3) It is _wildly_ under tested because wtihout (2) we can't do anything to really verify correct output (yay?)