### PR TITLE
PIX: Partial cherry pick of validator version fix 

### DIFF
--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -526,8 +526,17 @@ void Miss( inout Payload payload )
   TestPixUAVCase(hlsl, L"lib_6_3", L"");
   TestPixUAVCase(hlsl, L"lib_6_4", L"");
   TestPixUAVCase(hlsl, L"lib_6_5", L"");
+
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
   TestPixUAVCase(hlsl, L"lib_6_6", L"");
+
+  if (m_ver.SkipDxilVersion(1, 7))
+    return;
   TestPixUAVCase(hlsl, L"lib_6_7", L"");
+
+  if (m_ver.SkipDxilVersion(1, 8))
+    return;
   TestPixUAVCase(hlsl, L"lib_6_8", L"");
 }
 


### PR DESCRIPTION
Partial cherry pickfrom commit  0fd84aa81440b6827705785a927d32b9d726349d
https://github.com/microsoft/DirectXShaderCompiler/commit/0fd84aa81440b6827705785a927d32b9d726349d
Original PR: https://github.com/microsoft/DirectXShaderCompiler/pull/6901
