### PR TITLE
Don't force /Zi when using CMAKE_MSVC_DEBUG_INFORMATION_FORMAT

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -357,9 +357,11 @@ if( MSVC )
 
   # Change release to always build debug information out-of-line, but
   # also enable Reference optimization, ie dead function elimination.
-  append("/Zi" CMAKE_CXX_FLAGS_RELEASE)
-  append("/DEBUG /OPT:REF" CMAKE_SHARED_LINKER_FLAGS_RELEASE)
-  append("/DEBUG /OPT:REF" CMAKE_EXE_LINKER_FLAGS_RELEASE)
+  if (NOT CMAKE_MSVC_DEBUG_INFORMATION_FORMAT)
+    append("/Zi" CMAKE_CXX_FLAGS_RELEASE)
+    append("/DEBUG /OPT:REF" CMAKE_SHARED_LINKER_FLAGS_RELEASE)
+    append("/DEBUG /OPT:REF" CMAKE_EXE_LINKER_FLAGS_RELEASE)
+  endif()
 
   # HLSL Changes End
 


### PR DESCRIPTION
Newer versions of CMake have a more robust way of handling debug information settings for Windows. Forcing this on breaks the ability to control how debug info is generated and gets in the way of using sccache.

See CMake's docs:
https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html