### PR TITLE
Fix crash when printing instructions that have a metadata attached but no parent.

### DIFF
--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -3049,7 +3049,7 @@ void AssemblyWriter::printMetadataAttachments(
     return;
 
   if (MDNames.empty())
-    TheModule->getMDKindNames(MDNames);
+    MDs[0].second->getContext().getMDKindNames(MDNames);
 
   for (const auto &I : MDs) {
     unsigned Kind = I.first;

--- a/unittests/IR/AsmWriterTest.cpp
+++ b/unittests/IR/AsmWriterTest.cpp
@@ -1,0 +1,37 @@
+//===- llvm/unittest/IR/AsmWriter.cpp - AsmWriter tests -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/MDBuilder.h"
+#include "llvm/IR/Module.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+TEST(AsmWriterTest, DebugPrintDetachedInstruction) {
+
+  // PR24852: Ensure that an instruction can be printed even when it
+  // has metadata attached but no parent.
+  LLVMContext Ctx;
+  auto Ty = Type::getInt32Ty(Ctx);
+  auto Undef = UndefValue::get(Ty);
+  std::unique_ptr<BinaryOperator> Add(BinaryOperator::CreateAdd(Undef, Undef));
+  Add->setMetadata(
+      "", MDNode::get(Ctx, {ConstantAsMetadata::get(ConstantInt::get(Ty, 1))}));
+  std::string S;
+  raw_string_ostream OS(S);
+  Add->print(OS);
+  std::size_t r = OS.str().find("<badref> = add i32 undef, undef, !<empty");
+  EXPECT_TRUE(r != std::string::npos);
+}
+
+}

--- a/unittests/IR/AsmWriterTest.cpp
+++ b/unittests/IR/AsmWriterTest.cpp
@@ -6,8 +6,8 @@
 // License. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Module.h"
@@ -34,4 +34,4 @@ TEST(AsmWriterTest, DebugPrintDetachedInstruction) {
   EXPECT_TRUE(r != std::string::npos);
 }
 
-}
+} // namespace

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 set(IRSources
+  AsmWriterTest.cpp
   AttributesTest.cpp
   ConstantRangeTest.cpp
   ConstantsTest.cpp


### PR DESCRIPTION
Applying patch from upstream LLVM:
https://github.com/llvm/llvm-project/commit/b9b50aaffddf9b3d7b22f42a332811dddb6b9440#diff-69d28d03f6d27b8c800ff1dafb34ede6999a3165c109263e7da48dbbdf964f0aR9
