### PR TITLE
[NFC] Remove redundant GetCurrentThreadId function declaration

### DIFF
--- a/lib/IR/PassRegistry.cpp
+++ b/lib/IR/PassRegistry.cpp
@@ -35,7 +35,6 @@ using namespace llvm;
 // A simple global initialized at DllMain-time will do (still does more work
 // than we should likely perform though).
 static uint32_t g_PassRegistryTid;
-extern "C" uint32_t __stdcall GetCurrentThreadId(void);
 static void CheckThreadId() {
   if (g_PassRegistryTid == 0)
     g_PassRegistryTid = GetCurrentThreadId();


### PR DESCRIPTION

    GetCurrentThreadId is declared since Windows XP. The function declaration
    was added in first commit 6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437
    
    This fixes the following compiler error with clang 18.1.8 with mingw-w64 toolchain.
    
    PassRegistry.cpp:38:31: error: functions that differ only in
    their return type cannot be overloaded
       38 | extern "C" uint32_t __stdcall GetCurrentThreadId(void);
          |                               ^
    processthreadsapi.h:299:27: note: previous declaration is here
      299 |   WINBASEAPI DWORD WINAPI GetCurrentThreadId (VOID);
          |                           ^
