### PR TITLE
[SPIRV] Check if decl is identifier before getting name

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -778,7 +778,8 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
         }
       } else {
         const bool isPrototype = !funcDecl->isThisDeclarationADefinition();
-        if (funcDecl->getName() == hlslEntryFunctionName && !isPrototype) {
+        if (funcDecl->getIdentifier() &&
+            funcDecl->getName() == hlslEntryFunctionName && !isPrototype) {
           addFunctionToWorkQueue(spvContext.getCurrentShaderModelKind(),
                                  funcDecl, /*isEntryFunction*/ true);
           numEntryPoints++;

--- a/tools/clang/test/CodeGenSPIRV/func.noidentifier.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/func.noidentifier.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T cs_6_0 -E main -spirv -fcgl  %s -spirv | FileCheck %s
+
+
+// CHECK: %src_main = OpFunction %void
+// CHECK: OpFunctionCall %void %S_operator_Call %s
+// CHECK: OpFunctionEnd
+// CHECK: %S_operator_Call = OpFunction %void None
+// CHECK-NEXT: OpFunctionParameter
+// CHECK-NEXT: OpLabel
+// CHECK-NEXT: OpReturn
+// CHECK-NEXT: OpFunctionEnd
+
+
+struct S
+{
+    void operator()();
+};
+
+void S::operator()()
+{
+}
+
+[numthreads(8,8,1)]
+void main(uint32_t3 gl_GlobalInvocationID : SV_DispatchThreadID)
+{
+  S s;
+  s();
+}
+ 


### PR DESCRIPTION
We hit an assert when trying to get the name of `operator()`. This is
fixed by first checking if it function declatarion is an identifier.

Fixes #6973
