### PR TITLE
Move hlsl_header definition from lit.site.cfg.in to lit.cfg

### DIFF
--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -210,6 +210,7 @@ if has_plugins and config.llvm_plugin_ext:
 
 config.substitutions.append( ('%llvmshlibdir', config.llvm_shlib_dir) )
 config.substitutions.append( ('%pluginext', config.llvm_plugin_ext) )
+config.hlsl_headers_dir = "@HLSL_HEADERS_DIR@" # HLSL change
 config.substitutions.append( ('%hlsl_headers', config.hlsl_headers_dir) ) #HLSL change
 
 if config.clang_examples:

--- a/tools/clang/test/lit.site.cfg.in
+++ b/tools/clang/test/lit.site.cfg.in
@@ -21,6 +21,7 @@ config.enable_shared = @ENABLE_SHARED@
 config.enable_backtrace = "@ENABLE_BACKTRACES@"
 config.host_arch = "@HOST_ARCH@"
 config.spirv = "@ENABLE_SPIRV_CODEGEN@" =="ON"
+config.hlsl_headers_dir = "@HLSL_HEADERS_DIR@" # HLSL change
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/tools/clang/test/lit.site.cfg.in
+++ b/tools/clang/test/lit.site.cfg.in
@@ -21,7 +21,6 @@ config.enable_shared = @ENABLE_SHARED@
 config.enable_backtrace = "@ENABLE_BACKTRACES@"
 config.host_arch = "@HOST_ARCH@"
 config.spirv = "@ENABLE_SPIRV_CODEGEN@" =="ON"
-config.hlsl_headers_dir = "@HLSL_HEADERS_DIR@" # HLSL change
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
Internal pipelines fail because a definition that was added to lit.site.cfg.in isn't being recognized. This PR moves the definition over to the relevant lit.cfg file, which leaves this autogenerated file unedited. The new definition is picked up and recognized, which prevents failures.