### PR TITLE
Added implementation for ID3D12FunctionReflection::GetDesc1

### DIFF
--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -724,6 +724,7 @@ CInvalidFunctionParameter g_InvalidFunctionParameter;
 
 class CInvalidFunction final : public ID3D12FunctionReflection {
   STDMETHOD(GetDesc)(D3D12_FUNCTION_DESC *pDesc) { return E_FAIL; }
+  STDMETHOD(GetDesc1)(D3D12_FUNCTION_DESC1 *pDesc) { return E_FAIL; }
 
   STDMETHOD_(ID3D12ShaderReflectionConstantBuffer *, GetConstantBufferByIndex)
   (UINT BufferIndex) { return &g_InvalidSRConstantBuffer; }
@@ -2814,6 +2815,7 @@ public:
 
   // ID3D12FunctionReflection
   STDMETHOD(GetDesc)(D3D12_FUNCTION_DESC *pDesc);
+  STDMETHOD(GetDesc1)(D3D12_FUNCTION_DESC1 *pDesc);
 
   // BufferIndex relative to used constant buffers here
   STDMETHOD_(ID3D12ShaderReflectionConstantBuffer *, GetConstantBufferByIndex)
@@ -2906,6 +2908,164 @@ HRESULT CFunctionReflection::GetDesc(D3D12_FUNCTION_DESC *pDesc) {
   //                           a subroutine
   // Unset: BOOL Has10Level9VertexShader; // TRUE, if there is a 10L9 VS blob
   // Unset: BOOL Has10Level9PixelShader; // TRUE, if there is a 10L9 PS blob
+  return S_OK;
+}
+
+HRESULT CFunctionReflection::GetDesc1(D3D12_FUNCTION_DESC1 *pDesc) {
+  DXASSERT_NOMSG(m_pLibraryReflection);
+  IFR(ZeroMemoryToOut(pDesc));
+
+  const ShaderModel *pSM =
+      m_pLibraryReflection->m_pDxilModule->GetShaderModel();
+  DXIL::ShaderKind kind = DXIL::ShaderKind::Library;
+  if (m_pProps) {
+    kind = m_pProps->shaderKind;
+  }
+	
+  D3D12_COMPUTE_SHADER_DESC computeDesc = {
+        m_pProps->WaveSize.Min,
+        m_pProps->WaveSize.Max,
+        m_pProps->WaveSize.Preferred,
+        m_pProps->numThreads[0],
+        m_pProps->numThreads[1],
+        m_pProps->numThreads[2]
+  };
+
+  switch (kind) {
+
+      case ShaderKind::Pixel:
+        pDesc->ShaderType = D3D12_SHVER_PIXEL_SHADER;
+        pDesc->PixelShader.EarlyDepthStencil = m_pProps->ShaderProps.PS.EarlyDepthStencil;
+        break;
+
+      case ShaderKind::Vertex:
+        pDesc->ShaderType = D3D12_SHVER_VERTEX_SHADER;
+        break;
+
+      case ShaderKind::Geometry:
+        pDesc->ShaderType = D3D12_SHVER_GEOMETRY_SHADER;
+        pDesc->GeometryShader = D3D12_GEOMETRY_SHADER_DESC{
+            (D3D12_PRIMITIVE) m_pProps->ShaderProps.GS.inputPrimitive,
+            m_pProps->ShaderProps.GS.maxVertexCount,
+            m_pProps->ShaderProps.GS.instanceCount,
+            {
+                (D3D12_PRIMITIVE_TOPOLOGY) m_pProps->ShaderProps.GS.streamPrimitiveTopologies[0],
+                (D3D12_PRIMITIVE_TOPOLOGY) m_pProps->ShaderProps.GS.streamPrimitiveTopologies[1],
+                (D3D12_PRIMITIVE_TOPOLOGY) m_pProps->ShaderProps.GS.streamPrimitiveTopologies[2],
+                (D3D12_PRIMITIVE_TOPOLOGY) m_pProps->ShaderProps.GS.streamPrimitiveTopologies[3]
+            }
+        };
+        break;
+
+      case ShaderKind::Hull:
+        pDesc->ShaderType = D3D12_SHVER_HULL_SHADER;
+        pDesc->HullShader = D3D12_HULL_SHADER_DESC{
+            (D3D12_TESSELLATOR_DOMAIN) m_pProps->ShaderProps.HS.domain,
+            (D3D12_TESSELLATOR_PARTITIONING) m_pProps->ShaderProps.HS.partition,
+            (D3D12_TESSELLATOR_OUTPUT_PRIMITIVE) m_pProps->ShaderProps.HS.outputPrimitive,
+            m_pProps->ShaderProps.HS.inputControlPoints,
+            m_pProps->ShaderProps.HS.outputControlPoints,
+            m_pProps->ShaderProps.HS.maxTessFactor
+        };
+        break;
+
+      case ShaderKind::Domain:
+        pDesc->ShaderType = D3D12_SHVER_DOMAIN_SHADER;
+        pDesc->DomainShader = D3D12_DOMAIN_SHADER_DESC{
+            (D3D12_TESSELLATOR_DOMAIN) m_pProps->ShaderProps.DS.domain,
+            m_pProps->ShaderProps.DS.inputControlPoints
+        };
+        break;
+
+      case ShaderKind::Compute:
+        pDesc->ShaderType = D3D12_SHVER_COMPUTE_SHADER;
+        pDesc->ComputeShader = computeDesc;
+        break;
+
+      case ShaderKind::RayGeneration:
+        pDesc->ShaderType = D3D12_SHVER_RAY_GENERATION_SHADER;
+        break;
+
+      case ShaderKind::Intersection:
+        pDesc->ShaderType = D3D12_SHVER_INTERSECTION_SHADER;
+        pDesc->RaytracingShader = D3D12_RAYTRACING_SHADER_DESC{
+            m_pProps->ShaderProps.Ray.paramSizeInBytes,
+            m_pProps->ShaderProps.Ray.attributeSizeInBytes
+        };
+        break;
+
+      case ShaderKind::AnyHit:
+        pDesc->ShaderType = D3D12_SHVER_ANY_HIT_SHADER;
+        pDesc->RaytracingShader = D3D12_RAYTRACING_SHADER_DESC{
+            m_pProps->ShaderProps.Ray.paramSizeInBytes,
+            m_pProps->ShaderProps.Ray.attributeSizeInBytes
+        };
+        break;
+
+      case ShaderKind::ClosestHit:
+        pDesc->ShaderType = D3D12_SHVER_CLOSEST_HIT_SHADER;
+        pDesc->RaytracingShader = D3D12_RAYTRACING_SHADER_DESC{
+            m_pProps->ShaderProps.Ray.paramSizeInBytes,
+            m_pProps->ShaderProps.Ray.attributeSizeInBytes
+        };
+        break;
+
+      case ShaderKind::Miss:
+        pDesc->ShaderType = D3D12_SHVER_MISS_SHADER;
+        pDesc->RaytracingShader = D3D12_RAYTRACING_SHADER_DESC{
+            m_pProps->ShaderProps.Ray.paramSizeInBytes,
+            m_pProps->ShaderProps.Ray.attributeSizeInBytes
+        };
+        break;
+
+      case ShaderKind::Callable:
+        pDesc->ShaderType = D3D12_SHVER_CALLABLE_SHADER;
+        pDesc->RaytracingShader = D3D12_RAYTRACING_SHADER_DESC{
+            m_pProps->ShaderProps.Ray.paramSizeInBytes,
+            m_pProps->ShaderProps.Ray.attributeSizeInBytes
+        };
+        break;
+
+      case ShaderKind::Mesh:
+        pDesc->ShaderType = D3D12_SHVER_MESH_SHADER;
+        pDesc->MeshShader = D3D12_MESH_SHADER_DESC{
+            m_pProps->ShaderProps.MS.payloadSizeInBytes,
+            m_pProps->ShaderProps.MS.maxVertexCount,
+            m_pProps->ShaderProps.MS.maxPrimitiveCount,
+            (D3D12_MESH_OUTPUT_TOPOLOGY) m_pProps->ShaderProps.MS.outputTopology,
+        };
+        break;
+
+      case ShaderKind::Amplification:
+        pDesc->ShaderType = D3D12_SHVER_AMPLIFICATION_SHADER;
+        pDesc->AmplificationShader = D3D12_AMPLIFICATION_SHADER_DESC{
+            m_pProps->ShaderProps.AS.payloadSizeInBytes
+        };
+        break;
+
+      case ShaderKind::Node:
+        pDesc->ShaderType = D3D12_SHVER_NODE_SHADER;
+        pDesc->NodeShader = D3D12_NODE_SHADER_DESC{
+            computeDesc,
+            (D3D12_NODE_OVERRIDES_TYPE) m_pProps->Node.LaunchType,
+            m_pProps->Node.IsProgramEntry,
+            m_pProps->Node.LocalRootArgumentsTableIndex,
+            {
+                m_pProps->Node.DispatchGrid[0],
+                m_pProps->Node.DispatchGrid[1],
+                m_pProps->Node.DispatchGrid[2],
+            },
+            {
+                m_pProps->Node.MaxDispatchGrid[0],
+                m_pProps->Node.MaxDispatchGrid[1],
+                m_pProps->Node.MaxDispatchGrid[2],
+            },
+            m_pProps->Node.MaxRecursionDepth
+        };
+        break;
+
+  }
+
   return S_OK;
 }
 


### PR DESCRIPTION
Relates to https://github.com/microsoft/DirectX-Headers/pull/135.

I have tested this version in my own project and it seems to work. Only thing is that this requires the DirectX-Headers dep to be updated to ensure D3D12_FUNCTION_DESC1 and co can be found.