### PR TITLE
Disable the aggressive reassociation optimization by default

### DIFF
--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -39,7 +39,7 @@ static const Toggle TOGGLE_GVN = {"gvn", DEFAULT_ON};
 static const Toggle TOGGLE_LICM = {"licm", DEFAULT_ON};
 static const Toggle TOGGLE_SINK = {"sink", DEFAULT_ON};
 static const Toggle TOGGLE_ENABLE_AGGRESSIVE_REASSOCIATION = {
-    "aggressive-reassociation", DEFAULT_ON};
+    "aggressive-reassociation", DEFAULT_OFF};
 static const Toggle TOGGLE_LIFETIME_MARKERS = {"lifetime-markers", DEFAULT_ON};
 static const Toggle TOGGLE_PARTIAL_LIFETIME_MARKERS = {
     "partial-lifetime-markers", DEFAULT_OFF};


### PR DESCRIPTION
The aggressive reassociation optimization for this common factor issue (https://github.com/microsoft/DirectXShaderCompiler/issues/6593) can reduce redundant calculations obviously.

But it also exposed some issues for the final codegen and caused perf regressions for some shaders in runtime tests.

Fixing those codegen issues is non-trival, as a workaround, this PR disables the aggressive reassociation optimization by default and will get the perf loss back.