### PR TITLE
[SPIRV] Correct local variable declaration scope

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1487,7 +1487,11 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
   }
 
   if (spirvOptions.debugInfoRich) {
-    spvContext.pushDebugLexicalScope(info, debugFunction);
+    if (srcDebugFunction) {
+      spvContext.pushDebugLexicalScope(info, srcDebugFunction);
+    } else {
+      spvContext.pushDebugLexicalScope(info, debugFunction);
+    }
   }
 
   const QualType retType =

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
@@ -2,13 +2,13 @@
 
 // CHECK:  [[set:%[0-9]+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[compUnit:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit
-// CHECK: [[main:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction
-// CHECK: [[mainFnLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 17 1 [[main]]
-// CHECK: [[whileLoopLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 37 3 [[mainFnLexBlock]]
+// CHECK: [[srcMain:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction
+// CHECK: [[srcMainFnLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 17 1 [[srcMain]]
+// CHECK: [[whileLoopLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 37 3 [[srcMainFnLexBlock]]
 // CHECK: [[ifStmtLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 44 20 [[whileLoopLexBlock]]
 // CHECK: [[tempLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 49 7 [[ifStmtLexBlock]]
-// CHECK: [[forLoopLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 22 12 [[mainFnLexBlock]]
-// CHECK: [[srcMain:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction
+// CHECK: [[forLoopLexBlock:%[0-9]+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%[0-9]+}} 22 12 [[srcMainFnLexBlock]]
+// CHECK: [[main:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction
 
 float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:     %main = OpFunction
@@ -16,7 +16,7 @@ float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMain]]
 {
 // CHECK:     %bb_entry = OpLabel
-// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMainFnLexBlock]]
 
   float4 c = 0.xxxx;
   for (;;) {
@@ -26,13 +26,13 @@ float4 main(float4 color : COLOR) : SV_TARGET
     float4 b = 1.xxxx;
     c = c + a + b;
 // CHECK: %for_continue = OpLabel
-// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMainFnLexBlock]]
   }
 // CHECK:    %for_merge = OpLabel
-// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMainFnLexBlock]]
 
 // CHECK:  %while_check = OpLabel
-// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMainFnLexBlock]]
   while (c.x)
   {
 // CHECK:   %while_body = OpLabel
@@ -54,10 +54,10 @@ float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[whileLoopLexBlock]]
 
 // CHECK:%while_continue = OpLabel
-// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMainFnLexBlock]]
   }
 // CHECK:  %while_merge = OpLabel
-// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+// CHECK-NEXT: {{%[0-9]+}} = OpExtInst %void [[set]] DebugScope [[srcMainFnLexBlock]]
 
   return color + c;
 }

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.param.hlsl
@@ -7,21 +7,20 @@
 // CHECK:        [[emptyStr:%[0-9]+]] = OpString ""
 // CHECK:               [[y:%[0-9]+]] = OpString "y"
 // CHECK:               [[x:%[0-9]+]] = OpString "x"
-// CHECK:        [[mainName:%[0-9]+]] = OpString "wrapper"
-// CHECK:           [[color:%[0-9]+]] = OpString "color"
 // CHECK:     [[srcMainName:%[0-9]+]] = OpString "main"
+// CHECK:           [[color:%[0-9]+]] = OpString "color"
+// CHECK:        [[mainName:%[0-9]+]] = OpString "wrapper"
 
 // CHECK: [[int:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Signed
 // CHECK: [[float:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Float
 // CHECK: [[source:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
-// CHECK: [[foo:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[fooName]] {{%[0-9]+}} [[source]] 25 1 {{%[0-9]+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 26 %foo
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[y]] [[float]] [[source]] 25 23 [[foo]] FlagIsLocal 2
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[x]] [[int]] [[source]] 25 14 [[foo]] FlagIsLocal 1
-// CHECK: [[srcMain:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] {{%[0-9]+}} [[source]] 30 1 {{%[0-9]+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 31 %main
+// CHECK: [[foo:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[fooName]] {{%[0-9]+}} [[source]] 24 1 {{%[0-9]+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 25 %foo
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[y]] [[float]] [[source]] 24 23 [[foo]] FlagIsLocal 2
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[x]] [[int]] [[source]] 24 14 [[foo]] FlagIsLocal 1
 // CHECK: [[float4:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] 4
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[color]] [[float4]] [[source]] 30 20 [[srcMain]] FlagIsLocal 1
-// CHECK: [[main:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[srcMainName]] {{%[0-9]+}} [[source]] 30 1 {{%[0-9]+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 31 %src_main
-
+// CHECK: [[srcMain:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[srcMainName]] {{%[0-9]+}} [[source]] 29 1 {{%[0-9]+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 30 %src_main
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[color]] [[float4]] [[source]] 29 20 [[srcMain]] FlagIsLocal 1
+// CHECK: [[main:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] {{%[0-9]+}} [[source]] 29 1 {{%[0-9]+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 30 %main
 void foo(int x, float y)
 {
   x = x + y;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.global-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.global-variable.hlsl
@@ -4,10 +4,10 @@
 // CHECK: [[varNameCond:%[0-9]+]] = OpString "cond"
 // CHECK:    [[varNameC:%[0-9]+]] = OpString "c"
 
-// CHECK:      [[source:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
-// CHECK: [[compileUnit:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 // CHECK: [[floatType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Float
 // CHECK: [[float4Type:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeVector [[floatType]] 4
+// CHECK:      [[source:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
+// CHECK: [[compileUnit:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 // CHECK:  [[boolType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Boolean
 
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugGlobalVariable [[varNameCond]] [[boolType]] [[source]] 17 13 [[compileUnit]] [[varNameCond]] %cond FlagIsDefinition

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
@@ -7,6 +7,8 @@
 // CHECK:    [[varNameC:%[0-9]+]] = OpString "c"
 
 // CHECK:  [[uintType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Unsigned
+// CHECK: [[floatType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Float
+// CHECK: [[float4Type:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeVector [[floatType]] 4
 // CHECK:    [[source:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
 // CHECK: [[compileUnit:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 // CHECK:      [[main:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction
@@ -23,8 +25,6 @@
 // CHECK:  [[boolType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Boolean
 // CHECK:                {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameCond]] [[boolType]] [[source]] 34 8 [[mainFnLexBlock]] FlagIsLocal
 
-// CHECK: [[floatType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 Float
-// CHECK: [[float4Type:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeVector [[floatType]] 4
 // CHECK:                {{%[0-9]+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameC]] [[float4Type]] [[source]] 33 10 [[mainFnLexBlock]] FlagIsLocal
 
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.float.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.float.hlsl
@@ -2,11 +2,11 @@
 
 // CHECK:        [[set:%[0-9]+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK:  [[float64Name:%[0-9]+]] = OpString "float64_t"
-// CHECK:  [[float16Name:%[0-9]+]] = OpString "float16_t"
 // CHECK:    [[floatName:%[0-9]+]] = OpString "float"
+// CHECK:  [[float16Name:%[0-9]+]] = OpString "float16_t"
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugTypeBasic [[float64Name]] %uint_64 Float
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugTypeBasic [[float16Name]] %uint_16 Float
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugTypeBasic [[floatName]] %uint_32 Float
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugTypeBasic [[float16Name]] %uint_16 Float
 
 float4 main(float4 color : COLOR) : SV_TARGET {
   float a = 0;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.vulkan.member.function.param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.vulkan.member.function.param.hlsl
@@ -15,34 +15,34 @@
 // CHECK-DAG:    [[strFoo:%[0-9]+]] = OpString "foo"
 // CHECK-DAG:  [[strFunc1:%[0-9]+]] = OpString "foo.func1"
 
+
 // CHECK:    [[int:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic [[strInt]] %uint_32 %uint_4 %uint_0
 // CHECK:   [[unit:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit %uint_1 %uint_4 {{%[0-9]+}} %uint_5
 
 struct foo {
 
-// CHECK: [[a:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeMember [[strA]] [[int]] {{%[0-9]+}} %uint_24 %uint_7 %uint_0 %uint_32 %uint_3
+// CHECK: [[a:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeMember [[strA]] [[int]] {{%[0-9]+}} %uint_25 %uint_7 %uint_0 %uint_32 %uint_3
   int a;
 
 // CHECK:  [[float:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic [[strFloat]] %uint_32 %uint_3 %uint_0
 // CHECK:    [[v4f:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] %uint_4
-// CHECK:      [[b:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeMember [[strB]] [[v4f]] {{%[0-9]+}} %uint_29 %uint_10 %uint_32 %uint_128 %uint_3
+// CHECK:      [[b:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeMember [[strB]] [[v4f]] {{%[0-9]+}} %uint_30 %uint_10 %uint_32 %uint_128 %uint_3
   float4 b;
 
 // CHECK:   [[bool:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic [[strBool]] %uint_32 %uint_2 %uint_0
-// CHECK:      [[c:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeMember [[strC]] [[bool]] {{%[0-9]+}} %uint_33 %uint_8 %uint_160 %uint_32 %uint_3
+// CHECK:      [[c:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeMember [[strC]] [[bool]] {{%[0-9]+}} %uint_34 %uint_8 %uint_160 %uint_32 %uint_3
   bool c;
-
-// CHECK: [[func0t:%[0-9]+]] = OpExtInstWithForwardRefsKHR %void [[set]] DebugTypeFunction %uint_3 %void [[foo:%[0-9]+]] {{%[0-9]+}}
-// CHECK:  [[func0:%[0-9]+]] = OpExtInstWithForwardRefsKHR %void [[set]] DebugFunction [[strFunc0]] [[func0t]] {{%[0-9]+}} %uint_39 %uint_3 [[foo]] {{%[0-9]+}} %uint_3 %uint_39
-// CHECK:            [[foo]] = OpExtInstWithForwardRefsKHR %void [[set]] DebugTypeComposite [[strFoo]] %uint_1 {{%[0-9]+}} %uint_21 %uint_8 [[unit]] [[strFoo]] %uint_192 %uint_3 [[a]] [[b]] [[c]] [[func0]] [[func1:%[0-9]+]]
 
   void func0(float arg) {
     b.x = arg;
   }
 
+// CHECK: [[func0t:%[0-9]+]] = OpExtInstWithForwardRefsKHR %void [[set]] DebugTypeFunction %uint_3 %void [[foo:%[0-9]+]] {{%[0-9]+}}
+// CHECK:  [[func0:%[0-9]+]] = OpExtInstWithForwardRefsKHR %void [[set]] DebugFunction [[strFunc0]] [[func0t]] {{%[0-9]+}} %uint_36 %uint_3 [[foo]] {{%[0-9]+}} %uint_3 %uint_36
+// CHECK:            [[foo]] = OpExtInstWithForwardRefsKHR %void [[set]] DebugTypeComposite [[strFoo]] %uint_1 {{%[0-9]+}} %uint_22 %uint_8 [[unit:%[0-9]+]] [[strFoo]] %uint_192 %uint_3 [[a:%[0-9]+]] [[b:%[0-9]+]] [[c:%[0-9]+]] [[func0]] [[func1:%[0-9]+]]
 
 // CHECK:  [[func1t:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 [[int]] [[foo:%[0-9]+]] [[int]] [[float]] [[bool]]
-// CHECK:           [[func1]] = OpExtInst %void [[set]] DebugFunction [[strFunc1]] [[func1t]] {{%[0-9]+}} %uint_46 %uint_3 [[foo]] {{%[0-9]+}} %uint_3 %uint_46
+// CHECK:   [[func1:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[strFunc1]] [[func1t]] {{%[0-9]+}} %uint_46 %uint_3 [[foo]] {{%[0-9]+}} %uint_3 %uint_46
   int func1(int arg0, float arg1, bool arg2) {
     a = arg0;
     b.y = arg1;

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.function.hlsl
@@ -5,9 +5,9 @@
 // CHECK:             [[set:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 // CHECK:         [[fooName:%[0-9]+]] = OpString "foo"
 // CHECK:        [[emptyStr:%[0-9]+]] = OpString ""
+// CHECK:     [[srcMainName:%[0-9]+]] = OpString "main"
 // CHECK:        [[mainName:%[0-9]+]] = OpString "wrapper"
 // CHECK:          [[clOpts:%[0-9]+]] = OpString " -E main -T ps_6_0 -spirv -fcgl -fspv-debug=vulkan
-// CHECK:     [[srcMainName:%[0-9]+]] = OpString "main"
 
 // CHECK:    [[int:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 %uint_4 %uint_0
 // CHECK:  [[float:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeBasic {{%[0-9]+}} %uint_32 %uint_3 %uint_0
@@ -18,11 +18,11 @@
 
 // Check DebugFunction instructions
 //
-// CHECK: [[mainFnType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 %void
-// CHECK: [[mainDbgFn:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] %uint_46 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_47 
 // CHECK: [[float4:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] %uint_4
 // CHECK: [[srcMainFnType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 [[float4]] [[float4]]
 // CHECK: [[srcMainDbgFn:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[srcMainName]] [[srcMainFnType]] [[source]] %uint_46 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_47 
+// CHECK: [[mainFnType:%[0-9]+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 %void
+// CHECK: [[mainDbgFn:%[0-9]+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] %uint_46 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_47 
 // CHECK: [[mainDbgEp:%[0-9]+]] = OpExtInst %void [[set]] DebugEntryPoint [[mainDbgFn]] [[compilationUnit]] {{%[0-9]+}} [[clOpts]]
 
 // Check DebugFunctionDefinition is in main


### PR DESCRIPTION
Recent changes to the debug information generated by the wrapper function lacked one fix. This produced mismatches between function parameter DebugLocalVariable's and DebugDeclare instructions.  Following wrapper generation, the DebugScope should be set to src_main, not the wrapper.  This PR corrects this oversight.