### PR TITLE
[DO NOT MERGE] Testing adding ExecTests to PR validation and build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
       displayName: 'Building'
     - script: |
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
-        call utils\hct\hcttest.cmd -$(configuration) noexec
+        call utils\hct\hcttest.cmd -$(configuration)
       displayName: 'DXIL Tests'
 
   - job: Nix


### PR DESCRIPTION
Remove 'noexec' arg when calling hcttest.cmd in base azure-pipelines.yml