### PR TITLE
[SPIRV] Change "dxc" to "%dxc" in tests

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
 
 #include "vk/spirv.h"
 

--- a/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.varpointer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.varpointer.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
 
 #include "vk/spirv.h"
 


### PR DESCRIPTION
The workgroupspirvpointer tests use `dxc` in the run commands, and it
should be `%dxc`.
