### PR TITLE
[SPIRV] Add the vk::image_format to runtime arrays

### DIFF
--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -214,6 +214,17 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
                                                  arrayType->getStride());
             instr->setResultType(resultType);
           }
+        } else if (const auto *runtimeArrayType =
+                       dyn_cast<RuntimeArrayType>(resultType)) {
+          if (const auto *imageType =
+                  dyn_cast<ImageType>(runtimeArrayType->getElementType())) {
+            auto newImgType = spvContext.getImageType(
+                imageType,
+                vkImgFeatures.format.value_or(spv::ImageFormat::Unknown));
+            resultType = spvContext.getRuntimeArrayType(
+                newImgType, runtimeArrayType->getStride());
+            instr->setResultType(resultType);
+          }
         }
       }
     }

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.hlsl
@@ -60,6 +60,12 @@ RWBuffer<int64_t> Buf_r64i;
 [[vk::image_format("r64ui")]]
 RWBuffer<uint64_t> Buf_r64ui;
 
+[[vk::image_format("r16f")]]
+// CHECK: [[ImgType:%[0-9a-zA-Z_]+]] = OpTypeImage %float 2D 2 0 0 2 R16f
+// CHECK: [[ArrayType:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[ImgType]]
+// CHECK: [[PtrType:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[ArrayType]]
+RWTexture2D<float> Buf_r16f_bindless[];
+
 struct S {
     RWBuffer<float4> b;
 };


### PR DESCRIPTION
A case was missed when adding the `vk::image_format` to the image types.
We did not handle runtime arrays. We fix that oversight.

Fixes #6880
