### PR TITLE
Correct build exclusion in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ autoconf/autom4te.cache
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
 # Build directories
-build*
+/build*/
 # External projects that are tracked independently.
 external/*
 # Clang, which is tracked independently.


### PR DESCRIPTION
The build* entry in .gitignore was intended to exclude any build directories with whatever suffixes a developer might use for various build configurations. The way it was written made it exclude any file that had build in the name, which was more aggressive than needed.

By adding a leading slash, it is limited to items in the git root directory. By adding a trailing slash, it is limited to directories in the root directory. This accomplishes the intended exclusions as narrowly as possible.

(I swear I'm not trying to win a bet on writing the longest description of a two character change in history)

Fixes #4733