### PR TITLE
[Test] Add validator version check for tests

### DIFF
--- a/tools/clang/test/DXC/dumpPSV_AS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_AS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T as_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_CS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_CS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T cs_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_DS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_DS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T ds_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_GS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_GS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T gs_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_HS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_HS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T hs_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_MS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_MS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T ms_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_PS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_PS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T ps_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/test/DXC/dumpPSV_VS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_VS.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -E main -T vs_6_8 %s -Fo %t
 // RUN: %dxa %t -dumppsv | FileCheck %s
 

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -526,8 +526,17 @@ void Miss( inout Payload payload )
   TestPixUAVCase(hlsl, L"lib_6_3", L"");
   TestPixUAVCase(hlsl, L"lib_6_4", L"");
   TestPixUAVCase(hlsl, L"lib_6_5", L"");
+
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
   TestPixUAVCase(hlsl, L"lib_6_6", L"");
+
+  if (m_ver.SkipDxilVersion(1, 7))
+    return;
   TestPixUAVCase(hlsl, L"lib_6_7", L"");
+
+  if (m_ver.SkipDxilVersion(1, 8))
+    return;
   TestPixUAVCase(hlsl, L"lib_6_8", L"");
 }
 


### PR DESCRIPTION
This change adds validation version check for the tests.

This is for fix tests fail when running on different version of validator.