### PR TITLE
Support Mesh shader in GetInputToPCOutputTable.

### DIFF
--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -716,7 +716,7 @@ public:
     return PSVDependencyTable();
   }
   PSVDependencyTable GetInputToPCOutputTable() const {
-    if (IsHS() && m_pInputToPCOutputTable && m_pPSVRuntimeInfo1) {
+    if ((IsHS() || IsMS()) && m_pInputToPCOutputTable && m_pPSVRuntimeInfo1) {
       return PSVDependencyTable(m_pInputToPCOutputTable,
                                 m_pPSVRuntimeInfo1->SigInputVectors,
                                 m_pPSVRuntimeInfo1->SigPatchConstOrPrimVectors);

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -880,7 +880,7 @@ void DxilPipelineStateValidation::Print(raw_ostream &OS,
         ViewIDMask.Print(OS, "ViewID", OutputSetName.c_str());
       }
 
-      if (IsHS()) {
+      if (IsHS() || IsMS()) {
         OS << "PCOutputs affected by ViewID as a bitmask:\n";
         uint8_t OutputVectors = m_pPSVRuntimeInfo1->SigPatchConstOrPrimVectors;
         const PSVComponentMask ViewIDMask(m_pViewIDPCOrPrimOutputMask,
@@ -901,7 +901,7 @@ void DxilPipelineStateValidation::Print(raw_ostream &OS,
       Table.Print(OS, "Inputs", OutputSetName.c_str());
     }
 
-    if (IsHS()) {
+    if (IsHS() || IsMS()) {
       OS << "Patch constant outputs affected by inputs as a table of "
             "bitmasks:\n";
       uint8_t InputVectors = m_pPSVRuntimeInfo1->SigInputVectors;

--- a/tools/clang/test/DXC/dumpPSV_MS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_MS.hlsl
@@ -125,8 +125,12 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: Outputs affected by ViewID as a bitmask for stream 0:
 // CHECK-NEXT:    ViewID influencing Outputs[0] : 0  1  2  3  4  8  12  16
+// CHECK-NEXT: PCOutputs affected by ViewID as a bitmask:
+// CHECK-NEXT:   ViewID influencing PCOutputs :  None
 // CHECK-NEXT: Outputs affected by inputs as a table of bitmasks for stream 0:
 // CHECK-NEXT: Inputs contributing to computation of Outputs[0]:  None
+// CHECK-NEXT: Patch constant outputs affected by inputs as a table of bitmasks:
+// CHECK-NEXT: Inputs contributing to computation of PatchConstantOutputs:  None
 
 #define MAX_VERT 32
 #define MAX_PRIM 16


### PR DESCRIPTION
Mesh shader will have input to primitive output dependency table.
GetInputToPCOutputTable should return m_pInputToPCOutputTable instead of empty table for mesh shader.

Also fix the dump for mesh shader.

For #6817