### PR TITLE
[SPIRV] Fix decoration attributes on members.

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1341,7 +1341,7 @@ def VKDecorateExt : InheritableAttr {
 
 def VKDecorateIdExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_decorate_id">];
-  let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
+  let Subjects = SubjectList<[Function, Var, ParmVar, TypedefName], ErrorDiag>;
   let Args = [UnsignedArgument<"decorate">, VariadicExprArgument<"arguments">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
@@ -1349,7 +1349,7 @@ def VKDecorateIdExt : InheritableAttr {
 
 def VKDecorateStringExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_decorate_string">];
-  let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
+  let Subjects = SubjectList<[Function, Var, ParmVar, TypedefName], ErrorDiag>;
   let Args = [UnsignedArgument<"decorate">, VariadicStringArgument<"arguments">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2333,36 +2333,42 @@ def err_duplicate_mangled_name : Error<
   "definition with same mangled name as another definition">;
 def err_cyclic_alias : Error<
   "alias definition is part of a cycle">;
-def warn_attribute_wrong_decl_type : Warning<
-  "%0 attribute only applies to %select{functions|unions|"
-  "variables and functions|functions and methods|parameters|"
-  "functions, methods and blocks|functions, methods, and classes|"
-  "functions, methods, and parameters|classes|enums|variables|methods|"
-  "variables, functions and labels|fields and global variables|structs|"
-  "variables and typedefs|thread-local variables|"
-  "variables and fields|variables, data members and tag types|"
-  "types and namespaces|Objective-C interfaces|methods and properties|"
-  "struct or union|struct, union or class|types|"
-  "Objective-C instance methods|init methods of interface or class extension declarations|"
-  "variables, functions and classes|Objective-C protocols|"
-  "functions and global variables|structs, unions, and typedefs|structs and typedefs|"
-  "interface or protocol declarations|kernel functions|"
-  // SPIRV Change Starts
-  "fields|"
-  "global variables of scalar type|"
-  "global variables of struct type|"
-  "global variables, cbuffers, and tbuffers|"
-  "Textures and Samplers|"
-  "RWTextures, RasterizerOrderedTextures, Buffers, RWBuffers, and RasterizerOrderedBuffers|"
-  "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
-  "SubpassInput, SubpassInputMS|"
-  "cbuffer or ConstantBuffer|"
-  // SPIRV Change Ends
-  // HLSL Change Starts - add 3 more enum values
-  "variables and parameters|functions, parameters, and fields|"
-  "functions, variables, parameters, fields, and types}1">,
-  // HLSL Change Ends
-  InGroup<IgnoredAttributes>;
+def warn_attribute_wrong_decl_type
+    : Warning<
+          "%0 attribute only applies to %select{functions|unions|"
+          "variables and functions|functions and methods|parameters|"
+          "functions, methods and blocks|functions, methods, and classes|"
+          "functions, methods, and parameters|classes|enums|variables|methods|"
+          "variables, functions and labels|fields and global variables|structs|"
+          "variables and typedefs|thread-local variables|"
+          "variables and fields|variables, data members and tag types|"
+          "types and namespaces|Objective-C interfaces|methods and properties|"
+          "struct or union|struct, union or class|types|"
+          "Objective-C instance methods|init methods of interface or class "
+          "extension declarations|"
+          "variables, functions and classes|Objective-C protocols|"
+          "functions and global variables|structs, unions, and "
+          "typedefs|structs and typedefs|"
+          "interface or protocol declarations|kernel functions|"
+          // SPIRV Change Starts
+          "fields|"
+          "global variables of scalar type|"
+          "global variables of struct type|"
+          "global variables, cbuffers, and tbuffers|"
+          "Textures and Samplers|"
+          "RWTextures, RasterizerOrderedTextures, Buffers, RWBuffers, and "
+          "RasterizerOrderedBuffers|"
+          "RWStructuredBuffers, AppendStructuredBuffers, and "
+          "ConsumeStructuredBuffers|"
+          "SubpassInput, SubpassInputMS|"
+          "cbuffer or ConstantBuffer|"
+          "functions, variables, parameters, and types|"
+          // SPIRV Change Ends
+          // HLSL Change Starts - add 3 more enum values
+          "variables and parameters|functions, parameters, and fields|"
+          "functions, variables, parameters, fields, and types}1">,
+      // HLSL Change Ends
+      InGroup<IgnoredAttributes>;
 def err_attribute_wrong_decl_type : Error<warn_attribute_wrong_decl_type.Text>;
 def warn_type_attribute_wrong_type : Warning<
   "'%0' only applies to %select{function|pointer|"

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -302,11 +302,12 @@ public:
               llvm::Optional<uint32_t> offset_ = llvm::None,
               llvm::Optional<uint32_t> matrixStride_ = llvm::None,
               llvm::Optional<bool> isRowMajor_ = llvm::None,
-              bool relaxedPrecision = false, bool precise = false)
+              bool relaxedPrecision = false, bool precise = false,
+              llvm::Optional<AttrVec> attributes = llvm::None)
         : type(type_), fieldIndex(fieldIndex_), name(name_), offset(offset_),
           sizeInBytes(llvm::None), matrixStride(matrixStride_),
           isRowMajor(isRowMajor_), isRelaxedPrecision(relaxedPrecision),
-          isPrecise(precise) {
+          isPrecise(precise), bitfield(llvm::None), attributes(attributes) {
       // A StructType may not contain any hybrid types.
       assert(!isa<HybridType>(type_));
     }
@@ -335,6 +336,8 @@ public:
     bool isPrecise;
     // Information about the bitfield (if applicable).
     llvm::Optional<BitfieldInfo> bitfield;
+    // Other attributes applied to the field.
+    llvm::Optional<AttrVec> attributes;
   };
 
   StructType(
@@ -489,10 +492,11 @@ public:
               hlsl::ConstantPacking *packOffset = nullptr,
               const hlsl::RegisterAssignment *regC = nullptr,
               bool precise = false,
-              llvm::Optional<BitfieldInfo> bitfield = llvm::None)
+              llvm::Optional<BitfieldInfo> bitfield = llvm::None,
+              llvm::Optional<AttrVec> attributes = llvm::None)
         : astType(astType_), name(name_), vkOffsetAttr(offset),
           packOffsetAttr(packOffset), registerC(regC), isPrecise(precise),
-          bitfield(std::move(bitfield)) {}
+          bitfield(std::move(bitfield)), attributes(std::move(attributes)) {}
 
     // The field's type.
     QualType astType;
@@ -509,6 +513,8 @@ public:
     // Whether this field is a bitfield or not. If set to false, bitfield width
     // value is undefined.
     llvm::Optional<BitfieldInfo> bitfield;
+    // Other attributes applied to the field.
+    llvm::Optional<AttrVec> attributes;
   };
 
   HybridStructType(

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -867,6 +867,7 @@ enum AttributeDeclKind {
   ExpectedCounterStructuredBuffer,
   ExpectedSubpassInput,
   ExpectedCTBuffer,
+  ExpectedFunctionVariableParamOrTypedef,
   // SPIRV Change Ends
   // HLSL Change Begins - add attribute decl combinations
   ExpectedVariableOrParam,

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -2552,6 +2552,19 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
       // NonWritable decorations
       if (structType->isReadOnly())
         emitDecoration(id, spv::Decoration::NonWritable, {}, i);
+
+      if (field.attributes.hasValue()) {
+        for (auto &attr : field.attributes.getValue()) {
+          if (auto decorateExtAttr = dyn_cast<VKDecorateExtAttr>(attr)) {
+            emitDecoration(
+                id,
+                static_cast<spv::Decoration>(decorateExtAttr->getDecorate()),
+                {decorateExtAttr->literals_begin(),
+                 decorateExtAttr->literals_end()},
+                i);
+          }
+        }
+      }
     }
 
     // Emit Block or BufferBlock decorations if necessary.

--- a/tools/clang/test/CodeGenSPIRV/inline-spirv/spv.inline.decorate.member.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/inline-spirv/spv.inline.decorate.member.hlsl
@@ -1,0 +1,40 @@
+// RUN: %dxc -T ps_6_0 -E main -Vd -spirv %s -spirv | FileCheck %s
+
+template<class T, class U>
+[[vk::ext_instruction(/*spv::OpBitcast*/124)]]
+T Bitcast(U);
+
+// CHECK: OpMemberDecorate %S 0 Offset 0
+// CHECK: OpMemberDecorate %S 1 Offset 16
+// CHECK: %S = OpTypeStruct %v4float %v4float
+
+struct S
+{
+    [[vk::ext_decorate(/*offset*/ 35, 0)]] float4 f1;
+    [[vk::ext_decorate(/*offset*/ 35, 16)]] float4 f2;
+};
+
+using PointerType = vk::SpirvOpaqueType<
+    /* OpTypePointer */ 32,
+    /* PhysicalStorageBuffer */ vk::Literal<vk::integral_constant<uint,5349> >,
+    S>;
+
+[[vk::ext_capability(/*PhysicalStorageBufferAddresses */ 5347 )]]
+[[vk::ext_instruction( /*OpLoad*/ 61 )]]
+S Load(PointerType pointer,
+       [[vk::ext_literal]] uint32_t __aligned=/*Aligned*/0x00000002,
+       [[vk::ext_literal]] uint32_t __alignment=32);
+
+uint64_t address;
+
+float4 main() : SV_TARGET
+{
+
+// CHECK: [[BC:%[0-9]+]] = OpBitcast %_ptr_PhysicalStorageBuffer_S {{%[0-9]+}}
+  PointerType ptr = Bitcast<PointerType>(address);
+
+// CHECK: [[LD:%[0-9]+]] = OpLoad %S [[BC]] Aligned 32
+// CHECK: [[RET:%[0-9]+]] = OpCompositeExtract %v4float [[LD]] 0
+// CHECK: OpStore %out_var_SV_TARGET [[RET]]
+  return Load(ptr).f1;
+}

--- a/tools/clang/test/SemaHLSL/attributes/spv.inline.decorate.member.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/spv.inline.decorate.member.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T ps_6_0 -E main -verify -spirv %s
+
+struct S
+{
+    [[vk::ext_decorate_id(/*offset*/ 35, 0)]] float4 f1; /* expected-error{{'ext_decorate_id' attribute only applies to functions, variables, parameters, and types}} */
+    [[vk::ext_decorate_string(/*offset*/ 35, "16")]] float4 f2; /* expected-error{{'ext_decorate_string' attribute only applies to functions, variables, parameters, and types}} */
+};
+
+float4 main() : SV_TARGET
+{
+
+}

--- a/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -2327,6 +2327,10 @@ static std::string CalculateDiagnostic(const Record &S) {
     case ObjCProtocol | ObjCInterface:
       return "ExpectedObjectiveCInterfaceOrProtocol";
     case Field | Var: return "ExpectedFieldOrGlobalVar";
+    // SPIRV Changes Start
+    case Func | Var | Param | Type:
+      return "ExpectedFunctionVariableParamOrTypedef";
+    // SPIRV Changes End
     // HLSL Changes Start
     case Var | Param:
       return "ExpectedVariableOrParam";


### PR DESCRIPTION
This commit implements adding the `vk::ext_decorate` on a field. It also
adds an error in sema if `vk::ext_decorate_id` or
`vk::ext_decorate_string` are used on members.

For `vk::ext_decorate_id`, there is no `OpMemberDecorateId` instruction,
so we cannot add apply these decorations to members.

For `vk::ext_decorate_string`, there is only one decoration that uses
OpDecorateString or OpMemberDecorateString, UserSemantic. However, that
decoration could have used OpDecorate or OpMemberDecorate because those
instructions accept string literals. I do not expect any new decorations
to use OpDecorateString or OpMemberDecorateString. I may eventually want
to deprecate `vk::ext_decorate_string`.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/4195
