### PR TITLE
Remove static initializers for llvm::StringRef

### DIFF
--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -25,9 +25,9 @@ namespace hlsl {
 namespace options {
 
 struct Toggle {
-  const char* Name;
+  const char *Name;
   bool Default = false;
-  Toggle(char* Name, bool Default) : Name(Name), Default(Default) {}
+  Toggle(char *Name, bool Default) : Name(Name), Default(Default) {}
 };
 
 enum {

--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -25,9 +25,9 @@ namespace hlsl {
 namespace options {
 
 struct Toggle {
-  llvm::StringRef Name;
+  const char* Name;
   bool Default = false;
-  Toggle(llvm::StringRef Name, bool Default) : Name(Name), Default(Default) {}
+  Toggle(char* Name, bool Default) : Name(Name), Default(Default) {}
 };
 
 enum {

--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -27,7 +27,8 @@ namespace options {
 struct Toggle {
   llvm::StringRef Name;
   bool Default = false;
-  constexpr Toggle(llvm::StringRef Name, bool Default) : Name(Name), Default(Default) {}
+  constexpr Toggle(llvm::StringRef Name, bool Default)
+      : Name(Name), Default(Default) {}
 };
 
 enum {

--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -25,9 +25,9 @@ namespace hlsl {
 namespace options {
 
 struct Toggle {
-  const char *Name;
+  llvm::StringRef Name;
   bool Default = false;
-  Toggle(const char *Name, bool Default) : Name(Name), Default(Default) {}
+  constexpr Toggle(llvm::StringRef Name, bool Default) : Name(Name), Default(Default) {}
 };
 
 enum {
@@ -35,19 +35,20 @@ enum {
   DEFAULT_OFF = 0,
 };
 
-static const Toggle TOGGLE_GVN = {"gvn", DEFAULT_ON};
-static const Toggle TOGGLE_LICM = {"licm", DEFAULT_ON};
-static const Toggle TOGGLE_SINK = {"sink", DEFAULT_ON};
-static const Toggle TOGGLE_ENABLE_AGGRESSIVE_REASSOCIATION = {
+static constexpr Toggle TOGGLE_GVN = {"gvn", DEFAULT_ON};
+static constexpr Toggle TOGGLE_LICM = {"licm", DEFAULT_ON};
+static constexpr Toggle TOGGLE_SINK = {"sink", DEFAULT_ON};
+static constexpr Toggle TOGGLE_ENABLE_AGGRESSIVE_REASSOCIATION = {
     "aggressive-reassociation", DEFAULT_ON};
-static const Toggle TOGGLE_LIFETIME_MARKERS = {"lifetime-markers", DEFAULT_ON};
-static const Toggle TOGGLE_PARTIAL_LIFETIME_MARKERS = {
+static constexpr Toggle TOGGLE_LIFETIME_MARKERS = {"lifetime-markers",
+                                                   DEFAULT_ON};
+static constexpr Toggle TOGGLE_PARTIAL_LIFETIME_MARKERS = {
     "partial-lifetime-markers", DEFAULT_OFF};
-static const Toggle TOGGLE_STRUCTURIZE_LOOP_EXITS_FOR_UNROLL = {
+static constexpr Toggle TOGGLE_STRUCTURIZE_LOOP_EXITS_FOR_UNROLL = {
     "structurize-loop-exits-for-unroll", DEFAULT_ON};
-static const Toggle TOGGLE_DEBUG_NOPS = {"debug-nops", DEFAULT_ON};
-static const Toggle TOGGLE_STRUCTURIZE_RETURNS = {"structurize-returns",
-                                                  DEFAULT_OFF};
+static constexpr Toggle TOGGLE_DEBUG_NOPS = {"debug-nops", DEFAULT_ON};
+static constexpr Toggle TOGGLE_STRUCTURIZE_RETURNS = {"structurize-returns",
+                                                      DEFAULT_OFF};
 
 struct OptimizationToggles {
   // Optimization pass enables, disables and selects

--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -27,7 +27,7 @@ namespace options {
 struct Toggle {
   const char *Name;
   bool Default = false;
-  Toggle(char *Name, bool Default) : Name(Name), Default(Default) {}
+  Toggle(const char *Name, bool Default) : Name(Name), Default(Default) {}
 };
 
 enum {

--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -66,19 +66,21 @@ namespace llvm {
     /*implicit*/ StringRef() : Data(nullptr), Length(0) {}
     StringRef(std::nullptr_t) = delete; // HLSL Change - So we don't accidentally pass `false` again
 
+    // HLSL Change - Begin - Make StringRef constructors constexpr.
     /// Construct a string ref from a cstring.
-    /*implicit*/ StringRef(const char *Str)
-      : Data(Str) {
-        assert(Str && "StringRef cannot be built from a NULL argument");
-        Length = ::strlen(Str); // invoking strlen(NULL) is undefined behavior
-      }
+    /*implicit*/ constexpr StringRef(const char *Str)
+        : Data(Str), Length(Str ? std::char_traits<char>::length(Str) : 0) {
+      assert(Str && "StringRef cannot be built from a NULL argument");
+    }
 
     /// Construct a string ref from a pointer and length.
-    /*implicit*/ StringRef(const char *data, size_t length)
-      : Data(data), Length(length) {
-        assert((data || length == 0) &&
-        "StringRef cannot be built from a NULL argument with non-null length");
-      }
+    /*implicit*/ constexpr StringRef(const char *data, size_t length)
+        : Data(data), Length(length) {
+      assert((data || length == 0) && "StringRef cannot be built from a NULL "
+                                      "argument with non-null length");
+
+    }
+    // HLSL Change - End - Make StringRef constructors constexpr.
 
     /// Construct a string ref from an std::string.
     /*implicit*/ StringRef(const std::string &Str)

--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -78,7 +78,6 @@ namespace llvm {
         : Data(data), Length(length) {
       assert((data || length == 0) && "StringRef cannot be built from a NULL "
                                       "argument with non-null length");
-
     }
     // HLSL Change - End - Make StringRef constructors constexpr.
 


### PR DESCRIPTION
Small change to switch from llvm::StringRef to char* to prevent incurring a large number of static initializers.  See dump of static initializers before and after this change from a release build of dxcompiler.dll.


[static_initializers_after.txt](https://github.com/user-attachments/files/17283018/static_initializers_after.txt)
[static_initializers_before.txt](https://github.com/user-attachments/files/17283019/static_initializers_before.txt)

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/6896
