### PR TITLE
[Pipelines] Extend time and add PR trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
       displayName: 'DXIL Tests'
 
   - job: Nix
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
 
     variables:
       macOS: macOS-latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,10 @@
 trigger:
   - main
   - release*
+
+pr: 
+  - main
+  - release*
   
 resources:
 - repo: self
@@ -9,7 +13,7 @@ stages:
 - stage: Build
   jobs:
   - job: Windows
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
 
     pool:
       vmImage: windows-2022


### PR DESCRIPTION
When the pipeline builds and tests in a windows environment, the time limit of 90 minutes reached. There is an insufficient amount of time available to run the pipeline in the windows environment. So, this PR increases the limit to 120 minutes.
Here is an example of insufficient time constraints:
https://github.com/microsoft/DirectXShaderCompiler/pull/7065
Additionally, this PR explicitly adds a trigger when a PR is created, so that the pipeline is explicitly run when that event happens. This allows the pipeline to be run with stricter security rules.