### PR TITLE
[SPIRV] Register all decls for a variable.

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -981,6 +981,16 @@ private:
   /// views.
   void setInterlockExecutionMode(spv::ExecutionMode mode);
 
+  /// \brief Add |varInstr| to |astDecls| for every Decl for the variable |var|.
+  /// It is possible for a variable to have multiple declarations, and all of
+  /// them should be associated with the same variable.
+  void registerVariableForDecl(const VarDecl *var, SpirvInstruction *varInstr);
+
+  /// \brief Add |spirvInfo| to |astDecls| for every Decl for the variable
+  /// |var|. It is possible for a variable to have multiple declarations, and
+  /// all of them should be associated with the same variable.
+  void registerVariableForDecl(const VarDecl *var, DeclSpirvInfo spirvInfo);
+
 private:
   SpirvBuilder &spvBuilder;
   SpirvEmitter &theEmitter;

--- a/tools/clang/test/CodeGenSPIRV/static_member_var.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/static_member_var.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_6 -E PSMain %s -spirv | FileCheck %s
+
+struct PSInput
+{   
+    static const uint Val;
+    uint Func() { return Val; }
+};
+
+static const uint PSInput::Val = 3;
+
+// CHECK: OpStore %out_var_SV_Target0 %uint_3
+uint PSMain(PSInput input) : SV_Target0
+{   
+    return input.Func();
+}


### PR DESCRIPTION
Some variable can have multiple decls. In one case, there could be a
declaration of a const static member variable that is later defined. All
of these decls need to be in astDecls and associated with the same
variable.

The current code will only add the decl for the defintion. This leads to
problems when trying to find the variable for the declaration.

Fixes #6787
