### PR TITLE
[Dump] Fix PSV dump issues.

### DIFF
--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -901,7 +901,7 @@ void DxilPipelineStateValidation::Print(raw_ostream &OS,
       Table.Print(OS, "Inputs", OutputSetName.c_str());
     }
 
-    if (IsHS()) {
+    if (IsHS() || IsMS()) {
       OS << "Patch constant outputs affected by inputs as a table of "
             "bitmasks:\n";
       uint8_t InputVectors = m_pPSVRuntimeInfo1->SigInputVectors;

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -364,7 +364,7 @@ void PSVSignatureElement::Print(raw_ostream &OS) const {
   OS << "  SemanticName: " << GetSemanticName() << "\n";
   OS << "  SemanticIndex: ";
   const uint32_t *SemanticIndexes = GetSemanticIndexes();
-  for (unsigned i = 0; i < GetCols(); ++i) {
+  for (unsigned i = 0; i < GetRows(); ++i) {
     OS << *(SemanticIndexes + i) << " ";
   }
   OS << "\n";

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -880,7 +880,7 @@ void DxilPipelineStateValidation::Print(raw_ostream &OS,
         ViewIDMask.Print(OS, "ViewID", OutputSetName.c_str());
       }
 
-      if (IsHS()) {
+      if (IsHS() || IsMS()) {
         OS << "PCOutputs affected by ViewID as a bitmask:\n";
         uint8_t OutputVectors = m_pPSVRuntimeInfo1->SigPatchConstOrPrimVectors;
         const PSVComponentMask ViewIDMask(m_pViewIDPCOrPrimOutputMask,
@@ -901,7 +901,7 @@ void DxilPipelineStateValidation::Print(raw_ostream &OS,
       Table.Print(OS, "Inputs", OutputSetName.c_str());
     }
 
-    if (IsHS() || IsMS()) {
+    if (IsHS()) {
       OS << "Patch constant outputs affected by inputs as a table of "
             "bitmasks:\n";
       uint8_t InputVectors = m_pPSVRuntimeInfo1->SigInputVectors;

--- a/tools/clang/test/DXC/dumpPSV_DS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_DS.hlsl
@@ -20,60 +20,8 @@
 // CHECK-NEXT: ResourceCount : 0
 // CHECK-NEXT:  PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 0 1 2
-// CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 0
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 4
-// CHECK-NEXT:   SemanticKind: Position
-// CHECK-NEXT:   InterpolationMode: 4
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 3
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 0
-// CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 1
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 2
-// CHECK-NEXT:   SemanticKind: Arbitrary
-// CHECK-NEXT:   InterpolationMode: 2
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 3
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 0 1
-// CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 2
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 3
-// CHECK-NEXT:   SemanticKind: Arbitrary
-// CHECK-NEXT:   InterpolationMode: 2
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 3
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName:
 // CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 3
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 1
-// CHECK-NEXT:   SemanticKind: RenderTargetArrayIndex
-// CHECK-NEXT:   InterpolationMode: 1
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 1
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 0 1 2
-// CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
 // CHECK-NEXT:   Rows: 1
@@ -85,7 +33,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -98,7 +46,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 0 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 2
 // CHECK-NEXT:   StartCol: 0
@@ -125,6 +73,58 @@
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
 // CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 0
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 4
+// CHECK-NEXT:   SemanticKind: Position
+// CHECK-NEXT:   InterpolationMode: 4
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 3
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName: TEXCOORD
+// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 1
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 2
+// CHECK-NEXT:   SemanticKind: Arbitrary
+// CHECK-NEXT:   InterpolationMode: 2
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 3
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName: NORMAL
+// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 2
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 3
+// CHECK-NEXT:   SemanticKind: Arbitrary
+// CHECK-NEXT:   InterpolationMode: 2
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 3
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName:
+// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 3
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 1
+// CHECK-NEXT:   SemanticKind: RenderTargetArrayIndex
+// CHECK-NEXT:   InterpolationMode: 1
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 1
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName:
+// CHECK-NEXT:   SemanticIndex: 0 1 2
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 3

--- a/tools/clang/test/DXC/dumpPSV_GS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_GS.hlsl
@@ -30,7 +30,7 @@
 // CHECK-NEXT:   ResFlags: None
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: POSSIZE
-// CHECK-NEXT:   SemanticIndex: 0 16 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -43,7 +43,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: COLOR
-// CHECK-NEXT:   SemanticIndex: 0 16 1 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -69,7 +69,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 16
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -82,7 +82,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: COLOR
-// CHECK-NEXT:   SemanticIndex: 0 16 1 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -95,7 +95,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 16 1 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 2
 // CHECK-NEXT:   StartCol: 0

--- a/tools/clang/test/DXC/dumpPSV_HS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_HS.hlsl
@@ -23,7 +23,7 @@
 // CHECK-NEXT: ResourceCount : 0
 // CHECK-NEXT:  PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 0 1 2
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -36,7 +36,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -49,46 +49,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 0 1
-// CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 2
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 3
-// CHECK-NEXT:   SemanticKind: Arbitrary
-// CHECK-NEXT:   InterpolationMode: 2
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 3
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 0 1 2
-// CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 0
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 4
-// CHECK-NEXT:   SemanticKind: Position
-// CHECK-NEXT:   InterpolationMode: 4
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 3
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 0
-// CHECK-NEXT:   IsAllocated: 1
-// CHECK-NEXT:   StartRow: 1
-// CHECK-NEXT:   StartCol: 0
-// CHECK-NEXT:   Rows: 1
-// CHECK-NEXT:   Cols: 2
-// CHECK-NEXT:   SemanticKind: Arbitrary
-// CHECK-NEXT:   InterpolationMode: 2
-// CHECK-NEXT:   OutputStream: 0
-// CHECK-NEXT:   ComponentType: 3
-// CHECK-NEXT:   DynamicIndexMask: 0
-// CHECK-NEXT: PSVSignatureElement:
-// CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 0 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 2
 // CHECK-NEXT:   StartCol: 0
@@ -102,6 +63,45 @@
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
 // CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 0
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 4
+// CHECK-NEXT:   SemanticKind: Position
+// CHECK-NEXT:   InterpolationMode: 4
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 3
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName: TEXCOORD
+// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 1
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 2
+// CHECK-NEXT:   SemanticKind: Arbitrary
+// CHECK-NEXT:   InterpolationMode: 2
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 3
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName: NORMAL
+// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   IsAllocated: 1
+// CHECK-NEXT:   StartRow: 2
+// CHECK-NEXT:   StartCol: 0
+// CHECK-NEXT:   Rows: 1
+// CHECK-NEXT:   Cols: 3
+// CHECK-NEXT:   SemanticKind: Arbitrary
+// CHECK-NEXT:   InterpolationMode: 2
+// CHECK-NEXT:   OutputStream: 0
+// CHECK-NEXT:   ComponentType: 3
+// CHECK-NEXT:   DynamicIndexMask: 0
+// CHECK-NEXT: PSVSignatureElement:
+// CHECK-NEXT:   SemanticName:
+// CHECK-NEXT:   SemanticIndex: 0 1 2
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 3

--- a/tools/clang/test/DXC/dumpPSV_MS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_MS.hlsl
@@ -21,7 +21,7 @@
 // CHECK-NEXT: ResourceCount : 0
 // CHECK-NEXT:  PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 0 1 2
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -34,7 +34,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: COLOR
-// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   SemanticIndex: 0 1 2 3
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -99,7 +99,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: LAYER
-// CHECK-NEXT:   SemanticIndex: 0
+// CHECK-NEXT:   SemanticIndex: 0 1 2 3 4 5
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0

--- a/tools/clang/test/DXC/dumpPSV_MS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_MS.hlsl
@@ -125,10 +125,10 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: Outputs affected by ViewID as a bitmask for stream 0:
 // CHECK-NEXT:    ViewID influencing Outputs[0] : 0  1  2  3  4  8  12  16
+// CHECK-NEXT: PCOutputs affected by ViewID as a bitmask:
+// CHECK-NEXT:    ViewID influencing PCOutputs :  None
 // CHECK-NEXT: Outputs affected by inputs as a table of bitmasks for stream 0:
 // CHECK-NEXT: Inputs contributing to computation of Outputs[0]:  None
-// CHECK-NEXT: Patch constant outputs affected by inputs as a table of bitmasks:
-// CHECK-NEXT: Inputs contributing to computation of PatchConstantOutputs:  None
 
 #define MAX_VERT 32
 #define MAX_PRIM 16

--- a/tools/clang/test/DXC/dumpPSV_MS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_MS.hlsl
@@ -127,6 +127,8 @@
 // CHECK-NEXT:    ViewID influencing Outputs[0] : 0  1  2  3  4  8  12  16
 // CHECK-NEXT: Outputs affected by inputs as a table of bitmasks for stream 0:
 // CHECK-NEXT: Inputs contributing to computation of Outputs[0]:  None
+// CHECK-NEXT: Patch constant outputs affected by inputs as a table of bitmasks:
+// CHECK-NEXT: Inputs contributing to computation of PatchConstantOutputs:  None
 
 #define MAX_VERT 32
 #define MAX_PRIM 16

--- a/tools/clang/test/DXC/dumpPSV_PS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_PS.hlsl
@@ -42,7 +42,7 @@
 // CHECK-NEXT:   ResFlags: None
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 16 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -55,7 +55,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 16
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -68,7 +68,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 16 1 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0

--- a/tools/clang/test/DXC/dumpPSV_VS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_VS.hlsl
@@ -27,7 +27,7 @@
 // CHECK-NEXT:   ResFlags: None
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: POSITION
-// CHECK-NEXT:   SemanticIndex: 0 16 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -40,7 +40,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 16 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -53,7 +53,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 16
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 2
 // CHECK-NEXT:   StartCol: 0
@@ -66,7 +66,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: NORMAL
-// CHECK-NEXT:   SemanticIndex: 0 16 1
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 0
 // CHECK-NEXT:   StartCol: 0
@@ -79,7 +79,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName: TEXCOORD
-// CHECK-NEXT:   SemanticIndex: 0 16
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 1
 // CHECK-NEXT:   StartCol: 0
@@ -92,7 +92,7 @@
 // CHECK-NEXT:   DynamicIndexMask: 0
 // CHECK-NEXT: PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:
-// CHECK-NEXT:   SemanticIndex: 0 16 1 0
+// CHECK-NEXT:   SemanticIndex: 0
 // CHECK-NEXT:   IsAllocated: 1
 // CHECK-NEXT:   StartRow: 2
 // CHECK-NEXT:   StartCol: 0


### PR DESCRIPTION
1. Number of SemanticIndex should match number of rows instead of number of columns.
2. Mesh shader could have ViewID mask for Primitive output.

For #6817.