### PR TITLE
Conditionally include <assert.h> in DxilPipelineStateValidation.h

### DIFF
--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -12,19 +12,22 @@
 #ifndef __DXIL_PIPELINE_STATE_VALIDATION__H__
 #define __DXIL_PIPELINE_STATE_VALIDATION__H__
 
+// ------ Don't unconditionally #include <assert.h> here --------
+// Since this header is included from multiple environments,
+// Conditionally include <assert.h> here is to avoid overwriting
+// the assert that's using by the code which includes this header.
+//
+
 #include "dxc/WinAdapter.h"
+#ifndef assert
 #include <assert.h>
+#endif
 #include <cstring>
 #include <stdint.h>
 
 namespace llvm {
 class raw_ostream;
 }
-
-// Don't include assert.h here.
-// Since this header is included from multiple environments,
-// it is necessary to define assert before this header is included.
-// #include <assert.h>
 
 #ifndef UINT_MAX
 #define UINT_MAX 0xffffffff


### PR DESCRIPTION
DxilPipelineStateValidation.h is included from multiple environments. Conditionally include <assert.h> here is to avoid overwriting the assert that's using by the code which includes this header.

Fixes #6922