### PR TITLE
Update bug_report_spirv.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_spirv.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_spirv.md
@@ -12,11 +12,13 @@ assignees: ''
 
 **Steps to Reproduce**
 <!--- Provide a description of how to reproduce the error. If possible please 
-provide source and tool command line options. If the issue reproduces on
-Compiler Explorer (https://godbolt.org/) or Shader Playground
-(https://shader-playground.timjones.io/) please provide a link. If the source is
-split across multiple files, please preprocess into a single file using DXC's 
-command line `-P -Fi <path>`. --->
+provide source and tool command line options, or if the issue reproduces on
+Compiler Explorer (https://godbolt.org/), please provide a link.
+If the source is split across multiple files, please preprocess into a single file using DXC's 
+command line `-P -Fi <path>`.
+
+Note: Do **not** use Shader Playground. Its DXC version is very stale.
+ --->
 
 
 **Actual Behavior**

--- a/.github/ISSUE_TEMPLATE/bug_report_spirv.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_spirv.md
@@ -16,8 +16,6 @@ provide source and tool command line options, or if the issue reproduces on
 Compiler Explorer (https://godbolt.org/), please provide a link.
 If the source is split across multiple files, please preprocess into a single file using DXC's 
 command line `-P -Fi <path>`.
-
-Note: Do **not** use Shader Playground. Its DXC version is very stale.
  --->
 
 


### PR DESCRIPTION
Removes shader playground link. Shader playground hasn't been updated since earlier this year, hence DXC version is very stale.