### PR TITLE
Unwrap top-level array for OutVertices when flattenArgument.

### DIFF
--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -885,7 +885,7 @@ void HLModule::GetParameterRowsAndCols(
     DxilParameterAnnotation &paramAnnotation) {
   if (Ty->isPointerTy())
     Ty = Ty->getPointerElementType();
-  // For array input of HS, DS, GS,
+  // For array input of HS, DS, GS and array output of MS,
   // we need to skip the first level which size is based on primitive type.
   DxilParamInputQual inputQual = paramAnnotation.GetParamInputQual();
   bool skipOneLevelArray = inputQual == DxilParamInputQual::InputPatch;

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -5300,7 +5300,9 @@ void SROA_Parameter_HLSL::flattenArgument(
     // Unwrap top-level array if primitive
     if (inputQual == DxilParamInputQual::InputPatch ||
         inputQual == DxilParamInputQual::OutputPatch ||
-        inputQual == DxilParamInputQual::InputPrimitive) {
+        inputQual == DxilParamInputQual::InputPrimitive ||
+        inputQual == DxilParamInputQual::OutPrimitives ||
+        inputQual == DxilParamInputQual::OutVertices) {
       Type *Ty = Arg->getType();
       if (Ty->isPointerTy())
         Ty = Ty->getPointerElementType();

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/semantic_on_parameter.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/semantic_on_parameter.hlsl
@@ -1,0 +1,42 @@
+// RUN: %dxc -T ms_6_6 %s | FileCheck %s
+
+// For https://github.com/microsoft/DirectXShaderCompiler/issues/6940
+// Ensure the shader compiles when the semantic is directly on the parameter.
+// Only one semantic index should be created.
+
+// CHECK:; SV_Position              0   xyzw        0      POS   float   xyzw
+// CHECK-NOT:; SV_Position              1   xyzw        0      POS   float   xyzw
+
+// CHECK:; A                        0   xyzw        0     NONE    uint
+// CHECK-NOT: ; A                        1   xyzw        0     NONE    uint
+
+#define GROUP_SIZE 30
+
+cbuffer Constant : register(b0)
+{
+    uint numPrims;
+}
+static const uint numVerts = 3;
+
+[RootSignature("RootConstants(num32BitConstants=1, b0)")]
+[numthreads(GROUP_SIZE, 1, 1)]
+[OutputTopology("triangle")]
+void main(
+    uint gtid : SV_GroupThreadID,
+    out indices uint3 tris[GROUP_SIZE],
+    out vertices float4 verts[GROUP_SIZE] : SV_Position,
+    out  primitives uint4 t[GROUP_SIZE] : A
+)
+{
+    SetMeshOutputCounts(numVerts, numPrims);
+
+    if (gtid < numVerts)
+    {
+        verts[gtid] = 0;
+    }
+
+    if (gtid < numPrims)
+    {
+        tris[gtid] = uint3(0, 1, 2);
+    }
+}


### PR DESCRIPTION
For primitives and vertices output of mesh shader, we need to unwrap the top-level array to get correct semantic index.

Fixes #6940