### PR TITLE
Enable resource directory for DXC.

### DIFF
--- a/tools/clang/lib/Frontend/InitHeaderSearch.cpp
+++ b/tools/clang/lib/Frontend/InitHeaderSearch.cpp
@@ -442,7 +442,12 @@ void InitHeaderSearch::AddDefaultIncludePaths(const LangOptions &Lang,
                                               const llvm::Triple &triple,
                                             const HeaderSearchOptions &HSOpts) {
 #if 1 // HLSL Change Starts
-  return;
+    if (HSOpts.UseBuiltinIncludes) {
+        SmallString<128> P = StringRef(HSOpts.ResourceDir);
+        llvm::sys::path::append(P, "include");
+        AddUnmappedPath(P, Angled, false);
+    }
+    return;
 #else
   // NB: This code path is going away. All of the logic is moving into the
   // driver which has the information necessary to do target-specific

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -21,6 +21,7 @@
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/dxcfilesystem.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "llvm/Support/Path.h"
 
 #ifndef _WIN32
 #include <sys/stat.h>
@@ -394,6 +395,11 @@ public:
         ws += Unicode::UTF8ToWideStringOrThrow(E.Path.c_str());
         m_searchEntries.emplace_back(std::move(ws));
       }
+    }
+    if (compiler.getHeaderSearchOpts().UseBuiltinIncludes) {
+        SmallString<128> P = StringRef(compiler.getHeaderSearchOpts().ResourceDir);
+        llvm::sys::path::append(P, "include");
+        m_searchEntries.emplace_back(Unicode::UTF8ToWideStringOrThrow(P.c_str()));
     }
   }
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1404,7 +1404,9 @@ public:
 
     // Pick additional arguments.
     clang::HeaderSearchOptions &HSOpts = compiler.getHeaderSearchOpts();
-    HSOpts.UseBuiltinIncludes = 0;
+    HSOpts.UseBuiltinIncludes = true;
+    HSOpts.ResourceDir =
+      clang::CompilerInvocation::GetResourcesPath("Hoping this is not needed on any of our platforms", nullptr);
     // Consider: should we force-include '.' if the source file is relative?
     for (const llvm::opt::Arg *A : Opts.Args.filtered(options::OPT_I)) {
       const bool IsFrameworkFalse = false;


### PR DESCRIPTION
This change enables the resource directory for DXC. This will allow the HLSL standard headers to be accessed without using the `-I` option.