### PR TITLE
Fix MSAN use-after-free in SmallVectorImpl dtor

### DIFF
--- a/include/llvm/ADT/SmallVector.h
+++ b/include/llvm/ADT/SmallVector.h
@@ -359,8 +359,7 @@ protected:
 
 public:
   ~SmallVectorImpl() {
-    // Destroy the constructed elements in the vector.
-    this->destroy_range(this->begin(), this->end());
+    // Subclass has already destructed this vector's elements.
 
     // If this wasn't grown from the inline copy, deallocate the old space.
     if (!this->isSmall())
@@ -863,6 +862,11 @@ class SmallVector : public SmallVectorImpl<T> {
   SmallVectorStorage<T, N> Storage;
 public:
   SmallVector() : SmallVectorImpl<T>(N) {
+  }
+
+  ~SmallVector() {
+    // Destroy the constructed elements in the vector.
+    this->destroy_range(this->begin(), this->end());
   }
 
   explicit SmallVector(size_t Size, const T &Value = T())


### PR DESCRIPTION
Hit when compiled with `-fsanitize-memory-use-after-dtor`. This was fixed upstream here:
https://github.com/llvm/llvm-project/commit/527352b6ac01100f8a2d36ca895b663482202f00 This applies the same patch.