### PR TITLE
[SPIRV] Add vulkan memory option to DXC

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -396,6 +396,8 @@ def fspv_entrypoint_name_EQ : Joined<["-"], "fspv-entrypoint-name=">, Group<spir
   HelpText<"Specify the SPIR-V entry point name. Defaults to the HLSL entry point name.">;
 def fspv_enable_maximal_reconvergence: Flag<["-"], "fspv-enable-maximal-reconvergence">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Enables the MaximallyReconvergesKHR execution mode for this module.">;
+def fspv_use_vulkan_memory_model: Flag<["-"], "fspv-use-vulkan-memory-model">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Generates SPIR-V modules that use the Vulkan memory model instead of GLSL450.">;
 def fvk_auto_shift_bindings: Flag<["-"], "fvk-auto-shift-bindings">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Apply fvk-*-shift to resources without an explicit register assignment.">;
 def Wno_vk_ignored_features : Joined<["-"], "Wno-vk-ignored-features">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -68,6 +68,7 @@ struct SpirvCodeGenOptions {
   bool fixFuncCallArguments;
   bool allowRWStructuredBufferArrays;
   bool enableMaximalReconvergence;
+  bool useVulkanMemoryModel;
   bool IEEEStrict;
   /// Maximum length in words for the OpString literal containing the shader
   /// source for DebugSource and DebugSourceContinued. If the source code length

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1085,6 +1085,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fvk_allow_rwstructuredbuffer_arrays, OPT_INVALID, false);
   opts.SpirvOptions.enableMaximalReconvergence =
       Args.hasFlag(OPT_fspv_enable_maximal_reconvergence, OPT_INVALID, false);
+  opts.SpirvOptions.useVulkanMemoryModel =
+      Args.hasFlag(OPT_fspv_use_vulkan_memory_model, OPT_INVALID, false);
 
   if (!handleVkShiftArgs(Args, OPT_fvk_b_shift, "b", &opts.SpirvOptions.bShift,
                          errors) ||

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -770,9 +770,8 @@ public:
   /// the feature used at the given source location.
   inline void requireCapability(spv::Capability, SourceLocation loc = {});
 
-  /// \brief Adds the given capability to the module under construction due to
-  /// the feature used at the given source location.
-  inline bool requiresCapability(spv::Capability);
+  /// \brief Returns true if the module requires the given capability.
+  inline bool hasCapability(spv::Capability cap);
 
   /// \brief Adds an extension to the module under construction for translating
   /// the given target at the given source location.
@@ -900,7 +899,7 @@ void SpirvBuilder::requireCapability(spv::Capability cap, SourceLocation loc) {
   }
 }
 
-bool SpirvBuilder::requiresCapability(spv::Capability cap) {
+bool SpirvBuilder::hasCapability(spv::Capability cap) {
   SpirvCapability capability({}, cap);
   return mod->hasCapability(capability);
 }

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -770,6 +770,10 @@ public:
   /// the feature used at the given source location.
   inline void requireCapability(spv::Capability, SourceLocation loc = {});
 
+  /// \brief Adds the given capability to the module under construction due to
+  /// the feature used at the given source location.
+  inline bool requiresCapability(spv::Capability);
+
   /// \brief Adds an extension to the module under construction for translating
   /// the given target at the given source location.
   inline void requireExtension(llvm::StringRef extension, SourceLocation);
@@ -894,6 +898,11 @@ void SpirvBuilder::requireCapability(spv::Capability cap, SourceLocation loc) {
   } else {
     capability->releaseMemory();
   }
+}
+
+bool SpirvBuilder::requiresCapability(spv::Capability cap) {
+  SpirvCapability capability({}, cap);
+  return mod->hasCapability(capability);
 }
 
 void SpirvBuilder::requireExtension(llvm::StringRef ext, SourceLocation loc) {

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -102,7 +102,7 @@ public:
   // Returns false otherwise (e.g. if the capability already existed).
   bool addCapability(SpirvCapability *cap);
 
-  // Returns true if the capability is in the modudle.
+  // Returns true if the capability is in the module.
   bool hasCapability(SpirvCapability &cap);
 
   // Set the memory model of the module.

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -102,6 +102,9 @@ public:
   // Returns false otherwise (e.g. if the capability already existed).
   bool addCapability(SpirvCapability *cap);
 
+  // Returns true if the capability is in the modudle.
+  bool hasCapability(SpirvCapability &cap);
+
   // Set the memory model of the module.
   void setMemoryModel(SpirvMemoryModel *model);
 

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -46,7 +46,7 @@ void CapabilityVisitor::addCapability(spv::Capability cap, SourceLocation loc) {
 void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
                                              SourceLocation loc,
                                              spv::StorageClass sc) {
-  // Defent against instructions that do not have a return type.
+  // Defend against instructions that do not have a return type.
   if (!type)
     return;
 
@@ -827,8 +827,6 @@ void CapabilityVisitor::AddVulkanMemoryModelForVolatile(SpirvDecoration *decor,
                    "Volatile builtin variable in raytracing", loc);
     }
     addCapability(spv::Capability::VulkanMemoryModel, loc);
-    spvBuilder.setMemoryModel(spv::AddressingModel::Logical,
-                              spv::MemoryModel::VulkanKHR);
   }
 }
 
@@ -893,10 +891,6 @@ bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
     addExtensionAndCapabilitiesIfEnabled(Extension::KHR_ray_tracing,
                                          {spv::Capability::RayTracingKHR});
   }
-
-  addExtensionAndCapabilitiesIfEnabled(
-      Extension::KHR_vulkan_memory_model,
-      {spv::Capability::VulkanMemoryModelDeviceScope});
 
   addExtensionAndCapabilitiesIfEnabled(
       Extension::NV_shader_subgroup_partitioned,

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -87,6 +87,12 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
   } else {
     for (auto ext : opts.allowedExtensions)
       allowExtension(ext);
+
+    // The option to use the vulkan memory model implies the extension is
+    // available.
+    if (opts.useVulkanMemoryModel) {
+      allowExtension("SPV_KHR_vulkan_memory_model");
+    }
   }
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -874,6 +874,10 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
   if (context.getDiagnostics().hasErrorOccurred())
     return;
 
+  if (!UpgradeToVulkanMemoryModelIfNeeded(&m)) {
+    return;
+  }
+
   // Check the existance of Texture and Sampler with
   // [[vk::combinedImageSampler]] for the same descriptor set and binding.
   auto resourceInfoForSampledImages =
@@ -14691,8 +14695,9 @@ SpirvEmitter::createFunctionScopeTempFromParameter(const ParmVarDecl *param) {
   return tempVar;
 }
 
-bool SpirvEmitter::spirvToolsFixupOpExtInst(std::vector<uint32_t> *mod,
-                                            std::string *messages) {
+bool SpirvEmitter::spirvToolsRunPass(std::vector<uint32_t> *mod,
+                                     spvtools::Optimizer::PassToken token,
+                                     std::string *messages) {
   spvtools::Optimizer optimizer(featureManager.getTargetEnv());
   optimizer.SetMessageConsumer(
       [messages](spv_message_level_t /*level*/, const char * /*source*/,
@@ -14709,33 +14714,28 @@ bool SpirvEmitter::spirvToolsFixupOpExtInst(std::vector<uint32_t> *mod,
   options.set_preserve_bindings(spirvOptions.preserveBindings);
   options.set_max_id_bound(spirvOptions.maxId);
 
-  optimizer.RegisterPass(
-      spvtools::CreateOpExtInstWithForwardReferenceFixupPass());
-
+  optimizer.RegisterPass(std::move(token));
   return optimizer.Run(mod->data(), mod->size(), mod, options);
+}
+
+bool SpirvEmitter::spirvToolsFixupOpExtInst(std::vector<uint32_t> *mod,
+                                            std::string *messages) {
+  spvtools::Optimizer::PassToken token =
+      spvtools::CreateOpExtInstWithForwardReferenceFixupPass();
+  return spirvToolsRunPass(mod, std::move(token), messages);
 }
 
 bool SpirvEmitter::spirvToolsTrimCapabilities(std::vector<uint32_t> *mod,
                                               std::string *messages) {
-  spvtools::Optimizer optimizer(featureManager.getTargetEnv());
-  optimizer.SetMessageConsumer(
-      [messages](spv_message_level_t /*level*/, const char * /*source*/,
-                 const spv_position_t & /*position*/,
-                 const char *message) { *messages += message; });
+  spvtools::Optimizer::PassToken token = spvtools::CreateTrimCapabilitiesPass();
+  return spirvToolsRunPass(mod, std::move(token), messages);
+}
 
-  string::RawOstreamBuf printAllBuf(llvm::errs());
-  std::ostream printAllOS(&printAllBuf);
-  if (spirvOptions.printAll)
-    optimizer.SetPrintAll(&printAllOS);
-
-  spvtools::OptimizerOptions options;
-  options.set_run_validator(false);
-  options.set_preserve_bindings(spirvOptions.preserveBindings);
-  options.set_max_id_bound(spirvOptions.maxId);
-
-  optimizer.RegisterPass(spvtools::CreateTrimCapabilitiesPass());
-
-  return optimizer.Run(mod->data(), mod->size(), mod, options);
+bool SpirvEmitter::spirvToolsUpgradeMemoryModel(std::vector<uint32_t> *mod,
+                                                std::string *messages) {
+  spvtools::Optimizer::PassToken token =
+      spvtools::CreateUpgradeMemoryModelPass();
+  return spirvToolsRunPass(mod, std::move(token), messages);
 }
 
 bool SpirvEmitter::spirvToolsOptimize(std::vector<uint32_t> *mod,
@@ -15139,6 +15139,27 @@ SpirvEmitter::splatScalarToGenerate(QualType type, SpirvInstruction *scalar,
     llvm_unreachable("Trying to generate a type that we cannot generate");
   }
   return {};
+}
+
+bool SpirvEmitter::UpgradeToVulkanMemoryModelIfNeeded(
+    std::vector<uint32_t> *module) {
+  // DXC generates code assuming the vulkan memory model is not used. However,
+  // if a feature is used that requires the Vulkan memory model, then some code
+  // may need to be rewritten.
+  if (!spirvOptions.useVulkanMemoryModel &&
+      !spvBuilder.requiresCapability(spv::Capability::VulkanMemoryModel))
+    return true;
+
+  std::string messages;
+  if (!spirvToolsUpgradeMemoryModel(module, &messages)) {
+    emitFatalError("failed to use the vulkan memory model: %0", {}) << messages;
+    emitNote("please file a bug report on "
+             "https://github.com/Microsoft/DirectXShaderCompiler/issues "
+             "with source code if possible",
+             {});
+    return false;
+  }
+  return true;
 }
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -14731,8 +14731,8 @@ bool SpirvEmitter::spirvToolsTrimCapabilities(std::vector<uint32_t> *mod,
   return spirvToolsRunPass(mod, std::move(token), messages);
 }
 
-bool SpirvEmitter::spirvToolsUpgradeMemoryModel(std::vector<uint32_t> *mod,
-                                                std::string *messages) {
+bool SpirvEmitter::spirvToolsUpgradeToVulkanMemoryModel(
+    std::vector<uint32_t> *mod, std::string *messages) {
   spvtools::Optimizer::PassToken token =
       spvtools::CreateUpgradeMemoryModelPass();
   return spirvToolsRunPass(mod, std::move(token), messages);
@@ -15147,11 +15147,11 @@ bool SpirvEmitter::UpgradeToVulkanMemoryModelIfNeeded(
   // if a feature is used that requires the Vulkan memory model, then some code
   // may need to be rewritten.
   if (!spirvOptions.useVulkanMemoryModel &&
-      !spvBuilder.requiresCapability(spv::Capability::VulkanMemoryModel))
+      !spvBuilder.hasCapability(spv::Capability::VulkanMemoryModel))
     return true;
 
   std::string messages;
-  if (!spirvToolsUpgradeMemoryModel(module, &messages)) {
+  if (!spirvToolsUpgradeToVulkanMemoryModel(module, &messages)) {
     emitFatalError("failed to use the vulkan memory model: %0", {}) << messages;
     emitNote("please file a bug report on "
              "https://github.com/Microsoft/DirectXShaderCompiler/issues "

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1287,6 +1287,11 @@ private:
                                           SpirvInstruction *scalar,
                                           SpirvLayoutRule rule);
 
+  /// Modifies the instruction in the code that use the GLSL450 memory module to
+  /// use the Vulkan memory model. This is done only if it has been requested or
+  /// the Vulkan memory model capability has been added to the module.
+  bool UpgradeToVulkanMemoryModelIfNeeded(std::vector<uint32_t> *module);
+
 public:
   /// \brief Wrapper method to create a fatal error message and report it
   /// in the diagnostic engine associated with this consumer.
@@ -1469,7 +1474,6 @@ private:
 
   /// ParentMap of the current function.
   std::unique_ptr<ParentMap> parentMap = nullptr;
-  bool UpgradeToVulkanMemoryModelIfNeeded(std::vector<uint32_t> *module);
 };
 
 void SpirvEmitter::doDeclStmt(const DeclStmt *declStmt) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1225,13 +1225,11 @@ private:
                                   std::string *messages);
 
   // \brief Runs the upgrade memory model pass using SPIRV-Tools's optimizer.
-  // This pass will modify the module so that it conforms to the Vulkan memory
-  // model instead of the pass. Removes unused capabilities from the given
-  // SPIR-V module |mod|, and returns info/warning/error messages via
-  // |messages|. This pass doesn't trim all capabilities. To see the list of
-  // supported capabilities, check the pass headers.
-  bool spirvToolsUpgradeMemoryModel(std::vector<uint32_t> *mod,
-                                    std::string *messages);
+  // This pass will modify the module, |mod|, so that it conforms to the Vulkan
+  // memory model instead of the GLSL450 memory model. Returns
+  // info/warning/error messages via |messages|.
+  bool spirvToolsUpgradeToVulkanMemoryModel(std::vector<uint32_t> *mod,
+                                            std::string *messages);
 
   /// \brief Helper function to run SPIRV-Tools optimizer's legalization passes.
   /// Runs the SPIRV-Tools legalization on the given SPIR-V module |mod|, and

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -249,6 +249,10 @@ bool SpirvModule::addCapability(SpirvCapability *cap) {
   return capabilities.insert(cap);
 }
 
+bool SpirvModule::hasCapability(SpirvCapability &cap) {
+  return capabilities.count(&cap) != 0;
+}
+
 void SpirvModule::setMemoryModel(SpirvMemoryModel *model) {
   assert(model && "cannot set a null memory model");
   if (memoryModel)

--- a/tools/clang/test/CodeGenSPIRV/decoration.coherent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.coherent.hlsl
@@ -1,22 +1,65 @@
-// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s -check-prefix=GLSL450
+// RUN: %dxc -T ps_6_0 -E main -fcgl -fspv-use-vulkan-memory-model %s -spirv | FileCheck %s -check-prefix=VULKAN
+
+// When the GLSL450 memory model is used, there should be no memory operands on the loads and stores.
+// When the Vulkan memory model is used, there should be no decorations. There should be memory operands on the loads and stores instead.
 
 struct StructA
 {
     uint one;
 };
 
-// CHECK: OpDecorate %buffer1 Coherent
+// GLSL450: OpMemoryModel Logical GLSL450
+// VULKAN: OpMemoryModel Logical Vulkan
+
+// GLSL450: OpDecorate %buffer1 Coherent
+// VULKAN-NOT: OpDecorate %buffer1 Coherent
 globallycoherent RWByteAddressBuffer buffer1;
 
-// CHECK: OpDecorate %buffer2 Coherent
+// GLSL450: OpDecorate %buffer2 Coherent
+// VULKAN-NOT: OpDecorate %buffer2 Coherent
 globallycoherent RWStructuredBuffer<StructA> buffer2;
 
-// CHECK-NOT: OpDecorate %buffer3 Coherent
+// GLSL450-NOT: OpDecorate %buffer3 Coherent
+// VULKAN-NOT: OpDecorate %buffer3 Coherent
 RWByteAddressBuffer buffer3;
 
-// CHECK-NOT: OpDecorate %buffer4 Coherent
+// GLSL450-NOT: OpDecorate %buffer4 Coherent
+// VULKAN-NOT: OpDecorate %buffer3 Coherent
 RWStructuredBuffer<StructA> buffer4;
 
 void main()
 {
+
+// GLSL450: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer1
+// GLSL450: OpLoad %uint [[ac]]{{$}}
+// GLSL450: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer3
+// GLSL450: OpLoad %uint [[ac]]{{$}}
+// GLSL450: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer4
+// GLSL450: OpLoad %uint [[ac]]{{$}}
+// GLSL450: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer2
+// GLSL450: OpStore [[ac]] {{%[0-9]+$}}
+
+// VULKAN: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer1
+// VULKAN: OpLoad %uint [[ac]] MakePointerVisible|NonPrivatePointer %uint_5
+// VULKAN: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer3
+// VULKAN: OpLoad %uint [[ac]]{{$}}
+// VULKAN: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer4
+// VULKAN: OpLoad %uint [[ac]]{{$}}
+// VULKAN: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer2
+// VULKAN: OpStore [[ac]] {{%[0-9]+}} MakePointerAvailable|NonPrivatePointer %uint_5
+
+  buffer2[0].one = buffer1.Load(0) + buffer3.Load(0) + buffer4[0].one;
+
+// GLSL450: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer2
+// GLSL450: OpLoad %uint [[ac]]{{$}}
+// GLSL450: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer4
+// GLSL450: OpStore [[ac]] {{%[0-9]+$}}
+
+// VULKAN: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer2
+// VULKAN: OpLoad %uint [[ac]] MakePointerVisible|NonPrivatePointer %uint_5
+// VULKAN: [[ac:%[0-9]+]] = OpAccessChain {{.*}} %buffer4
+// VULKAN: OpStore [[ac]] {{%[0-9]+$}}
+  buffer4[0].one = buffer2[0].one;
+  
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.ps.hlsl
@@ -1,4 +1,5 @@
-// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s -check-prefix=CHECK -check-prefix=GLSL450
+// RUN: %dxc -T ps_6_0 -E main -fcgl -fspv-use-vulkan-memory-model %s -spirv | FileCheck %s -check-prefix=CHECK -check-prefix=VULKAN
 
 RWTexture1D <int>   g_tTex1di1;
 RWTexture1D <uint>  g_tTex1du1;
@@ -44,7 +45,8 @@ void main()
 // CHECK:         [[idx0:%[0-9]+]] = OpLoad %uint %u1
 // CHECK-NEXT:    [[ptr0:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 [[idx0]] %uint_0
 // CHECK-NEXT:    [[i1_0:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT:   [[iadd0:%[0-9]+]] = OpAtomicIAdd %int [[ptr0]] %uint_1 %uint_0 [[i1_0]]
+// GLSL450-NEXT:   [[iadd0:%[0-9]+]] = OpAtomicIAdd %int [[ptr0]] %uint_1 %uint_0 [[i1_0]]
+// VULKAN-NEXT:   [[iadd0:%[0-9]+]] = OpAtomicIAdd %int [[ptr0]] %uint_5 %uint_0 [[i1_0]]
 // CHECK-NEXT: [[iadd0_u:%[0-9]+]] = OpBitcast %uint [[iadd0]]
 // CHECK-NEXT:                    OpStore %out_u1 [[iadd0_u]]
   InterlockedAdd(g_tTex1di1[u1], i1, out_u1); // Addition result must be cast to uint before being written to out_u1
@@ -53,20 +55,23 @@ void main()
 // CHECK:        [[ptr1:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT:   [[u1_1:%[0-9]+]] = OpLoad %uint %u1
 // CHECK-NEXT: [[u1_int:%[0-9]+]] = OpBitcast %int [[u1_1]]
-// CHECK-NEXT:  [[iadd1:%[0-9]+]] = OpAtomicIAdd %int [[ptr1]] %uint_1 %uint_0 [[u1_int]]
+// GLSL450-NEXT:  [[iadd1:%[0-9]+]] = OpAtomicIAdd %int [[ptr1]] %uint_1 %uint_0 [[u1_int]]
+// VULKAN-NEXT:  [[iadd1:%[0-9]+]] = OpAtomicIAdd %int [[ptr1]] %uint_5 %uint_0 [[u1_int]]
 // CHECK-NEXT:                   OpStore %out_i1 [[iadd1]]
   InterlockedAdd(g_tTex1di1[u1], u1, out_i1); // u1 should be cast to int before being passed to addition instruction
 
 // CHECK:         [[ptr2:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT:    [[i1_2:%[0-9]+]] = OpLoad %int %i1
 // CHECK-NEXT: [[i1_uint:%[0-9]+]] = OpBitcast %uint [[i1_2]]
-// CHECK-NEXT:   [[iadd2:%[0-9]+]] = OpAtomicIAdd %uint [[ptr2]] %uint_1 %uint_0 [[i1_uint]]
+// GLSL450-NEXT:   [[iadd2:%[0-9]+]] = OpAtomicIAdd %uint [[ptr2]] %uint_1 %uint_0 [[i1_uint]]
+// VULKAN-NEXT:   [[iadd2:%[0-9]+]] = OpAtomicIAdd %uint [[ptr2]] %uint_5 %uint_0 [[i1_uint]]
 // CHECK-NEXT:                    OpStore %out_u1 [[iadd2]]
   InterlockedAdd(g_tTex1du1[u1], i1, out_u1); // i1 should be cast to uint before being passed to addition instruction
 
 // CHECK:           [[ptr3:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT:      [[u1_3:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT:     [[iadd3:%[0-9]+]] = OpAtomicIAdd %uint [[ptr3]] %uint_1 %uint_0 [[u1_3]]
+// GLSL450-NEXT:     [[iadd3:%[0-9]+]] = OpAtomicIAdd %uint [[ptr3]] %uint_1 %uint_0 [[u1_3]]
+// VULKAN-NEXT:     [[iadd3:%[0-9]+]] = OpAtomicIAdd %uint [[ptr3]] %uint_5 %uint_0 [[u1_3]]
 // CHECK-NEXT: [[iadd3_int:%[0-9]+]] = OpBitcast %int [[iadd3]]
 // CHECK-NEXT:                      OpStore %out_i1 [[iadd3_int]]
   InterlockedAdd(g_tTex1du1[u1], u1, out_i1); // Addition result must be cast to int before being written to out_i1
@@ -76,7 +81,8 @@ void main()
 // CHECK-NEXT:     [[u1b_4:%[0-9]+]] = OpLoad %uint %u1b
 // CHECK-NEXT: [[u1b_4_int:%[0-9]+]] = OpBitcast %int [[u1b_4]]
 // CHECK-NEXT:     [[i1c_4:%[0-9]+]] = OpLoad %int %i1c
-// CHECK-NEXT:      [[ace4:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr4]] %uint_1 %uint_0 %uint_0 [[i1c_4]] [[u1b_4_int]]
+// GLSL450-NEXT:      [[ace4:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr4]] %uint_1 %uint_0 %uint_0 [[i1c_4]] [[u1b_4_int]]
+// VULKAN-NEXT:      [[ace4:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr4]] %uint_5 %uint_0 %uint_0 [[i1c_4]] [[u1b_4_int]]
 // CHECK-NEXT:                      OpStore %out_i1 [[ace4]]
   InterlockedCompareExchange(g_tTex1di1[u1], u1b, i1c, out_i1); // u1b should first be cast to int
 
@@ -85,14 +91,16 @@ void main()
 // CHECK-NEXT:     [[i1b_5:%[0-9]+]] = OpLoad %int %i1b
 // CHECK-NEXT:     [[u1c_5:%[0-9]+]] = OpLoad %uint %u1c
 // CHECK-NEXT: [[u1c_5_int:%[0-9]+]] = OpBitcast %int [[u1c_5]]
-// CHECK-NEXT:      [[ace5:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr5]] %uint_1 %uint_0 %uint_0 [[u1c_5_int]] [[i1b_5]]
+// GLSL450-NEXT:      [[ace5:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr5]] %uint_1 %uint_0 %uint_0 [[u1c_5_int]] [[i1b_5]]
+// VULKAN-NEXT:      [[ace5:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr5]] %uint_5 %uint_0 %uint_0 [[u1c_5_int]] [[i1b_5]]
 // CHECK-NEXT:                      OpStore %out_i1 [[ace5]]
   InterlockedCompareExchange(g_tTex1di1[u1], i1b, u1c, out_i1); // u1c should first be cast to int
 
 // CHECK:           [[ptr6:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT:     [[i1b_6:%[0-9]+]] = OpLoad %int %i1b
 // CHECK-NEXT:     [[i1c_6:%[0-9]+]] = OpLoad %int %i1c
-// CHECK-NEXT:      [[ace6:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr6]] %uint_1 %uint_0 %uint_0 [[i1c_6]] [[i1b_6]]
+// GLSL450-NEXT:      [[ace6:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr6]] %uint_1 %uint_0 %uint_0 [[i1c_6]] [[i1b_6]]
+// VULKAN-NEXT:      [[ace6:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr6]] %uint_5 %uint_0 %uint_0 [[i1c_6]] [[i1b_6]]
 // CHECK-NEXT: [[ace6_uint:%[0-9]+]] = OpBitcast %uint [[ace6]]
 // CHECK-NEXT:                      OpStore %out_u1 [[ace6_uint]]
   InterlockedCompareExchange(g_tTex1di1[u1], i1b, i1c, out_u1); // original value must be cast to uint before being written to out_u1
@@ -101,7 +109,8 @@ void main()
 // CHECK-NEXT:      [[u1b_7:%[0-9]+]] = OpLoad %uint %u1b
 // CHECK-NEXT:      [[i1c_7:%[0-9]+]] = OpLoad %int %i1c
 // CHECK-NEXT: [[i1c_7_uint:%[0-9]+]] = OpBitcast %uint [[i1c_7]]
-// CHECK-NEXT:       [[ace7:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr7]] %uint_1 %uint_0 %uint_0 [[i1c_7_uint]] [[u1b_7]]
+// GLSL450-NEXT:       [[ace7:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr7]] %uint_1 %uint_0 %uint_0 [[i1c_7_uint]] [[u1b_7]]
+// VULKAN-NEXT:       [[ace7:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr7]] %uint_5 %uint_0 %uint_0 [[i1c_7_uint]] [[u1b_7]]
 // CHECK-NEXT:                       OpStore %out_u1 [[ace7]]
   InterlockedCompareExchange(g_tTex1du1[u1], u1b, i1c, out_u1); // i1c should first be cast to uint
 
@@ -110,7 +119,8 @@ void main()
 // CHECK-NEXT:      [[i1b_8:%[0-9]+]] = OpLoad %int %i1b
 // CHECK-NEXT: [[i1b_8_uint:%[0-9]+]] = OpBitcast %uint [[i1b_8]]
 // CHECK-NEXT:      [[u1c_8:%[0-9]+]] = OpLoad %uint %u1c
-// CHECK-NEXT:       [[ace8:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr8]] %uint_1 %uint_0 %uint_0 [[u1c_8]] [[i1b_8_uint]]
+// GLSL450-NEXT:       [[ace8:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr8]] %uint_1 %uint_0 %uint_0 [[u1c_8]] [[i1b_8_uint]]
+// VULKAN-NEXT:       [[ace8:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr8]] %uint_5 %uint_0 %uint_0 [[u1c_8]] [[i1b_8_uint]]
 // CHECK-NEXT:                       OpStore %out_u1 [[ace8]]
   InterlockedCompareExchange(g_tTex1du1[u1], i1b, u1c, out_u1); // i1b should first be cast to uint
 
@@ -118,7 +128,8 @@ void main()
 // CHECK:          [[ptr9:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT:    [[u1b_9:%[0-9]+]] = OpLoad %uint %u1b
 // CHECK-NEXT:    [[u1c_9:%[0-9]+]] = OpLoad %uint %u1c
-// CHECK-NEXT:     [[ace9:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr9]] %uint_1 %uint_0 %uint_0 [[u1c_9]] [[u1b_9]]
+// GLSL450-NEXT:     [[ace9:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr9]] %uint_1 %uint_0 %uint_0 [[u1c_9]] [[u1b_9]]
+// VULKAN-NEXT:     [[ace9:%[0-9]+]] = OpAtomicCompareExchange %uint [[ptr9]] %uint_5 %uint_0 %uint_0 [[u1c_9]] [[u1b_9]]
 // CHECK-NEXT: [[ace9_int:%[0-9]+]] = OpBitcast %int [[ace9]]
 // CHECK-NEXT:                     OpStore %out_i1 [[ace9_int]]
   InterlockedCompareExchange(g_tTex1du1[u1], u1b, u1c, out_i1); // original value must be cast to int before being written to out_i1
@@ -127,7 +138,8 @@ void main()
 //CHECK:             [[ptr10:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 //CHECK-NEXT:        [[u1_10:%[0-9]+]] = OpLoad %uint %u1
 //CHECK-NEXT:    [[u1_10_int:%[0-9]+]] = OpBitcast %int [[u1_10]]
-//CHECK-NEXT:      [[asmax10:%[0-9]+]] = OpAtomicSMax %int [[ptr10]] %uint_1 %uint_0 [[u1_10_int]]
+//GLSL450-NEXT:      [[asmax10:%[0-9]+]] = OpAtomicSMax %int [[ptr10]] %uint_1 %uint_0 [[u1_10_int]]
+//VULKAN-NEXT:      [[asmax10:%[0-9]+]] = OpAtomicSMax %int [[ptr10]] %uint_5 %uint_0 [[u1_10_int]]
 //CHECK-NEXT: [[asmax10_uint:%[0-9]+]] = OpBitcast %uint [[asmax10]]
 //CHECK-NEXT:                         OpStore %out_u1 [[asmax10_uint]]
   // u1 should be cast to int first.
@@ -139,7 +151,8 @@ void main()
 // CHECK:      [[ptr11:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1_11:%[0-9]+]] = OpLoad %int %i1
 // CHECK-NEXT: [[i1_11_uint:%[0-9]+]] = OpBitcast %uint [[i1_11]]
-// CHECK-NEXT: [[aumin11:%[0-9]+]] = OpAtomicUMin %uint [[ptr11]] %uint_1 %uint_0 [[i1_11_uint]]
+// GLSL450-NEXT: [[aumin11:%[0-9]+]] = OpAtomicUMin %uint [[ptr11]] %uint_1 %uint_0 [[i1_11_uint]]
+// VULKAN-NEXT: [[aumin11:%[0-9]+]] = OpAtomicUMin %uint [[ptr11]] %uint_5 %uint_0 [[i1_11_uint]]
 // CHECK-NEXT: [[aumin11_int:%[0-9]+]] = OpBitcast %int [[aumin11]]
 // CHECK-NEXT: OpStore %out_i1 [[aumin11_int]]
   // i1 should be cast to uint first.
@@ -155,95 +168,111 @@ void main()
 
 // CHECK:      [[ptr12:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1_12:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT:       {{%[0-9]+}} = OpAtomicIAdd %int [[ptr12]] %uint_1 %uint_0 [[i1_12]]
+// GLSL450-NEXT:       {{%[0-9]+}} = OpAtomicIAdd %int [[ptr12]] %uint_1 %uint_0 [[i1_12]]
+// VULKAN-NEXT:       {{%[0-9]+}} = OpAtomicIAdd %int [[ptr12]] %uint_5 %uint_0 [[i1_12]]
   InterlockedAdd            (g_tTex1di1[u1], i1);
 
 // CHECK:       [[ptr13:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT:  [[i1_13:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT: [[iadd13:%[0-9]+]] = OpAtomicIAdd %int [[ptr13]] %uint_1 %uint_0 [[i1_13]]
+// GLSL450-NEXT: [[iadd13:%[0-9]+]] = OpAtomicIAdd %int [[ptr13]] %uint_1 %uint_0 [[i1_13]]
+// VULKAN-NEXT: [[iadd13:%[0-9]+]] = OpAtomicIAdd %int [[ptr13]] %uint_5 %uint_0 [[i1_13]]
 // CHECK-NEXT:                   OpStore %out_i1 [[iadd13]]
   InterlockedAdd            (g_tTex1di1[u1], i1, out_i1);
 
 // CHECK:      [[ptr14:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1_14:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT:       {{%[0-9]+}} = OpAtomicAnd %int [[ptr14]] %uint_1 %uint_0 [[i1_14]]
+// GLSL450-NEXT:       {{%[0-9]+}} = OpAtomicAnd %int [[ptr14]] %uint_1 %uint_0 [[i1_14]]
+// VULKAN-NEXT:       {{%[0-9]+}} = OpAtomicAnd %int [[ptr14]] %uint_5 %uint_0 [[i1_14]]
   InterlockedAnd            (g_tTex1di1[u1], i1);
 
 // CHECK:      [[ptr15:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1_15:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT: [[and15:%[0-9]+]] = OpAtomicAnd %int [[ptr15]] %uint_1 %uint_0 [[i1_15]]
+// GLSL450-NEXT: [[and15:%[0-9]+]] = OpAtomicAnd %int [[ptr15]] %uint_1 %uint_0 [[i1_15]]
+// VULKAN-NEXT: [[and15:%[0-9]+]] = OpAtomicAnd %int [[ptr15]] %uint_5 %uint_0 [[i1_15]]
 // CHECK-NEXT:                  OpStore %out_i1 [[and15]]
   InterlockedAnd            (g_tTex1di1[u1], i1, out_i1);
 
 // CHECK:      [[ptr16:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[u1_16:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT: {{%[0-9]+}} = OpAtomicUMax %uint [[ptr16]] %uint_1 %uint_0 [[u1_16]]
+// GLSL450-NEXT: {{%[0-9]+}} = OpAtomicUMax %uint [[ptr16]] %uint_1 %uint_0 [[u1_16]]
+// VULKAN-NEXT: {{%[0-9]+}} = OpAtomicUMax %uint [[ptr16]] %uint_5 %uint_0 [[u1_16]]
   InterlockedMax(g_tTex1du1[u1], u1);
 
 // CHECK:        [[u2_17:%[0-9]+]] = OpLoad %v2uint %u2
 // CHECK-NEXT:   [[ptr17:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex2di1 [[u2_17]] %uint_0
 // CHECK-NEXT:   [[i1_17:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT: [[asmax17:%[0-9]+]] = OpAtomicSMax %int [[ptr17]] %uint_1 %uint_0 [[i1_17]]
+// GLSL450-NEXT: [[asmax17:%[0-9]+]] = OpAtomicSMax %int [[ptr17]] %uint_1 %uint_0 [[i1_17]]
+// VULKAN-NEXT: [[asmax17:%[0-9]+]] = OpAtomicSMax %int [[ptr17]] %uint_5 %uint_0 [[i1_17]]
 // CHECK-NEXT:                    OpStore %out_i1 [[asmax17]]
   InterlockedMax(g_tTex2di1[u2], i1, out_i1);
 
 // CHECK:      [[ptr18:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex2du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[u1_18:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT:       {{%[0-9]+}} = OpAtomicUMin %uint [[ptr18]] %uint_1 %uint_0 [[u1_18]]
+// GLSL450-NEXT:       {{%[0-9]+}} = OpAtomicUMin %uint [[ptr18]] %uint_1 %uint_0 [[u1_18]]
+// VULKAN-NEXT:       {{%[0-9]+}} = OpAtomicUMin %uint [[ptr18]] %uint_5 %uint_0 [[u1_18]]
   InterlockedMin(g_tTex2du1[u2], u1);
 
 // CHECK:        [[u3_19:%[0-9]+]] = OpLoad %v3uint %u3
 // CHECK-NEXT:   [[ptr19:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex3di1 [[u3_19]] %uint_0
 // CHECK-NEXT:   [[i1_19:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT: [[asmin19:%[0-9]+]] = OpAtomicSMin %int [[ptr19]] %uint_1 %uint_0 [[i1_19]]
+// GLSL450-NEXT: [[asmin19:%[0-9]+]] = OpAtomicSMin %int [[ptr19]] %uint_1 %uint_0 [[i1_19]]
+// VULKAN-NEXT: [[asmin19:%[0-9]+]] = OpAtomicSMin %int [[ptr19]] %uint_5 %uint_0 [[i1_19]]
 // CHECK-NEXT:                    OpStore %out_i1 [[asmin19]]
   InterlockedMin(g_tTex3di1[u3], i1, out_i1);
 
 // CHECK:      [[ptr20:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex3du1 {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[u1_20:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT:       {{%[0-9]+}} = OpAtomicOr %uint [[ptr20]] %uint_1 %uint_0 [[u1_20]]
+// GLSL450-NEXT:       {{%[0-9]+}} = OpAtomicOr %uint [[ptr20]] %uint_1 %uint_0 [[u1_20]]
+// VULKAN-NEXT:       {{%[0-9]+}} = OpAtomicOr %uint [[ptr20]] %uint_5 %uint_0 [[u1_20]]
   InterlockedOr (g_tTex3du1[u3], u1);
 
 // CHECK:      [[ptr21:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1a {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1_21:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT:  [[or21:%[0-9]+]] = OpAtomicOr %int [[ptr21]] %uint_1 %uint_0 [[i1_21]]
+// GLSL450-NEXT:  [[or21:%[0-9]+]] = OpAtomicOr %int [[ptr21]] %uint_1 %uint_0 [[i1_21]]
+// VULKAN-NEXT:  [[or21:%[0-9]+]] = OpAtomicOr %int [[ptr21]] %uint_5 %uint_0 [[i1_21]]
 // CHECK-NEXT:                  OpStore %out_i1 [[or21]]
   InterlockedOr (g_tTex1di1a[u2], i1, out_i1);
 
 // CHECK:      [[ptr22:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1a {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[u1_22:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT:       {{%[0-9]+}} = OpAtomicXor %uint [[ptr22]] %uint_1 %uint_0 [[u1_22]]
+// GLSL450-NEXT:       {{%[0-9]+}} = OpAtomicXor %uint [[ptr22]] %uint_1 %uint_0 [[u1_22]]
+// VULKAN-NEXT:       {{%[0-9]+}} = OpAtomicXor %uint [[ptr22]] %uint_5 %uint_0 [[u1_22]]
   InterlockedXor(g_tTex1du1a[u2], u1);
 
 // CHECK:      [[ptr23:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tTex1di1a {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1_23:%[0-9]+]] = OpLoad %int %i1
-// CHECK-NEXT: [[xor23:%[0-9]+]] = OpAtomicXor %int [[ptr23]] %uint_1 %uint_0 [[i1_23]]
+// GLSL450-NEXT: [[xor23:%[0-9]+]] = OpAtomicXor %int [[ptr23]] %uint_1 %uint_0 [[i1_23]]
+// VULKAN-NEXT: [[xor23:%[0-9]+]] = OpAtomicXor %int [[ptr23]] %uint_5 %uint_0 [[i1_23]]
 // CHECK-NEXT:                  OpStore %out_i1 [[xor23]]
   InterlockedXor(g_tTex1di1a[u2], i1, out_i1);
 
 // CHECK:       [[ptr24:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tTex1du1a {{%[0-9]+}} %uint_0
 // CHECK-NEXT:  [[u1_24:%[0-9]+]] = OpLoad %uint %u1
 // CHECK-NEXT: [[u1b_24:%[0-9]+]] = OpLoad %uint %u1b
-// CHECK-NEXT:        {{%[0-9]+}} = OpAtomicCompareExchange %uint [[ptr24]] %uint_1 %uint_0 %uint_0 [[u1b_24]] [[u1_24]]
+// GLSL450-NEXT:        {{%[0-9]+}} = OpAtomicCompareExchange %uint [[ptr24]] %uint_1 %uint_0 %uint_0 [[u1b_24]] [[u1_24]]
+// VULKAN-NEXT:        {{%[0-9]+}} = OpAtomicCompareExchange %uint [[ptr24]] %uint_5 %uint_0 %uint_0 [[u1b_24]] [[u1_24]]
   InterlockedCompareStore(g_tTex1du1a[u2], u1, u1b);
 
 // CHECK:       [[ptr25:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_int %g_tBuffI {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[i1b_25:%[0-9]+]] = OpLoad %int %i1b
 // CHECK-NEXT: [[i1c_25:%[0-9]+]] = OpLoad %int %i1c
-// CHECK-NEXT:  [[ace25:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr25]] %uint_1 %uint_0 %uint_0 [[i1c_25]] [[i1b_25]]
+// GLSL450-NEXT:  [[ace25:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr25]] %uint_1 %uint_0 %uint_0 [[i1c_25]] [[i1b_25]]
+// VULKAN-NEXT:  [[ace25:%[0-9]+]] = OpAtomicCompareExchange %int [[ptr25]] %uint_5 %uint_0 %uint_0 [[i1c_25]] [[i1b_25]]
 // CHECK-NEXT:                   OpStore %out_i1 [[ace25]]
   InterlockedCompareExchange(g_tBuffI[u1], i1b, i1c, out_i1);
 
 // CHECK:      [[ptr26:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %g_tBuffU {{%[0-9]+}} %uint_0
 // CHECK-NEXT: [[u1_26:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT:  [[ae26:%[0-9]+]] = OpAtomicExchange %uint [[ptr26]] %uint_1 %uint_0 [[u1_26]]
+// GLSL450-NEXT:  [[ae26:%[0-9]+]] = OpAtomicExchange %uint [[ptr26]] %uint_1 %uint_0 [[u1_26]]
+// VULKAN-NEXT:  [[ae26:%[0-9]+]] = OpAtomicExchange %uint [[ptr26]] %uint_5 %uint_0 [[u1_26]]
 // CHECK-NEXT:                  OpStore %out_u1 [[ae26]]
   InterlockedExchange(g_tBuffU[u1], u1, out_u1);
 
 // CHECK-NEXT:    [[u1:%[0-9]+]] = OpLoad %uint %u1
 // CHECK-NEXT:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %g_tRWBuffU %int_0 [[u1]]
 // CHECK-NEXT:    [[u1_0:%[0-9]+]] = OpLoad %uint %u1
-// CHECK-NEXT:   [[add:%[0-9]+]] = OpAtomicIAdd %uint [[ptr]] %uint_1 %uint_0 [[u1_0]]
+// GLSL450-NEXT:   [[add:%[0-9]+]] = OpAtomicIAdd %uint [[ptr]] %uint_1 %uint_0 [[u1_0]]
+// VULKAN-NEXT:   [[add:%[0-9]+]] = OpAtomicIAdd %uint [[ptr]] %uint_5 %uint_0 [[u1_0]]
 // CHECK-NEXT:                  OpStore %out_u1 [[add]]
   InterlockedAdd(g_tRWBuffU[u1], u1, out_u1);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.raygeneration.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.raygeneration.hlsl
@@ -3,13 +3,12 @@
 RWStructuredBuffer<int> g_buff;
 
 // CHECK-DAG: OpCapability VulkanMemoryModel
-// CHECK-DAG: OpCapability VulkanMemoryModelDeviceScope
 // CHECK:     OpMemoryModel Logical Vulkan
 
 [shader("raygeneration")]
 void main()
 {
-// CHECK: OpAtomicIAdd %int {{%[0-9]+}} %uint_1
-//                                      1 = Device scope
+// CHECK: OpAtomicIAdd %int {{%[0-9]+}} %uint_5
+//                                      5 = Queue family scope
     InterlockedAdd(g_buff[0], WaveGetLaneCount());
 }

--- a/tools/clang/test/CodeGenSPIRV/volatile.interface.raygen.vk1p1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/volatile.interface.raygen.vk1p1.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fspv-extension=SPV_KHR_vulkan_memory_model -fspv-target-env=vulkan1.1 -O0  %s -spirv | FileCheck %s
+// RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fspv-use-vulkan-memory-model -fspv-target-env=vulkan1.1 -O0  %s -spirv | FileCheck %s
 
 // CHECK: OpCapability VulkanMemoryModel
 // CHECK: OpExtension "SPV_KHR_vulkan_memory_model"

--- a/tools/clang/test/CodeGenSPIRV/volatile.interface.raygen.vk1p1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/volatile.interface.raygen.vk1p1.hlsl
@@ -1,3 +1,4 @@
+// RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fspv-extension=SPV_KHR_vulkan_memory_model -fspv-target-env=vulkan1.1 -O0  %s -spirv | FileCheck %s
 // RUN: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing -fspv-extension=SPV_KHR_ray_query -fspv-use-vulkan-memory-model -fspv-target-env=vulkan1.1 -O0  %s -spirv | FileCheck %s
 
 // CHECK: OpCapability VulkanMemoryModel


### PR DESCRIPTION
Some recent features require the vulkan memory model. We need a way to
support it in DXC. This commit adds an option to enable the Vulkan
memory model. The generated code will not change, but the compiler will
call the upgrade-memory-model pass in spirv-opt to generate the correct
code.

The expectation is that new code that requieres the vulkan memory model
can be written using the vulkan memory model, and then have the pass
update other references.

This change will undo the fix for #6066. The device scope in GLSL450 was
not a real device scope. It corresponds to QueueFamily scope in the
Vulkan memory model. We will start to use that scope for the atomic
operations in order to keep the behavoiur of the atomics the same
between the two memory models.

Haveing a true device scope atomic will not be possible with DXC. We
should be able to do something better when atomic operations are
implemented in clang.

Fixes #5784
