### PR TITLE
[Validator] Check content of PSV0 part in validation

### DIFF
--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -260,6 +260,13 @@ struct PSVComponentMask {
     }
     return *this;
   }
+  bool operator!=(const PSVComponentMask &other) const {
+    if (NumVectors != other.NumVectors)
+      return true;
+    return memcmp(Mask, other.Mask,
+                  PSVComputeMaskDwordsFromVectors(NumVectors) *
+                      sizeof(uint32_t));
+  }
   bool Get(uint32_t ComponentIndex) const {
     if (ComponentIndex < NumVectors * 4)
       return (bool)(Mask[ComponentIndex >> 5] & (1 << (ComponentIndex & 0x1F)));
@@ -294,6 +301,15 @@ struct PSVDependencyTable {
   }
   const PSVComponentMask GetMaskForInput(uint32_t inputComponentIndex) const {
     return getMaskForInput(inputComponentIndex);
+  }
+  bool operator!=(const PSVDependencyTable &other) const {
+    if (InputVectors != other.InputVectors ||
+        OutputVectors != other.OutputVectors)
+      return true;
+    return memcmp(
+        Table, other.Table,
+        PSVComputeInputOutputTableDwords(InputVectors, OutputVectors) *
+            sizeof(uint32_t));
   }
   bool IsValid() const { return Table != nullptr; }
   void Print(llvm::raw_ostream &, const char *, const char *) const;
@@ -449,6 +465,7 @@ public:
     return !m_pElement0 ? 0 : (uint32_t)m_pElement0->DynamicMaskAndStream & 0xF;
   }
   void Print(llvm::raw_ostream &O) const;
+  void Print(llvm::raw_ostream &O, const char *Name) const;
 };
 
 #define MAX_PSV_VERSION 3
@@ -1098,6 +1115,11 @@ void InitPSVSignatureElement(PSVSignatureElement0 &E,
 void InitPSVRuntimeInfo(PSVRuntimeInfo0 *pInfo, PSVRuntimeInfo1 *pInfo1,
                         PSVRuntimeInfo2 *pInfo2, PSVRuntimeInfo3 *pInfo3,
                         const DxilModule &DM);
+
+void PrintPSVRuntimeInfo(llvm::raw_ostream &OS, PSVRuntimeInfo0 *pInfo0,
+                         PSVRuntimeInfo1 *pInfo1, PSVRuntimeInfo2 *pInfo2,
+                         PSVRuntimeInfo3 *pInfo3, uint8_t ShaderKind,
+                         const char *EntryName, const char *Comment);
 
 } // namespace hlsl
 

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -613,6 +613,14 @@ public:
     return ReadOrWrite(pBuffer, pSize, Mode, initInfo);
   }
 
+  uint32_t GetRuntimeInfoSize() const { return m_uPSVRuntimeInfoSize; }
+  uint32_t GetResourceBindInfoSize() const {
+    return m_uPSVResourceBindInfoSize;
+  }
+  uint32_t GetSignatureElementSize() const {
+    return m_uPSVSignatureElementSize;
+  }
+
   PSVRuntimeInfo0 *GetPSVRuntimeInfo0() const { return m_pPSVRuntimeInfo0; }
 
   PSVRuntimeInfo1 *GetPSVRuntimeInfo1() const { return m_pPSVRuntimeInfo1; }
@@ -1102,6 +1110,9 @@ public:
 
 ViewIDValidator *NewViewIDValidator(unsigned viewIDCount,
                                     unsigned gsRastStreamIndex);
+
+uint32_t GetPSVVersion(uint32_t ValidatorMajorVersion,
+                       uint32_t ValidatorMinorVersion);
 
 void InitPSVResourceBinding(PSVResourceBindInfo0 *, PSVResourceBindInfo1 *,
                             DxilResourceBase *);

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -769,6 +769,7 @@ public:
   }
   void PrintPSVRuntimeInfo(llvm::raw_ostream &O, uint8_t ShaderKind,
                            const char *Comment) const;
+  void PrintViewIDState(llvm::raw_ostream &OS) const;
   void Print(llvm::raw_ostream &O, uint8_t ShaderKind) const;
 };
 

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -1123,11 +1123,10 @@ void InitPSVSignatureElement(PSVSignatureElement0 &E,
                              const DxilSignatureElement &SE,
                              bool i1ToUnknownCompat);
 
-// Setup PSVRuntimeInfo* with DxilModule.
-// Note that the EntryFunctionName is not done.
-void InitPSVRuntimeInfo(PSVRuntimeInfo0 *pInfo, PSVRuntimeInfo1 *pInfo1,
-                        PSVRuntimeInfo2 *pInfo2, PSVRuntimeInfo3 *pInfo3,
-                        const DxilModule &DM);
+// Setup shader properties for PSVRuntimeInfo* with DxilModule.
+void SetShaderProps(PSVRuntimeInfo0 *pInfo, const DxilModule &DM);
+void SetShaderProps(PSVRuntimeInfo1 *pInfo1, const DxilModule &DM);
+void SetShaderProps(PSVRuntimeInfo2 *pInfo2, const DxilModule &DM);
 
 void PrintPSVRuntimeInfo(llvm::raw_ostream &OS, PSVRuntimeInfo0 *pInfo0,
                          PSVRuntimeInfo1 *pInfo1, PSVRuntimeInfo2 *pInfo2,

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -465,7 +465,8 @@ public:
     return !m_pElement0 ? 0 : (uint32_t)m_pElement0->DynamicMaskAndStream & 0xF;
   }
   void Print(llvm::raw_ostream &O) const;
-  void Print(llvm::raw_ostream &O, const char *Name) const;
+  void Print(llvm::raw_ostream &O, const char *Name,
+             const uint32_t *SemanticIndexes) const;
 };
 
 #define MAX_PSV_VERSION 3

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -50,8 +50,9 @@ static_assert((unsigned)PSVShaderKind::Invalid ==
                   (unsigned)DXIL::ShaderKind::Invalid,
               "otherwise, PSVShaderKind enum out of sync.");
 
-static DxilProgramSigSemantic
-KindToSystemValue(Semantic::Kind kind, DXIL::TessellatorDomain domain) {
+DxilProgramSigSemantic
+hlsl::SemanticKindToSystemValue(Semantic::Kind kind,
+                                DXIL::TessellatorDomain domain) {
   switch (kind) {
   case Semantic::Kind::Arbitrary:
     return DxilProgramSigSemantic::Undefined;
@@ -291,7 +292,7 @@ private:
     memset(&sig, 0, sizeof(DxilProgramSignatureElement));
     sig.Stream = pElement->GetOutputStream();
     sig.SemanticName = GetSemanticOffset(pElement);
-    sig.SystemValue = KindToSystemValue(pElement->GetKind(), m_domain);
+    sig.SystemValue = SemanticKindToSystemValue(pElement->GetKind(), m_domain);
     sig.CompType =
         CompTypeToSigCompType(pElement->GetCompType().GetKind(), m_bCompat_1_4);
     sig.Register = pElement->GetStartRow();

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -739,17 +739,9 @@ public:
       : m_Module(mod), m_PSVInitInfo(PSVVersion) {
     m_Module.GetValidatorVersion(m_ValMajor, m_ValMinor);
     // Constraint PSVVersion based on validator version
-    if (PSVVersion > 0 &&
-        DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 1) < 0)
-      m_PSVInitInfo.PSVVersion = 0;
-    else if (PSVVersion > 1 &&
-             DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 6) < 0)
-      m_PSVInitInfo.PSVVersion = 1;
-    else if (PSVVersion > 2 &&
-             DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) < 0)
-      m_PSVInitInfo.PSVVersion = 2;
-    else if (PSVVersion > MAX_PSV_VERSION)
-      m_PSVInitInfo.PSVVersion = MAX_PSV_VERSION;
+    uint32_t PSVVersionConstraint = hlsl::GetPSVVersion(m_ValMajor, m_ValMinor);
+    if (PSVVersion > PSVVersionConstraint)
+      m_PSVInitInfo.PSVVersion = PSVVersionConstraint;
 
     const ShaderModel *SM = m_Module.GetShaderModel();
     UINT uCBuffers = m_Module.GetCBuffers().size();

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -827,8 +827,12 @@ public:
     PSVRuntimeInfo1 *pInfo1 = m_PSV.GetPSVRuntimeInfo1();
     PSVRuntimeInfo2 *pInfo2 = m_PSV.GetPSVRuntimeInfo2();
     PSVRuntimeInfo3 *pInfo3 = m_PSV.GetPSVRuntimeInfo3();
-
-    hlsl::InitPSVRuntimeInfo(pInfo, pInfo1, pInfo2, pInfo3, m_Module);
+    if (pInfo)
+      hlsl::SetShaderProps(pInfo, m_Module);
+    if (pInfo1)
+      hlsl::SetShaderProps(pInfo1, m_Module);
+    if (pInfo2)
+      hlsl::SetShaderProps(pInfo2, m_Module);
     if (pInfo3)
       pInfo3->EntryFunctionName = EntryFunctionName;
 

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -360,14 +360,14 @@ void PSVResourceBindInfo1::Print(raw_ostream &OS) const {
 }
 
 void PSVSignatureElement::Print(raw_ostream &OS) const {
-  Print(OS, GetSemanticName());
+  Print(OS, GetSemanticName(), GetSemanticIndexes());
 }
 
-void PSVSignatureElement::Print(raw_ostream &OS, const char *Name) const {
+void PSVSignatureElement::Print(raw_ostream &OS, const char *Name,
+                                const uint32_t *SemanticIndexes) const {
   OS << "PSVSignatureElement:\n";
   OS << "  SemanticName: " << Name << "\n";
   OS << "  SemanticIndex: ";
-  const uint32_t *SemanticIndexes = GetSemanticIndexes();
   for (unsigned i = 0; i < GetRows(); ++i) {
     OS << *(SemanticIndexes + i) << " ";
   }

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -24,6 +24,18 @@
 using namespace hlsl;
 using namespace llvm;
 
+uint32_t hlsl::GetPSVVersion(uint32_t ValMajor, uint32_t ValMinor) {
+  unsigned PSVVersion = MAX_PSV_VERSION;
+  // Constraint PSVVersion based on validator version
+  if (DXIL::CompareVersions(ValMajor, ValMinor, 1, 1) < 0)
+    PSVVersion = 0;
+  else if (DXIL::CompareVersions(ValMajor, ValMinor, 1, 6) < 0)
+    PSVVersion = 1;
+  else if (DXIL::CompareVersions(ValMajor, ValMinor, 1, 8) < 0)
+    PSVVersion = 2;
+  return PSVVersion;
+}
+
 void hlsl::InitPSVResourceBinding(PSVResourceBindInfo0 *Bind0,
                                   PSVResourceBindInfo1 *Bind1,
                                   DxilResourceBase *Res) {

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -360,8 +360,12 @@ void PSVResourceBindInfo1::Print(raw_ostream &OS) const {
 }
 
 void PSVSignatureElement::Print(raw_ostream &OS) const {
+  Print(OS, GetSemanticName());
+}
+
+void PSVSignatureElement::Print(raw_ostream &OS, const char *Name) const {
   OS << "PSVSignatureElement:\n";
-  OS << "  SemanticName: " << GetSemanticName() << "\n";
+  OS << "  SemanticName: " << Name << "\n";
   OS << "  SemanticIndex: ";
   const uint32_t *SemanticIndexes = GetSemanticIndexes();
   for (unsigned i = 0; i < GetRows(); ++i) {
@@ -518,13 +522,10 @@ void PSVDependencyTable::Print(raw_ostream &OS, const char *InputSetName,
   }
 }
 
-void DxilPipelineStateValidation::PrintPSVRuntimeInfo(
-    raw_ostream &OS, uint8_t ShaderKind, const char *Comment) const {
-  PSVRuntimeInfo0 *pInfo0 = m_pPSVRuntimeInfo0;
-  PSVRuntimeInfo1 *pInfo1 = m_pPSVRuntimeInfo1;
-  PSVRuntimeInfo2 *pInfo2 = m_pPSVRuntimeInfo2;
-  PSVRuntimeInfo3 *pInfo3 = m_pPSVRuntimeInfo3;
-
+void hlsl::PrintPSVRuntimeInfo(llvm::raw_ostream &OS, PSVRuntimeInfo0 *pInfo0,
+                               PSVRuntimeInfo1 *pInfo1, PSVRuntimeInfo2 *pInfo2,
+                               PSVRuntimeInfo3 *pInfo3, uint8_t ShaderKind,
+                               const char *EntryName, const char *Comment) {
   if (pInfo1 && pInfo1->ShaderStage != ShaderKind)
     ShaderKind = pInfo1->ShaderStage;
   OS << Comment << "PSVRuntimeInfo:\n";
@@ -817,9 +818,20 @@ void DxilPipelineStateValidation::PrintPSVRuntimeInfo(
     }
   }
   if (pInfo3)
-    OS << Comment
-       << " EntryFunctionName: " << m_StringTable.Get(pInfo3->EntryFunctionName)
-       << "\n";
+    OS << Comment << " EntryFunctionName: " << EntryName << "\n";
+}
+
+void DxilPipelineStateValidation::PrintPSVRuntimeInfo(
+    raw_ostream &OS, uint8_t ShaderKind, const char *Comment) const {
+  PSVRuntimeInfo0 *pInfo0 = m_pPSVRuntimeInfo0;
+  PSVRuntimeInfo1 *pInfo1 = m_pPSVRuntimeInfo1;
+  PSVRuntimeInfo2 *pInfo2 = m_pPSVRuntimeInfo2;
+  PSVRuntimeInfo3 *pInfo3 = m_pPSVRuntimeInfo3;
+
+  hlsl::PrintPSVRuntimeInfo(
+      OS, pInfo0, pInfo1, pInfo2, pInfo3, ShaderKind,
+      m_pPSVRuntimeInfo3 ? m_StringTable.Get(pInfo3->EntryFunctionName) : "",
+      Comment);
 }
 
 void DxilPipelineStateValidation::Print(raw_ostream &OS,

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -585,8 +585,8 @@ void PSVContentVerifier::Verify() {
   }
   if (PSVVersion > 2) {
     if (DM.GetEntryFunctionName() != PSV.GetEntryFunctionName())
-      EmitMismatchError("EntryFunctionName", DM.GetEntryFunctionName(),
-                        PSV.GetEntryFunctionName());
+      EmitMismatchError("EntryFunctionName", PSV.GetEntryFunctionName(),
+                        DM.GetEntryFunctionName());
   }
 
   if (!PSVContentValid)

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -344,7 +344,10 @@ void PSVContentVerifier::VerifyEntryProperties(const ShaderModel *SM,
                                                PSVRuntimeInfo2 *PSV2) {
   PSVRuntimeInfo3 DMPSV;
   memset(&DMPSV, 0, sizeof(PSVRuntimeInfo3));
-  hlsl::InitPSVRuntimeInfo(&DMPSV, &DMPSV, &DMPSV, &DMPSV, DM);
+
+  hlsl::SetShaderProps((PSVRuntimeInfo0 *)&DMPSV, DM);
+  hlsl::SetShaderProps((PSVRuntimeInfo1 *)&DMPSV, DM);
+  hlsl::SetShaderProps((PSVRuntimeInfo2 *)&DMPSV, DM);
   if (PSV1) {
     // Init things not set in InitPSVRuntimeInfo.
     DMPSV.ShaderStage = static_cast<uint8_t>(SM->GetKind());

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -155,7 +155,6 @@ public:
                      ValidationContext &ValCtx)
       : DM(DM), PSV(PSV), ValCtx(ValCtx) {}
   void Verify();
-  bool IsValid() { return PSVContentValid; }
 
 private:
   void VerifySignatures(unsigned ValMajor, unsigned ValMinor);
@@ -737,6 +736,10 @@ void PSVContentVerifier::Verify() {
     if (DM.GetEntryFunctionName() != PSV.GetEntryFunctionName())
       EmitFormatError("EntryFunctionName");
   }
+
+  if (!PSVContentValid)
+    ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
+                           {"Pipeline State Validation"});
 }
 
 } // namespace
@@ -825,9 +828,6 @@ static void VerifyPSVMatches(ValidationContext &ValCtx, const void *pPSVData,
   }
   PSVContentVerifier Verifier(PSV, ValCtx.DxilMod, ValCtx);
   Verifier.Verify();
-  if (!Verifier.IsValid())
-    ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
-                           {"Pipeline State Validation"});
 }
 
 static void VerifyFeatureInfoMatches(ValidationContext &ValCtx,

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -178,6 +178,8 @@ SimpleViewIDState::SimpleViewIDState(std::vector<uint32_t> &Data,
       Offset += MaskDwords;
     }
     unsigned TabSize = MaskDwords * NumInputSigScalars;
+    if (TabSize == 0)
+      continue;
     unsigned AlignedTabSize =
         MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
     InputToOutputTable[i] = std::vector<uint32_t>(AlignedTabSize, 0);
@@ -194,22 +196,26 @@ SimpleViewIDState::SimpleViewIDState(std::vector<uint32_t> &Data,
       Offset += MaskDwords;
     }
     unsigned TabSize = MaskDwords * NumInputSigScalars;
-    unsigned AlignedTabSize =
-        MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
-    InputToPCOutputTable = std::vector<uint32_t>(AlignedTabSize, 0);
-    memcpy(InputToPCOutputTable.data(), Data.data() + Offset, TabSize * 4);
-    Offset += TabSize;
+    if (TabSize) {
+      unsigned AlignedTabSize =
+          MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
+      InputToPCOutputTable = std::vector<uint32_t>(AlignedTabSize, 0);
+      memcpy(InputToPCOutputTable.data(), Data.data() + Offset, TabSize * 4);
+      Offset += TabSize;
+    }
   } else if (SK == PSVShaderKind::Domain) {
     // #PatchConstant.
     NumPCOrPrimSigScalars = Data[Offset++];
     unsigned OutputScalars = NumOutputSigScalars[0];
     unsigned MaskDwords = llvm::RoundUpToAlignment(OutputScalars, 32) / 32;
     unsigned TabSize = MaskDwords * NumPCOrPrimSigScalars;
-    unsigned AlignedTabSize =
-        MaskDwords * llvm::RoundUpToAlignment(NumPCOrPrimSigScalars, 4);
-    PCInputToOutputTable = std::vector<uint32_t>(AlignedTabSize, 0);
-    memcpy(PCInputToOutputTable.data(), Data.data() + Offset, TabSize * 4);
-    Offset += TabSize;
+    if (TabSize) {
+      unsigned AlignedTabSize =
+          MaskDwords * llvm::RoundUpToAlignment(NumPCOrPrimSigScalars, 4);
+      PCInputToOutputTable = std::vector<uint32_t>(AlignedTabSize, 0);
+      memcpy(PCInputToOutputTable.data(), Data.data() + Offset, TabSize * 4);
+      Offset += TabSize;
+    }
   }
   IsValid = Offset == Data.size();
 }

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -280,7 +280,7 @@ private:
   void VerifyResources(unsigned PSVVersion);
   template <typename T>
   void VerifyResourceTable(T &ResTab, PSVResourceSet &ResSet,
-                           unsigned &ResIndex, unsigned PSVVersion);
+                           unsigned PSVVersion);
   void VerifyViewIDDependence(PSVRuntimeInfo1 *PSV1);
   void VerifyEntryProperties(const ShaderModel *SM, PSVRuntimeInfo0 *PSV0,
                              PSVRuntimeInfo1 *PSV1, PSVRuntimeInfo2 *PSV2);
@@ -505,7 +505,6 @@ void PSVContentVerifier::VerifySignatureElement(
 
 template <typename T>
 void PSVContentVerifier::VerifyResourceTable(T &ResTab, PSVResourceSet &ResSet,
-                                             unsigned &ResIndex,
                                              unsigned PSVVersion) {
   for (auto &&R : ResTab) {
     PSVResourceBindInfo1 BI;
@@ -532,7 +531,6 @@ void PSVContentVerifier::VerifyResourceTable(T &ResTab, PSVResourceSet &ResSet,
         EmitMismatchError("ResourceBindInfo", Str, Str1);
       }
     }
-    ResIndex++;
   }
 }
 
@@ -547,7 +545,6 @@ void PSVContentVerifier::VerifyResources(unsigned PSVVersion) {
                       std::to_string(ResourceCount));
     return;
   }
-  unsigned ResIndex = 0;
   // Build PSVResourceSet with data in PSV.
   PSVResourceSet ResBindInfo0Set;
   for (unsigned i = 0; i < ResourceCount; i++) {
@@ -561,13 +558,13 @@ void PSVContentVerifier::VerifyResources(unsigned PSVVersion) {
 
   // Verify each resource table.
   // CBV
-  VerifyResourceTable(DM.GetCBuffers(), ResBindInfo0Set, ResIndex, PSVVersion);
+  VerifyResourceTable(DM.GetCBuffers(), ResBindInfo0Set, PSVVersion);
   // Sampler
-  VerifyResourceTable(DM.GetSamplers(), ResBindInfo0Set, ResIndex, PSVVersion);
+  VerifyResourceTable(DM.GetSamplers(), ResBindInfo0Set, PSVVersion);
   // SRV
-  VerifyResourceTable(DM.GetSRVs(), ResBindInfo0Set, ResIndex, PSVVersion);
+  VerifyResourceTable(DM.GetSRVs(), ResBindInfo0Set, PSVVersion);
   // UAV
-  VerifyResourceTable(DM.GetUAVs(), ResBindInfo0Set, ResIndex, PSVVersion);
+  VerifyResourceTable(DM.GetUAVs(), ResBindInfo0Set, PSVVersion);
 }
 
 void PSVContentVerifier::VerifyEntryProperties(const ShaderModel *SM,

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -125,27 +125,6 @@ private:
   }
 };
 
-bool ViewIDTableAndMaskMismatched(const PSVDependencyTable &PSVTable,
-                                  std::vector<uint32_t> &VecPSVTable,
-                                  const PSVComponentMask &&PSVMask,
-                                  MutableArrayRef<uint32_t> ArrayMask,
-                                  uint32_t NumInputVectors,
-                                  uint32_t NumOutputVectors, bool UsesViewID) {
-  if (NumInputVectors > 0 && NumOutputVectors > 0) {
-    const PSVDependencyTable DxilTable(VecPSVTable.data(), NumInputVectors,
-                                       NumOutputVectors);
-    if (PSVTable != DxilTable)
-      return true;
-  }
-
-  if (UsesViewID && NumOutputVectors > 0) {
-    PSVComponentMask DxilMask(ArrayMask.data(), NumOutputVectors);
-    if (PSVMask != DxilMask)
-      return true;
-  }
-  return false;
-}
-
 void PSVContentVerifier::VerifyViewIDDependence(PSVRuntimeInfo1 *PSV1,
                                                 unsigned PSVVersion) {
   std::vector<unsigned int> ViewStateInPSV;

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -92,7 +92,7 @@ struct SimpleViewIDState {
   bool IsValid = true;
   SimpleViewIDState(std::vector<uint32_t> &Data, PSVShaderKind,
                     bool UsesViewID);
-  void Print(raw_ostream& OS, PSVShaderKind ShaderStage, bool UsesViewID) {
+  void Print(raw_ostream &OS, PSVShaderKind ShaderStage, bool UsesViewID) {
     unsigned NumStreams =
         ShaderStage == PSVShaderKind::Geometry ? PSV_GS_MAX_STREAMS : 1;
 

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -567,7 +567,6 @@ void PSVContentVerifier::Verify() {
       return;
     }
     uint8_t ShaderStage = static_cast<uint8_t>(SM->GetKind());
-    PSVRuntimeInfo1 *PSV1 = PSV.GetPSVRuntimeInfo1();
     if (PSV1->ShaderStage != ShaderStage) {
       EmitMismatchError("ShaderStage", std::to_string(PSV1->ShaderStage),
                         std::to_string(ShaderStage));

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -23,10 +23,10 @@
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilUtil.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/Module.h"
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -113,7 +113,8 @@ SimpleViewIDState::SimpleViewIDState(std::vector<uint32_t> &Data,
       Offset += MaskDwords;
     }
     unsigned TabSize = MaskDwords * NumInputSigScalars;
-    unsigned AlignedTabSize = MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
+    unsigned AlignedTabSize =
+        MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
     InputToOutputTable[i] = std::vector<uint32_t>(AlignedTabSize, 0);
     memcpy(InputToOutputTable[i].data(), Data.data() + Offset, TabSize * 4);
     Offset += TabSize;
@@ -128,7 +129,8 @@ SimpleViewIDState::SimpleViewIDState(std::vector<uint32_t> &Data,
       Offset += MaskDwords;
     }
     unsigned TabSize = MaskDwords * NumInputSigScalars;
-    unsigned AlignedTabSize = MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
+    unsigned AlignedTabSize =
+        MaskDwords * llvm::RoundUpToAlignment(NumInputSigScalars, 4);
     InputToPCOutputTable = std::vector<uint32_t>(AlignedTabSize, 0);
     memcpy(InputToPCOutputTable.data(), Data.data() + Offset, TabSize * 4);
     Offset += TabSize;
@@ -138,7 +140,8 @@ SimpleViewIDState::SimpleViewIDState(std::vector<uint32_t> &Data,
     unsigned OutputScalars = NumOutputSigScalars[0];
     unsigned MaskDwords = llvm::RoundUpToAlignment(OutputScalars, 32) / 32;
     unsigned TabSize = MaskDwords * NumPCOrPrimSigScalars;
-    unsigned AlignedTabSize = MaskDwords * llvm::RoundUpToAlignment(NumPCOrPrimSigScalars, 4);
+    unsigned AlignedTabSize =
+        MaskDwords * llvm::RoundUpToAlignment(NumPCOrPrimSigScalars, 4);
     PCInputToOutputTable = std::vector<uint32_t>(AlignedTabSize, 0);
     memcpy(PCInputToOutputTable.data(), Data.data() + Offset, TabSize * 4);
     Offset += TabSize;
@@ -245,11 +248,11 @@ private:
 };
 
 bool ViewIDTableAndMaskMismatched(const PSVDependencyTable &PSVTable,
-                              std::vector<uint32_t> &VecPSVTable,
-                              const PSVComponentMask &&PSVMask,
-                              MutableArrayRef<uint32_t> ArrayMask,
-                              uint32_t NumInputVectors,
-                              uint32_t NumOutputVectors, bool UsesViewID) {
+                                  std::vector<uint32_t> &VecPSVTable,
+                                  const PSVComponentMask &&PSVMask,
+                                  MutableArrayRef<uint32_t> ArrayMask,
+                                  uint32_t NumInputVectors,
+                                  uint32_t NumOutputVectors, bool UsesViewID) {
   if (NumInputVectors == 0 || NumOutputVectors == 0)
     return false;
   const PSVDependencyTable DxilTable(VecPSVTable.data(), NumInputVectors,

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -1232,55 +1232,28 @@ AddDxilPipelineStateValidationToDXBC(DxilModule *pModule,
     DXASSERT_LOCALVAR_NOMSG(uTotalResources, uResIndex < uTotalResources);
     PSVResourceBindInfo0 *pBindInfo = PSV.GetPSVResourceBindInfo0(uResIndex);
     DXASSERT_NOMSG(pBindInfo);
-    pBindInfo->ResType = (UINT)PSVResourceType::CBV;
-    pBindInfo->Space = R->GetSpaceID();
-    pBindInfo->LowerBound = R->GetLowerBound();
-    pBindInfo->UpperBound = R->GetUpperBound();
+    InitPSVResourceBinding(pBindInfo, nullptr, R.get());
     uResIndex++;
   }
   for (auto &&R : pModule->GetSamplers()) {
     DXASSERT_NOMSG(uResIndex < uTotalResources);
     PSVResourceBindInfo0 *pBindInfo = PSV.GetPSVResourceBindInfo0(uResIndex);
     DXASSERT_NOMSG(pBindInfo);
-    pBindInfo->ResType = (UINT)PSVResourceType::Sampler;
-    pBindInfo->Space = R->GetSpaceID();
-    pBindInfo->LowerBound = R->GetLowerBound();
-    pBindInfo->UpperBound = R->GetUpperBound();
+    InitPSVResourceBinding(pBindInfo, nullptr, R.get());
     uResIndex++;
   }
   for (auto &&R : pModule->GetSRVs()) {
     DXASSERT_NOMSG(uResIndex < uTotalResources);
     PSVResourceBindInfo0 *pBindInfo = PSV.GetPSVResourceBindInfo0(uResIndex);
     DXASSERT_NOMSG(pBindInfo);
-    if (R->IsStructuredBuffer()) {
-      pBindInfo->ResType = (UINT)PSVResourceType::SRVStructured;
-    } else if (R->IsRawBuffer()) {
-      pBindInfo->ResType = (UINT)PSVResourceType::SRVRaw;
-    } else {
-      pBindInfo->ResType = (UINT)PSVResourceType::SRVTyped;
-    }
-    pBindInfo->Space = R->GetSpaceID();
-    pBindInfo->LowerBound = R->GetLowerBound();
-    pBindInfo->UpperBound = R->GetUpperBound();
+    InitPSVResourceBinding(pBindInfo, nullptr, R.get());
     uResIndex++;
   }
   for (auto &&R : pModule->GetUAVs()) {
     DXASSERT_NOMSG(uResIndex < uTotalResources);
     PSVResourceBindInfo0 *pBindInfo = PSV.GetPSVResourceBindInfo0(uResIndex);
     DXASSERT_NOMSG(pBindInfo);
-    if (R->IsStructuredBuffer()) {
-      if (R->HasCounter())
-        pBindInfo->ResType = (UINT)PSVResourceType::UAVStructuredWithCounter;
-      else
-        pBindInfo->ResType = (UINT)PSVResourceType::UAVStructured;
-    } else if (R->IsRawBuffer()) {
-      pBindInfo->ResType = (UINT)PSVResourceType::UAVRaw;
-    } else {
-      pBindInfo->ResType = (UINT)PSVResourceType::UAVTyped;
-    }
-    pBindInfo->Space = R->GetSpaceID();
-    pBindInfo->LowerBound = R->GetLowerBound();
-    pBindInfo->UpperBound = R->GetUpperBound();
+    InitPSVResourceBinding(pBindInfo, nullptr, R.get());
     uResIndex++;
   }
   DXASSERT_NOMSG(uResIndex == uTotalResources);

--- a/tools/clang/test/DXC/dumpPSV_HS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_HS.hlsl
@@ -10,7 +10,7 @@
 // CHECK-NEXT:  OutputPrimitive=triangle_cw
 // CHECK-NEXT:  MinimumExpectedWaveLaneCount: 0
 // CHECK-NEXT:  MaximumExpectedWaveLaneCount: 4294967295
-// CHECK-NEXT:  UsesViewID: false
+// CHECK-NEXT:  UsesViewID: true
 // CHECK-NEXT:  SigInputElements: 3
 // CHECK-NEXT:  SigOutputElements: 3
 // CHECK-NEXT:  SigPatchConstOrPrimElements: 2
@@ -125,6 +125,10 @@
 // CHECK-NEXT:   OutputStream: 0
 // CHECK-NEXT:   ComponentType: 3
 // CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: Outputs affected by ViewID as a bitmask for stream 0:
+// CHECK-NEXT:    ViewID influencing Outputs[0] : 8  9  10
+// CHECK-NEXT: PCOutputs affected by ViewID as a bitmask:
+// CHECK-NEXT:   ViewID influencing PCOutputs : 12
 // CHECK-NEXT: Outputs affected by inputs as a table of bitmasks for stream 0:
 // CHECK-NEXT: Inputs contributing to computation of Outputs[0]:
 // CHECK-NEXT:   Inputs[0] influencing Outputs[0] : 0
@@ -141,7 +145,7 @@
 // CHECK-NEXT:   Inputs[11] influencing Outputs[0] :  None
 // CHECK-NEXT: Patch constant outputs affected by inputs as a table of bitmasks:
 // CHECK-NEXT: Inputs contributing to computation of PatchConstantOutputs:
-// CHECK-NEXT:   Inputs[0] influencing PatchConstantOutputs :  None
+// CHECK-NEXT:   Inputs[0] influencing PatchConstantOutputs :  3
 // CHECK-NEXT:   Inputs[1] influencing PatchConstantOutputs :  None
 // CHECK-NEXT:   Inputs[2] influencing PatchConstantOutputs :  None
 // CHECK-NEXT:   Inputs[3] influencing PatchConstantOutputs :  None

--- a/tools/clang/test/DXC/dumpPSV_HS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_HS.hlsl
@@ -183,14 +183,14 @@ float4 HSPerPatchFunc()
     return 1.8;
 }
 
-HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 3 > points )
+HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 3 > points ,uint vid : SV_ViewID)
 {
     HSPerPatchData d;
 
-    d.edges[ 0 ] = 1;
+    d.edges[ 0 ] = points[0].pos.x;
     d.edges[ 1 ] = 1;
     d.edges[ 2 ] = 1;
-    d.inside = 1;
+    d.inside = vid;
 
     return d;
 }
@@ -202,12 +202,13 @@ HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 3 > points )
 [patchconstantfunc("HSPerPatchFunc")]
 [outputcontrolpoints(3)]
 HSPerVertexData main( const uint id : SV_OutputControlPointID,
-                               const InputPatch< PSSceneIn, 3 > points )
+                      uint vid : SV_ViewID,
+                      const InputPatch< PSSceneIn, 3 > points )
 {
     HSPerVertexData v;
 
     // Just forward the vertex
     v.v = points[ id ];
-
+    v.v.norm += vid;
 	return v;
 }

--- a/tools/clang/test/DXILValidation/hs_signatures.hlsl
+++ b/tools/clang/test/DXILValidation/hs_signatures.hlsl
@@ -3,8 +3,8 @@
 struct PSSceneIn
 {
     float4 pos  : SV_Position;
-    float2 tex  : TEXCOORD0;
-    float3 norm : NORMAL;
+    float2 tex  : TEXCOORD2;
+    float3 norm : NORMAL3;
 };
 
 struct HSPerVertexData

--- a/tools/clang/test/DXILValidation/hs_signatures.hlsl
+++ b/tools/clang/test/DXILValidation/hs_signatures.hlsl
@@ -1,0 +1,47 @@
+// For Validation::PSVSignatureTableReorder.
+
+struct PSSceneIn
+{
+    float4 pos  : SV_Position;
+    float2 tex  : TEXCOORD0;
+    float3 norm : NORMAL;
+};
+
+struct HSPerVertexData
+{
+    PSSceneIn v;
+};
+
+struct HSPerPatchData
+{
+	float	edges[2]	: SV_TessFactor;
+    float       t               : PN_POSITION;
+};
+
+HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 2 > points, const OutputPatch< HSPerVertexData, 2 > opoints  )
+{
+    HSPerPatchData d;
+
+    d.edges[0] = points[0].tex.x;
+    d.edges[1] = opoints[1].v.tex.x;
+    d.t = 2;
+
+    return d;
+}
+
+// hull per-control point shader
+[domain("isoline")]
+[partitioning("fractional_odd")]
+[outputtopology("line")]
+[patchconstantfunc("HSPerPatchFunc")]
+[outputcontrolpoints(2)]
+HSPerVertexData main( const uint id : SV_OutputControlPointID,
+                      const InputPatch< PSSceneIn, 2 > points )
+{
+    HSPerVertexData v;
+
+    // Just forward the vertex
+    v.v = points[ id ];
+
+	return v;
+}

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4678,7 +4678,7 @@ TEST_F(ValidationTest, PSVStringTableReorder) {
        "  DynamicIndexMask: 0",
        "')",
        "error: DXIL container mismatch for 'EntryFunctionName' between 'PSV0' "
-       "part:('main') and DXIL module:('ain')",
+       "part:('ain') and DXIL module:('main')",
        "error: Container part 'Pipeline State Validation' does not match "
        "expected for module.",
        "Validation failed."},

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4612,6 +4612,8 @@ TEST_F(ValidationTest, PSVStringTableReorder) {
   VERIFY_IS_NOT_NULL(pUpdatedTableResult);
   VERIFY_SUCCEEDED(pUpdatedTableResult->GetStatus(&status));
   VERIFY_FAILED(status);
+  CheckOperationResultMsgs(pUpdatedTableResult, {""},
+                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
 
   // Update string table index.
   SigInput->SemanticName = 2;
@@ -4687,6 +4689,8 @@ TEST_F(ValidationTest, PSVResourceTableReorder) {
   VERIFY_IS_NOT_NULL(pUpdatedTableResult);
   VERIFY_SUCCEEDED(pUpdatedTableResult->GetStatus(&status));
   VERIFY_FAILED(status);
+  CheckOperationResultMsgs(pUpdatedTableResult, {""},
+                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
 
   // Update both.
   *ResourceBindInfo1 = Tmp;
@@ -4720,6 +4724,8 @@ static void CheckSignatureReorder(IDxcBlob *pProgram,
   VERIFY_SUCCEEDED(pParitalUpdatedResult->GetStatus(&status));
   VERIFY_FAILED(status);
 
+  CheckOperationResultMsgs(pParitalUpdatedResult, {""},
+                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
   // Update both.
   *SigInput1 = Tmp;
 

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4998,7 +4998,8 @@ SimplePSV::SimplePSV(const DxilPartHeader *pPSVPart) {
   }
   if ((PSVInfo3->ShaderStage == static_cast<uint8_t>(PSVShaderKind::Hull) ||
        PSVInfo3->ShaderStage == static_cast<uint8_t>(PSVShaderKind::Mesh)) &&
-      PSVInfo3->SigInputVectors != 0 && PSVInfo3->SigPatchConstOrPrimVectors != 0) {
+      PSVInfo3->SigInputVectors != 0 &&
+      PSVInfo3->SigPatchConstOrPrimVectors != 0) {
     InputToPCOutputTable = llvm::MutableArrayRef<uint32_t>(
         (uint32_t *)PSVPtr,
         4 * PSVInfo3->SigInputVectors *

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -5039,7 +5039,7 @@ TEST_F(ValidationTest, PSVContentValidationVS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5194,7 +5194,7 @@ TEST_F(ValidationTest, PSVContentValidationHS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5343,7 +5343,7 @@ TEST_F(ValidationTest, PSVContentValidationDS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5498,7 +5498,7 @@ TEST_F(ValidationTest, PSVContentValidationGS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5584,7 +5584,7 @@ TEST_F(ValidationTest, PSVContentValidationPS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5667,7 +5667,7 @@ TEST_F(ValidationTest, PSVContentValidationCS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5747,7 +5747,7 @@ TEST_F(ValidationTest, PSVContentValidationMS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
@@ -5814,7 +5814,7 @@ TEST_F(ValidationTest, PSVContentValidationAS) {
   VERIFY_SUCCEEDED(pResult->GetStatus(&status));
   VERIFY_SUCCEEDED(status);
 
-  // Update PSV part.
+  // Get PSV part.
   hlsl::DxilContainerHeader *pHeader;
   hlsl::DxilPartIterator pPartIter(nullptr, 0);
   pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -5946,8 +5946,6 @@ TEST_F(ValidationTest, PSVContentValidationMS) {
        "  ViewID influencing PCOutputs : 3 ",
        "Outputs affected by inputs as a table of bitmasks for stream 0:",
        "Inputs contributing to computation of Outputs[0]:  None",
-       "Patch constant outputs affected by inputs as a table of bitmasks:",
-       "Inputs contributing to computation of PatchConstantOutputs:  None",
        "')",
        "error: Container part 'Pipeline State Validation' does not match "
        "expected for module.",

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -5945,8 +5945,7 @@ TEST_F(ValidationTest, PSVContentValidationMS) {
        "PCOutputs affected by ViewID as a bitmask:",
        "  ViewID influencing PCOutputs : 3 ",
        "Outputs affected by inputs as a table of bitmasks for stream 0:",
-       "Inputs contributing to computation of Outputs[0]:  None",
-       "')",
+       "Inputs contributing to computation of Outputs[0]:  None", "')",
        "error: Container part 'Pipeline State Validation' does not match "
        "expected for module.",
        "Validation failed."},

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4612,7 +4612,63 @@ TEST_F(ValidationTest, PSVStringTableReorder) {
   VERIFY_IS_NOT_NULL(pUpdatedTableResult);
   VERIFY_SUCCEEDED(pUpdatedTableResult->GetStatus(&status));
   VERIFY_FAILED(status);
-  CheckOperationResultMsgs(pUpdatedTableResult, {""},
+  CheckOperationResultMsgs(pUpdatedTableResult,
+                           {"error: 'SigInputElement' does not match, for "
+                            "container: 'PSVSignatureElement:",
+                            "  SemanticName: ",
+                            "  SemanticIndex: 0 ",
+                            "  IsAllocated: 1",
+                            "  StartRow: 0",
+                            "  StartCol: 0",
+                            "  Rows: 1",
+                            "  Cols: 1",
+                            "  SemanticKind: Arbitrary",
+                            "  InterpolationMode: 2",
+                            "  OutputStream: 0",
+                            "  ComponentType: 3",
+                            "  DynamicIndexMask: 0",
+                            "', for dxil module: 'PSVSignatureElement:",
+                            "  SemanticName: A",
+                            "  SemanticIndex: 0 ",
+                            "  IsAllocated: 1",
+                            "  StartRow: 0",
+                            "  StartCol: 0",
+                            "  Rows: 1",
+                            "  Cols: 1",
+                            "  SemanticKind: Arbitrary",
+                            "  InterpolationMode: 2",
+                            "  OutputStream: 0",
+                            "  ComponentType: 3",
+                            "  DynamicIndexMask: 0",
+                            "'.",
+                            "error: 'SigInputElement' does not match, for "
+                            "container: 'PSVSignatureElement:",
+                            "  SemanticName: ",
+                            "  SemanticIndex: 0 ",
+                            "  IsAllocated: 1",
+                            "  StartRow: 0",
+                            "  StartCol: 1",
+                            "  Rows: 1",
+                            "  Cols: 1",
+                            "  SemanticKind: Arbitrary",
+                            "  InterpolationMode: 2",
+                            "  OutputStream: 0",
+                            "  ComponentType: 3",
+                            "  DynamicIndexMask: 0",
+                            "', for dxil module: 'PSVSignatureElement:",
+                            "  SemanticName: B",
+                            "  SemanticIndex: 0 ",
+                            "  IsAllocated: 1",
+                            "  StartRow: 0",
+                            "  StartCol: 1",
+                            "  Rows: 1",
+                            "  Cols: 1",
+                            "  SemanticKind: Arbitrary",
+                            "  InterpolationMode: 2",
+                            "  OutputStream: 0",
+                            "  ComponentType: 3",
+                            "  DynamicIndexMask: 0",
+                            "'."},
                            /*maySucceedAnyway*/ false, /*bRegex*/ false);
 
   // Update string table index.
@@ -4689,8 +4745,12 @@ TEST_F(ValidationTest, PSVResourceTableReorder) {
   VERIFY_IS_NOT_NULL(pUpdatedTableResult);
   VERIFY_SUCCEEDED(pUpdatedTableResult->GetStatus(&status));
   VERIFY_FAILED(status);
-  CheckOperationResultMsgs(pUpdatedTableResult, {""},
-                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
+  CheckOperationResultMsgs(
+      pUpdatedTableResult,
+      {"error: 'ResourceBindInfo' with content 'PSVResourceBindInfo:",
+       "  Space: 0", "  LowerBound: 0", "  UpperBound: 0",
+       "  ResType: SRVTyped", "' duplicates."},
+      /*maySucceedAnyway*/ false, /*bRegex*/ false);
 
   // Update both.
   *ResourceBindInfo1 = Tmp;
@@ -4706,6 +4766,7 @@ TEST_F(ValidationTest, PSVResourceTableReorder) {
 
 static void CheckSignatureReorder(IDxcBlob *pProgram,
                                   PSVSignatureElement0 *SigInput,
+                                  llvm::ArrayRef<LPCSTR> pErrorMsgs,
                                   IDxcValidator *pValidator) {
   PSVSignatureElement0 *SigInput1 = SigInput + 1;
 
@@ -4724,7 +4785,7 @@ static void CheckSignatureReorder(IDxcBlob *pProgram,
   VERIFY_SUCCEEDED(pParitalUpdatedResult->GetStatus(&status));
   VERIFY_FAILED(status);
 
-  CheckOperationResultMsgs(pParitalUpdatedResult, {""},
+  CheckOperationResultMsgs(pParitalUpdatedResult, pErrorMsgs,
                            /*maySucceedAnyway*/ false, /*bRegex*/ false);
   // Update both.
   *SigInput1 = Tmp;
@@ -4791,15 +4852,39 @@ TEST_F(ValidationTest, PSVSignatureTableReorder) {
   VERIFY_ARE_EQUAL(PSVSignatureElement_size, sizeof(PSVSignatureElement0));
   PSVSignatureElement0 *SigInput =
       const_cast<PSVSignatureElement0 *>((const PSVSignatureElement0 *)PSVPtr);
-  CheckSignatureReorder(pProgram, SigInput, pValidator);
+  CheckSignatureReorder(pProgram, SigInput,
+                        {"'SigInputElement' with content 'PSVSignatureElement:",
+                         "  SemanticName: TEXCOORD", "  SemanticIndex: 0 0 ",
+                         "  IsAllocated: 1", "  StartRow: 1", "  StartCol: 0",
+                         "  Rows: 1", "  Cols: 2", "  SemanticKind: Arbitrary",
+                         "  InterpolationMode: 2", "  OutputStream: 0",
+                         "  ComponentType: 3", "  DynamicIndexMask: 0",
+                         "' duplicates"},
+                        pValidator);
 
   PSVPtr += PSVSignatureElement_size * PSVInfo->SigInputElements / 4;
   PSVSignatureElement0 *SigOutput =
       const_cast<PSVSignatureElement0 *>((const PSVSignatureElement0 *)PSVPtr);
-  CheckSignatureReorder(pProgram, SigOutput, pValidator);
+  CheckSignatureReorder(
+      pProgram, SigOutput,
+      {"'SigOutputElement' with content 'PSVSignatureElement:",
+       "  SemanticName: TEXCOORD", "  SemanticIndex: 0 0 ", "  IsAllocated: 1",
+       "  StartRow: 1", "  StartCol: 0", "  Rows: 1", "  Cols: 2",
+       "  SemanticKind: Arbitrary", "  InterpolationMode: 2",
+       "  OutputStream: 0", "  ComponentType: 3", "  DynamicIndexMask: 0",
+       "' duplicates"},
+      pValidator);
 
   PSVPtr += PSVSignatureElement_size * PSVInfo->SigOutputElements / 4;
   PSVSignatureElement0 *SigPatchConstOrPrim =
       const_cast<PSVSignatureElement0 *>((const PSVSignatureElement0 *)PSVPtr);
-  CheckSignatureReorder(pProgram, SigPatchConstOrPrim, pValidator);
+  CheckSignatureReorder(
+      pProgram, SigPatchConstOrPrim,
+      {"'SigPatchConstantOrPrimElement' with content 'PSVSignatureElement:",
+       "  SemanticName: PN_POSITION", "  SemanticIndex: 0 ", "  IsAllocated: 1",
+       "  StartRow: 0", "  StartCol: 0", "  Rows: 1", "  Cols: 1",
+       "  SemanticKind: Arbitrary", "  InterpolationMode: 0",
+       "  OutputStream: 0", "  ComponentType: 3", "  DynamicIndexMask: 0",
+       "' duplicates"},
+      pValidator);
 }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4862,7 +4862,7 @@ TEST_F(ValidationTest, PSVSignatureTableReorder) {
       const_cast<PSVSignatureElement0 *>((const PSVSignatureElement0 *)PSVPtr);
   CheckSignatureReorder(pProgram, SigInput,
                         {"'SigInputElement' with content 'PSVSignatureElement:",
-                         "  SemanticName: TEXCOORD", "  SemanticIndex: 0 0 ",
+                         "  SemanticName: TEXCOORD", "  SemanticIndex: 0",
                          "  IsAllocated: 1", "  StartRow: 1", "  StartCol: 0",
                          "  Rows: 1", "  Cols: 2", "  SemanticKind: Arbitrary",
                          "  InterpolationMode: 2", "  OutputStream: 0",
@@ -4876,7 +4876,7 @@ TEST_F(ValidationTest, PSVSignatureTableReorder) {
   CheckSignatureReorder(
       pProgram, SigOutput,
       {"'SigOutputElement' with content 'PSVSignatureElement:",
-       "  SemanticName: TEXCOORD", "  SemanticIndex: 0 0 ", "  IsAllocated: 1",
+       "  SemanticName: TEXCOORD", "  SemanticIndex: 0", "  IsAllocated: 1",
        "  StartRow: 1", "  StartCol: 0", "  Rows: 1", "  Cols: 2",
        "  SemanticKind: Arbitrary", "  InterpolationMode: 2",
        "  OutputStream: 0", "  ComponentType: 3", "  DynamicIndexMask: 0",
@@ -4889,7 +4889,7 @@ TEST_F(ValidationTest, PSVSignatureTableReorder) {
   CheckSignatureReorder(
       pProgram, SigPatchConstOrPrim,
       {"'SigPatchConstantOrPrimElement' with content 'PSVSignatureElement:",
-       "  SemanticName: PN_POSITION", "  SemanticIndex: 0 ", "  IsAllocated: 1",
+       "  SemanticName: PN_POSITION", "  SemanticIndex: 0", "  IsAllocated: 1",
        "  StartRow: 0", "  StartCol: 0", "  Rows: 1", "  Cols: 1",
        "  SemanticKind: Arbitrary", "  InterpolationMode: 0",
        "  OutputStream: 0", "  ComponentType: 3", "  DynamicIndexMask: 0",
@@ -5084,7 +5084,7 @@ TEST_F(ValidationTest, PSVContentValidationVS) {
           "error: 'SigInputElement' does not match, for container: "
           "'PSVSignatureElement:",
           "  SemanticName: POSITION",
-          "  SemanticIndex: 0 16 1 ",
+          "  SemanticIndex: 0",
           "  IsAllocated: 1",
           "  StartRow: 0",
           "  StartCol: 0",
@@ -5097,7 +5097,7 @@ TEST_F(ValidationTest, PSVContentValidationVS) {
           "  DynamicIndexMask: 0",
           "', for dxil module: 'PSVSignatureElement:",
           "  SemanticName: POSITION",
-          "  SemanticIndex: 0 16 1 ",
+          "  SemanticIndex: 0",
           "  IsAllocated: 1",
           "  StartRow: 0",
           "  StartCol: 0",
@@ -5112,7 +5112,7 @@ TEST_F(ValidationTest, PSVContentValidationVS) {
           "error: 'SigOutputElement' does not match, for container: "
           "'PSVSignatureElement:",
           "  SemanticName: NORMAL",
-          "  SemanticIndex: 0 16 1 ",
+          "  SemanticIndex: 0",
           "  IsAllocated: 1",
           "  StartRow: 0",
           "  StartCol: 0",
@@ -5125,7 +5125,7 @@ TEST_F(ValidationTest, PSVContentValidationVS) {
           "  DynamicIndexMask: 0",
           "', for dxil module: 'PSVSignatureElement:",
           "  SemanticName: NORMAL",
-          "  SemanticIndex: 0 16 1 ",
+          "  SemanticIndex: 0",
           "  IsAllocated: 1",
           "  StartRow: 0",
           "  StartCol: 0",

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -6926,22 +6926,12 @@ class db_dxil(object):
         self.add_valrule_msg(
             "Container.ContentMatches",
             "DXIL Container Content must match Module",
-            "'%0' does not match, for container: '%1', for dxil module: '%2'.",
-        )
-        self.add_valrule_msg(
-            "Container.ContentDuplicates",
-            "DXIL Container Content got duplication",
-            "'%0' with content '%1' duplicates.",
-        )
-        self.add_valrule_msg(
-            "Container.ContentMissing",
-            "DXIL Container Content missing",
-            "Cannot find '%0' with content '%1' in dxil container.",
+            "DXIL container mismatch for '%0' between '%1' part:('%2') and DXIL module:('%3')",
         )
         self.add_valrule_msg(
             "Container.ContentInvalid",
-            "DXIL Container Content invalid",
-            "'%0' is invalid in dxil container.",
+            "DXIL Container Content is well-formed",
+            "In '%0', '%1' is not well-formed",
         )
         self.add_valrule("Meta.Required", "Required metadata missing.")
         self.add_valrule_msg(

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -6923,7 +6923,26 @@ class db_dxil(object):
             "Root Signature in DXIL Container must be compatible with shader",
             "Root Signature in DXIL container is not compatible with shader.",
         )
-
+        self.add_valrule_msg(
+            "Container.ContentMatches",
+            "DXIL Container Content must match Module",
+            "'%0' does not match, for container: '%1', for dxil module: '%2'.",
+        )
+        self.add_valrule_msg(
+            "Container.ContentDuplicates",
+            "DXIL Container Content got duplication",
+            "'%0' with content '%1' duplicates.",
+        )
+        self.add_valrule_msg(
+            "Container.ContentMissing",
+            "DXIL Container Content missing",
+            "Cannot find '%0' with content '%1' in dxil container.",
+        )
+        self.add_valrule_msg(
+            "Container.ContentInvalid",
+            "DXIL Container Content invalid",
+            "'%0' is invalid in dxil container.",
+        )
         self.add_valrule("Meta.Required", "Required metadata missing.")
         self.add_valrule_msg(
             "Meta.ComputeWithNode",


### PR DESCRIPTION
Replace the memcpy check for PSV0 part.
Build DxilPipelineStateValidation object from data in PSV0 part. Then compare the content with information from input DxilModule.

With this change, the order of signature elements and resources could be different between the container and the DxilModule.
And the StringTable could be in different order as well.

Second step for #6817