### PR TITLE
[SPIRV] Cast operands to `and` and `or` to bool

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -767,6 +767,13 @@ private:
   SpirvInstruction *processIntrinsicExecutionMode(const CallExpr *expr,
                                                   bool useIdParams);
 
+  // Returns a spirv instruction with the given binary opcode with operands `a0`
+  // and `a1`. The operands will be cast to bool if they are not already bools.
+  SpirvInstruction *
+  createBinaryOpWithBoolOperands(spv::Op opcode, const Expr *a0, const Expr *a1,
+                                 QualType resultType, SourceLocation loc,
+                                 SourceRange range);
+
   /// Processes the 'firstbit{high|low}' intrinsic functions.
   SpirvInstruction *processIntrinsicFirstbit(const CallExpr *,
                                              GLSLstd450 glslOpcode);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.and.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.and.hlsl
@@ -1,6 +1,9 @@
 // RUN: %dxc -T ps_6_0 -E main -HV 2021 -fcgl  %s -spirv | FileCheck %s
 // RUN: %dxc -T ps_6_0 -E main -HV 2018 -fcgl  %s -spirv | FileCheck %s
 
+// CHECK-DAG: [[v3_0:%[0-9]+]] = OpConstantComposite %v3int %int_0 %int_0 %int_0
+// CHECK-DAG: [[v3_1:%[0-9]+]] = OpConstantComposite %v3int %int_1 %int_1 %int_1
+
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel
 
@@ -33,4 +36,46 @@ void main() {
 // CHECK-NEXT: [[and3:%[0-9]+]] = OpLogicalAnd %bool [[a1]] [[b1]]
 // CHECK-NEXT:      {{%[0-9]+}} = OpCompositeConstruct %v2bool [[and3]] %true
     bool2 t = bool2(and(a, b), true);
+
+    int a_0, b_0, c_0;
+    // Plain assign (scalar)
+// CHECK:      [[a0_int:%[0-9]+]] = OpLoad %int %a_0
+// CHECK-NEXT: [[a0:%[0-9]+]] = OpINotEqual %bool [[a0_int]] %int_0
+// CHECK-NEXT: [[b0_int:%[0-9]+]] = OpLoad %int %b_0
+// CHECK-NEXT: [[b0:%[0-9]+]] = OpINotEqual %bool [[b0_int]] %int_0
+// CHECK-NEXT: [[and0:%[0-9]+]] = OpLogicalAnd %bool [[a0]] [[b0]]
+// CHECK-NEXT: [[sel:%[0-9]+]] = OpSelect %int [[and0]] %int_1 %int_0
+// CHECK-NEXT: OpStore %c_0 [[sel]]
+    c_0 = and(a_0, b_0);
+
+    int1 i_0, j_0, k_0;
+    int3 o_0, p_0, q_0;
+    // Plain assign (vector)
+// CHECK-NEXT: [[i0_int:%[0-9]+]] = OpLoad %int %i_0
+// CHECK-NEXT: [[i0:%[0-9]+]] = OpINotEqual %bool [[i0_int]] %int_0
+// CHECK-NEXT: [[j0_int:%[0-9]+]] = OpLoad %int %j_0
+// CHECK-NEXT: [[j0:%[0-9]+]] = OpINotEqual %bool [[j0_int]] %int_0
+// CHECK-NEXT: [[and1:%[0-9]+]] = OpLogicalAnd %bool [[i0]] [[j0]]
+// CHECK-NEXT: [[sel:%[0-9]+]] = OpSelect %int [[and1]] %int_1 %int_0
+// CHECK-NEXT: OpStore %k_0 [[sel]]
+    k_0 = and(i_0, j_0);
+
+// CHECK-NEXT: [[o0_int:%[0-9]+]] = OpLoad %v3int %o_0
+// CHECK-NEXT: [[o0:%[0-9]+]] = OpINotEqual %v3bool [[o0_int]] [[v3_0]]
+// CHECK-NEXT: [[p0_int:%[0-9]+]] = OpLoad %v3int %p_0
+// CHECK-NEXT: [[p0:%[0-9]+]] = OpINotEqual %v3bool [[p0_int]] [[v3_0]]
+// CHECK-NEXT: [[and2:%[0-9]+]] = OpLogicalAnd %v3bool [[o0]] [[p0]]
+// CHECK-NEXT: [[sel:%[0-9]+]] = OpSelect %v3int [[and2]] [[v3_1]] [[v3_0]]
+// CHECK-NEXT: OpStore %q_0 [[sel]]
+    q_0 = and(o_0, p_0);
+
+// The result of '&&' could be 'const bool'. In such cases, make sure
+// the result type is correct.
+// CHECK:      [[a0_int:%[0-9]+]] = OpLoad %int %a_0
+// CHECK-NEXT: [[a0:%[0-9]+]] = OpINotEqual %bool [[a0_int]] %int_0
+// CHECK-NEXT: [[b0_int:%[0-9]+]] = OpLoad %int %b_0
+// CHECK-NEXT: [[b0:%[0-9]+]] = OpINotEqual %bool [[b0_int]] %int_0
+// CHECK-NEXT: [[and0:%[0-9]+]] = OpLogicalAnd %bool [[a0]] [[b0]]
+// CHECK-NEXT:      {{%[0-9]+}} = OpCompositeConstruct %v2bool [[and0]] %true
+    bool2 t = bool2(and(a_0, b_0), true);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.or.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.or.hlsl
@@ -1,6 +1,8 @@
 // RUN: %dxc -T ps_6_0 -E main -HV 2021 -fcgl  %s -spirv | FileCheck %s
 // RUN: %dxc -T ps_6_0 -E main -HV 2018 -fcgl  %s -spirv | FileCheck %s
 
+// CHECK: [[v3_0:%[0-9]+]] = OpConstantComposite %v3int %int_0 %int_0 %int_0
+
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel
 
@@ -25,4 +27,36 @@ void main() {
 // CHECK-NEXT: OpStore %q [[or2]]
     k = or(i, j);
     q = or(o, p);
+    
+    int r, s;
+    bool t;
+    // Plain assign (scalar)
+// CHECK:      [[r0_int:%[0-9]+]] = OpLoad %int %r
+// CHECK-NEXT: [[r0:%[0-9]+]] = OpINotEqual %bool [[r0_int]] %int_0
+// CHECK-NEXT: [[s0_int:%[0-9]+]] = OpLoad %int %s
+// CHECK-NEXT: [[s0:%[0-9]+]] = OpINotEqual %bool [[s0_int]] %int_0
+// CHECK-NEXT: [[or0:%[0-9]+]] = OpLogicalOr %bool [[r0]] [[s0]]
+// CHECK-NEXT: OpStore %t [[or0]]
+    t = or(r, s);
+
+    int1 u, v;
+    bool1 w;
+    // Plain assign (vector)
+// CHECK-NEXT: [[u0_int:%[0-9]+]] = OpLoad %int %u
+// CHECK-NEXT: [[u0:%[0-9]+]] = OpINotEqual %bool [[u0_int]] %int_0
+// CHECK-NEXT: [[v0_int:%[0-9]+]] = OpLoad %int %v
+// CHECK-NEXT: [[v0:%[0-9]+]] = OpINotEqual %bool [[v0_int]] %int_0
+// CHECK-NEXT: [[or1:%[0-9]+]] = OpLogicalOr %bool [[u0]] [[v0]]
+// CHECK-NEXT: OpStore %w [[or1]]
+    w = or(u, v);
+
+    int3 x, y;
+    bool3 z;
+// CHECK-NEXT: [[x0_int:%[0-9]+]] = OpLoad %v3int %x
+// CHECK-NEXT: [[x0:%[0-9]+]] = OpINotEqual %v3bool [[x0_int]] [[v3_0]]
+// CHECK-NEXT: [[y0_int:%[0-9]+]] = OpLoad %v3int %y
+// CHECK-NEXT: [[y0:%[0-9]+]] = OpINotEqual %v3bool [[y0_int]] [[v3_0]]
+// CHECK-NEXT: [[or2:%[0-9]+]] = OpLogicalOr %v3bool [[x0]] [[y0]]
+// CHECK-NEXT: OpStore %z [[or2]]
+    z = or(x, y);
 }


### PR DESCRIPTION
The `and` and `or` intrinsics are impliemented with templates for the
parameters. This means that the expansion of those intrinics for SPIR-V
must add a cast to bool to make the OpLogicalAnd instruction valid.

Fixes #6995
