### PR TITLE
sema: fix int enum implicit cast to float.

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -9102,7 +9102,10 @@ static bool ConvertComponent(ArTypeInfo TargetInfo, ArTypeInfo SourceInfo,
       return false;
     } else if (IS_BASIC_ENUM(SourceInfo.EltKind)) {
       // enum -> int/float
-      ComponentConversion = ICK_Integral_Conversion;
+      if (IS_BASIC_FLOAT(TargetInfo.EltKind))
+        ComponentConversion = ICK_Floating_Integral;
+      else
+        ComponentConversion = ICK_Integral_Conversion;
     } else if (TargetInfo.EltKind == AR_OBJECT_STRING) {
       if (SourceInfo.EltKind == AR_OBJECT_STRING_LITERAL) {
         ComponentConversion = ICK_Array_To_Pointer;

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/type-enum-cast.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/type-enum-cast.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc  -T vs_6_5 %s | FileCheck %s
+
+enum UE : uint {
+  UA = 1
+};
+
+enum SE : int {
+  SA = 3
+};
+
+struct Output {
+  float u;
+  float s;
+};
+
+Output main(UE u : A, SE s : B) : C {
+// CHECK-DAG: %[[U:.+]] = call i32 @dx.op.loadInput.i32(i32 4, i32 0, i32 0, i8 0, i32 undef)
+// CHECK-DAG: %[[S:.+]] = call i32 @dx.op.loadInput.i32(i32 4, i32 1, i32 0, i8 0, i32 undef)
+
+  Output o;
+
+  o.u = u;
+// CHECK-DAG: %[[FU:.+]] = uitofp i32 %[[U]] to float
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %[[FU]])
+
+  o.s = s;
+// CHECK-DAG: %[[FS:.+]] = sitofp i32 %[[S]] to float
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 0, float %[[FS]])
+
+  return o;
+}

--- a/tools/clang/test/CodeGenSPIRV/type.enum.cast.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.enum.cast.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T cs_6_6 -fspv-target-env=vulkan1.3 -E main %s -spirv -fcgl | FileCheck %s
+
+enum : uint {
+  UA = 1
+};
+
+enum : int {
+  SA = 3
+};
+
+static float p;
+
+[numthreads(1, 1, 1)]
+void main() {
+//CHECK:         OpStore %foo %float_1
+  float foo = UA;
+
+//CHECK:         OpStore %bar %float_3
+  float bar = SA;
+}

--- a/tools/clang/test/CodeGenSPIRV/type.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.enum.hlsl
@@ -101,7 +101,7 @@ void main() {
   testParamTypeCast(Second);
 
 //CHECK:        [[a_2:%[0-9]+]] = OpLoad %int %a
-//CHECK-NEXT:   [[a_3:%[0-9]+]] = OpBitcast %float [[a_2]]
+//CHECK-NEXT:   [[a_3:%[0-9]+]] = OpConvertSToF %float [[a_2]]
 //CHECK-NEXT: [[sin:%[0-9]+]] = OpExtInst %float {{%[0-9]+}} Sin [[a_3]]
 //CHECK-NEXT:                OpStore %bar [[sin]]
   float bar = sin(a);


### PR DESCRIPTION
An implicit cast from int enum to a float should be a Floating_Integral cast, not an Integral_Conversion.

Fixes #6884