### PR TITLE
sema: fix string literal allowed in templates

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7663,8 +7663,8 @@ def err_hlsl_unsupported_nested_typedef : Error<
 def err_hlsl_unsupported_operator : Error<
   "operator is not supported">;
 // This error is unused because the HLSL parser will catch all cases.
-//def err_hlsl_unsupported_string_literal : Error<
-//  "unsupported style of string literal - use a char-based literal">;
+def err_hlsl_unsupported_string_literal : Error<
+  "string literals parameters are not supported in HLSL">;
 def err_hlsl_unsupported_struct_op: Error<
   "operator cannot be used with user-defined type %0">;
 def err_hlsl_unsupported_subscript_base_rhs : Error<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11344,6 +11344,13 @@ static void DiagnoseReachableBarrier(Sema &S, CallExpr *CE,
   }
 }
 
+static bool isStringLiteral(QualType type) {
+  if (!type->isConstantArrayType())
+    return false;
+  const Type *eType = type->getArrayElementTypeNoTypeQual();
+  return eType->isSpecificBuiltinType(BuiltinType::Char_S);
+}
+
 // Check HLSL member call constraints for used functions.
 // locallyVisited is true if this call has been visited already from any other
 // entry function.  Used to avoid duplicate diagnostics when not dependent on
@@ -11356,6 +11363,13 @@ void Sema::DiagnoseReachableHLSLCall(CallExpr *CE, const hlsl::ShaderModel *SM,
   FunctionDecl *FD = CE->getDirectCallee();
   if (!FD)
     return;
+
+  for (ParmVarDecl *P : FD->parameters()) {
+    if (isStringLiteral(P->getType())) {
+      Diags.Report(CE->getExprLoc(), diag::err_hlsl_unsupported_string_literal);
+    }
+  }
+
   HLSLIntrinsicAttr *IntrinsicAttr = FD->getAttr<HLSLIntrinsicAttr>();
   if (!IntrinsicAttr)
     return;

--- a/tools/clang/test/SemaHLSL/string_literal.hlsl
+++ b/tools/clang/test/SemaHLSL/string_literal.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T cs_6_0 -verify %s
+
+template<typename T>
+void take_string(T s) {
+}
+
+[numthreads(1, 1, 1)]
+void main() {
+  take_string("toto"); /* expected-error {{string literals parameters are not supported in HLSL}} */
+
+  // Fine.
+  printf("toto");
+}


### PR DESCRIPTION
String literal are not supported in HLSL, except in the special printf case.
Most cases were handled, but not the templated function case.

Fixes #6877