### PR TITLE
[SPIRV] Fix NonSemanticDebugInfo to include all files

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -385,12 +385,6 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
     debugColumnEnd = columnEnd;
   }
 
-  if ((emittedSource[fileId] == 0) && (spvOptions.debugInfoVulkan)) {
-    SpirvDebugSource *src = new (context) SpirvDebugSource(fileName, "");
-    visit(src);
-    spvInstructions.push_back(src);
-  }
-
   curInst.clear();
   if (!spvOptions.debugInfoVulkan) {
     curInst.push_back(static_cast<uint32_t>(spv::Op::OpLine));

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -653,8 +653,7 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
 
   // Rich DebugInfo DebugSource
   if (spirvOptions.debugInfoRich) {
-    auto *dbgSrc =
-        spvBuilder.createDebugSource(mainSourceFile->getString(), source);
+    auto *dbgSrc = spvBuilder.createDebugSource(mainSourceFile->getString());
     // spvContext.getDebugInfo().insert() inserts {string key, RichDebugInfo}
     // pair and returns {{string key, RichDebugInfo}, true /*Success*/}.
     // spvContext.getDebugInfo().insert().first->second is a RichDebugInfo.
@@ -830,17 +829,23 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
     return;
 
   // Add source instruction(s)
-  if ((spirvOptions.debugInfoSource || spirvOptions.debugInfoFile) &&
-      !spirvOptions.debugInfoVulkan) {
+  if (spirvOptions.debugInfoSource || spirvOptions.debugInfoFile) {
     std::vector<llvm::StringRef> fileNames;
     fileNames.clear();
     const auto &sm = context.getSourceManager();
     // Add each include file from preprocessor output
     for (unsigned int i = 0; i < sm.getNumLineTableFilenames(); i++) {
-      fileNames.push_back(sm.getLineTableFilename(i));
+      llvm::StringRef file = sm.getLineTableFilename(i);
+      if (spirvOptions.debugInfoVulkan) {
+        getOrCreateRichDebugInfoImpl(file);
+      } else {
+        fileNames.push_back(file);
+      }
     }
-    spvBuilder.setDebugSource(spvContext.getMajorVersion(),
-                              spvContext.getMinorVersion(), fileNames);
+    if (!spirvOptions.debugInfoVulkan) {
+      spvBuilder.setDebugSource(spvContext.getMajorVersion(),
+                                spvContext.getMinorVersion(), fileNames);
+    }
   }
 
   if (spirvOptions.enableMaximalReconvergence) {
@@ -1032,6 +1037,11 @@ RichDebugInfo *
 SpirvEmitter::getOrCreateRichDebugInfo(const SourceLocation &loc) {
   const StringRef file =
       astContext.getSourceManager().getPresumedLoc(loc).getFilename();
+  return getOrCreateRichDebugInfoImpl(file);
+}
+
+RichDebugInfo *
+SpirvEmitter::getOrCreateRichDebugInfoImpl(llvm::StringRef file) {
   auto &debugInfo = spvContext.getDebugInfo();
   auto it = debugInfo.find(file);
   if (it != debugInfo.end())

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -72,6 +72,7 @@ public:
   /// created, we just return RichDebugInfo containing it. Otherwise,
   /// create DebugSource and DebugCompilationUnit for loc and return it.
   RichDebugInfo *getOrCreateRichDebugInfo(const SourceLocation &loc);
+  RichDebugInfo *getOrCreateRichDebugInfoImpl(llvm::StringRef file);
 
   void doDecl(const Decl *decl);
   void doStmt(const Stmt *stmt, llvm::ArrayRef<const Attr *> attrs = {});

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.opsource.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.opsource.include.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T ps_6_0 -E main -Zi %s -spirv -fspv-debug=vulkan-with-source | FileCheck %s
+
+// CHECK:      [[main:%[0-9]+]] = OpString
+// CHECK-SAME: shader.debug.opsource.include.hlsl
+// CHECK:      [[file1:%[0-9]+]] = OpString
+// CHECK-SAME: spirv.debug.opsource.include-file.hlsli
+// CHECK:      [[file1string:%[0-9]+]] = OpString "#define UBER_TYPE(x) x ## Type
+// CHECK:      [[mainstring:%[0-9]+]] = OpString "// RUN: %dxc -T ps_6_0 -E main -Zi %s -spirv -fspv-debug=vulkan-with-source | FileCheck %s
+
+// CHECK:      DebugSource [[file1]] [[file1string]] 
+// CHECK:      DebugSource [[main]] [[mainstring]] 
+
+#include "spirv.debug.opsource.include-file.hlsli"
+
+struct ColorType
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(UBER_TYPE(Color) input) : SV_TARGET
+{
+    return input.color;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -620,8 +620,7 @@ public:
       // pre-seeding with #line directives. We invoke Preprocess() here
       // first for such case. Then we invoke the compilation process over the
       // preprocessed source code.
-      if (!isPreprocessing && opts.GenSPIRV && opts.DebugInfo &&
-          !opts.SpirvOptions.debugInfoVulkan) {
+      if (!isPreprocessing && opts.GenSPIRV && opts.DebugInfo) {
         // Convert source code encoding
         CComPtr<IDxcBlobUtf8> pOrigUtf8Source;
         IFC(hlsl::DxcGetBlobAsUtf8(pSourceEncoding, m_pMalloc,


### PR DESCRIPTION
Previously, we fixed the SPIRV OpenCL debug info to always represent all include files, even those that only have preprocessor definitions.  This work was merged in https://github.com/microsoft/DirectXShaderCompiler/pull/6094.  This PR applies the same fix to the NonSemantic debug info, and resolves https://github.com/microsoft/DirectXShaderCompiler/issues/6907