### PR TITLE
[SPIR-V] Allow built-in object types as arguments to SpirvType

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/spv.inline.type.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.type.hlsl
@@ -1,12 +1,8 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
-// TODO(6498): enable Array test when using `Texture2D` with an alias template of `SpirvType` is fixed
-// CHECK-TODO: %type_Array_type_2d_image = OpTypeArray %type_2d_image
-// template<typename SomeType>
-// using Array = vk::SpirvOpaqueType</* OpTypeArray */ 28, SomeType, 4>;
-
 // CHECK: %spirvIntrinsicType = OpTypeArray %type_2d_image %uint_4
-typedef vk::SpirvOpaqueType</* OpTypeArray */ 28, Texture2D, vk::integral_constant<uint, 4> > ArrayTex2D;
+template<typename SomeType>
+using Array = vk::SpirvOpaqueType</* OpTypeArray */ 28, SomeType, vk::integral_constant<uint, 4> >;
 
 // CHECK: %spirvIntrinsicType_0 = OpTypeInt 8 0
 using uint8_t [[vk::ext_capability(/* Int8 */ 39)]] = vk::SpirvType</* OpTypeInt */ 21, 8, 8, vk::Literal<vk::integral_constant<uint, 8> >, vk::Literal<vk::integral_constant<bool, false> > >;
@@ -15,8 +11,7 @@ using uint8_t [[vk::ext_capability(/* Int8 */ 39)]] = vk::SpirvType</* OpTypeInt
 
 void main() {
   // CHECK: %image = OpVariable %_ptr_Function_spirvIntrinsicType Function
-  // Array<Texture2D> image;
-  ArrayTex2D image;
+  Array<Texture2D> image;
 
   // CHECK: %byte = OpVariable %_ptr_Function_spirvIntrinsicType_0
   uint8_t byte;


### PR DESCRIPTION
There has been a validation error for passing in a built-in type to a template since the first commit to DXC. This check exists to prevent instances like this:

```
Texture2D<SamplerState> image;
```

When DXC was first created, users could not create their own templates, and therefore having a generic check for this did not cause any problems. However, now that HLSL 2021 allows users to create their own templates, and inline SPIR-V lets users pass types in to the `SpirvType` and `SpirvOpaqueType` templates in order to reference them, this is causing problems.

This PR allows the `SpirvType` and `SpirvOpaqueType` templates to take HLSL built-in types as arguments.

Fixes #6498