### PR TITLE
[NFC] Remove unused functions in ExecutionTest.cpp and assert.cpp (#7129)

### DIFF
--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -10,6 +10,8 @@
 #include "assert.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
+
+#if defined(LLVM_ASSERTIONS_TRAP) || !defined(WIN32)
 namespace {
 void llvm_assert_trap(const char *_Message, const char *_File, unsigned _Line,
                       const char *_Function) {
@@ -18,6 +20,7 @@ void llvm_assert_trap(const char *_Message, const char *_File, unsigned _Line,
   LLVM_BUILTIN_TRAP;
 }
 } // namespace
+#endif
 
 #ifdef _WIN32
 #include "dxc/Support/Global.h"

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -6881,22 +6881,6 @@ ToleranceType ToleranceStringToEnum(LPCWSTR toleranceType) {
 }
 
 static bool CompareOutputWithExpectedValueFloat(
-    float output, float ref, ToleranceType type, double tolerance,
-    hlsl::DXIL::Float32DenormMode mode = hlsl::DXIL::Float32DenormMode::Any) {
-  if (type == ToleranceType::RELATIVE_EPSILON) {
-    return CompareFloatRelativeEpsilon(output, ref, (int)tolerance, mode);
-  } else if (type == ToleranceType::EPSILON) {
-    return CompareFloatEpsilon(output, ref, (float)tolerance, mode);
-  } else if (type == ToleranceType::ULP) {
-    return CompareFloatULP(output, ref, (int)tolerance, mode);
-  } else {
-    LogErrorFmt(L"Failed to read comparison type %S", type);
-  }
-
-  return false;
-}
-
-static bool CompareOutputWithExpectedValueFloat(
     float output, float ref, LPCWSTR type, double tolerance,
     hlsl::DXIL::Float32DenormMode mode = hlsl::DXIL::Float32DenormMode::Any) {
   if (_wcsicmp(type, L"Relative") == 0) {
@@ -6920,21 +6904,6 @@ static bool VerifyOutputWithExpectedValueFloat(
 }
 
 static bool CompareOutputWithExpectedValueHalf(uint16_t output, uint16_t ref,
-                                               ToleranceType type,
-                                               double tolerance) {
-  if (type == ToleranceType::RELATIVE_EPSILON) {
-    return CompareHalfRelativeEpsilon(output, ref, (int)tolerance);
-  } else if (type == ToleranceType::EPSILON) {
-    return CompareHalfEpsilon(output, ref, (float)tolerance);
-  } else if (type == ToleranceType::ULP) {
-    return CompareHalfULP(output, ref, (float)tolerance);
-  } else {
-    LogErrorFmt(L"Failed to read comparison type %S", type);
-    return false;
-  }
-}
-
-static bool CompareOutputWithExpectedValueHalf(uint16_t output, uint16_t ref,
                                                LPCWSTR type, double tolerance) {
   if (_wcsicmp(type, L"Relative") == 0) {
     return CompareHalfRelativeEpsilon(output, ref, (int)tolerance);
@@ -6952,29 +6921,6 @@ static bool VerifyOutputWithExpectedValueHalf(uint16_t output, uint16_t ref,
                                               LPCWSTR type, double tolerance) {
   return VERIFY_IS_TRUE(
       CompareOutputWithExpectedValueHalf(output, ref, type, tolerance));
-}
-
-template <typename T>
-static bool CompareOutputWithExpectedValue(T output, T ref,
-                                           ToleranceType toleranceType,
-                                           double tolerance) {
-  if (std::is_same<T, DirectX::PackedVector::HALF>::value) { // uint16 treated
-                                                             // as half
-    return CompareOutputWithExpectedValueHalf((uint16_t)output, (uint16_t)ref,
-                                              toleranceType, tolerance);
-  } else if (std::is_integral<T>::value &&
-             std::is_signed<T>::value) { // signed ints
-    return CompareOutputWithExpectedValueInt((int)output, (int)ref,
-                                             (int)tolerance);
-  } else if (std::is_integral<T>::value) { // unsigned ints
-    return CompareOutputWithExpectedValueUInt((uint32_t)output, (uint32_t)ref,
-                                              (uint32_t)tolerance);
-  } else if (std::is_floating_point<T>::value) { // floating point
-    return CompareOutputWithExpectedValueFloat((float)output, (float)ref,
-                                               toleranceType, tolerance);
-  }
-
-  DXASSERT_NOMSG("Invalid Parameter Type");
 }
 
 template <typename T>


### PR DESCRIPTION
Some functions need to be removed / changed to unblock some internal pipelines. They are emitting warnings that they are unused. Specifically, `CompareOutputWithExpectedValueFloat`, `CompareOutputWithExpectedValueHalf`, and
`CompareOutputWithExpectedValueFloat` need to be removed because they are unused.
Additionally, there is a case in assert.cpp where `llvm_assert_trap` is left unused depending on what's been defined and how the preprocessor directives execute. This needs to be remedied so that the function is only defined when it is used.