### PR TITLE
Fix crash in constant initializer lowering for global variable.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2979,11 +2979,13 @@ bool BuildImmInit(Function *Ctor) {
       }
       // If initializing an array, make sure init value type matches array
       // element type
-      llvm::Type *GVElemTy = GV->getType()->getElementType();
-      if (llvm::ArrayType *AT = dyn_cast<llvm::ArrayType>(GVElemTy)) {
-        llvm::Type *ElTy = AT->getElementType();
-        if (V->getType() != ElTy)
-          return false;
+      if (GV) {
+        llvm::Type *GVElemTy = GV->getType()->getElementType();
+        if (llvm::ArrayType *AT = dyn_cast<llvm::ArrayType>(GVElemTy)) {
+          llvm::Type *ElTy = AT->getElementType();
+          if (V->getType() != ElTy)
+            return false;
+        }
       }
       ImmList.emplace_back(cast<Constant>(V));
     } else {

--- a/tools/clang/test/DXC/FinishCodeGen/construct-global.hlsl
+++ b/tools/clang/test/DXC/FinishCodeGen/construct-global.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T ps_6_0 %s | FileCheck %s
+
+// Regression test to make sure we can compile a global constant with
+// initializer. Previously this shader would crash in the compiler.
+
+// CHECK: define void @main
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x3FE14A2800000000)
+
+static const float val = cos(1.0f);
+
+float main() : SV_Target
+{
+    return val;
+}


### PR DESCRIPTION
In #6814, we modified the compiler to avoid generating bad code in some cases for array initializers. However, this caused a crash in the case where the initializer does not use a GEP expression for addressing because the `GV` will be null.

I considered setting `GV` to the value in the `store` pointer operand, but it looked like `GV` was also checked elsewhere for null and did not want to modify the behavior of the code in other places.

The fix is to check if we found a global variable before validating the array case.