### PR TITLE
[spirv] Avoid adding spec and push constants to global ubo

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -320,6 +320,15 @@ bool shouldSkipInStructLayout(const Decl *decl) {
   // $Globals' "struct" is the TranslationUnit, so we should ignore resources
   // in the TranslationUnit "struct" and its child namespaces.
   if (declContext->isTranslationUnit() || declContext->isNamespace()) {
+
+    if (decl->hasAttr<VKConstantIdAttr>()) {
+      return true;
+    }
+
+    if (decl->hasAttr<VKPushConstantAttr>()) {
+      return true;
+    }
+
     // External visibility
     if (const auto *declDecl = dyn_cast<DeclaratorDecl>(decl))
       if (!declDecl->hasExternalFormalLinkage())

--- a/tools/clang/test/CodeGenSPIRV/implicit.global.ubo.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/implicit.global.ubo.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_0 -E main %s -spirv | FileCheck %s
+
+// This test checks that the specialization constant and push constants are not
+// included in the implicit global ubo.
+
+// CHECK: OpDecorate %mySpecializationConstant SpecId 1
+// CHECK: %mySpecializationConstant = OpSpecConstant %int 0
+[[ vk::constant_id ( 1 )]] const int mySpecializationConstant = 0;
+
+// CHECK:  %push_const = OpVariable %_ptr_PushConstant_type_PushConstant_ PushConstant
+[[ vk::push_constant]] struct { int value; } push_const;
+
+
+
+float myGlobal;
+
+float4 main(float4 col : COLOR) : SV_Target0
+{
+	if(mySpecializationConstant && push_const.value)
+		return 0.xxxx;
+	
+	return myGlobal.xxxx;
+}


### PR DESCRIPTION
The code the decides which global variables to include in the implicit
global cbuffer does not check for spec constant or push constant. They
end up being incorrectly include in it, causing problems.

The solution is to add those to the type of variable that should be
skipped.

Fixes #4542
