### PR TITLE
Process subrecord decls in spirv backend

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1801,6 +1801,8 @@ void SpirvEmitter::doRecordDecl(const RecordDecl *recordDecl) {
         doVarDecl(varDecl);
     } else if (auto *enumDecl = dyn_cast<EnumDecl>(subDecl)) {
       doEnumDecl(enumDecl);
+    } else if (auto recordDecl = dyn_cast<RecordDecl>(subDecl)) {
+      doRecordDecl(recordDecl);
     }
   }
 }

--- a/tools/clang/test/CodeGenSPIRV/nested.static.var.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/nested.static.var.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T cs_6_0 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
+
+// Check that the variable `value` is defined, and set to 6 in the entry point wrapper.
+// CHECK: %value = OpVariable %_ptr_Private_uint Private
+// CHECK: %main = OpFunction %void None
+// CHECK-NEXT: OpLabel
+// CHECK-NEXT: OpStore %value %uint_6
+
+struct A {
+    struct B { static const uint value = 6u; };
+};
+
+[[vk::binding(0,4)]] RWStructuredBuffer<uint> a;
+
+[numthreads(1,1,1)]
+void main() {
+    a[0] = A::B::value;
+}


### PR DESCRIPTION
The spir-v backend does not recurse into structs defined in struct in
doRecoredDecl. This causes us to miss some declarations.

Fixes #5916
