### PR TITLE
[SPIR-V] Fix OpBitFieldExtract emulation for unsigned integer

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -978,11 +978,15 @@ SpirvInstruction *SpirvBuilder::createEmulatedBitFieldExtract(
                                    base, leftShiftOffset, loc, range);
 
   //  input: BBBBCCCCCCCCDDDD0000
-  // output: SSSSSSSSSSSSSSSSBBBB
+  // output: SSSSSSSSSSSSSSSSBBBB for signed
+  //         0000000000000000BBBB for unsigned
+  auto rightShiftOp = resultType->isSignedIntegerOrEnumerationType()
+                          ? spv::Op::OpShiftRightArithmetic
+                          : spv::Op::OpShiftRightLogical;
   auto *rightShiftOffset = getConstantInt(
       astContext.UnsignedIntTy, llvm::APInt(32, baseTypeBitwidth - bitCount));
-  auto *rightShift = createBinaryOp(spv::Op::OpShiftRightArithmetic, resultType,
-                                    leftShift, rightShiftOffset, loc, range);
+  auto *rightShift = createBinaryOp(rightShiftOp, resultType, leftShift,
+                                    rightShiftOffset, loc, range);
 
   if (resultType == QualType({})) {
     auto baseType = dyn_cast<IntegerType>(base->getResultType());

--- a/tools/clang/test/CodeGenSPIRV/op.struct.access.bitfield.sized.read.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.struct.access.bitfield.sized.read.hlsl
@@ -32,13 +32,13 @@ void main() {
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s1 %int_0
 // CHECK: [[raw:%[0-9]+]] = OpLoad %ulong [[ptr]]
 // CHECK: [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[raw]] %uint_32
-// CHECK: [[out:%[0-9]+]] = OpShiftRightArithmetic %ulong [[tmp]] %uint_32
+// CHECK: [[out:%[0-9]+]] = OpShiftRightLogical %ulong [[tmp]] %uint_32
 // CHECK:                   OpStore %vulong [[out]]
   vulong = s1.f2;
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s1 %int_0
 // CHECK: [[raw:%[0-9]+]] = OpLoad %ulong [[ptr]]
 // CHECK: [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[raw]] %uint_31
-// CHECK: [[out:%[0-9]+]] = OpShiftRightArithmetic %ulong [[tmp]] %uint_63
+// CHECK: [[out:%[0-9]+]] = OpShiftRightLogical %ulong [[tmp]] %uint_63
 // CHECK:                   OpStore %vulong [[out]]
 
   S2 s2;
@@ -60,20 +60,20 @@ void main() {
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s3 %int_0
 // CHECK: [[raw:%[0-9]+]] = OpLoad %ulong [[ptr]]
 // CHECK: [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[raw]] %uint_19
-// CHECK: [[out:%[0-9]+]] = OpShiftRightArithmetic %ulong [[tmp]] %uint_19
+// CHECK: [[out:%[0-9]+]] = OpShiftRightLogical %ulong [[tmp]] %uint_19
 // CHECK:                   OpStore %vulong [[out]]
   vulong = s3.f2;
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s3 %int_0
 // CHECK: [[raw:%[0-9]+]] = OpLoad %ulong [[ptr]]
 // CHECK: [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[raw]] %uint_9
-// CHECK: [[out:%[0-9]+]] = OpShiftRightArithmetic %ulong [[tmp]] %uint_54
+// CHECK: [[out:%[0-9]+]] = OpShiftRightLogical %ulong [[tmp]] %uint_54
 // CHECK:                   OpStore %vulong [[out]]
 
   vushort = s3.f3;
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s3 %int_1
 // CHECK: [[raw:%[0-9]+]] = OpLoad %ushort [[ptr]]
 // CHECK: [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[raw]] %uint_9
-// CHECK: [[out:%[0-9]+]] = OpShiftRightArithmetic %ushort [[tmp]] %uint_9
+// CHECK: [[out:%[0-9]+]] = OpShiftRightLogical %ushort [[tmp]] %uint_9
 // CHECK:                   OpStore %vushort [[out]]
 
   vuint = s3.f4;


### PR DESCRIPTION
For an unsigned integer, we should OpShiftRightLogical instead of OpShiftRightArithmetic. Otherwise the value may be extended incorrectly.

For example:
```
struct S {
  uint16_t m1 : 8;
  uint16_t m2 : 8;
};

void main() {
  S s;
  s.m1 = 0xff;
  s.m2 = 0xff;
  uint16_t result = s.m1;
}
```

If we do OpShiftRightArithmetic here, the result will be 0xffff.