### PR TITLE
Fix warning when use implicit launch type.

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
+++ b/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
@@ -523,7 +523,7 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
     }
 
     DXIL::ShaderKind EntrySK = shaderModel->GetKind();
-    DXIL::NodeLaunchType NodeLaunchTy = DXIL::NodeLaunchType::Broadcasting;
+    DXIL::NodeLaunchType NodeLaunchTy = DXIL::NodeLaunchType::Invalid;
     if (EntrySK == DXIL::ShaderKind::Library) {
       // For library, check if the exported function is entry with shader
       // attribute.
@@ -533,6 +533,8 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
         if (const auto *pAttr = FDecl->getAttr<HLSLNodeLaunchAttr>())
           NodeLaunchTy =
               ShaderModel::NodeLaunchTypeFromName(pAttr->getLaunchType());
+        else
+          NodeLaunchTy = DXIL::NodeLaunchType::Broadcasting;
     }
     // Visit all visited functions in call graph to collect illegal intrinsic
     // calls.

--- a/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
+++ b/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
@@ -523,7 +523,7 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
     }
 
     DXIL::ShaderKind EntrySK = shaderModel->GetKind();
-    DXIL::NodeLaunchType NodeLaunchTy = DXIL::NodeLaunchType::Invalid;
+    DXIL::NodeLaunchType NodeLaunchTy = DXIL::NodeLaunchType::Broadcasting;
     if (EntrySK == DXIL::ShaderKind::Library) {
       // For library, check if the exported function is entry with shader
       // attribute.

--- a/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
+++ b/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
@@ -529,12 +529,13 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
       // attribute.
       if (const auto *Attr = FDecl->getAttr<clang::HLSLShaderAttr>())
         EntrySK = ShaderModel::KindFromFullName(Attr->getStage());
-      if (EntrySK == DXIL::ShaderKind::Node)
+      if (EntrySK == DXIL::ShaderKind::Node) {
         if (const auto *pAttr = FDecl->getAttr<HLSLNodeLaunchAttr>())
           NodeLaunchTy =
               ShaderModel::NodeLaunchTypeFromName(pAttr->getLaunchType());
         else
           NodeLaunchTy = DXIL::NodeLaunchType::Broadcasting;
+      }
     }
     // Visit all visited functions in call graph to collect illegal intrinsic
     // calls.

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
@@ -193,11 +193,14 @@ void node02(RWThreadNodeInputRecord<RECORD> input,
   threadRec.OutputComplete();
 }
 
-// Make sure default broadingcast launch is supported when dignose barrier.
+// Default launch type is broadingcast which has a visible group.
+// It is OK to use GROUP_SYNC or GROUP_SCOPE.
 [Shader("node")]
 [NumThreads(64,1,1)]
 [NodeDispatchGrid(1, 1, 1)]
 void defaultBroadcastingLaunch(RWDispatchNodeInputRecord<RECORD> input,
             [MaxRecords(11)] NodeOutput<RECORD> output) {
-  Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SCOPE);
+  Barrier(UAV_MEMORY, GROUP_SYNC);
+  Barrier(UAV_MEMORY, GROUP_SCOPE);
+  Barrier(UAV_MEMORY, GROUP_SCOPE|GROUP_SYNC);
 }

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
@@ -193,7 +193,7 @@ void node02(RWThreadNodeInputRecord<RECORD> input,
   threadRec.OutputComplete();
 }
 
-// Default launch type is broadingcast which has a visible group.
+// Default launch type is broadcasting which has a visible group.
 // It is OK to use GROUP_SYNC or GROUP_SCOPE.
 [Shader("node")]
 [NumThreads(64,1,1)]

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
@@ -192,3 +192,12 @@ void node02(RWThreadNodeInputRecord<RECORD> input,
   Barrier(threadRec, DEVICE_SCOPE);
   threadRec.OutputComplete();
 }
+
+// Make sure default broadingcast launch is supported when dignose barrier.
+[Shader("node")]
+[NumThreads(64,1,1)]
+[NodeDispatchGrid(1, 1, 1)]
+void defaultBroadcastingLaunch(RWDispatchNodeInputRecord<RECORD> input,
+            [MaxRecords(11)] NodeOutput<RECORD> output) {
+  Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SCOPE);
+}


### PR DESCRIPTION
By default, the launch type should be set to ‘Broadcast’ when diagnosing barriers. However, the current behavior sets the default launch type to ‘Invalid,’ resulting in warnings when the launch type is not explicitly specified as an attribute.

To address this issue, we’ll adjust the default setting to ‘Broadcast’ and thereby resolve the problem.

Fixes #6836