### PR TITLE
[NFC] Fix a spelling mistake

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -190,7 +190,7 @@ For API clients and LLVM developers.
 
 :doc:`CodeGenerator`
    The design and implementation of the LLVM code generator.  Useful if you are
-   working on retargetting LLVM to a new architecture, designing a new codegen
+   working on retargeting LLVM to a new architecture, designing a new codegen
    pass, or enhancing existing components.
 
 :doc:`TableGen <TableGen/index>`

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -78,7 +78,7 @@ public:
   uint32_t emitType(const SpirvType *);
 
   // Emits OpDecorate (or OpMemberDecorate if memberIndex is non-zero)
-  // targetting the given type. Uses the given decoration kind and its
+  // targeting the given type. Uses the given decoration kind and its
   // parameters.
   void emitDecoration(uint32_t typeResultId, spv::Decoration,
                       llvm::ArrayRef<uint32_t> decorationParams,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9014,7 +9014,7 @@ SpirvEmitter::processIntrinsicFirstbit(const CallExpr *callExpr,
       astContext, argType, spirvOptions.enable16BitTypes);
   if (bitwidth != 32) {
     emitError("%0 is currently limited to 32-bit width components when "
-              "targetting SPIR-V",
+              "targeting SPIR-V",
               srcLoc)
         << getFunctionOrOperatorName(callee, true);
     return nullptr;

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
@@ -3,8 +3,8 @@
 void main() {
   uint64_t   uint_1;
   int64_t2   int_2;
-// CHECK: error: firstbithigh is currently limited to 32-bit width components when targetting SPIR-V
+// CHECK: error: firstbithigh is currently limited to 32-bit width components when targeting SPIR-V
   int fbh = firstbithigh(uint_1);
-// CHECK: error: firstbithigh is currently limited to 32-bit width components when targetting SPIR-V
+// CHECK: error: firstbithigh is currently limited to 32-bit width components when targeting SPIR-V
   int64_t2 fbh2 = firstbithigh(int_2);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
@@ -2,6 +2,6 @@
 
 void main() {
   uint64_t   uint_1;
-// CHECK: error: firstbitlow is currently limited to 32-bit width components when targetting SPIR-V
+// CHECK: error: firstbitlow is currently limited to 32-bit width components when targeting SPIR-V
   int fbl = firstbitlow(uint_1);
 }


### PR DESCRIPTION
We have folks implementing the `firstbithigh` intrinsic and I noticed this SPIRV error has a misspelling. 