### PR TITLE
[SPIRV] Stop running ReplaceInvalidOpcPass

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -15218,7 +15218,6 @@ bool SpirvEmitter::spirvToolsLegalize(std::vector<uint32_t> *mod,
     optimizer.RegisterPass(
         spvtools::CreateAggressiveDCEPass(spirvOptions.preserveInterface));
   }
-  optimizer.RegisterPass(spvtools::CreateReplaceInvalidOpcodePass());
   optimizer.RegisterPass(spvtools::CreateCompactIdsPass());
   optimizer.RegisterPass(spvtools::CreateSpreadVolatileSemanticsPass());
   if (spirvOptions.fixFuncCallArguments) {

--- a/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.compute.linear.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s --check-prefix=CHECK
 
 // CHECK: OpCapability ComputeDerivativeGroupLinearKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.compute.quad.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupQuadsKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.unclamped.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.unclamped.compute.linear.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupLinearKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.unclamped.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.calculate.lod.unclamped.compute.quad.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupQuadsKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.compute.linear.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupLinearKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.compute.quad.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupQuadsKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.samplebias.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.samplebias.compute.linear.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupLinearKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
@@ -13,9 +13,10 @@ Texture1D        <float>  t1;
 [numthreads(8,1,1)]
 void main(uint3 id : SV_GroupThreadID)
 {
+    Texture1D<float> local_texture = t1;
     // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
     // CHECK-NEXT:   [[ss:%[0-9]+]] = OpLoad %type_sampler %ss
     // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss]]
     // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_1 Bias %float_0_5
-    o[0] = t1.SampleBias(ss, 1, 0.5);
+    o[0] = local_texture.SampleBias(ss, 1, 0.5);
 }

--- a/tools/clang/test/CodeGenSPIRV/texture.samplebias.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.samplebias.compute.quad.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupQuadsKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.samplecmp.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.samplecmp.compute.linear.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupLinearKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"

--- a/tools/clang/test/CodeGenSPIRV/texture.samplecmp.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.samplecmp.compute.quad.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives %s -spirv  2>&1 | FileCheck %s
 
 // CHECK: OpCapability ComputeDerivativeGroupQuadsKHR
 // CHECK: OpExtension "SPV_NV_compute_shader_derivatives"


### PR DESCRIPTION
That pass was intended to remove derivative instructions used in
non-fragment shaders. Now they are available in more places because of
new extensions. In general,
it is better practice to issue an error if they are used in an place
they are not allowed.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7086
