### PR TITLE
[NFC] Fix incorrect use of UNREFERENCED_PARAMETER macro

### DIFF
--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1509,7 +1509,6 @@ void CShaderReflectionConstantBuffer::Initialize(
 }
 
 static unsigned CalcResTypeSize(DxilModule &M, DxilResource &R) {
-  UNREFERENCED_PARAMETER(M);
   Type *Ty = R.GetHLSLType()->getPointerElementType();
   if (R.IsStructuredBuffer()) {
     Ty = dxilutil::StripArrayTypes(Ty);


### PR DESCRIPTION

    In CalcResTypeSize function, UNREFERENCED_PARAMETER macro is used with a
    parameter which is referenced in return statement. That macro was added in
    6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437 but it was not removed when
    "DxilModule &M" was referenced in 86073a3b0b45fe41b8ffe6c8a33c9b7c913e6b8c
    
    This fixes the following compiler error with clang 18.1.8 with mingw-w64 toolchain.
    
    DxilContainerReflection.cpp:1512:3: error: object of type 'DxilModule'
    cannot be assigned because its copy assignment operator is implicitly deleted
     1512 |   UNREFERENCED_PARAMETER(M);
          |   ^
    winnt.h:1387:40: note: expanded from macro 'UNREFERENCED_PARAMETER'
     1387 | #define UNREFERENCED_PARAMETER(P) {(P) = (P);}
          |                                        ^
