### PR TITLE
Fix escape in Python string in lit.cfg

### DIFF
--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -308,7 +308,7 @@ else:
 config.substitutions.append(
     (' clang ', """*** Do not use 'clang' in tests, use '%clang'. ***""") )
 config.substitutions.append(
-    (' clang\+\+ ', """*** Do not use 'clang++' in tests, use '%clangxx'. ***"""))
+    (' clang\\+\\+ ', """*** Do not use 'clang++' in tests, use '%clangxx'. ***"""))
 config.substitutions.append(
     (' clang-cc ',
      """*** Do not use 'clang-cc' in tests, use '%clang_cc1'. ***""") )


### PR DESCRIPTION
Change Python regexp ' clang\+\+ ' to ' clang\\+\\+' We're trying to match fixed strings like ` clang++ `, but `\+` is not a valid Python escape sequence.  Use `\\+` so the regexp machinery sees `\+`