### PR TITLE
existence proof that is_deriv isn't needed

### DIFF
--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -82,7 +82,6 @@ class db_dxil_inst(object):
         self.is_allowed = True  # whether this instruction is allowed in a DXIL program
         self.oload_types = ""  # overload types if applicable
         self.fn_attr = ""  # attribute shorthands: rn=does not access memory,ro=only reads from memory,
-        self.is_deriv = False  # whether this is some kind of derivative
         self.is_gradient = False  # whether this requires a gradient calculation
         self.is_feedback = False  # whether this is a sampler feedback op
         self.is_wave = False  # whether this requires in-wave, cross-lane functionality
@@ -5523,11 +5522,6 @@ class db_dxil(object):
             ","
         ):
             self.name_idx[i].is_gradient = True
-        for i in "DerivCoarseX,DerivCoarseY,DerivFineX,DerivFineY".split(","):
-            assert (
-                self.name_idx[i].is_gradient == True
-            ), "all derivatives are marked as requiring gradients"
-            self.name_idx[i].is_deriv = True
 
         # TODO - some arguments are required to be immediate constants in DXIL, eg resource kinds; add this information
         # consider - report instructions that are overloaded on a single type, then turn them into non-overloaded version of that type


### PR DESCRIPTION
hctdb.py set is_deriv, but only actually used the equivalent is_gradient flag