### PR TITLE
Add option to enable asserts in non-debug and to make asserts trap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,9 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
+option(LLVM_ENABLE_ASSERT_IN_NDEBUG "Enable assertions in non-debug builds" OFF)
+option(LLVM_ASSERT_TRAPS "Force assertions to always trap, rather than the default unspecified behavior (e.g. RaiseException on Windows)" OFF)
+
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING
   "Enable abi-breaking checks.  Can be WITH_ASSERTS, FORCE_ON or FORCE_OFF.")
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
           configuration: Release
           CC: clang
           CXX: clang++
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER='Address;Undefined' -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER='Address;Undefined' -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_ASSERT_IN_NDEBUG=On -DLLVM_ASSERT_TRAPS=On
           CHECK_ALL_ENV: ASAN_OPTIONS=alloc_dealloc_mismatch=0
           OS: Linux
         Linux_Clang_Debug:

--- a/include/llvm/llvm_assert/assert.h
+++ b/include/llvm/llvm_assert/assert.h
@@ -22,11 +22,21 @@
 #define STATUS_LLVM_UNREACHABLE 0xE0000002
 #define STATUS_LLVM_FATAL 0xE0000003
 
-#ifdef NDEBUG
+// Define LLVM_ENABLE_ASSERT_IN_NDEBUG to enable assertions in non-debug builds.
+// Define LLVM_ASSERT_TRAPS to force assertions to trap (LLVM_BUILTIN_TRAP).
+
+// Use ASSERTS_ENABLED instead of NDEBUG to wrap assert-only code
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_ASSERT_IN_NDEBUG)
+#define ASSERTS_ENABLED 1
+#else
+#define ASSERTS_ENABLED 0
+#endif
+
+#if !ASSERTS_ENABLED
 
 #define assert(_Expression) ((void)0)
 
-#else /* NDEBUG */
+#else /* ASSERTS_ENABLED */
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,4 +51,4 @@ void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
   ((void)((!!(_Expression)) ||                                                 \
           (llvm_assert(#_Expression, __FILE__, __LINE__, __FUNCTION__), 0)))
 
-#endif /* NDEBUG */
+#endif /* ASSERTS_ENABLED */

--- a/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/lib/Analysis/BasicAliasAnalysis.cpp
@@ -412,7 +412,7 @@ DecomposeGEPExpression(const Value *V, int64_t &BaseOffs,
 // BasicAliasAnalysis Pass
 //===----------------------------------------------------------------------===//
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 static const Function *getParent(const Value *V) {
   if (const Instruction *inst = dyn_cast<Instruction>(V))
     return inst->getParent()->getParent();

--- a/lib/Analysis/CFG.cpp
+++ b/lib/Analysis/CFG.cpp
@@ -71,7 +71,7 @@ void llvm::FindFunctionBackedges(const Function &F,
 /// successor.
 unsigned llvm::GetSuccessorNumber(BasicBlock *BB, BasicBlock *Succ) {
   TerminatorInst *Term = BB->getTerminator();
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   unsigned e = Term->getNumSuccessors();
 #endif
   for (unsigned i = 0; ; ++i) {

--- a/lib/Analysis/IPA/CallGraph.cpp
+++ b/lib/Analysis/IPA/CallGraph.cpp
@@ -48,7 +48,7 @@ CallGraph::~CallGraph() {
 
 // Reset all node's use counts to zero before deleting them to prevent an
 // assertion from firing.
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   for (auto &I : FunctionMap)
     I.second->allReferencesDropped();
 #endif

--- a/lib/IR/Constants.cpp
+++ b/lib/IR/Constants.cpp
@@ -1697,7 +1697,7 @@ Constant *ConstantExpr::getFPCast(Constant *C, Type *Ty) {
 }
 
 Constant *ConstantExpr::getTrunc(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1711,7 +1711,7 @@ Constant *ConstantExpr::getTrunc(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getSExt(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1725,7 +1725,7 @@ Constant *ConstantExpr::getSExt(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getZExt(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1739,7 +1739,7 @@ Constant *ConstantExpr::getZExt(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getFPTrunc(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1751,7 +1751,7 @@ Constant *ConstantExpr::getFPTrunc(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getFPExtend(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1763,7 +1763,7 @@ Constant *ConstantExpr::getFPExtend(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getUIToFP(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1774,7 +1774,7 @@ Constant *ConstantExpr::getUIToFP(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getSIToFP(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1785,7 +1785,7 @@ Constant *ConstantExpr::getSIToFP(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getFPToUI(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif
@@ -1796,7 +1796,7 @@ Constant *ConstantExpr::getFPToUI(Constant *C, Type *Ty, bool OnlyIfReduced) {
 }
 
 Constant *ConstantExpr::getFPToSI(Constant *C, Type *Ty, bool OnlyIfReduced) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   bool fromVec = C->getType()->getTypeID() == Type::VectorTyID;
   bool toVec = Ty->getTypeID() == Type::VectorTyID;
 #endif

--- a/lib/IR/DebugInfoMetadata.cpp
+++ b/lib/IR/DebugInfoMetadata.cpp
@@ -167,7 +167,7 @@ static StringRef getString(const MDString *S) {
   return StringRef();
 }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 static bool isCanonical(const MDString *S) {
   return !S || !S->getString().empty();
 }

--- a/lib/IR/Type.cpp
+++ b/lib/IR/Type.cpp
@@ -753,7 +753,7 @@ PointerType *PointerType::get(Type *EltTy, unsigned AddressSpace) {
 
 PointerType::PointerType(Type *E, unsigned AddrSpace)
   : SequentialType(PointerTyID, E) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   const unsigned oldNCT = NumContainedTys;
 #endif
   setSubclassData(AddrSpace);

--- a/lib/IR/Value.cpp
+++ b/lib/IR/Value.cpp
@@ -322,7 +322,7 @@ void Value::takeName(Value *V) {
     ST->reinsertValue(this);
 }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 static bool contains(SmallPtrSetImpl<ConstantExpr *> &Cache, ConstantExpr *Expr,
                      Constant *C) {
   if (!Cache.insert(Expr).second)

--- a/lib/MC/MachObjectWriter.cpp
+++ b/lib/MC/MachObjectWriter.cpp
@@ -900,7 +900,7 @@ void MachObjectWriter::writeObject(MCAssembler &Asm,
 
   // Write out the loh commands, if there is one.
   if (LOHSize) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
     unsigned Start = OS.tell();
 #endif
     Asm.getLOHContainer().emit(*this, Layout);

--- a/lib/Support/regengine.inc
+++ b/lib/Support/regengine.inc
@@ -118,10 +118,12 @@ static char *pchar(int);
 #define	AT(t, p1, p2, s1, s2)	at(m, t, p1, p2, s1, s2)
 #define	NOTE(str)	{ if (m->eflags&REG_TRACE) (void)printf("=%s\n", (str)); }
 static int nope = 0;
+#define ASSERT_NOPE() assert(nope)
 #else
 #define	SP(t, s, c)	/* nothing */
 #define	AT(t, p1, p2, s1, s2)	/* nothing */
 #define	NOTE(s)	/* nothing */
+#define ASSERT_NOPE() /* nothing */
 #endif
 
 /*
@@ -328,7 +330,7 @@ dissect(struct match *m, const char *start, const char *stop, sopno startst,
 		/* figure out what it matched */
 		switch (OP(m->g->strip[ss])) {
 		case OEND:
-			assert(nope);
+			ASSERT_NOPE();
 			break;
 		case OCHAR:
 			sp++;
@@ -344,7 +346,7 @@ dissect(struct match *m, const char *start, const char *stop, sopno startst,
 			break;
 		case OBACK_:
 		case O_BACK:
-			assert(nope);
+			ASSERT_NOPE();
 			break;
 		/* cases where length of match is hard to find */
 		case OQUEST_:
@@ -454,7 +456,7 @@ dissect(struct match *m, const char *start, const char *stop, sopno startst,
 		case OOR1:
 		case OOR2:
 		case O_CH:
-			assert(nope);
+			ASSERT_NOPE();
 			break;
 		case OLPAREN:
 			i = OPND(m->g->strip[ss]);
@@ -467,7 +469,7 @@ dissect(struct match *m, const char *start, const char *stop, sopno startst,
 			m->pmatch[i].rm_eo = sp - m->offp;
 			break;
 		default:		/* uh oh */
-			assert(nope);
+			ASSERT_NOPE();
 			break;
 		}
 	}
@@ -666,12 +668,12 @@ backref(struct match *m, const char *start, const char *stop, sopno startst,
 		return(NULL);
 		break;
 	default:		/* uh oh */
-		assert(nope);
+		ASSERT_NOPE();
 		break;
 	}
 
 	/* "can't happen" */
-	assert(nope);
+	ASSERT_NOPE();
 	/* NOTREACHED */
         return NULL;
 }
@@ -950,7 +952,7 @@ step(struct re_guts *g,
 			FWD(aft, aft, 1);
 			break;
 		default:		/* ooooops... */
-			assert(nope);
+			ASSERT_NOPE();
 			break;
 		}
 	}

--- a/lib/Transforms/Scalar/LICM.cpp
+++ b/lib/Transforms/Scalar/LICM.cpp
@@ -592,7 +592,7 @@ static bool sink(Instruction &I, const LoopInfo *LI, const DominatorTree *DT,
   ++NumSunk;
   Changed = true;
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   SmallVector<BasicBlock *, 32> ExitBlocks;
   CurLoop->getUniqueExitBlocks(ExitBlocks);
   SmallPtrSet<BasicBlock *, 32> ExitBlockSet(ExitBlocks.begin(), 

--- a/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -868,7 +868,7 @@ public:
 
   void Lose();
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   // Once any of the metrics loses, they must all remain losers.
   bool isValid() {
     return ((NumRegs | AddRecCost | NumIVMuls | NumBaseAdds

--- a/lib/Transforms/Scalar/Reassociate.cpp
+++ b/lib/Transforms/Scalar/Reassociate.cpp
@@ -643,7 +643,7 @@ static bool LinearizeExprTree(BinaryOperator *I,
   LeafMap Leaves; // Leaf -> Total weight so far.
   SmallVector<Value*, 8> LeafOrder; // Ensure deterministic leaf output order.
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   SmallPtrSet<Value*, 8> Visited; // For sanity checking the iteration scheme.
 #endif
   while (!Worklist.empty()) {

--- a/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -222,7 +222,7 @@ static bool isHandledGCPointerType(Type *T) {
   return false;
 }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 /// Returns true if this type contains a gc pointer whether we know how to
 /// handle that type or not.
 static bool containsGCPtrType(Type *Ty) {
@@ -784,7 +784,7 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &cache) {
 
   bool progress = true;
   while (progress) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
     size_t oldSize = states.size();
 #endif
     progress = false;
@@ -808,8 +808,10 @@ static Value *findBasePointer(Value *I, DefiningValueMapTy &cache) {
       }
     }
 
+#if ASSERTS_ENABLED
     assert(oldSize <= states.size());
     assert(oldSize == states.size() || progress);
+#endif
   }
 
   if (TraceLSP) {
@@ -2633,7 +2635,7 @@ static void recomputeLiveInValues(GCPtrLivenessData &RevisedLivenessData,
   StatepointLiveSetTy Updated;
   findLiveSetAtInst(Inst, RevisedLivenessData, Updated);
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   DenseSet<Value *> Bases;
   for (auto KVPair : Info.PointerToBase) {
     Bases.insert(KVPair.second);
@@ -2648,7 +2650,7 @@ static void recomputeLiveInValues(GCPtrLivenessData &RevisedLivenessData,
       continue;
     }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   for (auto V : Updated) {
     assert(Info.PointerToBase.count(V) &&
            "must be able to find base for live value");

--- a/tools/clang/lib/AST/ASTContext.cpp
+++ b/tools/clang/lib/AST/ASTContext.cpp
@@ -3145,7 +3145,7 @@ ASTContext::getFunctionType(QualType ResultTy, ArrayRef<QualType> ArgArray,
   return QualType(FTP, 0);
 }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 static bool NeedsInjectedClassNameType(const RecordDecl *D) {
   if (!isa<CXXRecordDecl>(D)) return false;
   const CXXRecordDecl *RD = cast<CXXRecordDecl>(D);
@@ -3400,7 +3400,7 @@ ASTContext::getTemplateSpecializationType(TemplateName Template,
                                        Underlying);
 }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 static bool hasAnyPackExpansions(const TemplateArgument *Args,
                                  unsigned NumArgs) {
   for (unsigned I = 0; I != NumArgs; ++I)

--- a/tools/clang/lib/Basic/VirtualFileSystem.cpp
+++ b/tools/clang/lib/Basic/VirtualFileSystem.cpp
@@ -992,7 +992,7 @@ UniqueID vfs::getNextVirtualUniqueID() {
   return UniqueID(std::numeric_limits<uint64_t>::max(), ID);
 }
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
 static bool pathHasTraversal(StringRef Path) {
   using namespace llvm::sys;
   for (StringRef Comp : llvm::make_range(path::begin(Path), path::end(Path)))

--- a/tools/clang/lib/CodeGen/CGVTables.cpp
+++ b/tools/clang/lib/CodeGen/CGVTables.cpp
@@ -826,7 +826,7 @@ static bool shouldEmitVTableAtEndOfTranslationUnit(CodeGenModule &CGM,
 /// v-tables, and that we are now at the end of the translation unit,
 /// decide whether we should emit them.
 void CodeGenModule::EmitDeferredVTables() {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   // Remember the size of DeferredVTables, because we're going to assume
   // that this entire operation doesn't modify it.
   size_t savedSize = DeferredVTables.size();

--- a/tools/clang/lib/CodeGen/CodeGenFunction.h
+++ b/tools/clang/lib/CodeGen/CodeGenFunction.h
@@ -3001,7 +3001,7 @@ private:
                                   SourceLocation Loc);
 
 public:
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   // Determine whether the given argument is an Objective-C method
   // that may have type parameters in its signature.
   static bool isObjCMethodWithTypeParams(const ObjCMethodDecl *method) {
@@ -3034,7 +3034,7 @@ public:
     assert((ParamsToSkip == 0 || CallArgTypeInfo) &&
            "Can't skip parameters if type info is not provided");
     if (CallArgTypeInfo) {
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
       bool isGenericMethod = isObjCMethodWithTypeParams(CallArgTypeInfo);
 #endif
 

--- a/tools/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/tools/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -2330,7 +2330,7 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
   /// just after the stmt record.
   llvm::DenseMap<uint64_t, Stmt *> StmtEntries;
 
-#ifndef NDEBUG
+#if ASSERTS_ENABLED
   unsigned PrevNumStmts = StmtStack.size();
 #endif
 


### PR DESCRIPTION
If LLVM_ENABLE_ASSERT_IN_NDEBUG is defined, asserts are enabled in NDEBUG builds. When asserts are enabled, macro ASSERTS_ENABLED is defined. This is used instead of NDEBUG to wrap assert-only code. Note that this change does not replace _all_ uses of NDEBUG with ASSERTS_ENABLED, only the ones required to get the build compiling. The rest will be handled in future changes.

If LLVM_ASSERT_TRAPS is defined, assert will always trap. Currently, assert calls RaiseException on Windows, and invokes the standard assert macro on non-Windows. This macro makes the behaviour well-defined and consistent across platforms.