### PR TITLE
Remove assert.h include from DxilPipelineStateValidation.h

### DIFF
--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -12,19 +12,18 @@
 #ifndef __DXIL_PIPELINE_STATE_VALIDATION__H__
 #define __DXIL_PIPELINE_STATE_VALIDATION__H__
 
+// Don't include assert.h here.
+// Since this header is included from multiple environments,
+// it is necessary to define assert before this header is included.
+// #include <assert.h>
+
 #include "dxc/WinAdapter.h"
-#include <assert.h>
 #include <cstring>
 #include <stdint.h>
 
 namespace llvm {
 class raw_ostream;
 }
-
-// Don't include assert.h here.
-// Since this header is included from multiple environments,
-// it is necessary to define assert before this header is included.
-// #include <assert.h>
 
 #ifndef UINT_MAX
 #define UINT_MAX 0xffffffff

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -9,6 +9,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <assert.h>  // Needed for DxilPipelineStateValidation.h
+
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilResource.h"

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -9,7 +9,7 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <assert.h>  // Needed for DxilPipelineStateValidation.h
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/DXIL/DxilModule.h"

--- a/lib/DxilContainer/DxilRDATBuilder.cpp
+++ b/lib/DxilContainer/DxilRDATBuilder.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>  // Needed for DxilPipelineStateValidation.h
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 
 #include "dxc/DxilContainer/DxilRDATBuilder.h"
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"

--- a/lib/DxilContainer/DxilRDATBuilder.cpp
+++ b/lib/DxilContainer/DxilRDATBuilder.cpp
@@ -1,3 +1,5 @@
+#include <assert.h>  // Needed for DxilPipelineStateValidation.h
+
 #include "dxc/DxilContainer/DxilRDATBuilder.h"
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/Support/FileIOHelper.h"

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -31,8 +31,8 @@
 
 #include "DxilValidationUtils.h"
 
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 #include <memory>
-#include <assert.h>  // Needed for DxilPipelineStateValidation.h
 
 using std::unique_ptr;
 using std::unordered_set;

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -32,6 +32,7 @@
 #include "DxilValidationUtils.h"
 
 #include <memory>
+#include <assert.h>  // Needed for DxilPipelineStateValidation.h
 
 using std::unique_ptr;
 using std::unordered_set;

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -42,9 +42,9 @@
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 #include <algorithm>
-#include <list> // should change this for string_table
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
+#include <list>     // should change this for string_table
 #include <vector>
-#include <assert.h>  // Needed for DxilPipelineStateValidation.h
 
 #include "llvm/PassPrinters/PassPrinters.h"
 

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -44,6 +44,7 @@
 #include <algorithm>
 #include <list> // should change this for string_table
 #include <vector>
+#include <assert.h>  // Needed for DxilPipelineStateValidation.h
 
 #include "llvm/PassPrinters/PassPrinters.h"
 

--- a/tools/clang/tools/dxa/dxa.cpp
+++ b/tools/clang/tools/dxa/dxa.cpp
@@ -9,6 +9,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
+
 #include "dxc/Support/Global.h"
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/WinIncludes.h"

--- a/tools/clang/unittests/HLSL/OptimizerTest.cpp
+++ b/tools/clang/unittests/HLSL/OptimizerTest.cpp
@@ -14,13 +14,13 @@
 #endif
 
 #include <algorithm>
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 #include <cassert>
 #include <map>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <assert.h> // Needed for DxilPipelineStateValidation.h
 
 // For DxilRuntimeReflection.h:
 #include "dxc/Support/WinIncludes.h"

--- a/tools/clang/unittests/HLSL/OptimizerTest.cpp
+++ b/tools/clang/unittests/HLSL/OptimizerTest.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 
 // For DxilRuntimeReflection.h:
 #include "dxc/Support/WinIncludes.h"


### PR DESCRIPTION
DxilPipelineStateValidation.h is included from multiple environments. Don't include assert.h in it, otherwise it might overwrite the custom assert in the code that includes DxilPipelineStateValidation.h.

Fixes #6922