### PR TITLE
[Validator] Check size of PSV.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,6 +23,7 @@ The included licenses apply to the following files:
 Place release notes for the upcoming release below this line and remove this line upon naming this release.
 
 - The incomplete WaveMatrix implementation has been removed.
+- The DXIL validator supports the string table and semantic index table in any order.
 
 ### Version 1.8.2407
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ The included licenses apply to the following files:
 Place release notes for the upcoming release below this line and remove this line upon naming this release.
 
 - The incomplete WaveMatrix implementation has been removed.
-- The DXIL validator supports the string table and semantic index table in any order.
+- DXIL container validation for PSV0 part allows any content ordering inside string and semantic index tables.
 
 ### Version 1.8.2407
 

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -596,9 +596,12 @@ private:
                    const PSVInitInfo &initInfo = PSVInitInfo(MAX_PSV_VERSION));
 
 public:
-  bool InitFromPSV0(const void *pBits, uint32_t size,
-                    uint32_t PSVVersion = MAX_PSV_VERSION) {
-    return ReadOrWrite(pBits, &size, RWMode::Read, PSVInitInfo(PSVVersion));
+  bool InitFromPSV0(const void *pBits, uint32_t size) {
+    return ReadOrWrite(pBits, &size, RWMode::Read);
+  }
+
+  bool InitFromPSV0(const void *pBits, uint32_t *pSize, uint32_t PSVVersion) {
+    return ReadOrWrite(pBits, pSize, RWMode::Read, PSVInitInfo(PSVVersion));
   }
 
   // Initialize a new buffer
@@ -1084,8 +1087,7 @@ DxilPipelineStateValidation::ReadOrWrite(const void *pBits, uint32_t *pSize,
     *pSize = rw.GetSize();
     m_pPSVRuntimeInfo1 = nullptr; // clear ptr to tempRuntimeInfo
   } else if (mode == RWMode::Read) {
-    if (rw.GetSize() != rw.GetOffset())
-      return false;
+    *pSize = rw.GetOffset();
   }
   return true;
 }

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -940,15 +940,12 @@ DxilPipelineStateValidation::ReadOrWrite(const void *pBits, uint32_t *pSize,
 
   PSV_RETB(rw.MapValue(&m_uPSVRuntimeInfoSize, initInfo.RuntimeInfoSize()));
   PSV_RETB(rw.MapArray(&m_pPSVRuntimeInfo0, 1, m_uPSVRuntimeInfoSize));
-  if (initInfo.PSVVersion > 0)
-    AssignDerived(&m_pPSVRuntimeInfo1, m_pPSVRuntimeInfo0,
-                  m_uPSVRuntimeInfoSize); // failure ok
-  if (initInfo.PSVVersion > 1)
-    AssignDerived(&m_pPSVRuntimeInfo2, m_pPSVRuntimeInfo0,
-                  m_uPSVRuntimeInfoSize); // failure ok
-  if (initInfo.PSVVersion > 2)
-    AssignDerived(&m_pPSVRuntimeInfo3, m_pPSVRuntimeInfo0,
-                  m_uPSVRuntimeInfoSize); // failure ok
+  AssignDerived(&m_pPSVRuntimeInfo1, m_pPSVRuntimeInfo0,
+                m_uPSVRuntimeInfoSize); // failure ok
+  AssignDerived(&m_pPSVRuntimeInfo2, m_pPSVRuntimeInfo0,
+                m_uPSVRuntimeInfoSize); // failure ok
+  AssignDerived(&m_pPSVRuntimeInfo3, m_pPSVRuntimeInfo0,
+                m_uPSVRuntimeInfoSize); // failure ok
 
   // In RWMode::CalcSize, use temp runtime info to hold needed values from
   // initInfo

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -81,7 +81,7 @@ static void emitDxilDiag(LLVMContext &Ctx, const char *str) {
 }
 
 class StringTableVerifier {
-  MapVector<unsigned, unsigned> OffsetToUseCountMap;
+  std::unordered_map<unsigned, unsigned> OffsetToUseCountMap;
   const PSVStringTable &Table;
 
 public:

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -760,8 +760,8 @@ static void VerifyPSVMatches(ValidationContext &ValCtx, const void *pPSVData,
                              uint32_t PSVSize) {
   SimplePSV SimplePSV(pPSVData, PSVSize);
   if (!SimplePSV.IsValid) {
-    ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
-                           {"Pipeline State Validation"});
+    ValCtx.EmitFormatError(ValidationRule::ContainerContentInvalid,
+                           {"DxilContainer", "PSV0 part"});
     return;
   }
 

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -510,7 +510,13 @@ static void VerifyPSVMatches(ValidationContext &ValCtx, const void *pPSVData,
   ValCtx.DxilMod.GetValidatorVersion(ValMajor, ValMinor);
   unsigned PSVVersion = hlsl::GetPSVVersion(ValMajor, ValMinor);
   DxilPipelineStateValidation PSV;
-  if (!PSV.InitFromPSV0(pPSVData, PSVSize, PSVVersion)) {
+  uint32_t PSVSizeRead = PSVSize;
+  if (!PSV.InitFromPSV0(pPSVData, &PSVSizeRead, PSVVersion)) {
+    ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
+                           {"Pipeline State Validation"});
+    return;
+  }
+  if (PSVSizeRead != PSVSize) {
     ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
                            {"Pipeline State Validation"});
     return;

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -707,15 +707,10 @@ static void VerifyPSVMatches(ValidationContext &ValCtx, const void *pPSVData,
   if (!SimplePSV.ValidatePSVInit(PSVInfo, ValCtx))
     return;
 
-  DxilPipelineStateValidation PSV;
-  if (!PSV.InitFromPSV0(pPSVData, PSVSize)) {
-    ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
-                           {"Pipeline State Validation"});
-    return;
-  }
-
-  PSVInfo.StringTable = PSV.GetStringTable();
-  PSVInfo.SemanticIndexTable = PSV.GetSemanticIndexTable();
+  PSVInfo.StringTable =
+      PSVStringTable(SimplePSV.StringTable, SimplePSV.StringTableSize);
+  PSVInfo.SemanticIndexTable = PSVSemanticIndexTable(
+      SimplePSV.SemanticIndexTable, SimplePSV.SemanticIndexTableEntries);
   uint32_t ExpectedSize = 0;
   DxilPipelineStateValidation SizePSV;
   if (!SizePSV.InitNew(PSVInfo, nullptr, &ExpectedSize)) {
@@ -725,6 +720,13 @@ static void VerifyPSVMatches(ValidationContext &ValCtx, const void *pPSVData,
   }
 
   if (ExpectedSize != PSVSize) {
+    ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
+                           {"Pipeline State Validation"});
+    return;
+  }
+
+  DxilPipelineStateValidation PSV;
+  if (!PSV.InitFromPSV0(pPSVData, PSVSize)) {
     ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches,
                            {"Pipeline State Validation"});
     return;

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -125,8 +125,8 @@ public:
 };
 
 class SemanticIndexTableVerifier {
-  std::vector<bool> UseMask;
   const PSVSemanticIndexTable &Table;
+  std::vector<bool> UseMask;
 
 public:
   SemanticIndexTableVerifier(const PSVSemanticIndexTable &Table)
@@ -602,11 +602,11 @@ struct SimplePSV {
   uint32_t PSVNumResources = 0;
   uint32_t PSVResourceBindInfoSize = 0;
   uint32_t StringTableSize = 0;
-  char *StringTable = nullptr;
+  const char *StringTable = nullptr;
   uint32_t SemanticIndexTableEntries = 0;
-  uint32_t *SemanticIndexTable = nullptr;
+  const uint32_t *SemanticIndexTable = nullptr;
   uint32_t PSVSignatureElementSize = 0;
-  PSVRuntimeInfo1 *RuntimeInfo1 = nullptr;
+  const PSVRuntimeInfo1 *RuntimeInfo1 = nullptr;
   bool IsValid = true;
   SimplePSV(const void *pPSVData, uint32_t PSVSize) {
     uint32_t Offset = 4;
@@ -614,23 +614,24 @@ struct SimplePSV {
       IsValid = false;
       return;
     }
-    PSVRuntimeInfoSize = *(uint32_t *)pPSVData;
+    PSVRuntimeInfoSize = *(const uint32_t *)pPSVData;
     if (PSVRuntimeInfoSize >= sizeof(PSVRuntimeInfo1))
-      RuntimeInfo1 = (PSVRuntimeInfo1 *)((char *)pPSVData + Offset);
+      RuntimeInfo1 = (const PSVRuntimeInfo1 *)((const char *)pPSVData + Offset);
     Offset += PSVRuntimeInfoSize;
     if (PSVSize < Offset) {
       IsValid = false;
       return;
     }
 
-    PSVNumResources = *(uint32_t *)((char *)pPSVData + Offset);
+    PSVNumResources = *(const uint32_t *)((const char *)pPSVData + Offset);
     Offset += 4;
     if (PSVSize < Offset) {
       IsValid = false;
       return;
     }
     if (PSVNumResources > 0) {
-      PSVResourceBindInfoSize = *(uint32_t *)((char *)pPSVData + Offset);
+      PSVResourceBindInfoSize =
+          *(const uint32_t *)((const char *)pPSVData + Offset);
       Offset += 4;
       if (PSVSize < Offset) {
         IsValid = false;
@@ -643,7 +644,7 @@ struct SimplePSV {
       }
     }
     if (RuntimeInfo1) {
-      StringTableSize = *(uint32_t *)((char *)pPSVData + Offset);
+      StringTableSize = *(const uint32_t *)((const char *)pPSVData + Offset);
       Offset += 4;
       if (PSVSize < Offset) {
         IsValid = false;
@@ -655,17 +656,19 @@ struct SimplePSV {
         return;
       }
       if (StringTableSize) {
-        StringTable = (char *)pPSVData + Offset;
+        StringTable = (const char *)pPSVData + Offset;
         Offset += StringTableSize;
       }
-      SemanticIndexTableEntries = *(uint32_t *)((char *)pPSVData + Offset);
+      SemanticIndexTableEntries =
+          *(const uint32_t *)((const char *)pPSVData + Offset);
       Offset += 4;
       if (PSVSize < Offset) {
         IsValid = false;
         return;
       }
       if (SemanticIndexTableEntries) {
-        SemanticIndexTable = (uint32_t *)((char *)pPSVData + Offset);
+        SemanticIndexTable =
+            (const uint32_t *)((const char *)pPSVData + Offset);
         Offset += SemanticIndexTableEntries * 4;
         if (PSVSize < Offset) {
           IsValid = false;
@@ -674,7 +677,8 @@ struct SimplePSV {
       }
       if (RuntimeInfo1->SigInputElements || RuntimeInfo1->SigOutputElements ||
           RuntimeInfo1->SigPatchConstOrPrimElements) {
-        PSVSignatureElementSize = *(uint32_t *)((char *)pPSVData + Offset);
+        PSVSignatureElementSize =
+            *(const uint32_t *)((const char *)pPSVData + Offset);
         Offset += 4;
         if (PSVSize < Offset) {
           IsValid = false;

--- a/lib/DxilValidation/DxilContainerValidation.cpp
+++ b/lib/DxilValidation/DxilContainerValidation.cpp
@@ -24,6 +24,7 @@
 #include "dxc/DXIL/DxilUtil.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/Module.h"
@@ -126,7 +127,7 @@ public:
 
 class SemanticIndexTableVerifier {
   const PSVSemanticIndexTable &Table;
-  std::vector<bool> UseMask;
+  llvm::BitVector UseMask;
 
 public:
   SemanticIndexTableVerifier(const PSVSemanticIndexTable &Table)

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -6326,10 +6326,11 @@ TEST_F(ValidationTest, WrongPSVVersion) {
   VERIFY_IS_NOT_NULL(p60WithPSV68Result);
   VERIFY_SUCCEEDED(p60WithPSV68Result->GetStatus(&status));
   VERIFY_FAILED(status);
-  CheckOperationResultMsgs(p60WithPSV68Result,
-                           {"Container part 'Pipeline State Validation' does "
-                            "not match expected for module."},
-                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
+  CheckOperationResultMsgs(
+      p60WithPSV68Result,
+      {"DXIL container mismatch for 'PSVRuntimeInfoSize' between 'PSV0' "
+       "part:('52') and DXIL module:('24')"},
+      /*maySucceedAnyway*/ false, /*bRegex*/ false);
 
   // Create a new Blob.
   CComPtr<IDxcBlobEncoding> pProgram68WithPSV60;

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -6202,10 +6202,9 @@ TEST_F(ValidationTest, WrongPSVSize) {
   VERIFY_SUCCEEDED(pUpdatedResult->GetStatus(&status));
   VERIFY_FAILED(status);
 
-  CheckOperationResultMsgs(pUpdatedResult,
-                           {"Container part 'Pipeline State Validation' does "
-                            "not match expected for module."},
-                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
+  CheckOperationResultMsgs(
+      pUpdatedResult, {"In 'DxilContainer', 'PSV0 part' is not well-formed"},
+      /*maySucceedAnyway*/ false, /*bRegex*/ false);
 }
 
 TEST_F(ValidationTest, WrongPSVVersion) {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -321,6 +321,8 @@ public:
   TEST_METHOD(PSVContentValidationCS)
   TEST_METHOD(PSVContentValidationMS)
   TEST_METHOD(PSVContentValidationAS)
+  TEST_METHOD(WrongPSVSize)
+  TEST_METHOD(WrongPSVVersion)
 
   dxc::DxcDllSupport m_dllSupport;
   VersionSupportInfo m_ver;
@@ -425,6 +427,18 @@ public:
         pLibrary->CreateBlobFromFile(fullPath.c_str(), nullptr, &pSource));
     return CompileSource(pSource, pShaderModel, nullptr, 0, nullptr, 0,
                          pResultBlob);
+  }
+
+  bool CompileFile(LPCWSTR fileName, LPCSTR pShaderModel, LPCWSTR *pArguments,
+                   UINT32 argCount, IDxcBlob **pResultBlob) {
+    std::wstring fullPath = hlsl_test::GetPathToHlslDataFile(fileName);
+    CComPtr<IDxcLibrary> pLibrary;
+    CComPtr<IDxcBlobEncoding> pSource;
+    VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
+    VERIFY_SUCCEEDED(
+        pLibrary->CreateBlobFromFile(fullPath.c_str(), nullptr, &pSource));
+    return CompileSource(pSource, pShaderModel, pArguments, argCount, nullptr,
+                         0, pResultBlob);
   }
 
   bool CompileSource(IDxcBlobEncoding *pSource, LPCSTR pShaderModel,
@@ -6032,5 +6046,306 @@ TEST_F(ValidationTest, PSVContentValidationAS) {
        "error: Container part 'Pipeline State Validation' does not match "
        "expected for module.",
        "Validation failed."},
+      /*maySucceedAnyway*/ false, /*bRegex*/ false);
+}
+
+struct SimpleContainer {
+  hlsl::DxilContainerHeader *Header;
+  std::vector<uint32_t> PartOffsets;
+  std::vector<const DxilPartHeader *> PartHeaders;
+  SimpleContainer(void *Ptr) {
+    Header = (hlsl::DxilContainerHeader *)Ptr;
+    hlsl::DxilPartIterator pPartIter(nullptr, 0);
+    pPartIter = hlsl::begin(Header);
+    for (unsigned i = 0; i < Header->PartCount; ++i) {
+      VERIFY_IS_TRUE(pPartIter != hlsl::end(Header));
+      PartOffsets.push_back(
+          (uint32_t)((const char *)(*pPartIter) - (const char *)Header));
+      PartHeaders.push_back((const DxilPartHeader *)(*pPartIter));
+      ++pPartIter;
+    }
+    VERIFY_ARE_EQUAL(pPartIter, hlsl::end(Header));
+  }
+};
+
+TEST_F(ValidationTest, WrongPSVSize) {
+  if (!m_ver.m_InternalValidator)
+    if (m_ver.SkipDxilVersion(1, 8))
+      return;
+
+  CComPtr<IDxcBlob> pProgram;
+  CompileFile(L"..\\DXC\\dumpPSV_AS.hlsl", "as_6_8", &pProgram);
+
+  CComPtr<IDxcValidator> pValidator;
+  CComPtr<IDxcOperationResult> pResult;
+  unsigned Flags = 0;
+  VERIFY_SUCCEEDED(
+      m_dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
+  VERIFY_SUCCEEDED(pValidator->Validate(pProgram, Flags, &pResult));
+  // Make sure the validation was successful.
+  HRESULT status;
+  VERIFY_IS_NOT_NULL(pResult);
+  VERIFY_SUCCEEDED(pResult->GetStatus(&status));
+  VERIFY_SUCCEEDED(status);
+
+  hlsl::DxilContainerHeader *pHeader;
+  hlsl::DxilPartIterator pPartIter(nullptr, 0);
+  pHeader = (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
+  // Make sure the PSV part exists.
+  pPartIter =
+      std::find_if(hlsl::begin(pHeader), hlsl::end(pHeader),
+                   hlsl::DxilPartIsType(hlsl::DFCC_PipelineStateValidation));
+  VERIFY_ARE_NOT_EQUAL(hlsl::end(pHeader), pPartIter);
+
+  // Create a new Blob which is 16 bytes larger than the original one.
+  std::vector<char> pProgram2Data(pProgram->GetBufferSize() + 16, 0);
+  // Copy data from the original blob part by part.
+  // Copy all parts to program2.
+  SimpleContainer Container(pProgram->GetBufferPointer());
+  uint32_t PartOffsetsSize = pHeader->PartCount * sizeof(uint32_t);
+  uint32_t Offset = sizeof(hlsl::DxilContainerHeader) + PartOffsetsSize;
+  std::vector<uint32_t> PartOffsets;
+  const uint32_t ExtraSize = 16;
+  // copy all parts to program2.
+  for (unsigned i = 0; i < pHeader->PartCount; ++i) {
+    PartOffsets.emplace_back(Offset);
+    const DxilPartHeader *pPartHeader = Container.PartHeaders[i];
+
+    // Copy part header.
+    memcpy(pProgram2Data.data() + Offset, pPartHeader, sizeof(DxilPartHeader));
+    Offset += sizeof(DxilPartHeader);
+
+    // Copy part content.
+    uint32_t *PartPtr =
+        const_cast<uint32_t *>((const uint32_t *)GetDxilPartData(pPartHeader));
+    memcpy(pProgram2Data.data() + Offset, PartPtr, pPartHeader->PartSize);
+
+    Offset += pPartHeader->PartSize;
+
+    if (pPartHeader->PartFourCC == hlsl::DFCC_PipelineStateValidation) {
+      // Update the size of PSV part.
+      DxilPartHeader *pPSVPartHeader =
+          (DxilPartHeader *)(pProgram2Data.data() + PartOffsets.back());
+      pPSVPartHeader->PartSize += ExtraSize;
+      Offset += ExtraSize;
+    }
+  }
+  // Copy header.
+  pHeader->ContainerSizeInBytes += ExtraSize;
+  memcpy(pProgram2Data.data(), pHeader, sizeof(hlsl::DxilContainerHeader));
+  // Copy partOffsets.
+  memcpy(pProgram2Data.data() + sizeof(hlsl::DxilContainerHeader),
+         PartOffsets.data(), PartOffsetsSize);
+
+  // Create a new Blob from pProgram2Data.
+  CComPtr<IDxcBlobEncoding> pProgram2;
+  CComPtr<IDxcLibrary> pLibrary;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
+  VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(
+      pProgram2Data.data(), pProgram2Data.size(), CP_UTF8, &pProgram2));
+
+  // Run validation on updated container.
+  CComPtr<IDxcOperationResult> pUpdatedResult;
+  VERIFY_SUCCEEDED(pValidator->Validate(pProgram2, Flags, &pUpdatedResult));
+  // Make sure the validation was fail.
+  VERIFY_IS_NOT_NULL(pUpdatedResult);
+  VERIFY_SUCCEEDED(pUpdatedResult->GetStatus(&status));
+  VERIFY_FAILED(status);
+
+  CheckOperationResultMsgs(pUpdatedResult,
+                           {"Container part 'Pipeline State Validation' does "
+                            "not match expected for module."},
+                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
+}
+
+TEST_F(ValidationTest, WrongPSVVersion) {
+  if (!m_ver.m_InternalValidator)
+    if (m_ver.SkipDxilVersion(1, 8))
+      return;
+
+  CComPtr<IDxcBlob> pProgram60;
+  std::vector<LPCWSTR> args;
+  args.emplace_back(L"-validator-version");
+  args.emplace_back(L"1.0");
+  CompileFile(L"..\\DXC\\dumpPSV_CS.hlsl", "cs_6_0", args.data(), args.size(),
+              &pProgram60);
+
+  CComPtr<IDxcValidator> pValidator;
+  CComPtr<IDxcOperationResult> pResult;
+  unsigned Flags = DxcValidatorFlags_InPlaceEdit;
+  VERIFY_SUCCEEDED(
+      m_dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
+  VERIFY_SUCCEEDED(pValidator->Validate(pProgram60, Flags, &pResult));
+  // Make sure the validation was successful.
+  HRESULT status;
+  VERIFY_IS_NOT_NULL(pResult);
+  VERIFY_SUCCEEDED(pResult->GetStatus(&status));
+  VERIFY_SUCCEEDED(status);
+
+  hlsl::DxilContainerHeader *pHeader60;
+  hlsl::DxilPartIterator pPartIter(nullptr, 0);
+  pHeader60 = (hlsl::DxilContainerHeader *)pProgram60->GetBufferPointer();
+  // Make sure the PSV part exists.
+  pPartIter =
+      std::find_if(hlsl::begin(pHeader60), hlsl::end(pHeader60),
+                   hlsl::DxilPartIsType(hlsl::DFCC_PipelineStateValidation));
+  VERIFY_ARE_NOT_EQUAL(hlsl::end(pHeader60), pPartIter);
+
+  CComPtr<IDxcBlob> pProgram68;
+
+  CompileFile(L"..\\DXC\\dumpPSV_CS.hlsl", "cs_6_8", &pProgram68);
+  CComPtr<IDxcOperationResult> pResult2;
+  VERIFY_SUCCEEDED(pValidator->Validate(pProgram68, Flags, &pResult2));
+  // Make sure the validation was successful.
+  VERIFY_IS_NOT_NULL(pResult);
+  VERIFY_SUCCEEDED(pResult->GetStatus(&status));
+  VERIFY_SUCCEEDED(status);
+
+  hlsl::DxilContainerHeader *pHeader68;
+  pHeader68 = (hlsl::DxilContainerHeader *)pProgram68->GetBufferPointer();
+  // Make sure the PSV part exists.
+  pPartIter =
+      std::find_if(hlsl::begin(pHeader68), hlsl::end(pHeader68),
+                   hlsl::DxilPartIsType(hlsl::DFCC_PipelineStateValidation));
+  VERIFY_ARE_NOT_EQUAL(hlsl::end(pHeader68), pPartIter);
+
+  // Switch the PSV part between 6.0 to 6.8.
+  SimpleContainer Container60(pProgram60->GetBufferPointer());
+  SimpleContainer Container68(pProgram68->GetBufferPointer());
+  uint32_t Container60WithPSV68Size = sizeof(hlsl::DxilContainerHeader) +
+                                      pHeader60->PartCount * sizeof(uint32_t);
+  uint32_t Container68WithPSV60Size = sizeof(hlsl::DxilContainerHeader) +
+                                      pHeader60->PartCount * sizeof(uint32_t);
+  unsigned Container68PartSkipped = 0;
+  for (unsigned i = 0; i < pHeader60->PartCount; ++i) {
+    const DxilPartHeader *pPartHeader60 = Container60.PartHeaders[i];
+    const DxilPartHeader *pPartHeader68 =
+        Container68.PartHeaders[i + Container68PartSkipped];
+    if (pPartHeader68->PartFourCC == hlsl::DFCC_ShaderHash) {
+      Container68PartSkipped++;
+      pPartHeader68 = Container68.PartHeaders[i + Container68PartSkipped];
+    }
+
+    VERIFY_ARE_EQUAL(pPartHeader60->PartFourCC, pPartHeader68->PartFourCC);
+    Container60WithPSV68Size += sizeof(DxilPartHeader);
+    Container68WithPSV60Size += sizeof(DxilPartHeader);
+    if (pPartHeader60->PartFourCC == hlsl::DFCC_PipelineStateValidation) {
+      Container60WithPSV68Size += pPartHeader68->PartSize;
+      Container68WithPSV60Size += pPartHeader60->PartSize;
+    } else {
+      Container60WithPSV68Size += pPartHeader60->PartSize;
+      Container68WithPSV60Size += pPartHeader68->PartSize;
+    }
+  }
+
+  // Create mixed container.
+  std::vector<char> pProgram60WithPSV68Data(Container60WithPSV68Size, 0);
+  std::vector<char> pProgram68WithPSV60Data(Container68WithPSV60Size, 0);
+
+  uint32_t PartOffsetsSize = pHeader60->PartCount * sizeof(uint32_t);
+  uint32_t Offset60 = sizeof(hlsl::DxilContainerHeader) + PartOffsetsSize;
+  std::vector<uint32_t> PartOffsets60;
+  uint32_t Offset68 = sizeof(hlsl::DxilContainerHeader) + PartOffsetsSize;
+  std::vector<uint32_t> PartOffsets68;
+  Container68PartSkipped = 0;
+  for (unsigned i = 0; i < pHeader60->PartCount; ++i) {
+    PartOffsets60.emplace_back(Offset60);
+    PartOffsets68.emplace_back(Offset68);
+
+    const DxilPartHeader *pPartHeader60 = Container60.PartHeaders[i];
+    const DxilPartHeader *pPartHeader68 =
+        Container68.PartHeaders[i + Container68PartSkipped];
+    if (pPartHeader68->PartFourCC == hlsl::DFCC_ShaderHash) {
+      Container68PartSkipped++;
+      pPartHeader68 = Container68.PartHeaders[i + Container68PartSkipped];
+    }
+
+    if (pPartHeader60->PartFourCC == hlsl::DFCC_PipelineStateValidation) {
+      // Copy PSV part from 6.8 to 6.0.
+      memcpy(pProgram60WithPSV68Data.data() + Offset60, pPartHeader68,
+             sizeof(DxilPartHeader));
+      Offset60 += sizeof(DxilPartHeader);
+      memcpy(pProgram60WithPSV68Data.data() + Offset60,
+             GetDxilPartData(pPartHeader68), pPartHeader68->PartSize);
+      Offset60 += pPartHeader68->PartSize;
+      // Copy PSV part from 6.0 to 6.8.
+      memcpy(pProgram68WithPSV60Data.data() + Offset68, pPartHeader60,
+             sizeof(DxilPartHeader));
+      Offset68 += sizeof(DxilPartHeader);
+      memcpy(pProgram68WithPSV60Data.data() + Offset68,
+             GetDxilPartData(pPartHeader60), pPartHeader60->PartSize);
+
+      Offset68 += pPartHeader60->PartSize;
+    } else {
+      // Copy PSV part from 6.0 to 6.0.
+      memcpy(pProgram60WithPSV68Data.data() + Offset60, pPartHeader60,
+             sizeof(DxilPartHeader));
+      Offset60 += sizeof(DxilPartHeader);
+      memcpy(pProgram60WithPSV68Data.data() + Offset60,
+             GetDxilPartData(pPartHeader60), pPartHeader60->PartSize);
+      Offset60 += pPartHeader60->PartSize;
+      // Copy PSV part from 6.8 to 6.8.
+      memcpy(pProgram68WithPSV60Data.data() + Offset68, pPartHeader68,
+             sizeof(DxilPartHeader));
+      Offset68 += sizeof(DxilPartHeader);
+      memcpy(pProgram68WithPSV60Data.data() + Offset68,
+             GetDxilPartData(pPartHeader68), pPartHeader68->PartSize);
+      Offset68 += pPartHeader68->PartSize;
+    }
+  }
+
+  // Copy header.
+  VERIFY_ARE_EQUAL(Container60WithPSV68Size, Offset60);
+  pHeader60->ContainerSizeInBytes = Container60WithPSV68Size;
+  memcpy(pProgram60WithPSV68Data.data(), pHeader60,
+         sizeof(hlsl::DxilContainerHeader));
+  VERIFY_ARE_EQUAL(Container68WithPSV60Size, Offset68);
+  pHeader68->ContainerSizeInBytes = Container68WithPSV60Size;
+  pHeader68->PartCount -= Container68PartSkipped;
+  memcpy(pProgram68WithPSV60Data.data(), pHeader68,
+         sizeof(hlsl::DxilContainerHeader));
+  // Copy partOffsets.
+  memcpy(pProgram60WithPSV68Data.data() + sizeof(hlsl::DxilContainerHeader),
+         PartOffsets60.data(), PartOffsetsSize);
+  memcpy(pProgram68WithPSV60Data.data() + sizeof(hlsl::DxilContainerHeader),
+         PartOffsets68.data(), PartOffsetsSize);
+
+  // Create a new Blob.
+  CComPtr<IDxcBlobEncoding> pProgram60WithPSV68;
+  CComPtr<IDxcLibrary> pLibrary;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
+  VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(
+      pProgram60WithPSV68Data.data(), pProgram60WithPSV68Data.size(), CP_UTF8,
+      &pProgram60WithPSV68));
+
+  // Run validation on new containers.
+  CComPtr<IDxcOperationResult> p60WithPSV68Result;
+  VERIFY_SUCCEEDED(
+      pValidator->Validate(pProgram60WithPSV68, Flags, &p60WithPSV68Result));
+  // Make sure the validation was fail.
+  VERIFY_IS_NOT_NULL(p60WithPSV68Result);
+  VERIFY_SUCCEEDED(p60WithPSV68Result->GetStatus(&status));
+  VERIFY_FAILED(status);
+  CheckOperationResultMsgs(p60WithPSV68Result,
+                           {"Container part 'Pipeline State Validation' does "
+                            "not match expected for module."},
+                           /*maySucceedAnyway*/ false, /*bRegex*/ false);
+
+  // Create a new Blob.
+  CComPtr<IDxcBlobEncoding> pProgram68WithPSV60;
+  VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(
+      pProgram68WithPSV60Data.data(), pProgram68WithPSV60Data.size(), CP_UTF8,
+      &pProgram68WithPSV60));
+  CComPtr<IDxcOperationResult> p68WithPSV60Result;
+  VERIFY_SUCCEEDED(
+      pValidator->Validate(pProgram68WithPSV60, Flags, &p68WithPSV60Result));
+  // Make sure the validation was fail.
+  VERIFY_IS_NOT_NULL(p68WithPSV60Result);
+  VERIFY_SUCCEEDED(p68WithPSV60Result->GetStatus(&status));
+  VERIFY_FAILED(status);
+  CheckOperationResultMsgs(
+      p68WithPSV60Result,
+      {"DXIL container mismatch for 'PSVRuntimeInfoSize' between 'PSV0' "
+       "part:('24') and DXIL module:('52')"},
       /*maySucceedAnyway*/ false, /*bRegex*/ false);
 }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4715,7 +4715,7 @@ TEST_F(ValidationTest, PSVStringTableReorder) {
   VERIFY_SUCCEEDED(status);
 
   // Create unused name in String table.
-  PSVInfo->EntryFunctionName = 2;
+  PSVInfo->EntryFunctionName = UINT32_MAX;
 
   // Run validation again.
   CComPtr<IDxcOperationResult> pUpdatedTableResult2;
@@ -4728,8 +4728,7 @@ TEST_F(ValidationTest, PSVStringTableReorder) {
   CheckOperationResultMsgs(
       pUpdatedTableResult2,
       {
-          "error: DXIL container mismatch for 'EntryFunctionName' between "
-          "'PSV0' part:('A') and DXIL module:('main')",
+          "In 'PSV0 part', 'EntryFunctionName' is not well-formed",
           "error: In 'StringTable', 'main' is not used",
       },
       /*maySucceedAnyway*/ false, /*bRegex*/ false);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -6933,6 +6933,11 @@ class db_dxil(object):
             "DXIL Container Content is well-formed",
             "In '%0', '%1' is not well-formed",
         )
+        self.add_valrule_msg(
+            "Container.UnusedItemInTable",
+            "Items in Table must be used",
+            "In '%0', '%1' is not used",
+        )
         self.add_valrule("Meta.Required", "Required metadata missing.")
         self.add_valrule_msg(
             "Meta.ComputeWithNode",


### PR DESCRIPTION
Check size of PSV part matches the PSVVersion.
Updated DxilPipelineStateValidation::ReadOrWrite to read based on initInfo.PSVVersion.
And return fail when size mismatch in RWMode::Read.

Fixes #6817