### PR TITLE
[SPIR-V] Fixes SPV_KHR_fragment_shading_rate preventing optimizations

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/vk.shading-rate.optimized.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.shading-rate.optimized.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T vs_6_6 -E main -spirv -fspv-target-env=vulkan1.3 %s | FileCheck %s
+
+// CHECK-NOT: OpDecorate %unused DescriptorSet
+// CHECK-NOT: OpDecorate %unused Binding
+RWStructuredBuffer<uint> unused;
+
+struct in0
+{
+	float4 position : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+struct out0
+{
+	float4 pos : SV_Position;
+	uint sr : SV_ShadingRate;
+};
+
+// CHECK-NOT: OpEntryPoint Vertex %main "main" %in_var_POSITION %in_var_TEXCOORD0 %gl_Position %{{.*}} %unused
+// CHECK:     OpEntryPoint Vertex %main "main" %gl_Position %{{.*}}
+out0 main(in0 i)
+{
+	return (out0) 0;
+}


### PR DESCRIPTION
Updated the SPIRV-Tools version to bring 2 fixes.

Fixes #6915