### PR TITLE
Cherry-Pick: PIX: Rationalize UAV generation (#6883)

### DIFF
--- a/lib/DxilPIXPasses/DxilAddPixelHitInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilAddPixelHitInstrumentation.cpp
@@ -78,8 +78,8 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M) {
     IRBuilder<> Builder(dxilutil::FirstNonAllocaInsertionPt(
         PIXPassHelpers::GetEntryFunction(DM)));
 
-    HandleForUAV =
-        PIXPassHelpers::CreateUAV(DM, Builder, 0, "PIX_CountUAV_Handle");
+    HandleForUAV = PIXPassHelpers::CreateUAVOnceForModule(
+        DM, Builder, 0, "PIX_CountUAV_Handle");
 
     DM.ReEmitDxilResources();
   }

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -322,7 +322,8 @@ public:
   void applyOptions(PassOptions O) override;
   bool runOnModule(Module &M) override;
 
-  bool RunOnFunction(Module &M, DxilModule &DM, llvm::Function *function);
+  bool RunOnFunction(Module &M, DxilModule &DM, hlsl::DxilResource *uav,
+                     llvm::Function *function);
 
 private:
   SystemValueIndices addRequiredSystemValues(BuilderContext &BC,
@@ -447,6 +448,7 @@ DxilDebugInstrumentation::addRequiredSystemValues(BuilderContext &BC,
   case DXIL::ShaderKind::AnyHit:
   case DXIL::ShaderKind::ClosestHit:
   case DXIL::ShaderKind::Miss:
+  case DXIL::ShaderKind::Node:
     // Dispatch* thread Id is not in the input signature
     break;
   case DXIL::ShaderKind::Vertex: {
@@ -703,6 +705,9 @@ void DxilDebugInstrumentation::addInvocationSelectionProlog(
   case DXIL::ShaderKind::Miss:
     ParameterTestResult = addRaygenShaderProlog(BC);
     break;
+  case DXIL::ShaderKind::Node:
+    ParameterTestResult = BC.HlslOP->GetI1Const(1);
+    break;
   case DXIL::ShaderKind::Compute:
   case DXIL::ShaderKind::Amplification:
   case DXIL::ShaderKind::Mesh:
@@ -895,10 +900,10 @@ uint32_t DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
     BytesToBeEmitted += addDebugEntryValue(BC, AsFloat);
   } else {
     Function *StoreValue =
-        BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore,
+        BC.HlslOP->GetOpFunc(OP::OpCode::RawBufferStore,
                              TheValue->getType()); // Type::getInt32Ty(BC.Ctx));
     Constant *StoreValueOpcode =
-        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
+        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::RawBufferStore);
     UndefValue *Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
     UndefValue *UndefArg = nullptr;
     if (TheValueTypeID == Type::TypeID::IntegerTyID) {
@@ -913,6 +918,7 @@ uint32_t DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
     Constant *WriteMask_X = BC.HlslOP->GetI8Const(1);
 
     auto &values = m_FunctionToValues[BC.Builder.GetInsertBlock()->getParent()];
+    Constant *RawBufferStoreAlignment = BC.HlslOP->GetU32Const(4);
 
     (void)BC.Builder.CreateCall(
         StoreValue, {StoreValueOpcode,    // i32 opcode
@@ -923,7 +929,7 @@ uint32_t DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
                      UndefArg, // unused values
                      UndefArg, // unused values
                      UndefArg, // unused values
-                     WriteMask_X});
+                     WriteMask_X, RawBufferStoreAlignment});
 
     assert(m_RemainingReservedSpaceInBytes >= 4); // check for underflow
     m_RemainingReservedSpaceInBytes -= 4;
@@ -1211,19 +1217,20 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
 
   auto ShaderModel = DM.GetShaderModel();
   auto shaderKind = ShaderModel->GetKind();
-
+  auto HLSLBindId = 0;
+  auto *uav = PIXPassHelpers::CreateGlobalUAVResource(DM, HLSLBindId, "PIXUAV");
   bool modified = false;
   if (shaderKind == DXIL::ShaderKind::Library) {
     auto instrumentableFunctions =
         PIXPassHelpers::GetAllInstrumentableFunctions(DM);
     for (auto *F : instrumentableFunctions) {
-      if (RunOnFunction(M, DM, F)) {
+      if (RunOnFunction(M, DM, uav, F)) {
         modified = true;
       }
     }
   } else {
     llvm::Function *entryFunction = PIXPassHelpers::GetEntryFunction(DM);
-    modified = RunOnFunction(M, DM, entryFunction);
+    modified = RunOnFunction(M, DM, uav, entryFunction);
   }
   return modified;
 }
@@ -1379,6 +1386,7 @@ DxilDebugInstrumentation::FindInstrumentableInstructionsInBlock(
 }
 
 bool DxilDebugInstrumentation::RunOnFunction(Module &M, DxilModule &DM,
+                                             hlsl::DxilResource *uav,
                                              llvm::Function *function) {
   DXIL::ShaderKind shaderKind =
       PIXPassHelpers::GetFunctionShaderKind(DM, function);
@@ -1397,6 +1405,7 @@ bool DxilDebugInstrumentation::RunOnFunction(Module &M, DxilModule &DM,
   case DXIL::ShaderKind::AnyHit:
   case DXIL::ShaderKind::ClosestHit:
   case DXIL::ShaderKind::Miss:
+  case DXIL::ShaderKind::Node:
     break;
   default:
     return false;
@@ -1431,8 +1440,8 @@ bool DxilDebugInstrumentation::RunOnFunction(Module &M, DxilModule &DM,
     break;
   }
 
-  values.UAVHandle = PIXPassHelpers::CreateUAV(DM, Builder, UAVRegisterId,
-                                               "PIX_DebugUAV_Handle");
+  values.UAVHandle = PIXPassHelpers::CreateHandleForResource(
+      DM, Builder, uav, "PIX_DebugUAV_Handle");
 
   auto SystemValues = addRequiredSystemValues(BC, shaderKind);
   addInvocationSelectionProlog(BC, SystemValues, shaderKind);

--- a/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
+++ b/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
@@ -161,7 +161,7 @@ bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
     std::unique_ptr<DxilCBuffer> pCBuf = llvm::make_unique<DxilCBuffer>();
     pCBuf->SetGlobalName("PIX_ConstantColorCBName");
     pCBuf->SetGlobalSymbol(UndefValue::get(CBStructTy));
-    pCBuf->SetID(0);
+    pCBuf->SetID(static_cast<unsigned int>(DM.GetCBuffers().size()));
     pCBuf->SetSpaceID(
         (unsigned int)-2); // This is the reserved-for-tools register space
     pCBuf->SetLowerBound(0);

--- a/lib/DxilPIXPasses/DxilPIXDXRInvocationsLog.cpp
+++ b/lib/DxilPIXPasses/DxilPIXDXRInvocationsLog.cpp
@@ -88,9 +88,9 @@ bool DxilPIXDXRInvocationsLog::runOnModule(Module &M) {
     IRBuilder<> Builder(dxilutil::FirstNonAllocaInsertionPt(entryFunction));
 
     // Add the UAVs that we're going to write to
-    CallInst *HandleForCountUAV = PIXPassHelpers::CreateUAV(
+    CallInst *HandleForCountUAV = PIXPassHelpers::CreateUAVOnceForModule(
         DM, Builder, /* registerID */ 0, "PIX_CountUAV_Handle");
-    CallInst *HandleForUAV = PIXPassHelpers::CreateUAV(
+    CallInst *HandleForUAV = PIXPassHelpers::CreateUAVOnceForModule(
         DM, Builder, /* registerID */ 1, "PIX_UAV_Handle");
 
     DM.ReEmitDxilResources();

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -337,7 +337,7 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
 
   m_OffsetMask = BC.HlslOP->GetU32Const(UAVDumpingGroundOffset() - 1);
 
-  m_OutputUAV = CreateUAV(DM, Builder, 0, "PIX_DebugUAV_Handle");
+  m_OutputUAV = CreateUAVOnceForModule(DM, Builder, 0, "PIX_DebugUAV_Handle");
 
   if (FirstNewStructGetMeshPayload == nullptr) {
     Instruction *firstInsertionPt = dxilutil::FirstNonAllocaInsertionPt(

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -34,8 +34,14 @@ public:
 
 void FindRayQueryHandlesForFunction(
     llvm::Function *F, llvm::SmallPtrSetImpl<llvm::Value *> &RayQueryHandles);
-llvm::CallInst *CreateUAV(hlsl::DxilModule &DM, llvm::IRBuilder<> &Builder,
-                          unsigned int registerId, const char *name);
+enum class PixUAVHandleMode { NonLib, Lib };
+llvm::CallInst *CreateUAVOnceForModule(hlsl::DxilModule &DM,
+                                       llvm::IRBuilder<> &Builder,
+                                       unsigned int hlslBindIndex,
+                                       const char *name);
+hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
+                                            unsigned int hlslBindIndex,
+                                            const char *name);
 llvm::CallInst *CreateHandleForResource(hlsl::DxilModule &DM,
                                         llvm::IRBuilder<> &Builder,
                                         hlsl::DxilResourceBase *resource,

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTracking.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -ECSMain -Tcs_6_0 %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=S0:1:1i1;U0:2:10i0;.0;0;0. | %FileCheck %s
 
-// Check we added the UAV:
-// CHECK:  %PIX_CountUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK:  %PIX_ShaderAccessUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 
 // check for correct out-of-bounds calculation
 // CHECK: CompareWithSlotLimit = icmp uge i32
@@ -12,7 +12,7 @@
 // CHECK: slotIndex = mul i32
 
 // Check for udpate of UAV:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 
 
 ByteAddressBuffer inBuffer : register(t0);

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
@@ -1,16 +1,16 @@
 // RUN: %dxc -Emain -Tcs_6_5 %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=M0:0:1i0;S0:1:1i0;U0:2:10i0;.0;0;0. | %FileCheck %s
 
-// Check we added the UAV:
-// CHECK:  %PIX_CountUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK:  %PIX_ShaderAccessUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 
 // Feedback UAV:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle, i32 28
 
 // Texture:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 12
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle, i32 12
 
 // Sampler:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 0
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle, i32 0
 
 Texture2D texture : register(t0);
 SamplerState samplerState : register(s0);

--- a/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the basic starting header is present:
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %XPos = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK: %YPos = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1, i32 undef)
 // CHECK: %XIndex = fptoui float %XPos to i32

--- a/tools/clang/test/HLSLFileCheck/pix/DebugCSParameters.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugCSParameters.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the CS thread IDs are added properly
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %ThreadIdX = call i32 @dx.op.threadId.i32(i32 93, i32 0)
 // CHECK: %ThreadIdY = call i32 @dx.op.threadId.i32(i32 93, i32 1)
 // CHECK: %ThreadIdZ = call i32 @dx.op.threadId.i32(i32 93, i32 2)

--- a/tools/clang/test/HLSLFileCheck/pix/DebugMs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugMs.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the MS thread IDs are added properly
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %ThreadIdX = call i32 @dx.op.threadId.i32(i32 93, i32 0)
 // CHECK: %ThreadIdY = call i32 @dx.op.threadId.i32(i32 93, i32 1)
 // CHECK: %ThreadIdZ = call i32 @dx.op.threadId.i32(i32 93, i32 2)

--- a/tools/clang/test/HLSLFileCheck/pix/DebugPSParameters.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugPSParameters.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the basic starting header is present:
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %XPos = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK: %YPos = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1, i32 undef)
 // CHECK: %XIndex = fptoui float %XPos to i32

--- a/tools/clang/test/HLSLFileCheck/pix/DebugPreexistingSVInstance.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugPreexistingSVInstance.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the SV_InstanceId check is present:
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %VertId = call i32 @dx.op.loadInput.i32(i32 4, i32 1, i32 0, i8 0, i32 undef)
 // CHECK: %InstanceId = call i32 @dx.op.loadInput.i32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK: %CompareToVertId = icmp eq i32 %VertId, 0

--- a/tools/clang/test/HLSLFileCheck/pix/DebugPreexistingSVPosition.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugPreexistingSVPosition.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the basic SV_Position check is present:
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %XPos = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK: %YPos = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1, i32 undef)
 // CHECK: %XIndex = fptoui float %XPos to i32

--- a/tools/clang/test/HLSLFileCheck/pix/DebugPreexistingSVVertex.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugPreexistingSVVertex.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the vertex id check is present:
 
-// CHECK:  %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK:  %VertId = call i32 @dx.op.loadInput.i32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK:  %InstanceId = call i32 @dx.op.loadInput.i32(i32 4, i32 1, i32 0, i8 0, i32 undef)
 // CHECK:  %CompareToVertId = icmp eq i32 %VertId, 0

--- a/tools/clang/test/HLSLFileCheck/pix/DebugVSParameters.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugVSParameters.hlsl
@@ -2,7 +2,8 @@
 
 // Check that the instance and vertex id are parsed and present:
 
-// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)
+// Check we added the UAV:                                                                      v----metadata position: not important for this check
+// CHECK: %PIX_DebugUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 [[S:[0-9]+]], i32 0, i1 false)
 // CHECK: %VertId = call i32 @dx.op.loadInput.i32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK: %InstanceId = call i32 @dx.op.loadInput.i32(i32 4, i32 1, i32 0, i8 0, i32 undef)
 // CHECK: %CompareToVertId = icmp eq i32 %VertId, 1

--- a/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
@@ -2,24 +2,24 @@
 
 // Check that the expected PIX UAV read-tracking is emitted (the atomicBinOp "|= 1") followed by the expected raw read:
 
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16
 
 // Now the writes with atomicBinOp "|=2":
 
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.f32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.i32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.f16
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_ShaderAccessUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.i16
 
 struct S


### PR DESCRIPTION
The impetus for these changes was unexplained crashes in a display driver while attempting to create a debug-instrumented shader for PIX. The heart of it is the new test in pixtest.cpp: use the compiler to generate a raw UAV, and then compare the generated DXIL with what PIX generates for the same purpose.
Some of the PIX passes need only one UAV for a module, but some need two or more. In the latter case, the previous code was a bit loose about what it was doing with respect to adding the UAV resource, and creating its handles for each interested function. Most of the actual changes herein are to do with that.
Lastly, the PIX UAV is raw at the D3D API level, but the instrumentation had been doing non-raw writes. No driver seemed to care, but I've fixed it anyway.

(cherry picked from commit bf24b7a54d7d615bdf1cb225158fe4a99bb8102c)