### PR TITLE
[SPIRV] Avoid invlid SIPR-V

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8095,7 +8095,8 @@ void SpirvEmitter::assignToMSOutAttribute(
   // All other attribute writes are handled below.
   auto *varInstr = declIdMapper.getStageVarInstruction(decl);
   QualType valueType = value->getAstResultType();
-  if (valueType->isBooleanType()) {
+  if (valueType->isBooleanType() &&
+      semanticInfo.getKind() != hlsl::Semantic::Kind::CullPrimitive) {
     // Externally visible variables are changed to uint, so we need to cast the
     // value to uint.
     value = castToInt(value, valueType, astContext.UnsignedIntTy, loc);

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.cullprimative.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.cullprimative.hlsl
@@ -9,7 +9,7 @@ struct MeshletPrimitiveOut
 // specification says that externally visible variables cannot be bool.
 // CHECK: OpDecorate [[var:%[0-9]+]] BuiltIn CullPrimitiveEXT
 // CHECK: OpDecorate [[var]] PerPrimitiveEXT
-// CHECK: [[var]] = OpVariable %_ptr_Output__arr_uint_uint_2 Output
+// CHECK: [[var]] = OpVariable %_ptr_Output__arr_bool_uint_2 Output
 
 struct VertOut
 {
@@ -28,7 +28,7 @@ void main(uint svGroupIndex : SV_GROUPINDEX,
 
 // Make sure that the references to m_cullPrimitive use uints.
 // CHECK: [[idx:%[0-9]+]] = OpLoad %uint %gl_LocalInvocationIndex
-// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Output_uint [[var]] [[idx]]
-// CHECK: OpStore [[ac]] %uint_0
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Output_bool [[var]] [[idx]]
+// CHECK: OpStore [[ac]] %false
     primitives[svGroupIndex].m_cullPrimitive = false;
 }

--- a/tools/clang/test/CodeGenSPIRV/sm6_6.descriptorheap.acbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6_6.descriptorheap.acbuffer.hlsl
@@ -9,6 +9,7 @@
 // CHECK:   OpDecorate [[resource_heap_abuffer]] Binding 0
 // CHECK:   OpDecorate [[resource_heap_abuffer_counter:%[_a-zA-Z0-9]+]] DescriptorSet 0
 // CHECK:   OpDecorate [[resource_heap_abuffer_counter]] Binding 1
+// CHECK-NOT: OpDecorate %_runtimearr_type_ACSBuffer_counter ArrayStride
 
 
 // CHECK-DAG:           [[ra_uint_t:%[_a-zA-Z0-9]+]] = OpTypeRuntimeArray %uint

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.hlsl
@@ -7,8 +7,10 @@ struct PSInput
 
 // CHECK: OpDecorate %g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %g_rwbuffer Binding 0
+// CHECK-NOT: OpDecorate %_arr_type_ACSBuffer_counter_uint_5 ArrayStride
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
+// CHECK-NOT: OpDecorate %_arr_type_ACSBuffer_counter_uint_5 ArrayStride
 
 // CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.unbounded.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.unbounded.counter.hlsl
@@ -7,8 +7,10 @@ struct PSInput
 
 // CHECK: OpDecorate %g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %g_rwbuffer Binding 0
+// CHECK-NOT: OpDecorate %_runtimearr_type_ACSBuffer_counter ArrayStride
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
+// CHECK-NOT: OpDecorate %_runtimearr_type_ACSBuffer_counter ArrayStride
 
 // CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_RWStructuredBuffer_uint Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_ACSBuffer_counter Uniform


### PR DESCRIPTION
1. Array with the block decoration are not suppose to have an array
   stride.
2. The CullPrimitive output should be an array of bools.
