### PR TITLE
Fix CMake gen failing when HLSL_BUILD_DXILCONV=0

### DIFF
--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -1,7 +1,11 @@
 set(DXC_PROJECTS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(DXC_PROJECTS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-if(WIN32 AND HLSL_BUILD_DXILCONV)
-  add_subdirectory(include/Tracing)
+if(WIN32)
+add_subdirectory(include/Tracing) # DxcRuntimeEtw target
+
+if(HLSL_BUILD_DXILCONV)
   add_subdirectory(dxilconv)
-endif (WIN32 AND HLSL_BUILD_DXILCONV)
+endif (HLSL_BUILD_DXILCONV)
+
+endif (WIN32)


### PR DESCRIPTION
Target dxildll depends on DxcRuntimeEtw, so make sure to add this target, even when HLSL_BUILD_DXILCONV is false.