### PR TITLE
[SPIR-V] Handle vectors passed to asuint

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11593,12 +11593,7 @@ SpirvEmitter::processIntrinsicAsType(const CallExpr *callExpr) {
   case 3: {
     // Handling Method 6.
     const Expr *arg1 = callExpr->getArg(1);
-    SourceLocation arg1loc = arg1->getExprLoc();
-    SourceRange arg1range = arg1->getSourceRange();
-
     const Expr *arg2 = callExpr->getArg(2);
-    SourceLocation arg2loc = arg2->getExprLoc();
-    SourceRange arg2range = arg2->getSourceRange();
 
     SpirvInstruction *value = doExpr(arg0);
     SpirvInstruction *lowbits = doExpr(arg1);
@@ -11621,10 +11616,8 @@ SpirvEmitter::processIntrinsicAsType(const CallExpr *callExpr) {
                         lowbitsResult, highbitsResult, loc, range);
     }
 
-    spvBuilder.createStore(lowbits, lowbitsResult, arg1loc, arg1range);
-    spvBuilder.createStore(highbits, highbitsResult, arg2loc, arg2range);
-
-    // TODO: handle matrices
+    spvBuilder.createStore(lowbits, lowbitsResult, loc, range);
+    spvBuilder.createStore(highbits, highbitsResult, loc, range);
 
     return nullptr;
   }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11465,13 +11465,13 @@ void SpirvEmitter::splitDoubleMatrix(QualType elemType, uint32_t rowCount,
   llvm::SmallVector<SpirvInstruction *, 4> lowElems;
   llvm::SmallVector<SpirvInstruction *, 4> highElems;
 
-  QualType colType = astContext.getExtVectorType(elemType, rowCount);
+  QualType colType = astContext.getExtVectorType(elemType, colCount);
 
   const QualType uintType = astContext.UnsignedIntTy;
   const QualType outputColType =
-      astContext.getExtVectorType(uintType, rowCount);
+      astContext.getExtVectorType(uintType, colCount);
 
-  for (uint32_t i = 0; i < colCount; ++i) {
+  for (uint32_t i = 0; i < rowCount; ++i) {
     SpirvInstruction *column =
         spvBuilder.createCompositeExtract(colType, value, {i}, loc, range);
     SpirvInstruction *lowbitsResult = nullptr;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11519,23 +11519,45 @@ SpirvEmitter::processIntrinsicAsType(const CallExpr *callExpr) {
   }
   case 3: {
     // Handling Method 6.
-    auto *value = doExpr(arg0);
-    auto *lowbits = doExpr(callExpr->getArg(1));
-    auto *highbits = doExpr(callExpr->getArg(2));
-    const auto uintType = astContext.UnsignedIntTy;
-    const auto uintVec2Type = astContext.getExtVectorType(uintType, 2);
-    auto *vecResult = spvBuilder.createUnaryOp(spv::Op::OpBitcast, uintVec2Type,
-                                               value, loc, range);
-    spvBuilder.createStore(
-        lowbits,
-        spvBuilder.createCompositeExtract(uintType, vecResult, {0},
-                                          arg0->getLocStart(), range),
-        loc, range);
-    spvBuilder.createStore(
-        highbits,
-        spvBuilder.createCompositeExtract(uintType, vecResult, {1},
-                                          arg0->getLocStart(), range),
-        loc, range);
+    const Expr *arg1 = callExpr->getArg(1);
+    SourceLocation arg1loc = arg1->getExprLoc();
+    SourceRange arg1range = arg1->getSourceRange();
+
+    const Expr *arg2 = callExpr->getArg(2);
+    SourceLocation arg2loc = arg2->getExprLoc();
+    SourceRange arg2range = arg2->getSourceRange();
+
+    SpirvInstruction *value = doExpr(arg0->IgnoreParenLValueCasts());
+    if (!value->isLValue()) {
+      value = turnIntoLValue(argType, value, arg0->getExprLoc());
+    }
+    SpirvInstruction *lowbits = doExpr(arg1);
+    SpirvInstruction *highbits = doExpr(arg2);
+
+    QualType outType = arg1->getType();
+    QualType arrayType = astContext.getConstantArrayType(
+        outType, llvm::APInt(32, 2), clang::ArrayType::Normal, 0);
+
+    const SpirvType *arrayPtrType =
+        spvContext.getPointerType(arrayType, spv::StorageClass::Function);
+
+    auto *arrayResultPtr =
+        spvBuilder.createUnaryOp(spv::Op::OpBitcast, arrayPtrType, value, loc);
+
+    SpirvInstruction *lowbitsResultPtr = spvBuilder.createAccessChain(
+        outType, arrayResultPtr, {getValueZero(astContext.UnsignedIntTy)},
+        arg1loc);
+    SpirvInstruction *lowbitsResult =
+        spvBuilder.createLoad(outType, lowbitsResultPtr, arg1loc, arg1range);
+    spvBuilder.createStore(lowbits, lowbitsResult, arg1loc, arg1range);
+
+    SpirvInstruction *highbitsResultPtr = spvBuilder.createAccessChain(
+        outType, arrayResultPtr, {getValueOne(astContext.UnsignedIntTy)},
+        arg2loc);
+    SpirvInstruction *highbitsResult =
+        spvBuilder.createLoad(outType, highbitsResultPtr, arg2loc, arg2range);
+    spvBuilder.createStore(highbits, highbitsResult, arg2loc, arg2range);
+
     return nullptr;
   }
   default:

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1312,6 +1312,22 @@ private:
   /// the Vulkan memory model capability has been added to the module.
   bool UpgradeToVulkanMemoryModelIfNeeded(std::vector<uint32_t> *module);
 
+  // TODO: docs
+  void splitDouble(SpirvInstruction *value, SpirvInstruction *&lowbits,
+                   SpirvInstruction *&highbits, SourceLocation loc,
+                   SourceRange range);
+
+  void splitDoubleVector(QualType elemType, uint32_t count, QualType outputType,
+                         SpirvInstruction *value, SpirvInstruction *&lowbits,
+                         SpirvInstruction *&highbits, SourceLocation loc,
+                         SourceRange range);
+
+  void splitDoubleMatrix(QualType elemType, uint32_t rowCount,
+                         uint32_t colCount, QualType outputType,
+                         SpirvInstruction *value, SpirvInstruction *&lowbits,
+                         SpirvInstruction *&highbits, SourceLocation loc,
+                         SourceRange range);
+
 public:
   /// \brief Wrapper method to create a fatal error message and report it
   /// in the diagnostic engine associated with this consumer.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1314,9 +1314,9 @@ private:
 
   // Splits the `value`, which must be a 64-bit scalar, into two 32-bit wide
   // uints, stored in `lowbits` and `highbits`.
-  void splitDouble(SpirvInstruction *value, SpirvInstruction *&lowbits,
-                   SpirvInstruction *&highbits, SourceLocation loc,
-                   SourceRange range);
+  void splitDouble(SpirvInstruction *value, SourceLocation loc,
+                   SourceRange range, SpirvInstruction *&lowbits,
+                   SpirvInstruction *&highbits);
 
   // Splits the value, which must be a vector with element type `elemType` and
   // size `count`, into two composite values of size `count` and type
@@ -1324,9 +1324,9 @@ private:
   // {0x0123456789abcdef, 0x0123456789abcdef} is split into `lowbits`
   // {0x89abcdef, 0x89abcdef} and and `highbits` {0x01234567, 0x01234567}.
   void splitDoubleVector(QualType elemType, uint32_t count, QualType outputType,
-                         SpirvInstruction *value, SpirvInstruction *&lowbits,
-                         SpirvInstruction *&highbits, SourceLocation loc,
-                         SourceRange range);
+                         SpirvInstruction *value, SourceLocation loc,
+                         SourceRange range, SpirvInstruction *&lowbits,
+                         SpirvInstruction *&highbits);
 
   // Splits the value, which must be a matrix with element type `elemType` and
   // dimensions `rowCount` and `colCount`, into two composite values of
@@ -1347,9 +1347,9 @@ private:
   //   0x012345678, 0x012345678 }.
   void splitDoubleMatrix(QualType elemType, uint32_t rowCount,
                          uint32_t colCount, QualType outputType,
-                         SpirvInstruction *value, SpirvInstruction *&lowbits,
-                         SpirvInstruction *&highbits, SourceLocation loc,
-                         SourceRange range);
+                         SpirvInstruction *value, SourceLocation loc,
+                         SourceRange range, SpirvInstruction *&lowbits,
+                         SpirvInstruction *&highbits);
 
 public:
   /// \brief Wrapper method to create a fatal error message and report it

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1312,16 +1312,39 @@ private:
   /// the Vulkan memory model capability has been added to the module.
   bool UpgradeToVulkanMemoryModelIfNeeded(std::vector<uint32_t> *module);
 
-  // TODO: docs
+  // Splits the `value`, which must be a 64-bit scalar, into two 32-bit wide
+  // uints, stored in `lowbits` and `highbits`.
   void splitDouble(SpirvInstruction *value, SpirvInstruction *&lowbits,
                    SpirvInstruction *&highbits, SourceLocation loc,
                    SourceRange range);
 
+  // Splits the value, which must be a vector with element type `elemType` and
+  // size `count`, into two composite values of size `count` and type
+  // `outputType`. The elements are split component-wise: the vector
+  // {0x0123456789abcdef, 0x0123456789abcdef} is split into `lowbits`
+  // {0x89abcdef, 0x89abcdef} and and `highbits` {0x01234567, 0x01234567}.
   void splitDoubleVector(QualType elemType, uint32_t count, QualType outputType,
                          SpirvInstruction *value, SpirvInstruction *&lowbits,
                          SpirvInstruction *&highbits, SourceLocation loc,
                          SourceRange range);
 
+  // Splits the value, which must be a matrix with element type `elemType` and
+  // dimensions `rowCount` and `colCount`, into two composite values of
+  // dimensions `rowCount` and `colCount`. The elements are split
+  // component-wise: the matrix
+  //
+  // { 0x0123456789abcdef, 0x0123456789abcdef,
+  //   0x0123456789abcdef, 0x0123456789abcdef }
+  //
+  // is split into `lowbits`
+  //
+  // { 0x89abcdef, 0x89abcdef,
+  //   0x89abcdef, 0x89abcdef }
+  //
+  //  and `highbits`
+  //
+  // { 0x012345678, 0x012345678,
+  //   0x012345678, 0x012345678 }.
   void splitDoubleMatrix(QualType elemType, uint32_t rowCount,
                          uint32_t colCount, QualType outputType,
                          SpirvInstruction *value, SpirvInstruction *&lowbits,

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
@@ -76,34 +76,65 @@ void main() {
     double value;
     uint lowbits;
     uint highbits;
-// CHECK-NEXT:  [[resultArr:%[0-9]+]] = OpBitcast %_ptr_Function__arr_uint_uint_2 %value
-// CHECK-NEXT:     [[chain0:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_0
-// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpLoad %uint [[chain0]]
+// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %double %value
+// CHECK-NEXT:  [[resultVec:%[0-9]+]] = OpBitcast %v2uint [[value]]
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec]] 0
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec]] 1
 // CHECK-NEXT:                       OpStore %lowbits [[resultVec0]]
-// CHECK-NEXT:     [[chain1:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_1
-// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpLoad %uint [[chain1]]
 // CHECK-NEXT:                       OpStore %highbits [[resultVec1]]
     asuint(value, lowbits, highbits);
 
-    double4 value4;
-    uint4 lowbits4;
-    uint4 highbits4;
-// CHECK-NEXT:  [[resultArr:%[0-9]+]] = OpBitcast %_ptr_Function__arr_v4uint_uint_2 %value4
-// CHECK-NEXT:     [[chain0:%[0-9]+]] = OpAccessChain %_ptr_Function_v4uint [[resultArr]] %uint_0
-// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpLoad %v4uint [[chain0]]
-// CHECK-NEXT:                       OpStore %lowbits4 [[resultVec0]]
-// CHECK-NEXT:     [[chain1:%[0-9]+]] = OpAccessChain %_ptr_Function_v4uint [[resultArr]] %uint_1
-// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpLoad %v4uint [[chain1]]
-// CHECK-NEXT:                       OpStore %highbits4 [[resultVec1]]
-    asuint(value4, lowbits4, highbits4);
+    double3 value3;
+    uint3 lowbits3;
+    uint3 highbits3;
+// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %v3double %value3
+// CHECK-NEXT:     [[value0:%[0-9]+]] = OpCompositeExtract %double [[value]] 0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpBitcast %v2uint [[value0]]
+// CHECK-NEXT:       [[low0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 0
+// CHECK-NEXT:      [[high0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 1
+// CHECK-NEXT:     [[value1:%[0-9]+]] = OpCompositeExtract %double [[value]] 1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpBitcast %v2uint [[value1]]
+// CHECK-NEXT:       [[low1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 0
+// CHECK-NEXT:      [[high1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 1
+// CHECK-NEXT:     [[value2:%[0-9]+]] = OpCompositeExtract %double [[value]] 2
+// CHECK-NEXT: [[resultVec2:%[0-9]+]] = OpBitcast %v2uint [[value2]]
+// CHECK-NEXT:       [[low2:%[0-9]+]] = OpCompositeExtract %uint [[resultVec2]] 0
+// CHECK-NEXT:      [[high2:%[0-9]+]] = OpCompositeExtract %uint [[resultVec2]] 1
+// CHECK-NEXT:        [[low:%[0-9]+]] = OpCompositeConstruct %v3uint [[low0]] [[low1]] [[low2]]
+// CHECK-NEXT:       [[high:%[0-9]+]] = OpCompositeConstruct %v3uint [[high0]] [[high1]] [[high2]]
+// CHECK-NEXT:                          OpStore %lowbits3 [[low]]
+// CHECK-NEXT:                          OpStore %highbits3 [[high]]
+    asuint(value3, lowbits3, highbits3);
 
-// CHECK-NEXT:                          OpStore %temp_var_double %double_1234
-// CHECK-NEXT:  [[resultArr:%[0-9]+]] = OpBitcast %_ptr_Function__arr_uint_uint_2 %temp_var_double
-// CHECK-NEXT:     [[chain0:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_0
-// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpLoad %uint [[chain0]]
-// CHECK-NEXT:                       OpStore %lowbits [[resultVec0]]
-// CHECK-NEXT:     [[chain1:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_1
-// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpLoad %uint [[chain1]]
-// CHECK-NEXT:                       OpStore %highbits [[resultVec1]]
-    asuint(1234.0, lowbits, highbits);
+    double2x2 value2x2;
+    uint2x2 lowbits2x2;
+    uint2x2 highbits2x2;
+// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %mat2v2double %value2x2
+// CHECK-NEXT:       [[row0:%[0-9]+]] = OpCompositeExtract %v2double [[value]] 0
+// CHECK-NEXT:     [[value0:%[0-9]+]] = OpCompositeExtract %double [[row0]] 0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpBitcast %v2uint [[value0]]
+// CHECK-NEXT:       [[low0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 0
+// CHECK-NEXT:      [[high0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 1
+// CHECK-NEXT:     [[value1:%[0-9]+]] = OpCompositeExtract %double [[row0]] 1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpBitcast %v2uint [[value1]]
+// CHECK-NEXT:       [[low1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 0
+// CHECK-NEXT:      [[high1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 1
+// CHECK-NEXT:    [[lowRow0:%[0-9]+]] = OpCompositeConstruct %v2uint [[low0]] [[low1]]
+// CHECK-NEXT:   [[highRow0:%[0-9]+]] = OpCompositeConstruct %v2uint [[high0]] [[high1]]
+// CHECK-NEXT:       [[row1:%[0-9]+]] = OpCompositeExtract %v2double [[value]] 1
+// CHECK-NEXT:     [[value2:%[0-9]+]] = OpCompositeExtract %double [[row1]] 0
+// CHECK-NEXT: [[resultVec2:%[0-9]+]] = OpBitcast %v2uint [[value2]]
+// CHECK-NEXT:       [[low2:%[0-9]+]] = OpCompositeExtract %uint [[resultVec2]] 0
+// CHECK-NEXT:      [[high2:%[0-9]+]] = OpCompositeExtract %uint [[resultVec2]] 1
+// CHECK-NEXT:     [[value3:%[0-9]+]] = OpCompositeExtract %double [[row1]] 1
+// CHECK-NEXT: [[resultVec3:%[0-9]+]] = OpBitcast %v2uint [[value3]]
+// CHECK-NEXT:       [[low3:%[0-9]+]] = OpCompositeExtract %uint [[resultVec3]] 0
+// CHECK-NEXT:      [[high3:%[0-9]+]] = OpCompositeExtract %uint [[resultVec3]] 1
+// CHECK-NEXT:    [[lowRow1:%[0-9]+]] = OpCompositeConstruct %v2uint [[low2]] [[low3]]
+// CHECK-NEXT:   [[highRow1:%[0-9]+]] = OpCompositeConstruct %v2uint [[high2]] [[high3]]
+// CHECK-NEXT:        [[low:%[0-9]+]] = OpCompositeConstruct %_arr_v2uint_uint_2 [[lowRow0]] [[lowRow1]]
+// CHECK-NEXT:       [[high:%[0-9]+]] = OpCompositeConstruct %_arr_v2uint_uint_2 [[highRow0]] [[highRow1]]
+// CHECK-NEXT:                          OpStore %lowbits2x2 [[low]]
+// CHECK-NEXT:                          OpStore %highbits2x2 [[high]]
+    asuint(value2x2, lowbits2x2, highbits2x2);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
@@ -76,11 +76,34 @@ void main() {
     double value;
     uint lowbits;
     uint highbits;
-// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %double %value
-// CHECK-NEXT:  [[resultVec:%[0-9]+]] = OpBitcast %v2uint [[value]]
-// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec]] 0
+// CHECK-NEXT:  [[resultArr:%[0-9]+]] = OpBitcast %_ptr_Function__arr_uint_uint_2 %value
+// CHECK-NEXT:     [[chain0:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpLoad %uint [[chain0]]
 // CHECK-NEXT:                       OpStore %lowbits [[resultVec0]]
-// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec]] 1
+// CHECK-NEXT:     [[chain1:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpLoad %uint [[chain1]]
 // CHECK-NEXT:                       OpStore %highbits [[resultVec1]]
     asuint(value, lowbits, highbits);
+
+    double4 value4;
+    uint4 lowbits4;
+    uint4 highbits4;
+// CHECK-NEXT:  [[resultArr:%[0-9]+]] = OpBitcast %_ptr_Function__arr_v4uint_uint_2 %value4
+// CHECK-NEXT:     [[chain0:%[0-9]+]] = OpAccessChain %_ptr_Function_v4uint [[resultArr]] %uint_0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpLoad %v4uint [[chain0]]
+// CHECK-NEXT:                       OpStore %lowbits4 [[resultVec0]]
+// CHECK-NEXT:     [[chain1:%[0-9]+]] = OpAccessChain %_ptr_Function_v4uint [[resultArr]] %uint_1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpLoad %v4uint [[chain1]]
+// CHECK-NEXT:                       OpStore %highbits4 [[resultVec1]]
+    asuint(value4, lowbits4, highbits4);
+
+// CHECK-NEXT:                          OpStore %temp_var_double %double_1234
+// CHECK-NEXT:  [[resultArr:%[0-9]+]] = OpBitcast %_ptr_Function__arr_uint_uint_2 %temp_var_double
+// CHECK-NEXT:     [[chain0:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpLoad %uint [[chain0]]
+// CHECK-NEXT:                       OpStore %lowbits [[resultVec0]]
+// CHECK-NEXT:     [[chain1:%[0-9]+]] = OpAccessChain %_ptr_Function_uint [[resultArr]] %uint_1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpLoad %uint [[chain1]]
+// CHECK-NEXT:                       OpStore %highbits [[resultVec1]]
+    asuint(1234.0, lowbits, highbits);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
@@ -180,4 +180,40 @@ void main() {
 // CHECK-NEXT:                          OpStore %lowbits3x2 [[low]]
 // CHECK-NEXT:                          OpStore %highbits3x2 [[high]]
     asuint(value3x2, lowbits3x2, highbits3x2);
+
+    double2x1 value2x1;
+    uint2x1 lowbits2x1;
+    uint2x1 highbits2x1;
+// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %v2double %value2x1
+// CHECK-NEXT:     [[value0:%[0-9]+]] = OpCompositeExtract %double [[value]] 0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpBitcast %v2uint [[value0]]
+// CHECK-NEXT:       [[low0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 0
+// CHECK-NEXT:      [[high0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 1
+// CHECK-NEXT:     [[value1:%[0-9]+]] = OpCompositeExtract %double [[value]] 1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpBitcast %v2uint [[value1]]
+// CHECK-NEXT:       [[low1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 0
+// CHECK-NEXT:      [[high1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 1
+// CHECK-NEXT:        [[low:%[0-9]+]] = OpCompositeConstruct %v2uint [[low0]] [[low1]]
+// CHECK-NEXT:       [[high:%[0-9]+]] = OpCompositeConstruct %v2uint [[high0]] [[high1]]
+// CHECK-NEXT:                          OpStore %lowbits2x1 [[low]]
+// CHECK-NEXT:                          OpStore %highbits2x1 [[high]]
+    asuint(value2x1, lowbits2x1, highbits2x1);
+
+    double1x2 value1x2;
+    uint1x2 lowbits1x2;
+    uint1x2 highbits1x2;
+// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %v2double %value1x2
+// CHECK-NEXT:     [[value0:%[0-9]+]] = OpCompositeExtract %double [[value]] 0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpBitcast %v2uint [[value0]]
+// CHECK-NEXT:       [[low0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 0
+// CHECK-NEXT:      [[high0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 1
+// CHECK-NEXT:     [[value1:%[0-9]+]] = OpCompositeExtract %double [[value]] 1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpBitcast %v2uint [[value1]]
+// CHECK-NEXT:       [[low1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 0
+// CHECK-NEXT:      [[high1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 1
+// CHECK-NEXT:        [[low:%[0-9]+]] = OpCompositeConstruct %v2uint [[low0]] [[low1]]
+// CHECK-NEXT:       [[high:%[0-9]+]] = OpCompositeConstruct %v2uint [[high0]] [[high1]]
+// CHECK-NEXT:                          OpStore %lowbits1x2 [[low]]
+// CHECK-NEXT:                          OpStore %highbits1x2 [[high]]
+    asuint(value1x2, lowbits1x2, highbits1x2);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.asuint.hlsl
@@ -137,4 +137,47 @@ void main() {
 // CHECK-NEXT:                          OpStore %lowbits2x2 [[low]]
 // CHECK-NEXT:                          OpStore %highbits2x2 [[high]]
     asuint(value2x2, lowbits2x2, highbits2x2);
+
+    double3x2 value3x2;
+    uint3x2 lowbits3x2;
+    uint3x2 highbits3x2;
+// CHECK-NEXT:      [[value:%[0-9]+]] = OpLoad %mat3v2double %value3x2
+// CHECK-NEXT:       [[row0:%[0-9]+]] = OpCompositeExtract %v2double [[value]] 0
+// CHECK-NEXT:     [[value0:%[0-9]+]] = OpCompositeExtract %double [[row0]] 0
+// CHECK-NEXT: [[resultVec0:%[0-9]+]] = OpBitcast %v2uint [[value0]]
+// CHECK-NEXT:       [[low0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 0
+// CHECK-NEXT:      [[high0:%[0-9]+]] = OpCompositeExtract %uint [[resultVec0]] 1
+// CHECK-NEXT:     [[value1:%[0-9]+]] = OpCompositeExtract %double [[row0]] 1
+// CHECK-NEXT: [[resultVec1:%[0-9]+]] = OpBitcast %v2uint [[value1]]
+// CHECK-NEXT:       [[low1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 0
+// CHECK-NEXT:      [[high1:%[0-9]+]] = OpCompositeExtract %uint [[resultVec1]] 1
+// CHECK-NEXT:    [[lowRow0:%[0-9]+]] = OpCompositeConstruct %v2uint [[low0]] [[low1]]
+// CHECK-NEXT:   [[highRow0:%[0-9]+]] = OpCompositeConstruct %v2uint [[high0]] [[high1]]
+// CHECK-NEXT:       [[row1:%[0-9]+]] = OpCompositeExtract %v2double [[value]] 1
+// CHECK-NEXT:     [[value2:%[0-9]+]] = OpCompositeExtract %double [[row1]] 0
+// CHECK-NEXT: [[resultVec2:%[0-9]+]] = OpBitcast %v2uint [[value2]]
+// CHECK-NEXT:       [[low2:%[0-9]+]] = OpCompositeExtract %uint [[resultVec2]] 0
+// CHECK-NEXT:      [[high2:%[0-9]+]] = OpCompositeExtract %uint [[resultVec2]] 1
+// CHECK-NEXT:     [[value3:%[0-9]+]] = OpCompositeExtract %double [[row1]] 1
+// CHECK-NEXT: [[resultVec3:%[0-9]+]] = OpBitcast %v2uint [[value3]]
+// CHECK-NEXT:       [[low3:%[0-9]+]] = OpCompositeExtract %uint [[resultVec3]] 0
+// CHECK-NEXT:      [[high3:%[0-9]+]] = OpCompositeExtract %uint [[resultVec3]] 1
+// CHECK-NEXT:    [[lowRow1:%[0-9]+]] = OpCompositeConstruct %v2uint [[low2]] [[low3]]
+// CHECK-NEXT:   [[highRow1:%[0-9]+]] = OpCompositeConstruct %v2uint [[high2]] [[high3]]
+// CHECK-NEXT:       [[row2:%[0-9]+]] = OpCompositeExtract %v2double [[value]] 2
+// CHECK-NEXT:     [[value4:%[0-9]+]] = OpCompositeExtract %double [[row2]] 0
+// CHECK-NEXT: [[resultVec4:%[0-9]+]] = OpBitcast %v2uint [[value4]]
+// CHECK-NEXT:       [[low4:%[0-9]+]] = OpCompositeExtract %uint [[resultVec4]] 0
+// CHECK-NEXT:      [[high4:%[0-9]+]] = OpCompositeExtract %uint [[resultVec4]] 1
+// CHECK-NEXT:     [[value5:%[0-9]+]] = OpCompositeExtract %double [[row2]] 1
+// CHECK-NEXT: [[resultVec5:%[0-9]+]] = OpBitcast %v2uint [[value5]]
+// CHECK-NEXT:       [[low5:%[0-9]+]] = OpCompositeExtract %uint [[resultVec5]] 0
+// CHECK-NEXT:      [[high5:%[0-9]+]] = OpCompositeExtract %uint [[resultVec5]] 1
+// CHECK-NEXT:    [[lowRow2:%[0-9]+]] = OpCompositeConstruct %v2uint [[low4]] [[low5]]
+// CHECK-NEXT:   [[highRow2:%[0-9]+]] = OpCompositeConstruct %v2uint [[high4]] [[high5]]
+// CHECK-NEXT:        [[low:%[0-9]+]] = OpCompositeConstruct %_arr_v2uint_uint_3 [[lowRow0]] [[lowRow1]] [[lowRow2]]
+// CHECK-NEXT:       [[high:%[0-9]+]] = OpCompositeConstruct %_arr_v2uint_uint_3 [[highRow0]] [[highRow1]] [[highRow2]]
+// CHECK-NEXT:                          OpStore %lowbits3x2 [[low]]
+// CHECK-NEXT:                          OpStore %highbits3x2 [[high]]
+    asuint(value3x2, lowbits3x2, highbits3x2);
 }


### PR DESCRIPTION
`asuint` should be able to take vectors in addition to scalar values. Previously, it would be lowered as a bitcast from the input value to a vector of uints with a width of 2, which is not large enough if the input value is larger than a scalar value. In order to handle, for example, an input value that is a `double4`, we instead perform a component-wise bitcast.

Fixes #6735