### PR TITLE
[SPIR-V] Fix image write to unknown format

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <limits>
+#include <optional>
 
 #include "dxc/DXIL/DxilShaderModel.h"
 #include "clang/AST/DeclTemplate.h"
@@ -138,7 +139,7 @@ struct FunctionTypeMapInfo {
 struct VkImageFeatures {
   // True if it is a Vulkan "Combined Image Sampler".
   bool isCombinedImageSampler;
-  spv::ImageFormat format; // SPIR-V image format.
+  std::optional<spv::ImageFormat> format; // SPIR-V image format.
 };
 
 // A struct that contains the information of a resource that will be used to
@@ -378,7 +379,7 @@ public:
   getVkImageFeaturesForSpirvVariable(const SpirvVariable *spvVar) {
     auto itr = spvVarToVkImageFeatures.find(spvVar);
     if (itr == spvVarToVkImageFeatures.end())
-      return {false, spv::ImageFormat::Unknown};
+      return {false, std::nullopt};
     return itr->second;
   }
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -198,15 +198,17 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
       }
 
       auto vkImgFeatures = spvContext.getVkImageFeaturesForSpirvVariable(var);
-      if (vkImgFeatures.format != spv::ImageFormat::Unknown) {
+      if (vkImgFeatures.format) {
         if (const auto *imageType = dyn_cast<ImageType>(resultType)) {
-          resultType = spvContext.getImageType(imageType, vkImgFeatures.format);
+          resultType =
+              spvContext.getImageType(imageType, *vkImgFeatures.format);
           instr->setResultType(resultType);
         } else if (const auto *arrayType = dyn_cast<ArrayType>(resultType)) {
           if (const auto *imageType =
                   dyn_cast<ImageType>(arrayType->getElementType())) {
-            auto newImgType =
-                spvContext.getImageType(imageType, vkImgFeatures.format);
+            auto newImgType = spvContext.getImageType(
+                imageType,
+                vkImgFeatures.format.value_or(spv::ImageFormat::Unknown));
             resultType = spvContext.getArrayType(newImgType,
                                                  arrayType->getElementCount(),
                                                  arrayType->getStride());

--- a/tools/clang/test/CodeGenSPIRV/op.buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.buffer.access.hlsl
@@ -1,8 +1,7 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
 // CHECK: OpCapability ImageBuffer
-// CHECK: OpCapability StorageImageReadWithoutFormat
-
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
 
 // CHECK: %type_buffer_image = OpTypeImage %int Buffer 2 0 0 1 R32i
 // CHECK: %type_buffer_image_0 = OpTypeImage %uint Buffer 2 0 0 1 R32ui

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.unknown.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.unknown.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T cs_6_7 -E main -spirv -fspv-target-env=vulkan1.3 %s
+
+// CHECK: OpCapability StorageImageWriteWithoutFormat
+
+// CHECK: %[[#image:]] = OpTypeImage %float 3D 2 0 0 2 Unknown
+[[vk::image_format("unknown")]] RWTexture3D<float32_t2> untypedImage;
+
+[numthreads(8,8,8)]
+void main(uint32_t3 gl_GlobalInvocationID : SV_DispatchThreadID)
+{
+// CHECK: %[[#tmp:]] = OpLoad %[[#image]] %[[#]]
+// CHECK:              OpImageWrite [[#tmp]] %[[#]] %[[#]] None
+    untypedImage[gl_GlobalInvocationID] = float32_t2(4,5);
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.unknown.read.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.unknown.read.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -T cs_6_7 -E main -spirv -fspv-target-env=vulkan1.3 %s
+
+// CHECK: OpCapability StorageImageReadWithoutFormat
+
+// CHECK: %[[#image:]] = OpTypeImage %float 1D 2 0 0 2 Unknown
+[[vk::image_format("unknown")]] RWTexture1D<float32_t2> untypedImage;
+RWStructuredBuffer<float32_t2> output;
+
+[numthreads(8,8,8)]
+void main()
+{
+// CHECK: %[[#tmp:]] = OpLoad %[[#image]] %[[#]]
+// CHECK:              OpImageRead %[[#]] [[#tmp]] %[[#]] None
+    output[0] = untypedImage[0];
+}
+


### PR DESCRIPTION
By default, texture format is guessed from the type. But the `vk::image_format` attribute can be added to specify it.
The `unknown` value was used to convey `no format selected`, and require the guess to happen.
This made selecting `unknown` as value impossible.

Once the optional added, we have a new issue:
- The format setup relied on the legalizer.
- load/stores are done using the default format, then we fix it, then we use the legalizer to propagate the format fix to all users.

The capability visitor is running before the legalizer, meaning it can look at a non-fixed load, which still carries the old type.
The way to solve this is to remove this logic, and move the capability addition/deletion to the capability_trimming pass, run after legalization.

Fixes #6981