### PR TITLE
Handle heap samplers as intrinsic params

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -6025,24 +6025,21 @@ static bool CombineObjectTypes(ArBasicKind Target, ArBasicKind Source,
   }
 
   switch (Target) {
-  AR_BASIC_ROBJECT_CASES:
-    if (Source == AR_OBJECT_STATEBLOCK) {
+  AR_BASIC_TEXTURE_CASES:
+    if (Source == AR_OBJECT_HEAP_RESOURCE) {
       AssignOpt(Target, pCombined);
       return true;
     }
     break;
-
-  AR_BASIC_TEXTURE_CASES:
-
   AR_BASIC_NON_CMP_SAMPLER_CASES:
-    if (Source == AR_OBJECT_SAMPLER || Source == AR_OBJECT_STATEBLOCK) {
+    if (Source == AR_OBJECT_SAMPLER || Source == AR_OBJECT_HEAP_SAMPLER) {
       AssignOpt(Target, pCombined);
       return true;
     }
     break;
 
   case AR_OBJECT_SAMPLERCOMPARISON:
-    if (Source == AR_OBJECT_STATEBLOCK) {
+    if (Source == AR_OBJECT_HEAP_SAMPLER) {
       AssignOpt(Target, pCombined);
       return true;
     }

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/DescriptorHeapParams.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/DescriptorHeapParams.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -T ps_6_6 %s | %FileCheck %s
+
+// Tests using descriptor heap elements directly as parameters to intrinsics
+// Previously, the overload matching rejected this before it had a chance
+// to add the implicit cast.
+
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> feedbackMinMip;
+
+Texture2D<float> texture2D;
+SamplerState samp;
+
+float4 main(uint texIdx : TI, uint sampIdx : SI, float2 coord : C) : SV_Target {
+    Texture2D<float4> tex = ResourceDescriptorHeap[texIdx];
+    feedbackMinMip.WriteSamplerFeedback(ResourceDescriptorHeap[texIdx], samp, coord, 4);
+    return tex.Sample(SamplerDescriptorHeap[sampIdx], coord) * tex.SampleCmp(SamplerDescriptorHeap[sampIdx + 1], coord, 1.0);
+}


### PR DESCRIPTION
Samplers taken directly from sampler heaps were disallowed from parameters for intrinsics because they were not included in the list of acceptable parameters. This removes an obsolete state object param and replaces it with the heap samplers.

Not mentioning bug number 2^3 * 5 * 113 just yet