### PR TITLE
[SPIR-V] Fix isfinite/isinf generation for mat/buffers

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8894,9 +8894,6 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
   case hlsl::IntrinsicOp::IOP_D3DCOLORtoUBYTE4:
     retVal = processD3DCOLORtoUBYTE4(callExpr);
     break;
-  case hlsl::IntrinsicOp::IOP_isfinite:
-    retVal = processIntrinsicIsFinite(callExpr);
-    break;
   case hlsl::IntrinsicOp::IOP_sincos:
     retVal = processIntrinsicSinCos(callExpr);
     break;
@@ -9201,15 +9198,22 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     retVal = processIntrinsicFirstbit(callExpr, GLSLstd450::GLSLstd450FindILsb);
     break;
   }
-  case hlsl::IntrinsicOp::IOP_isnan: {
-    retVal = processIntrinsicUsingSpirvInst(callExpr, spv::Op::OpIsNan,
-                                            /* doEachVec= */ true);
-    // OpIsNan returns a bool/vec<bool>, so the only valid layout is void. It
-    // will be the responsibility of the store to do an OpSelect and correctly
-    // convert this type to an externally storable type.
+  case hlsl::IntrinsicOp::IOP_isnan:
+  case hlsl::IntrinsicOp::IOP_isinf: {
+    spv::Op opcode = hlslOpcode == hlsl::IntrinsicOp::IOP_isinf
+                         ? spv::Op::OpIsInf
+                         : spv::Op::OpIsNan;
+    retVal = processIntrinsicUsingSpirvInst(callExpr, opcode,
+                                            /* actPerRowForMatrices= */ true);
+    // OpIsNan/OpIsInf returns a bool/vec<bool>, so the only valid layout is
+    // void. It will be the responsibility of the store to do an OpSelect and
+    // correctly convert this type to an externally storable type.
     retVal->setLayoutRule(SpirvLayoutRule::Void);
     break;
   }
+  case hlsl::IntrinsicOp::IOP_isfinite:
+    retVal = processIntrinsicIsFinite(callExpr);
+    break;
     INTRINSIC_SPIRV_OP_CASE(ddx, DPdx, true);
     INTRINSIC_SPIRV_OP_CASE(ddx_coarse, DPdxCoarse, false);
     INTRINSIC_SPIRV_OP_CASE(ddx_fine, DPdxFine, false);
@@ -9217,7 +9221,6 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     INTRINSIC_SPIRV_OP_CASE(ddy_coarse, DPdyCoarse, false);
     INTRINSIC_SPIRV_OP_CASE(ddy_fine, DPdyFine, false);
     INTRINSIC_SPIRV_OP_CASE(countbits, BitCount, false);
-    INTRINSIC_SPIRV_OP_CASE(isinf, IsInf, true);
     INTRINSIC_SPIRV_OP_CASE(fmod, FRem, true);
     INTRINSIC_SPIRV_OP_CASE(fwidth, Fwidth, true);
     INTRINSIC_SPIRV_OP_CASE(reversebits, BitReverse, false);
@@ -11408,18 +11411,38 @@ SpirvEmitter::processIntrinsicIsFinite(const CallExpr *callExpr) {
   // Since OpIsFinite needs the Kernel capability, translation is instead done
   // using OpIsNan and OpIsInf:
   // isFinite = !(isNan || isInf)
-  const auto arg = doExpr(callExpr->getArg(0));
-  const auto returnType = callExpr->getType();
   const auto loc = callExpr->getExprLoc();
   const auto range = callExpr->getSourceRange();
-  const auto isNan =
-      spvBuilder.createUnaryOp(spv::Op::OpIsNan, returnType, arg, loc, range);
-  const auto isInf =
-      spvBuilder.createUnaryOp(spv::Op::OpIsInf, returnType, arg, loc, range);
-  const auto isNanOrInf = spvBuilder.createBinaryOp(
-      spv::Op::OpLogicalOr, returnType, isNan, isInf, loc, range);
-  return spvBuilder.createUnaryOp(spv::Op::OpLogicalNot, returnType, isNanOrInf,
-                                  loc, range);
+  const QualType returnType = callExpr->getType();
+  const Expr *arg = callExpr->getArg(0);
+  auto *argId = doExpr(arg);
+
+  const auto actOnEachVec = [this, loc, range](
+                                uint32_t /*index*/, QualType inType,
+                                QualType outType, SpirvInstruction *curRow) {
+    const auto isNan =
+        spvBuilder.createUnaryOp(spv::Op::OpIsNan, outType, curRow, loc, range);
+    isNan->setLayoutRule(SpirvLayoutRule::Void);
+    const auto isInf =
+        spvBuilder.createUnaryOp(spv::Op::OpIsInf, outType, curRow, loc, range);
+    isInf->setLayoutRule(SpirvLayoutRule::Void);
+    const auto isNanOrInf = spvBuilder.createBinaryOp(
+        spv::Op::OpLogicalOr, outType, isNan, isInf, loc, range);
+    isNanOrInf->setLayoutRule(SpirvLayoutRule::Void);
+    const auto output = spvBuilder.createUnaryOp(spv::Op::OpLogicalNot, outType,
+                                                 isNanOrInf, loc, range);
+    output->setLayoutRule(SpirvLayoutRule::Void);
+    return output;
+  };
+
+  // If the instruction does not operate on matrices, we can perform the
+  // instruction on each vector of the matrix.
+  if (isMxNMatrix(arg->getType())) {
+    assert(isMxNMatrix(returnType));
+    return processEachVectorInMatrix(arg, returnType, argId, actOnEachVec, loc,
+                                     range);
+  }
+  return actOnEachVec(/* index= */ 0, arg->getType(), returnType, argId);
 }
 
 SpirvInstruction *

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.isfinite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.isfinite.hlsl
@@ -1,5 +1,9 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
+RWStructuredBuffer<float> buffer;
+RWStructuredBuffer<float2x3> buffer_mat;
+RWByteAddressBuffer byte_buffer;
+
 // Since OpIsFinite needs the Kernel capability, translation is done using OpIsNan and OpIsInf.
 // isFinite = !(isNan || isInf)
 
@@ -24,4 +28,67 @@ void main() {
 
   // TODO: We can not translate the following since boolean matrices are currently not supported.
   // bool2x3 isf_c = isfinite(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %buffer %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %float [[ptr]]
+// CHECK:      [[nan:%[0-9]+]] = OpIsNan %bool [[tmp]]
+// CHECK:      [[inf:%[0-9]+]] = OpIsInf %bool [[tmp]]
+// CHECK:       [[or:%[0-9]+]] = OpLogicalOr %bool [[nan]] [[inf]]
+// CHECK:      [[res:%[0-9]+]] = OpLogicalNot %bool [[or]]
+// CHECK:                        OpStore %res [[res]]
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %res
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %float [[res]] %float_1 %float_0
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %buffer %int_0 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  bool res = isfinite(buffer[0]);
+  buffer[0] = (float)res;
+
+// CHECK:        [[c:%[0-9]+]] = OpLoad %mat2v3float %c
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3float [[c]] 0
+// CHECK: [[isnan_r0:%[0-9]+]] = OpIsNan %v3bool [[r0]]
+// CHECK: [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:    [[or_r0:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r0]] [[isinf_r0]]
+// CHECK:   [[not_r0:%[0-9]+]] = OpLogicalNot %v3bool [[or_r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3float [[c]] 1
+// CHECK: [[isnan_r1:%[0-9]+]] = OpIsNan %v3bool [[r1]]
+// CHECK: [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:    [[or_r1:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r1]] [[isinf_r1]]
+// CHECK:   [[not_r1:%[0-9]+]] = OpLogicalNot %v3bool [[or_r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[not_r0]] [[not_r1]]
+// CHECK:                        OpStore %isfinite_c [[tmp]]
+  bool2x3 isfinite_c = isfinite(c);
+
+// CHECK:         [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_mat2v3float %buffer_mat %int_0 %uint_0
+// CHECK:         [[tmp:%[0-9]+]] = OpLoad %mat2v3float [[ptr]]
+// CHECK:          [[r0:%[0-9]+]] = OpCompositeExtract %v3float [[tmp]] 0
+// CHECK:    [[isnan_r0:%[0-9]+]] = OpIsNan %v3bool [[r0]]
+// CHECK:    [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:       [[or_r0:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r0]] [[isinf_r0]]
+// CHECK: [[isfinite_r0:%[0-9]+]] = OpLogicalNot %v3bool [[or_r0]]
+// CHECK:          [[r1:%[0-9]+]] = OpCompositeExtract %v3float [[tmp]] 1
+// CHECK:    [[isnan_r1:%[0-9]+]] = OpIsNan %v3bool [[r1]]
+// CHECK:    [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:       [[or_r1:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r1]] [[isinf_r1]]
+// CHECK: [[isfinite_r1:%[0-9]+]] = OpLogicalNot %v3bool [[or_r1]]
+// CHECK:         [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isfinite_r0]] [[isfinite_r1]]
+// CHECK:                           OpStore %isfinite_d [[tmp]]
+  bool2x3 isfinite_d = isfinite(buffer_mat[0]);
+
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[val:%[0-9]+]] = OpBitcast %float [[tmp]]
+// CHECK:      [[nan:%[0-9]+]] = OpIsNan %bool [[val]]
+// CHECK:      [[inf:%[0-9]+]] = OpIsInf %bool [[val]]
+// CHECK:       [[or:%[0-9]+]] = OpLogicalOr %bool [[nan]] [[inf]]
+// CHECK:      [[res:%[0-9]+]] = OpLogicalNot %bool [[or]]
+// CHECK:                        OpStore %isfinite_e [[res]]
+  bool isfinite_e = isfinite(byte_buffer.Load<float>(0));
+
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %isfinite_e
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %uint [[res]] %uint_1 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  byte_buffer.Store(0, isfinite_e);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.isinf.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.isinf.hlsl
@@ -1,5 +1,9 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
+RWStructuredBuffer<float> buffer;
+RWStructuredBuffer<float2x3> buffer_mat;
+RWByteAddressBuffer byte_buffer;
+
 void main() {
   float    a;
   float4   b;
@@ -15,4 +19,49 @@ void main() {
 
   // TODO: We can not translate the following since boolean matrices are currently not supported.
   // bool2x3 isinf_c = isinf(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %buffer %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %float [[ptr]]
+// CHECK:      [[res:%[0-9]+]] = OpIsInf %bool [[tmp]]
+// CHECK:                        OpStore %res [[res]]
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %res
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %float [[res]] %float_1 %float_0
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %buffer %int_0 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  bool res = isinf(buffer[0]);
+  buffer[0] = (float)res;
+
+// CHECK:        [[c:%[0-9]+]] = OpLoad %mat2v3float %c
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3float [[c]] 0
+// CHECK: [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3float [[c]] 1
+// CHECK: [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isinf_r0]] [[isinf_r1]]
+// CHECK:                        OpStore %isinf_c [[tmp]]
+  bool2x3 isinf_c = isinf(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_mat2v3float %buffer_mat %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %mat2v3float [[ptr]]
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3float [[tmp]] 0
+// CHECK: [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3float [[tmp]] 1
+// CHECK: [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isinf_r0]] [[isinf_r1]]
+// CHECK:                        OpStore %isinf_d [[tmp]]
+  bool2x3 isinf_d = isinf(buffer_mat[0]);
+
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[val:%[0-9]+]] = OpBitcast %float [[tmp]]
+// CHECK:      [[res:%[0-9]+]] = OpIsInf %bool [[val]]
+// CHECK:                        OpStore %isinf_e [[res]]
+  bool isinf_e = isinf(byte_buffer.Load<float>(0));
+
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %isinf_e
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %uint [[res]] %uint_1 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  byte_buffer.Store(0, isinf_e);
 }


### PR DESCRIPTION
In some cases (matrices for ex), we generated the wrong result type for isinf/isfinite.

Fixes #6783