### PR TITLE
Fix mismatched memory allocation and deallocation.

### DIFF
--- a/tools/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/tools/clang/lib/AST/NestedNameSpecifier.cpp
@@ -512,7 +512,7 @@ operator=(const NestedNameSpecifierLocBuilder &Other) {
   
   // Free our storage, if we have any.
   if (BufferCapacity) {
-    free(Buffer);
+    delete[] Buffer;
     BufferCapacity = 0;
   }
   
@@ -647,7 +647,7 @@ void NestedNameSpecifierLocBuilder::MakeTrivial(ASTContext &Context,
 
 void NestedNameSpecifierLocBuilder::Adopt(NestedNameSpecifierLoc Other) {
   if (BufferCapacity)
-    free(Buffer);
+    delete[] Buffer;
 
   if (!Other) {
     Representation = nullptr;

--- a/tools/clang/test/CodeGenSPIRV/nestednamespecifier.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/nestednamespecifier.hlsl
@@ -1,0 +1,16 @@
+// Nothing special about the output, but want to make sure it does not fail to run.
+// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 %s
+
+template <typename T>
+class C {
+  C cast();
+};
+
+template <class T>
+C<T>
+C<T>::cast() {
+  C result;
+  return result;
+}
+
+[numthreads(64, 1, 1)] void main() {}


### PR DESCRIPTION
In NestedNameSpecifier.cpp, the Append function allocates data using `new`:

https://github.com/microsoft/DirectXShaderCompiler/blob/e1bb926f63ba44119577c845e9d7a1a10c0f50e9/tools/clang/lib/AST/NestedNameSpecifier.cpp#L449-L450

However, if it deallocated using `free`:

https://github.com/microsoft/DirectXShaderCompiler/blob/e1bb926f63ba44119577c845e9d7a1a10c0f50e9/tools/clang/lib/AST/NestedNameSpecifier.cpp#L514-L516

This can cause problems. I'm changing the `free` to `delete`.