### PR TITLE
Do not require __STDC_LIMIT_MACROS and others

### DIFF
--- a/include/llvm/Support/DataTypes.h.cmake
+++ b/include/llvm/Support/DataTypes.h.cmake
@@ -49,17 +49,14 @@
 
 #ifndef _MSC_VER
 
-/* Note that this header's correct operation depends on __STDC_LIMIT_MACROS
-   being defined.  We would define it here, but in order to prevent Bad Things
-   happening when system headers or C++ STL headers include stdint.h before we
-   define it here, we define it on the g++ command line (in Makefile.rules). */
-#if !defined(__STDC_LIMIT_MACROS)
-# error "Must #define __STDC_LIMIT_MACROS before #including Support/DataTypes.h"
+#if !defined(UINT32_MAX)
+# error "The standard header <cstdint> is not C++11 compliant. Must #define "\
+"__STDC_LIMIT_MACROS before #including Support/DataTypes.h"
 #endif
 
-#if !defined(__STDC_CONSTANT_MACROS)
-# error "Must #define __STDC_CONSTANT_MACROS before " \
-        "#including Support/DataTypes.h"
+#if !defined(UINT32_C)
+# error "The standard header <cstdint> is not C++11 compliant. Must #define "\
+        "__STDC_CONSTANT_MACROS before #including Support/DataTypes.h"
 #endif
 
 /* Note that <inttypes.h> includes <stdint.h>, if this is a C99 system. */


### PR DESCRIPTION
Apply LLVM patch: https://reviews.llvm.org/D21553
GitHub commit: https://github.com/llvm/llvm-project/commit/f4437e9b488d3340e0c01642e925ca6c54f5c426#diff-5fb0c3e347a7fc69d806be92c7b786cda1018152b3d264e3293697a1ac41eb7eR61

This fixes compilation of DXC with latest libc++, which removes C headers like locale.h and stdint.h:
https://github.com/llvm/llvm-project/commit/aa7f377c965ca79cf3022ddafe6cbd419bd52db5