### PR TITLE
[SPIRV] More test fixes

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/convert.selector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/convert.selector.hlsl
@@ -1,104 +1,104 @@
 // Convert to half
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=half -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
 
 // Convert to float
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=float -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
 
 // Convert to double
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UTOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=STOF
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=double -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FCONVERT
 
 // int type to int16_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
 
 // float type to int16_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
 
 // int type to int32_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
 
 // float type to int32_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
 
 // int type to int64_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=SCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
 
 // float type to int64_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=int64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOS
 
 // int type to uint16_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
 
 // float type to uint16_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint16_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
 
 // int type to uint32_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint64_t -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
 
 // float type to uint32_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint32_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
 
 // int type to uint64_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=int16_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int32_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint16_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=uint32_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=UCONVERT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=int64_t -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=BITCAST
 
 // float type to uint64_t
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
-// RUN: dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=half -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -enable-16bit-types -T cs_6_2 -E main -spirv -HV 2021 -DSOURCE_TYPE=float -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -DSOURCE_TYPE=double -DTARGET_TYPE=uint64_t -I %hlsl_headers %s | FileCheck %s --check-prefix=CHECK --check-prefix=FTOU
 
 #include "vk/opcode_selector.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.arithmetic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.arithmetic.hlsl
@@ -1,13 +1,13 @@
-// RUN: dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int16_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT16
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT32
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int64_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT64
-// RUN: dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint16_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT16
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT32
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint64_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT64
-// RUN: dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=half %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=HALF-ENABLED
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=half %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=HALF-DISABLED
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=float %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=FLOAT
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=double %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=DOUBLE
+// RUN: %dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int16_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT16
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT32
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int64_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT64
+// RUN: %dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint16_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT16
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT32
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=uint64_t %s | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=UINT64
+// RUN: %dxc -enable-16bit-types -fspv-target-env=vulkan1.3 -T cs_6_2 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=half %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=HALF-ENABLED
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=half %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=HALF-DISABLED
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=float %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=FLOAT
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=double %s | FileCheck %s --check-prefix=CHECK --check-prefix=FLOATS --check-prefix=DOUBLE
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.convert.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.convert.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.element.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.element.access.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.globallycoherent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.globallycoherent.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.groupshared.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.groupshared.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.memory.operand.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.memory.operand.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix.old.spirv.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix.old.spirv.hlsl
@@ -1,4 +1,4 @@
-// RUN: not dxc -fspv-target-env=vulkan1.1 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT32
+// RUN: not %dxc -fspv-target-env=vulkan1.1 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers -DTYPE=int %s 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=INTEGERS --check-prefix=INT32
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/coopmatrix_muladd_test.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/coopmatrix_muladd_test.hlsl
@@ -1,4 +1,4 @@
-// RUN: dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
+// RUN: %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 

--- a/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.const.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/workgroupspirvpointer.const.hlsl
@@ -1,4 +1,4 @@
-// RUN: not dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
+// RUN: not %dxc -fspv-target-env=vulkan1.3 -T cs_6_0 -E main -spirv -HV 2021 -I %hlsl_headers %s 2>&1 | FileCheck %s
 
 #include "vk/khr/cooperative_matrix.h"
 


### PR DESCRIPTION
The coop matrix tests all use `dxc` instead of `%dxc` in the tests.
Fixing that up.
