### PR TITLE
[Test] fix typo in CompileToShaderHash which compares same value.

### DIFF
--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -599,7 +599,7 @@ public:
       VERIFY_SUCCEEDED(pDxcResult->GetOutput(
           DXC_OUT_SHADER_HASH, IID_PPV_ARGS(&pHashBlob), nullptr));
       std::string hashFromResult = RetrieveHashFromBlob(pHashBlob);
-      VERIFY_ARE_EQUAL(hashFromPart, hashFromPart);
+      VERIFY_ARE_EQUAL(hashFromPart, hashFromResult);
     }
 
     return hashFromPart;


### PR DESCRIPTION
Compare hashFromPart and hashFromResult.

Fixes #5147