### PR TITLE
Cherry-Pick: Fix debug info offsets for vectors with 16-bit types (#6775)

### DIFF
--- a/tools/clang/test/DXC/min16vector_disabled.hlsl
+++ b/tools/clang/test/DXC/min16vector_disabled.hlsl
@@ -1,0 +1,19 @@
+// Validate that the offsets for a min16float vector is correct if 16-bit types aren't enabled
+// RUN: %dxc -T cs_6_5 -Od -Zi -Qembed_debug %s | FileCheck %s
+
+// CHECK-NOT: {{.*}}!DIDerivedType{{.*}}name: "x"{{.*}}offset: {{.*}}
+// CHECK: {{.*}}!DIDerivedType{{.*}}name: "y"{{.*}}offset: 32{{.*}}
+// CHECK: {{.*}}!DIDerivedType{{.*}}name: "z"{{.*}}offset: 64{{.*}}
+// CHECK: {{.*}}!DIDerivedType{{.*}}name: "w"{{.*}}offset: 96{{.*}}
+
+RWStructuredBuffer<int> UAV : register(u0);
+
+[numthreads(1, 1, 1)] 
+void main() {
+    min16float4 vector;
+    vector.x = UAV[0];
+    vector.y = UAV[1];
+    vector.z = UAV[2];
+    vector.w = UAV[3];
+    UAV[16] = vector.x + vector.y + vector.z + vector.w;
+}

--- a/tools/clang/test/DXC/min16vector_enabled.hlsl
+++ b/tools/clang/test/DXC/min16vector_enabled.hlsl
@@ -1,0 +1,19 @@
+// Validate that the offsets for a min16float vector is correct if 16-bit types are enabled
+// RUN: %dxc -T cs_6_5 -Od -Zi -Qembed_debug -enable-16bit-types %s | FileCheck %s
+
+// CHECK-NOT: {{.*}}!DIDerivedType{{.*}}name: "x"{{.*}}offset: {{.*}}
+// CHECK: {{.*}}!DIDerivedType{{.*}}name: "y"{{.*}}offset: 16{{.*}}
+// CHECK: {{.*}}!DIDerivedType{{.*}}name: "z"{{.*}}offset: 32{{.*}}
+// CHECK: {{.*}}!DIDerivedType{{.*}}name: "w"{{.*}}offset: 48{{.*}}
+
+RWStructuredBuffer<int> UAV : register(u0);
+
+[numthreads(1, 1, 1)] 
+void main() {
+    min16float4 vector;
+    vector.x = UAV[0];
+    vector.y = UAV[1];
+    vector.z = UAV[2];
+    vector.w = UAV[3];
+    UAV[16] = vector.x + vector.y + vector.z + vector.w;
+}


### PR DESCRIPTION
This fixes a bug where the offsets for elements in vectors with 16-bit types doesn't take into account alignment bits and PIX wouldn't display vector element values correctly in the shader debugger. Eg. if `-enable-16bit-types` wasn't set, the offsets for a min16float4 would be 0, 16, 32, 48 instead of 0, 32, 64, 96.

Also removed the assert in PopulateAllocaMap_StructType that was checking whether the calculated aligned offset matches the packed offset (from SortedMembers) because it was false for members with sizes smaller than the alignment size.

(cherry picked from commit 84c0a095576c63d8103ffffc56bb165b3cf9ddf3)