### PR TITLE
Fix warning when use implicit launch type. (#6837)

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
+++ b/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
@@ -529,10 +529,13 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
       // attribute.
       if (const auto *Attr = FDecl->getAttr<clang::HLSLShaderAttr>())
         EntrySK = ShaderModel::KindFromFullName(Attr->getStage());
-      if (EntrySK == DXIL::ShaderKind::Node)
+      if (EntrySK == DXIL::ShaderKind::Node) {
         if (const auto *pAttr = FDecl->getAttr<HLSLNodeLaunchAttr>())
           NodeLaunchTy =
               ShaderModel::NodeLaunchTypeFromName(pAttr->getLaunchType());
+        else
+          NodeLaunchTy = DXIL::NodeLaunchType::Broadcasting;
+      }
     }
     // Visit all visited functions in call graph to collect illegal intrinsic
     // calls.

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
@@ -192,3 +192,15 @@ void node02(RWThreadNodeInputRecord<RECORD> input,
   Barrier(threadRec, DEVICE_SCOPE);
   threadRec.OutputComplete();
 }
+
+// Default launch type is broadcasting which has a visible group.
+// It is OK to use GROUP_SYNC or GROUP_SCOPE.
+[Shader("node")]
+[NumThreads(64,1,1)]
+[NodeDispatchGrid(1, 1, 1)]
+void defaultBroadcastingLaunch(RWDispatchNodeInputRecord<RECORD> input,
+            [MaxRecords(11)] NodeOutput<RECORD> output) {
+  Barrier(UAV_MEMORY, GROUP_SYNC);
+  Barrier(UAV_MEMORY, GROUP_SCOPE);
+  Barrier(UAV_MEMORY, GROUP_SCOPE|GROUP_SYNC);
+}


### PR DESCRIPTION
By default, the launch type should be set to ‘Broadcast’ when diagnosing barriers. However, the current behavior sets the default launch type to ‘Invalid,’ resulting in warnings when the launch type is not explicitly specified as an attribute.

To address this issue, we’ll adjust the default setting to ‘Broadcast’ and thereby resolve the problem.

Fixes #6836

---------

Co-authored-by: Damyan Pepper <damyanp@microsoft.com>
(cherry picked from commit ef043e90f3f3c5b2db899380591b5091b05f002e)