### PR TITLE
[Doc] Release note update for 1.8.2407.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,7 +33,8 @@ Here are some highlights:
 - [SPIR-V] Implement WaveMutliPrefix* in [#6600](https://github.com/microsoft/DirectXShaderCompiler/issues/6600)
 - [SPIR-V] Implement SampleCmpLevel for SM6.7 in [#6613](https://github.com/microsoft/DirectXShaderCompiler/issues/6613)
 - Avoid adding types to default namespace in [#6646](https://github.com/microsoft/DirectXShaderCompiler/issues/6646)
-- Release notes once found in `README.md` can now be found in `docs/ReleaseNotes.md`
+- Release notes once found in `README.md` can now be found in `ReleaseNotes.md`
+- Fixed several bugs in the loop restructurizer. Shader developers who are using -opt-disable structurize-loop-exits-for-unroll to disable the loop restructurizer should consider removing that workaround.
 
 ### Version 1.8.2405
 


### PR DESCRIPTION
Add note for loop structurizer fixes.
Fix the ReleaseNotes.md path.