### PR TITLE
[SPIR-V] Fix bad OpLoad on loaded texture

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -7900,8 +7900,12 @@ SpirvInstruction *SpirvEmitter::tryToAssignToRWBufferRWTexture(
       beginInvocationInterlock(baseExpr->getExprLoc(), range);
     }
 
-    auto *image = spvBuilder.createLoad(imageType, baseInfo,
-                                        baseExpr->getExprLoc(), range);
+    SpirvInstruction *image = baseInfo;
+    // If the base is an L-value (OpVariable, OpAccessChain to OpVariable), we
+    // need a load.
+    if (baseInfo->isLValue())
+      image = spvBuilder.createLoad(imageType, baseInfo, baseExpr->getExprLoc(),
+                                    range);
     spvBuilder.createImageWrite(imageType, image, loc, rhs, lhs->getExprLoc(),
                                 range);
 

--- a/tools/clang/test/CodeGenSPIRV/type.rwtexture.load.function.return.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwtexture.load.function.return.hlsl
@@ -1,0 +1,32 @@
+// RUN: %dxc -T cs_6_7 -E main -spirv -fspv-target-env=vulkan1.1 %s -fcgl | FileCheck %s
+
+RWTexture2D<float2> textures[];
+
+cbuffer CB {
+	uint index;
+}
+
+RWTexture2D<float2> GetTexture() {
+	return textures[index];
+}
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+// We need to make sure there is no OpLoad on the already loaded texture.
+// CHECK: [[img:%[0-9]+]] = OpFunctionCall %type_2d_image %GetTexture
+// CHECK:                   OpImageWrite [[img]] {{.*}} {{.*}} None
+	GetTexture()[tid.xy] = float2(1.0, 0.0);
+
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_UniformConstant_type_2d_image %textures %int_0
+// CHECK: [[tmp:%[0-9]+]] = OpLoad %type_2d_image [[ptr]]
+// CHECK:                   OpImageWrite [[tmp]] {{.*}} {{.*}} None
+  textures[0][tid.xy] = float2(1.0, 0.0);
+
+// CHECK: [[img:%[0-9]+]] = OpFunctionCall %type_2d_image %GetTexture
+// CHECK:                   OpStore %tex [[img]]
+// CHECK: [[tmp:%[0-9]+]] = OpLoad %type_2d_image %tex
+// CHECK:                   OpImageWrite [[tmp]] {{.*}} {{.*}} None
+	RWTexture2D<float2> tex = GetTexture();
+  tex[tid.xy] = float2(1.0, 0.0);
+}


### PR DESCRIPTION
This code path always added an OpLoad since it expected either an OpAccessChain or a variable.
This is wrong if we get the texture from a called function.

There is one thing I do find weird is the OpAccessChain result is considered to be an L-value. But I'd expect this to be an r-value.

Fixes #4136