### PR TITLE
[SPIR-V] HLSL style register assignment for resource arrays

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -390,8 +390,8 @@ def fspv_target_env_EQ : Joined<["-"], "fspv-target-env=">, Group<spirv_Group>, 
   HelpText<"Specify the target environment: vulkan1.0 (default), vulkan1.1, vulkan1.1spirv1.4, vulkan1.2, vulkan1.3, or universal1.5">;
 def fspv_flatten_resource_arrays: Flag<["-"], "fspv-flatten-resource-arrays">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Flatten arrays of resources so each array element takes one binding number">;
-def fspv_implicit_hlsl_resource_arrays: Flag<["-"], "fspv-implicit-hlsl-resource-arrays">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Resource arrays with implicit register assignment use one binding per array element to match hlsl style">;
+def fspv_hlsl_resource_arrays: Flag<["-"], "fspv-hlsl-resource-arrays">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Resource arrays use one binding per array element to match hlsl style">;
 def fspv_reduce_load_size: Flag<["-"], "fspv-reduce-load-size">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Replaces loads of composite objects to reduce memory pressure for the loads">;
 def fspv_fix_func_call_arguments: Flag<["-"], "fspv-fix-func-call-arguments">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -390,6 +390,8 @@ def fspv_target_env_EQ : Joined<["-"], "fspv-target-env=">, Group<spirv_Group>, 
   HelpText<"Specify the target environment: vulkan1.0 (default), vulkan1.1, vulkan1.1spirv1.4, vulkan1.2, vulkan1.3, or universal1.5">;
 def fspv_flatten_resource_arrays: Flag<["-"], "fspv-flatten-resource-arrays">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Flatten arrays of resources so each array element takes one binding number">;
+def fspv_implicit_hlsl_resource_arrays: Flag<["-"], "fspv-implicit-hlsl-resource-arrays">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Resource arrays with implicit register assignment use one binding per array element to match hlsl style">;
 def fspv_reduce_load_size: Flag<["-"], "fspv-reduce-load-size">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Replaces loads of composite objects to reduce memory pressure for the loads">;
 def fspv_fix_func_call_arguments: Flag<["-"], "fspv-fix-func-call-arguments">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -64,6 +64,7 @@ struct SpirvCodeGenOptions {
   bool useLegacyBufferMatrixOrder;
   bool useScalarLayout;
   bool flattenResourceArrays;
+  bool hlslResourceArrays;
   bool reduceLoadSize;
   bool autoShiftBindings;
   bool supportNonzeroBaseInstance;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1285,7 +1285,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fspv_use_legacy_buffer_matrix_order, OPT_INVALID,
                    false) ||
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false) ||
-      Args.hasFlag(OPT_fspv_implicit_hlsl_resource_arrays, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fspv_implicit_hlsl_resource_arrays, OPT_INVALID,
+                   false) ||
       Args.hasFlag(OPT_fspv_reduce_load_size, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_fix_func_call_arguments, OPT_INVALID, false) ||

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1115,7 +1115,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.flattenResourceArrays =
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false);
   opts.SpirvOptions.hlslResourceArrays =
-      Args.hasFlag(OPT_fspv_implicit_hlsl_resource_arrays, OPT_INVALID, false);
+      Args.hasFlag(OPT_fspv_hlsl_resource_arrays, OPT_INVALID, false);
   opts.SpirvOptions.reduceLoadSize =
       Args.hasFlag(OPT_fspv_reduce_load_size, OPT_INVALID, false);
   opts.SpirvOptions.fixFuncCallArguments =

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1114,6 +1114,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_Wno_vk_emulated_features, OPT_INVALID, false);
   opts.SpirvOptions.flattenResourceArrays =
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false);
+  opts.SpirvOptions.hlslResourceArrays =
+      Args.hasFlag(OPT_fspv_implicit_hlsl_resource_arrays, OPT_INVALID, false);
   opts.SpirvOptions.reduceLoadSize =
       Args.hasFlag(OPT_fspv_reduce_load_size, OPT_INVALID, false);
   opts.SpirvOptions.fixFuncCallArguments =
@@ -1283,6 +1285,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fspv_use_legacy_buffer_matrix_order, OPT_INVALID,
                    false) ||
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fspv_hlsl_resource_arrays, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reduce_load_size, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_fix_func_call_arguments, OPT_INVALID, false) ||

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1285,7 +1285,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fspv_use_legacy_buffer_matrix_order, OPT_INVALID,
                    false) ||
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false) ||
-      Args.hasFlag(OPT_fspv_hlsl_resource_arrays, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fspv_implicit_hlsl_resource_arrays, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reduce_load_size, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_fix_func_call_arguments, OPT_INVALID, false) ||

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2621,8 +2621,7 @@ bool DeclResultIdMapper::decorateResourceBindings() {
     // assignment
     uint32_t numBindingsToUse = 1;
     if (spirvOptions.flattenResourceArrays ||
-        needsFlatteningCompositeResources ||
-        spirvOptions.hlslResourceArrays)
+        needsFlatteningCompositeResources || spirvOptions.hlslResourceArrays)
       numBindingsToUse = getNumBindingsUsedByResourceType(
           var.getSpirvInstr()->getAstResultType());
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2617,12 +2617,12 @@ bool DeclResultIdMapper::decorateResourceBindings() {
     // resources also gets only one binding number. However, for array of
     // resources (e.g. array of textures), DX uses one binding number per array
     // element. We can match this behavior via a command line option.
-    // hlslResourceArrays - Use only if var doesn't have explicit binding
+    // hlslResourceArrays - One binding number per array element
     // assignment
     uint32_t numBindingsToUse = 1;
     if (spirvOptions.flattenResourceArrays ||
         needsFlatteningCompositeResources ||
-        (spirvOptions.hlslResourceArrays && !var.getBinding()))
+        spirvOptions.hlslResourceArrays)
       numBindingsToUse = getNumBindingsUsedByResourceType(
           var.getSpirvInstr()->getAstResultType());
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2617,9 +2617,12 @@ bool DeclResultIdMapper::decorateResourceBindings() {
     // resources also gets only one binding number. However, for array of
     // resources (e.g. array of textures), DX uses one binding number per array
     // element. We can match this behavior via a command line option.
-    // hlslResourceArrays - Use only if var doesn't have explicit binding assignment
+    // hlslResourceArrays - Use only if var doesn't have explicit binding
+    // assignment
     uint32_t numBindingsToUse = 1;
-    if (spirvOptions.flattenResourceArrays || needsFlatteningCompositeResources || (spirvOptions.hlslResourceArrays && !var.getBinding()))
+    if (spirvOptions.flattenResourceArrays ||
+        needsFlatteningCompositeResources ||
+        (spirvOptions.hlslResourceArrays && !var.getBinding()))
       numBindingsToUse = getNumBindingsUsedByResourceType(
           var.getSpirvInstr()->getAstResultType());
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2617,8 +2617,9 @@ bool DeclResultIdMapper::decorateResourceBindings() {
     // resources also gets only one binding number. However, for array of
     // resources (e.g. array of textures), DX uses one binding number per array
     // element. We can match this behavior via a command line option.
+    // hlslResourceArrays - Use only if var doesn't have explicit binding assignment
     uint32_t numBindingsToUse = 1;
-    if (spirvOptions.flattenResourceArrays || needsFlatteningCompositeResources)
+    if (spirvOptions.flattenResourceArrays || needsFlatteningCompositeResources || (spirvOptions.hlslResourceArrays && !var.getBinding()))
       numBindingsToUse = getNumBindingsUsedByResourceType(
           var.getSpirvInstr()->getAstResultType());
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -T ps_6_0 -E main -fspv-hlsl-resource-arrays -fcgl  %s -spirv | FileCheck %s
 
 // CHECK: OpDecorate %MyTextures Binding 0
-// CHECK: OpDecorate %AnotherTexture Binding 5
-// CHECK: OpDecorate %NextTexture Binding 6
+// CHECK: OpDecorate %NextTexture Binding 5
+// CHECK: OpDecorate %AnotherTexture Binding 6
 // CHECK: OpDecorate %MySamplers Binding 7
 Texture2D    MyTextures[5];
 Texture2D    NextTexture;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
@@ -1,9 +1,9 @@
 // RUN: %dxc -T ps_6_0 -E main -fspv-implicit-hlsl-resource-arrays -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: OpDecorate %AnotherTexture Binding 0
 // CHECK: OpDecorate %MyTexturesExplicit Binding 1
-// CHECK: OpDecorate %MyTextures Binding 2
 // CHECK: OpDecorate %MySamplersExplicit Binding 7
+// CHECK: OpDecorate %AnotherTexture Binding 0
+// CHECK: OpDecorate %MyTextures Binding 2
 // CHECK: OpDecorate %MySamplers Binding 8
 // CHECK: OpDecorate NextSampler Binding 10
 Texture2D    AnotherTexture;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-implicit-hlsl-resource-arrays -fcgl  %s -spirv | FileCheck %s
+
+// CHECK: OpDecorate %AnotherTexture Binding 0
+// CHECK: OpDecorate %NextTextures Binding 1
+// CHECK: OpDecorate %MyTextures Binding 2
+// CHECK: OpDecorate %MySamplersExplicit Binding 7
+// CHECK: OpDecorate %MySamplers Binding 8
+// CHECK: OpDecorate NextSampler Binding 10
+Texture2D    AnotherTexture;
+Texture2D    NextTextures[5] : register(t1);  // This is suppose to be t6.
+Texture2D    MyTextures[5];
+SamplerState MySamplersExplicit[2] : register(s7);
+SamplerState MySamplers[2];
+SamplerState NextSampler;
+
+float4 main(float2 TexCoord : TexCoord) : SV_Target0
+{
+  float4 result =
+    MyTextures[0].Sample(MySamplers[0], TexCoord) +
+    MyTextures[1].Sample(MySamplers[0], TexCoord) +
+    MyTextures[2].Sample(MySamplers[0], TexCoord) +
+    MyTextures[3].Sample(MySamplers[1], TexCoord) +
+    MyTextures[4].Sample(MySamplersExplicit[1], TexCoord) +
+    AnotherTexture.Sample(MySamplers[1], TexCoord) +
+    NextTextures[0].Sample(NextSampler, TexCoord);
+  return result;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
@@ -7,7 +7,7 @@
 // CHECK: OpDecorate %MySamplers Binding 8
 // CHECK: OpDecorate NextSampler Binding 10
 Texture2D    AnotherTexture;
-Texture2D    NextTextures[5] : register(t1);  // This is suppose to be t6.
+Texture2D    MyTexturesExplicit[5] : register(t1);
 Texture2D    MyTextures[5];
 SamplerState MySamplersExplicit[2] : register(s7);
 SamplerState MySamplers[2];
@@ -22,6 +22,6 @@ float4 main(float2 TexCoord : TexCoord) : SV_Target0
     MyTextures[3].Sample(MySamplers[1], TexCoord) +
     MyTextures[4].Sample(MySamplersExplicit[1], TexCoord) +
     AnotherTexture.Sample(MySamplers[1], TexCoord) +
-    NextTextures[0].Sample(NextSampler, TexCoord);
+    MyTexturesExplicit[0].Sample(NextSampler, TexCoord);
   return result;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T ps_6_0 -E main -fspv-implicit-hlsl-resource-arrays -fcgl  %s -spirv | FileCheck %s
 
 // CHECK: OpDecorate %AnotherTexture Binding 0
-// CHECK: OpDecorate %NextTextures Binding 1
+// CHECK: OpDecorate %MyTexturesExplicit Binding 1
 // CHECK: OpDecorate %MyTextures Binding 2
 // CHECK: OpDecorate %MySamplersExplicit Binding 7
 // CHECK: OpDecorate %MySamplers Binding 8

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl-arrays.example1.hlsl
@@ -1,17 +1,13 @@
-// RUN: %dxc -T ps_6_0 -E main -fspv-implicit-hlsl-resource-arrays -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T ps_6_0 -E main -fspv-hlsl-resource-arrays -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: OpDecorate %MyTexturesExplicit Binding 1
-// CHECK: OpDecorate %MySamplersExplicit Binding 7
-// CHECK: OpDecorate %AnotherTexture Binding 0
-// CHECK: OpDecorate %MyTextures Binding 2
-// CHECK: OpDecorate %MySamplers Binding 8
-// CHECK: OpDecorate NextSampler Binding 10
-Texture2D    AnotherTexture;
-Texture2D    MyTexturesExplicit[5] : register(t1);
+// CHECK: OpDecorate %MyTextures Binding 0
+// CHECK: OpDecorate %AnotherTexture Binding 5
+// CHECK: OpDecorate %NextTexture Binding 6
+// CHECK: OpDecorate %MySamplers Binding 7
 Texture2D    MyTextures[5];
-SamplerState MySamplersExplicit[2] : register(s7);
+Texture2D    NextTexture;
+Texture2D    AnotherTexture;
 SamplerState MySamplers[2];
-SamplerState NextSampler;
 
 float4 main(float2 TexCoord : TexCoord) : SV_Target0
 {
@@ -20,8 +16,8 @@ float4 main(float2 TexCoord : TexCoord) : SV_Target0
     MyTextures[1].Sample(MySamplers[0], TexCoord) +
     MyTextures[2].Sample(MySamplers[0], TexCoord) +
     MyTextures[3].Sample(MySamplers[1], TexCoord) +
-    MyTextures[4].Sample(MySamplersExplicit[1], TexCoord) +
+    MyTextures[4].Sample(MySamplers[1], TexCoord) +
     AnotherTexture.Sample(MySamplers[1], TexCoord) +
-    MyTexturesExplicit[0].Sample(NextSampler, TexCoord);
+    NextTexture.Sample(MySamplers[1], TexCoord);
   return result;
 }


### PR DESCRIPTION
- New spirv flag -fspv-hlsl-resource-arrays
- When the flag is specified, resource arrays will use one binding per array element
  - We need this change to support array textures in our engine
- Matches with hlsl style register where arrays take up one register per array element
- Added test shader for the clang tests

```
Texture2D MyTextures[5];
Texture2D AnotherTexture;
```
MyTextures will take 5 bindings, AnotherTexture will be at binding 5

Closes https://github.com/microsoft/DirectXShaderCompiler/issues/6927