### PR TITLE
Fix -link -Qstrip_debug failing

### DIFF
--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -969,6 +969,10 @@ int DxcContext::Link() {
                     wpInputFiles.size(), args.data(), args.size(),
                     &pLinkResult));
 
+  // Link will not include any debug info if StripDebug is set, so clear it
+  // here so we don't attempt to remove it again in UpdatePart
+  m_Opts.StripDebug = false;
+
   HRESULT status;
   IFT(pLinkResult->GetStatus(&status));
   if (SUCCEEDED(status)) {


### PR DESCRIPTION
Fixes #5737

Link doesn't include the ILDB chunk in the first place when -Qstrip_debug is used, so this fixes it failing in UpdatePart.

The compiler does the same thing, sort of, except the compiler's default behavior is different (it doesn't embed debug by default), so this omits the condition to reflect that.

This will cause -link -Fd to fail, but -link -Fd doesn't work properly anyway due to #5739 (which will be fixed in a separate forthcoming PR that doesn't conflict with this one)