### PR TITLE
[SPIRV] Simplify looking for input storage class

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -1146,8 +1146,7 @@ bool DeclResultIdMapper::decorateStageIOLocations() {
 }
 
 bool DeclResultIdMapper::isInputStorageClass(const StageVar &v) {
-  return getStorageClassForSigPoint(v.getSigPoint()) ==
-         spv::StorageClass::Input;
+  return v.getStorageClass() == spv::StorageClass::Input;
 }
 
 void DeclResultIdMapper::createFnParamCounterVar(const VarDecl *param) {

--- a/tools/clang/test/CodeGenSPIRV/ext_builtin_input.lib.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/ext_builtin_input.lib.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -spirv -enable-16bit-types -T lib_6_7 -HV 202x %s | FileCheck %s
+
+// CHECK: OpEntryPoint Fragment %psmain "psmain" %gl_HelperInvocation %out_var_SV_Target0
+// CHECK: OpDecorate %gl_HelperInvocation BuiltIn HelperInvocation
+// CHECK: %gl_HelperInvocation = OpVariable %_ptr_Input_bool Input
+
+[[vk::ext_builtin_input(23 /* BuiltInHelperInvocation */)]]
+static const bool HelperInvocation;
+
+[shader("pixel")]
+float4 psmain() : SV_Target0 {
+
+    if (HelperInvocation)
+      return 0;
+    return 1;
+}


### PR DESCRIPTION
The function `DeclResultIdMapper::isInputStorageClass` tries to
determine the storage class for the stage variable by looking at its
SigPoint. This does not always work.

This change simply looks at the storage class that is already associated
with the variable, which should have been set when the StageVar was
created.

Fixes #6959
