### PR TITLE
Allow unsigned as a full type

### DIFF
--- a/tools/clang/include/clang/Sema/DeclSpec.h
+++ b/tools/clang/include/clang/Sema/DeclSpec.h
@@ -619,9 +619,9 @@ public:
   /// \brief Return true if any type-specifier has been found.
   bool hasTypeSpecifier() const {
       return getTypeSpecType() != DeclSpec::TST_unspecified ||
-            getTypeSpecWidth() != DeclSpec::TSW_unspecified ||
-          getTypeSpecComplex() != DeclSpec::TSC_unspecified;
-           //getTypeSpecSign() != DeclSpec::TSS_unspecified; // HLSL Change - unsigned is not a complete type specifier.
+             getTypeSpecWidth() != DeclSpec::TSW_unspecified ||
+             getTypeSpecComplex() != DeclSpec::TSC_unspecified ||
+             getTypeSpecSign() != DeclSpec::TSS_unspecified;
   }
 
   /// \brief Return a bitmask of which flavors of specifiers this

--- a/tools/clang/lib/Sema/DeclSpec.cpp
+++ b/tools/clang/lib/Sema/DeclSpec.cpp
@@ -1051,12 +1051,9 @@ void DeclSpec::Finish(DiagnosticsEngine &D, Preprocessor &PP, const PrintingPoli
 
   // signed/unsigned are only valid with int/char/wchar_t.
   if (TypeSpecSign != TSS_unspecified) {
-    // HLSL Change starts - signed/unsigned are not complete type specifiers.
-    #if 0
     if (TypeSpecType == TST_unspecified)
       TypeSpecType = TST_int;
-    #endif
-    // shorthand vectors and matrices can have signed/unsigned specifiers.
+    // HLSL Change starts - shorthand vectors and matrices can have signed/unsigned specifiers.
     // If other typenames are used with signed/unsigned, it is already diagnosed by hlsl external source
     if (TypeSpecType != TST_int && TypeSpecType != TST_int128 &&
         TypeSpecType != TST_char && TypeSpecType != TST_wchar &&

--- a/tools/clang/test/CodeGenHLSL/unsigned-int.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unsigned-int.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -fcgl -T vs_6_0 %s | FileCheck %s
+
+// Test that unsigned alone is accepted and equivalent to an unsigned int
+
+// CHECK: @"\01?g_u@@3IB" = external constant i32, align 4
+unsigned g_u;
+
+// CHECK: @"\01?buf_u@@3V?$RWBuffer@I@@A" = external global %"class.RWBuffer<unsigned int>", align 4
+// CHECK: @"\01?sbuf_u@@3V?$RWStructuredBuffer@I@@A" = external global %"class.RWStructuredBuffer<unsigned int>", align 4
+RWBuffer<uint> buf_u;
+RWStructuredBuffer<unsigned> sbuf_u;
+RWByteAddressBuffer bab_u;
+
+unsigned doit(uint i, unsigned j);
+
+float4 main(unsigned VID : SV_VertexID, unsigned IID : SV_InstanceID) : SV_Position {
+  uint i = g_u;
+  // CHECK: %call = call i32 @"\01?doit@@YAIII@Z"(i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
+  buf_u[0] = doit(VID, i);
+  sbuf_u[0] = doit(IID, bab_u.Load<unsigned>(0));
+  return doit(buf_u[1], sbuf_u[1]);
+}
+
+// CHECK: define internal i32 @"\01?doit@@YAIII@Z"(i32 %i, i32 %j)
+unsigned doit(uint i, unsigned j) {
+  return i + j;
+}


### PR DESCRIPTION
#106 disabled the unsigned keyword as a complete type specifier among other changes. While it gave no rationale for that decision nor any tests, it was likely because FXC doesn't allow it. It's harmless and sure not to break any code. It also represents a discrepancy with the developing clang HLSL support that I'm not inclined to change there. 

This restores the ability to promote a variable with just the `unsigned` keyword as an `unsigned int` and includes tests that affirm it's availability in a number of contexts and compatibility with `uint`