### PR TITLE
Use llvm_assert/assert.h on all platforms, not just Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,9 +623,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # HLSL Change Starts - override assert to RaiseException instead of abort
 # for better test behavior
-if(WIN32 AND NOT UNIX)
-  include_directories(BEFORE "${LLVM_MAIN_INCLUDE_DIR}/llvm/llvm_assert")
-endif()
+include_directories(BEFORE "${LLVM_MAIN_INCLUDE_DIR}/llvm/llvm_assert")
 # HLSL Change Ends
 
 include_directories( ${LLVM_INCLUDE_DIR} ${LLVM_MAIN_INCLUDE_DIR})

--- a/include/llvm/llvm_assert/assert.h
+++ b/include/llvm/llvm_assert/assert.h
@@ -31,14 +31,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
-                 const char *_Function);
+void llvm_assert(const char *Message, const char *File, unsigned Line,
+                 const char *Function);
 #ifdef __cplusplus
 }
 #endif
 
-#define assert(_Expression)                                                    \
-  ((void)((!!(_Expression)) ||                                                 \
-          (llvm_assert(#_Expression, __FILE__, __LINE__, __FUNCTION__), 0)))
+#define assert(Expression)                                                     \
+  ((void)((!!(Expression)) ||                                                  \
+          (llvm_assert(#Expression, __FILE__, __LINE__, __FUNCTION__), 0)))
 
 #endif /* NDEBUG */

--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -14,10 +14,10 @@
 #include "dxc/Support/Global.h"
 #include "windows.h"
 
-void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
-                 const char *_Function) {
-  OutputDebugFormatA("Error: assert(%s)\nFile:\n%s(%d)\nFunc:\t%s\n", _Message,
-                     _File, _Line, _Function);
+void llvm_assert(const char *Message, const char *File, unsigned Line,
+                 const char *Function) {
+  OutputDebugFormatA("Error: assert(%s)\nFile:\n%s(%d)\nFunc:\t%s\n", Message,
+                     File, Line, Function);
   RaiseException(STATUS_LLVM_ASSERT, 0, 0, 0);
 }
 
@@ -26,10 +26,10 @@ void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
-void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
-                 const char *_Function) {
-  llvm::errs() << "Error: assert(" << _Message << ")\nFile:\n"
-               << _File << "(" << _Line << ")\nFunc:\t" << _Function << "\n";
+void llvm_assert(const char *Message, const char *File, unsigned Line,
+                 const char *Function) {
+  llvm::errs() << "Error: assert(" << Message << ")\nFile:\n"
+               << File << "(" << Line << ")\nFunc:\t" << Function << "\n";
   LLVM_BUILTIN_TRAP;
 }
 

--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -23,11 +23,15 @@ void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
 
 #else
 
-#include <assert.h>
+#include "llvm/Support/Compiler.h"
+#include <cstdio>
 
-void llvm_assert(const char *message, const char *, unsigned,
+void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
                  const char *_Function) {
-  assert(false && message);
+  fprintf(stderr, "Error: assert(%s)\nFile:\n%s(%d)\nFunc:\t%s\n", _Message,
+          _File, _Line, _Function);
+  fflush(stderr);
+  LLVM_BUILTIN_TRAP;
 }
 
 #endif

--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -24,13 +24,12 @@ void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
 #else
 
 #include "llvm/Support/Compiler.h"
-#include <cstdio>
+#include "llvm/Support/raw_ostream.h"
 
 void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
                  const char *_Function) {
-  fprintf(stderr, "Error: assert(%s)\nFile:\n%s(%d)\nFunc:\t%s\n", _Message,
-          _File, _Line, _Function);
-  fflush(stderr);
+  llvm::errs() << "Error: assert(" << _Message << ")\nFile:\n"
+               << _File << "(" << _Line << ")\nFunc:\t" << _Function << "\n";
   LLVM_BUILTIN_TRAP;
 }
 

--- a/tools/clang/lib/SPIRV/String.cpp
+++ b/tools/clang/lib/SPIRV/String.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/SPIRV/String.h"
-#include "llvm/llvm_assert/assert.h"
+#include <assert.h>
 
 namespace clang {
 namespace spirv {


### PR DESCRIPTION
This makes it possible to define how assert works on all platforms. The header was already being included by String.cpp, and was already designed to work for non-Windows platforms.

Also modify the non-Windows llvm_assert to emit the assertion message to stderr and trap. We cannot call standard assert as we are overriding it via include dirs, so there's no way to include the standard one and call it.