### PR TITLE
Add SPIRV version macros to DXC

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -397,8 +397,8 @@ interface variables:
   main([[vk::location(N)]] float4 input: A) : B
   { ... }
 
-Macro for SPIR-V
-----------------
+Macros for SPIR-V
+-----------------
 
 If SPIR-V CodeGen is enabled and ``-spirv`` flag is used as one of the command
 line options (meaning that "generates SPIR-V code"), it defines an implicit
@@ -411,6 +411,12 @@ specific part of the HLSL code:
   [[vk::binding(X, Y), vk::counter_binding(Z)]]
   #endif
   RWStructuredBuffer<S> mySBuffer;
+
+When the ``-spirv`` flag is used, the ``-fspv-target-env`` option will
+implicitly define the macros ``__SPIRV_MAJOR_VERSION__`` and
+``__SPIRV_MINOR_VERSION__``, which will be integers representing the major and
+minor version of the SPIR-V being generated. This can be used to enable code that uses a feature
+only for environments where that feature is available.
 
 SPIR-V version and extension
 ----------------------------

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -171,7 +171,9 @@ public:
   // HLSL Change Ends
 
   bool SPIRV = false;  // SPIRV Change
-  
+  unsigned SpirvMajorVersion; // SPIRV Change
+  unsigned SpirvMinorVersion; // SPIRV Change
+
   bool isSignedOverflowDefined() const {
     return getSignedOverflowBehavior() == SOB_Defined;
   }

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -20,6 +20,7 @@
 #include "dxc/Support/SPIRVOptions.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/VersionTuple.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -137,6 +138,9 @@ public:
   /// Returns an empty Optional if no matching env is found.
   static llvm::Optional<spv_target_env>
   stringToSpvEnvironment(const std::string &target_env);
+
+  // Returns the SPIR-V version used for the target environment.
+  static clang::VersionTuple getSpirvVersion(spv_target_env env);
 
   /// Returns the equivalent to spv_target_env in pretty, human readable form.
   /// (SPV_ENV_VULKAN_1_0 -> "Vulkan 1.0").

--- a/tools/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/tools/clang/lib/Frontend/InitPreprocessor.cpp
@@ -401,6 +401,10 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
 #ifdef ENABLE_SPIRV_CODEGEN
     if (LangOpts.SPIRV) {
       Builder.defineMacro("__spirv__");
+      Builder.defineMacro("__SPIRV_MAJOR_VERSION__",
+                          Twine(LangOpts.SpirvMajorVersion));
+      Builder.defineMacro("__SPIRV_MINOR_VERSION__",
+                          Twine(LangOpts.SpirvMinorVersion));
     }
 #endif // ENABLE_SPIRV_CODEGEN
     // SPIRV Change Ends

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -35,6 +35,15 @@ constexpr std::array<std::pair<spv_target_env, const char *>, 6>
          {SPV_ENV_VULKAN_1_3, "Vulkan 1.3"},
          {SPV_ENV_UNIVERSAL_1_5, "SPIR-V 1.5"}}};
 
+constexpr std::array<std::pair<spv_target_env, std::pair<uint32_t, uint32_t>>,
+                     6>
+    kTargetEnvToSpirvVersion = {{{SPV_ENV_VULKAN_1_0, {1, 0}},
+                                 {SPV_ENV_VULKAN_1_1, {1, 3}},
+                                 {SPV_ENV_VULKAN_1_1_SPIRV_1_4, {1, 4}},
+                                 {SPV_ENV_VULKAN_1_2, {1, 5}},
+                                 {SPV_ENV_VULKAN_1_3, {1, 6}},
+                                 {SPV_ENV_UNIVERSAL_1_5, {1, 5}}}};
+
 static_assert(
     kKnownTargetEnv.size() == kHumanReadableTargetEnv.size(),
     "kKnownTargetEnv and kHumanReadableTargetEnv should remain in sync.");
@@ -50,6 +59,16 @@ FeatureManager::stringToSpvEnvironment(const std::string &target_env) {
   return it == kKnownTargetEnv.end()
              ? llvm::None
              : llvm::Optional<spv_target_env>(it->second);
+}
+
+clang::VersionTuple FeatureManager::getSpirvVersion(spv_target_env env) {
+  auto it = std::find_if(kTargetEnvToSpirvVersion.cbegin(),
+                         kTargetEnvToSpirvVersion.cend(),
+                         [&](const auto &pair) { return pair.first == env; });
+
+  return it == kTargetEnvToSpirvVersion.end()
+             ? clang::VersionTuple()
+             : clang::VersionTuple(it->second.first, it->second.second);
 }
 
 llvm::Optional<std::string>

--- a/tools/clang/test/CodeGenSPIRV/spirv.version.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.version.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T vs_6_5 -P -spirv -fspv-target-env=vulkan1.0 -Fi %t.vk_1_0.hlsl.pp %s
+// RUN: FileCheck --input-file=%t.vk_1_0.hlsl.pp %s --check-prefix=VK_1_0
+// VK_1_0: SPIR-V version 1 0
+
+// RUN: %dxc -T vs_6_5 -P -spirv -fspv-target-env=vulkan1.1 -Fi %t.vk_1_1.hlsl.pp %s
+// RUN: FileCheck --input-file=%t.vk_1_1.hlsl.pp %s --check-prefix=VK_1_1
+// VK_1_1: SPIR-V version 1 3
+
+// RUN: %dxc -T vs_6_5 -P -spirv -fspv-target-env=vulkan1.1spirv1.4 -Fi %t.vk_1_1.hlsl.pp %s
+// RUN: FileCheck --input-file=%t.vk_1_1.hlsl.pp %s --check-prefix=VK_1_1_SPV_1_4
+// VK_1_1_SPV_1_4: SPIR-V version 1 4
+
+// RUN: %dxc -T vs_6_5 -P -spirv -fspv-target-env=vulkan1.2 -Fi %t.vk_1_2.hlsl.pp %s
+// RUN: FileCheck --input-file=%t.vk_1_2.hlsl.pp %s --check-prefix=VK_1_2
+// VK_1_2: SPIR-V version 1 5
+
+// RUN: %dxc -T vs_6_5 -P -spirv -fspv-target-env=universal1.5 -Fi %t.universal_1_5.hlsl.pp %s
+// RUN: FileCheck --input-file=%t.universal_1_5.hlsl.pp %s --check-prefix=UNI_1_5
+// UNI_1_5: SPIR-V version 1 5
+
+// RUN: %dxc -T vs_6_5 -P -spirv -fspv-target-env=vulkan1.3 -Fi %t.vk_1_3.hlsl.pp %s
+// RUN: FileCheck --input-file=%t.vk_1_3.hlsl.pp %s --check-prefix=VK_1_3
+// VK_1_3: SPIR-V version 1 6
+
+SPIR-V version __SPIRV_MAJOR_VERSION__ __SPIRV_MINOR_VERSION__

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -63,6 +63,7 @@
 // SPIRV change starts
 #ifdef ENABLE_SPIRV_CODEGEN
 #include "clang/SPIRV/EmitSpirvAction.h"
+#include "clang/SPIRV/FeatureManager.h"
 #endif
 // SPIRV change ends
 
@@ -1451,6 +1452,22 @@ public:
 // SPIRV change starts
 #ifdef ENABLE_SPIRV_CODEGEN
     compiler.getLangOpts().SPIRV = Opts.GenSPIRV;
+    llvm::Optional<spv_target_env> spirvTargetEnv =
+        spirv::FeatureManager::stringToSpvEnvironment(
+            Opts.SpirvOptions.targetEnv);
+
+    // If we do not have a valid target environment, the error will be handled
+    // later.
+    if (spirvTargetEnv.hasValue()) {
+      VersionTuple spirvVersion =
+          spirv::FeatureManager::getSpirvVersion(spirvTargetEnv.getValue());
+      compiler.getLangOpts().SpirvMajorVersion = spirvVersion.getMajor();
+      assert(spirvVersion.getMinor().hasValue() &&
+             "There must always be a major and minor version number when "
+             "targeting SPIR-V.");
+      compiler.getLangOpts().SpirvMinorVersion =
+          spirvVersion.getMinor().getValue();
+    }
 #endif
     // SPIRV change ends
 


### PR DESCRIPTION
With inline spir-v, it becomes important for users to know which version
of SPIR-V is being targeted. They may need to generate different code
depending on the version.

This commit add these `__SPIRV_MAJOR_VERSION__` and
`__SPIRV_MINOR_VERSION__` to the compiler.
