### PR TITLE
[Error Handling] Fix DxcContainerBuilder error handling

### DIFF
--- a/lib/DxilContainer/DxcContainerBuilder.cpp
+++ b/lib/DxilContainer/DxcContainerBuilder.cpp
@@ -105,7 +105,7 @@ HRESULT STDMETHODCALLTYPE DxcContainerBuilder::RemovePart(UINT32 fourCC) {
 HRESULT STDMETHODCALLTYPE
 DxcContainerBuilder::SerializeContainer(IDxcOperationResult **ppResult) {
   DxcThreadMalloc TM(m_pMalloc);
-  if (ppResult == nullptr || *ppResult == nullptr)
+  if (ppResult == nullptr)
     return E_INVALIDARG;
 
   try {

--- a/lib/DxilContainer/DxcContainerBuilder.cpp
+++ b/lib/DxilContainer/DxcContainerBuilder.cpp
@@ -104,9 +104,10 @@ HRESULT STDMETHODCALLTYPE DxcContainerBuilder::RemovePart(UINT32 fourCC) {
 
 HRESULT STDMETHODCALLTYPE
 DxcContainerBuilder::SerializeContainer(IDxcOperationResult **ppResult) {
-  DxcThreadMalloc TM(m_pMalloc);
   if (ppResult == nullptr)
     return E_INVALIDARG;
+
+  DxcThreadMalloc TM(m_pMalloc);
 
   try {
     // Allocate memory for new dxil container.
@@ -165,11 +166,9 @@ DxcContainerBuilder::SerializeContainer(IDxcOperationResult **ppResult) {
     }
 
     // Add Hash.
-    LPVOID PTR = pResult->GetBufferPointer();
-    if (!IsDxilContainerLike(PTR, pResult->GetBufferSize()))
-      return E_FAIL;
-
-    HashAndUpdate((DxilContainerHeader *)PTR);
+    if (SUCCEEDED(valHR))
+      HashAndUpdate(IsDxilContainerLike(pResult->GetBufferPointer(),
+                                        pResult->GetBufferSize()));
 
     IFT(DxcResult::Create(
         valHR, DXC_OUT_OBJECT,

--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -644,7 +644,7 @@ int DxcContext::VerifyRootSignature() {
   IFT(pContainerBuilder->AddPart(hlsl::DxilFourCC::DFCC_RootSignature,
                                  pRootSignature));
   CComPtr<IDxcOperationResult> pOperationResult;
-  pContainerBuilder->SerializeContainer(&pOperationResult);
+  IFT(pContainerBuilder->SerializeContainer(&pOperationResult));
   HRESULT status = E_FAIL;
   CComPtr<IDxcBlob> pResult;
   IFT(pOperationResult->GetStatus(&status));

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1228,7 +1228,7 @@ TEST_F(ValidationTest, ValidationFailNoHash) {
   VERIFY_IS_NOT_NULL(pHeader);
 
   BYTE ZeroHash[DxilContainerHashSize] = {0, 0, 0, 0, 0, 0, 0, 0,
-                                        0, 0, 0, 0, 0, 0, 0, 0};
+                                          0, 0, 0, 0, 0, 0, 0, 0};
 
   // Should be equal, this proves the hash isn't written when validation fails
   VERIFY_ARE_EQUAL(memcmp(ZeroHash, pHeader->Hash.Digest, sizeof(ZeroHash)), 0);

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1186,7 +1186,8 @@ TEST_F(ValidationTest, ValidationFailNoHash) {
     return;
   CComPtr<IDxcBlob> pProgram;
 
-  // we need any shader that will pass compilation but fail validation
+  // We need any shader that will pass compilation but fail validation.
+  // This shader reads from uninitialized 'float a', which works for now.
   LPCSTR pSource = R"(
     float main(snorm float b : B) : SV_DEPTH
     {
@@ -1226,11 +1227,11 @@ TEST_F(ValidationTest, ValidationFailNoHash) {
       pProgram->GetBufferPointer(), pProgram->GetBufferSize());
   VERIFY_IS_NOT_NULL(pHeader);
 
-  BYTE Result[DxilContainerHashSize] = {0, 0, 0, 0, 0, 0, 0, 0,
+  BYTE ZeroHash[DxilContainerHashSize] = {0, 0, 0, 0, 0, 0, 0, 0,
                                         0, 0, 0, 0, 0, 0, 0, 0};
-  // ComputeHashRetail(DataToHash, AmountToHash, Result);
-  // Should be unequal, this proves the hash isn't written when validation fails
-  VERIFY_ARE_EQUAL(memcmp(Result, pHeader->Hash.Digest, sizeof(Result)), 0);
+
+  // Should be equal, this proves the hash isn't written when validation fails
+  VERIFY_ARE_EQUAL(memcmp(ZeroHash, pHeader->Hash.Digest, sizeof(ZeroHash)), 0);
 }
 TEST_F(ValidationTest, UpdateCounterFail) {
   if (m_ver.SkipIRSensitiveTest())

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -205,6 +205,7 @@ public:
   TEST_METHOD(SimpleGs1Fail)
   TEST_METHOD(UavBarrierFail)
   TEST_METHOD(UndefValueFail)
+  TEST_METHOD(ValidationFailNoHash)
   TEST_METHOD(UpdateCounterFail)
   TEST_METHOD(LocalResCopy)
   TEST_METHOD(ResCounter)
@@ -1177,6 +1178,57 @@ TEST_F(ValidationTest, UavBarrierFail) {
 }
 TEST_F(ValidationTest, UndefValueFail) {
   TestCheck(L"..\\CodeGenHLSL\\UndefValue.hlsl");
+}
+// verify that containers that are not valid DXIL do not
+// get assigned a hash.
+TEST_F(ValidationTest, ValidationFailNoHash) {
+  if (m_ver.SkipDxilVersion(1, 8))
+    return;
+  CComPtr<IDxcBlob> pProgram;
+  LPCSTR pSource = "float main(snorm float b : B) : SV_DEPTH \
+                 { \
+                   float a; \
+                   return b + a; \
+                 }";
+
+  CComPtr<IDxcBlobEncoding> pSourceBlob;
+  Utf8ToBlob(m_dllSupport, pSource, &pSourceBlob);
+  std::vector<LPCWSTR> pArguments = {L"-Vd"};
+  LPCSTR pShaderModel = "ps_6_0";
+  bool result = CompileSource(pSourceBlob, pShaderModel, pArguments.data(), 1,
+                              nullptr, 0, &pProgram);
+
+  VERIFY_IS_TRUE(result);
+
+  CComPtr<IDxcValidator> pValidator;
+  CComPtr<IDxcOperationResult> pResult;
+  unsigned Flags = 0;
+  VERIFY_SUCCEEDED(
+      m_dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
+
+  VERIFY_SUCCEEDED(pValidator->Validate(pProgram, Flags, &pResult));
+  HRESULT status;
+  VERIFY_IS_NOT_NULL(pResult);
+  CComPtr<IDxcBlob> pValidationOutput;
+  pResult->GetStatus(&status);
+
+  // expect validation to fail
+  VERIFY_FAILED(status);
+  pResult->GetResult(&pValidationOutput);
+  // Make sure the validation output is not null when hashing.
+  VERIFY_SUCCEEDED(pValidationOutput != nullptr);
+
+  hlsl::DxilContainerHeader *pHeader =
+      (hlsl::DxilContainerHeader *)pProgram->GetBufferPointer();
+  // Validate the hash.
+  constexpr uint32_t HashStartOffset =
+      offsetof(struct DxilContainerHeader, Version);
+  auto *DataToHash = (const BYTE *)pHeader + HashStartOffset;
+  UINT AmountToHash = pHeader->ContainerSizeInBytes - HashStartOffset;
+  BYTE Result[DxilContainerHashSize];
+  ComputeHashRetail(DataToHash, AmountToHash, Result);
+  // Should be unequal, this proves the hash isn't written when validation fails
+  VERIFY_ARE_NOT_EQUAL(memcmp(Result, pHeader->Hash.Digest, sizeof(Result)), 0);
 }
 TEST_F(ValidationTest, UpdateCounterFail) {
   if (m_ver.SkipIRSensitiveTest())

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1222,11 +1222,12 @@ TEST_F(ValidationTest, ValidationFailNoHash) {
   // Make sure the validation output is not null even when validation fails
   VERIFY_SUCCEEDED(pValidationOutput != nullptr);
 
-  hlsl::DxilContainerHeader *pHeader =
-      IsDxilContainerLike(pProgram->GetBufferPointer(), pProgram->GetBufferSize());
+  hlsl::DxilContainerHeader *pHeader = IsDxilContainerLike(
+      pProgram->GetBufferPointer(), pProgram->GetBufferSize());
   VERIFY_IS_NOT_NULL(pHeader);
 
-  BYTE Result[DxilContainerHashSize] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  BYTE Result[DxilContainerHashSize] = {0, 0, 0, 0, 0, 0, 0, 0,
+                                        0, 0, 0, 0, 0, 0, 0, 0};
   // ComputeHashRetail(DataToHash, AmountToHash, Result);
   // Should be unequal, this proves the hash isn't written when validation fails
   VERIFY_ARE_EQUAL(memcmp(Result, pHeader->Hash.Digest, sizeof(Result)), 0);


### PR DESCRIPTION
Some error handling changes were incorrectly made to the container assembler, as described in the issue below. 
This is bad because the API protocol for error handling must remain consistent across all functions. This PR
aims to restore the correct semantic meaning of returning bad HR values. 
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7051