### PR TITLE
[tools] add -help option for opt.

### DIFF
--- a/test/HLSL/opt/help.ll
+++ b/test/HLSL/opt/help.ll
@@ -1,0 +1,5 @@
+; RUN: opt -help | FileCheck %s
+
+; Make sure the help message is printed.
+; CHECK: -O1
+; CHECK-SAME: - Optimization level 1. Similar to clang -O1

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -128,6 +128,10 @@ StandardLinkOpts("std-link-opts",
                  cl::desc("Include the standard link time optimizations"));
 #endif // HLSL Change Ends
 
+// HLSL Change Starts: add help option.
+static cl::opt<bool> Help("help", cl::desc("Print help"));
+// HLSL Change Ends
+
 static cl::opt<bool>
 OptLevelO1("O1",
            cl::desc("Optimization level 1. Similar to clang -O1"));
@@ -383,6 +387,12 @@ int __cdecl main(int argc, char **argv) {
 
   cl::ParseCommandLineOptions(argc, argv,
     "llvm .bc -> .bc modular optimizer and analysis printer\n");
+// HLSL Change Starts: add help option.
+  if (Help) {
+      cl::PrintHelpMessage();
+      return 2;
+  }
+// HLSL Change Ends
 
   if (AnalyzeOnly && NoOutput) {
     errs() << argv[0] << ": analyze mode conflicts with no-output mode.\n";

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -387,12 +387,12 @@ int __cdecl main(int argc, char **argv) {
 
   cl::ParseCommandLineOptions(argc, argv,
     "llvm .bc -> .bc modular optimizer and analysis printer\n");
-// HLSL Change Starts: add help option.
+  // HLSL Change Starts: add help option.
   if (Help) {
-      cl::PrintHelpMessage();
-      return 2;
+    cl::PrintHelpMessage();
+    return 2;
   }
-// HLSL Change Ends
+  // HLSL Change Ends
 
   if (AnalyzeOnly && NoOutput) {
     errs() << argv[0] << ": analyze mode conflicts with no-output mode.\n";


### PR DESCRIPTION
Add -help option to opt in opt.cpp.

The -help option for opt in clean llvm3.7 was disabled with 
[disable -help](https://github.com/microsoft/DirectXShaderCompiler/commit/d5bb3089cf20456d70941b2b00febd7f7dde4a53#diff-1c7e1b16bc72f52ebd811ef2a24aa91fc4df0f9b47c279b75d0bbb0ae1684d0aR1719)

Fixes #5514