### PR TITLE
Make unsigned dot test more robust

### DIFF
--- a/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/dot.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/dot.hlsl
@@ -14,8 +14,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK-DAG: [[I0:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 0, i32 0, i8 0, i32 undef)
   // CHECK-DAG: [[I1:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 0, i32 1, i8 0, i32 undef)
   // CHECK: mul i32 [[I0]], [[I1]]
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 134, <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 167, <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 [[IDOT:[0-9]*]], <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 [[IMUL:[0-9]*]], <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
   i += FUNC(i1[0], i1[1]);
 
   // CHECK-DAG: [[I00:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 1, i32 0, i8 0, i32 undef)
@@ -25,8 +25,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
 
   // CHECK: [[MUL:%.*]] = mul i32 [[I00]], [[I10]]
   // CHECK: call i32 @dx.op.tertiary.i32(i32 48, i32 [[I01]], i32 [[I11]], i32 [[MUL]])  ; IMad(a,b,c)
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 134, <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 167, <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 [[IDOT]], <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 [[IMUL]], <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
   i += FUNC(i2[0], i2[1]);
 
   // CHECK-DAG: [[I00:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 2, i32 0, i8 0, i32 undef)
@@ -41,8 +41,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK: [[PING:%.*]] = mul i32 [[I00]], [[I10]]
   // CHECK: [[PONG:%.*]] = call i32 @dx.op.tertiary.i32(i32 48, i32 [[I01]], i32 [[I11]], i32 [[PING]])  ; IMad(a,b,c)
   // CHECK: [[PING:%.*]] = call i32 @dx.op.tertiary.i32(i32 48, i32 [[I02]], i32 [[I12]], i32 [[PONG]])  ; IMad(a,b,c)
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 134, <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 167, <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 [[IDOT]], <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 [[IMUL]], <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
   i += FUNC(i3[0], i3[1]);
 
   // CHECK-DAG: [[I00:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 3, i32 0, i8 0, i32 undef)
@@ -58,8 +58,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK: [[PONG:%.*]] = call i32 @dx.op.tertiary.i32(i32 48, i32 [[I01]], i32 [[I11]], i32 [[PING]])  ; IMad(a,b,c)
   // CHECK: [[PING:%.*]] = call i32 @dx.op.tertiary.i32(i32 48, i32 [[I02]], i32 [[I12]], i32 [[PONG]])  ; IMad(a,b,c)
   // CHECK: [[PONG:%.*]] = call i32 @dx.op.tertiary.i32(i32 48, i32 [[I03]], i32 [[I13]], i32 [[PING]])  ; IMad(a,b,c)
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 134, <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 167, <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 [[IDOT]], <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 [[IMUL]], <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
   i += FUNC(i4[0], i4[1]);
 
   float f = 0.0;
@@ -67,8 +67,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK-DAG: [[F0:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 4, i32 0, i8 0, i32 undef)
   // CHECK-DAG: [[F1:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 4, i32 1, i8 0, i32 undef)
   // CHECK: mul fast float [[F0]], [[F1]]
-  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <1 x float>, <1 x float>)"(i32 134, <1 x float> %{{.*}}, <1 x float> %{{.*}})
-  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <1 x float>, <1 x float>)"(i32 167, <1 x float> %{{.*}}, <1 x float> %{{.*}})
+  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <1 x float>, <1 x float>)"(i32 [[IDOT]], <1 x float> %{{.*}}, <1 x float> %{{.*}})
+  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <1 x float>, <1 x float>)"(i32 [[IMUL]], <1 x float> %{{.*}}, <1 x float> %{{.*}})
   f += FUNC(f1[0], f1[1]);
 
   // CHECK-DAG: [[F00:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 5, i32 0, i8 0, i32 undef)
@@ -77,8 +77,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK-DAG: [[F11:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 5, i32 1, i8 1, i32 undef)
 
   // CHECK: call float @dx.op.dot2.f32(i32 54, float [[F00]], float [[F01]], float [[F10]], float [[F11]])
-  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <2 x float>, <2 x float>)"(i32 134, <2 x float> %{{.*}}, <2 x float> %{{.*}})
-  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <2 x float>, <2 x float>)"(i32 167, <2 x float> %{{.*}}, <2 x float> %{{.*}})
+  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <2 x float>, <2 x float>)"(i32 [[IDOT]], <2 x float> %{{.*}}, <2 x float> %{{.*}})
+  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <2 x float>, <2 x float>)"(i32 [[IMUL]], <2 x float> %{{.*}}, <2 x float> %{{.*}})
   f += FUNC(f2[0], f2[1]);
 
   // CHECK-DAG: [[F00:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 6, i32 0, i8 0, i32 undef)
@@ -89,8 +89,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK-DAG: [[F12:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 6, i32 1, i8 2, i32 undef)
 
   // CHECK: call float @dx.op.dot3.f32(i32 55, float [[F00]], float [[F01]], float [[F02]], float [[F10]], float [[F11]], float [[F12]])
-  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <3 x float>, <3 x float>)"(i32 134, <3 x float> %{{.*}}, <3 x float> %{{.*}})
-  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <3 x float>, <3 x float>)"(i32 167, <3 x float> %{{.*}}, <3 x float> %{{.*}})
+  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <3 x float>, <3 x float>)"(i32 [[IDOT]], <3 x float> %{{.*}}, <3 x float> %{{.*}})
+  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <3 x float>, <3 x float>)"(i32 [[IMUL]], <3 x float> %{{.*}}, <3 x float> %{{.*}})
   f += FUNC(f3[0], f3[1]);
 
   // CHECK-DAG: [[F00:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 7, i32 0, i8 0, i32 undef)
@@ -103,16 +103,16 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK-DAG: [[F13:%.*]] = call float @dx.op.loadInput.f32(i32 4, i32 7, i32 1, i8 3, i32 undef)
 
   // CHECK: call float @dx.op.dot4.f32(i32 56, float [[F00]], float [[F01]], float [[F02]], float [[F03]], float [[F10]], float [[F11]], float [[F12]], float [[F13]])
-  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <4 x float>, <4 x float>)"(i32 134, <4 x float> %{{.*}}, <4 x float> %{{.*}})
-  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <4 x float>, <4 x float>)"(i32 167, <4 x float> %{{.*}}, <4 x float> %{{.*}})
+  // CGLDOT: call float @"dx.hl.op.rn.float (i32, <4 x float>, <4 x float>)"(i32 [[IDOT]], <4 x float> %{{.*}}, <4 x float> %{{.*}})
+  // CGLMUL: call float @"dx.hl.op.rn.float (i32, <4 x float>, <4 x float>)"(i32 [[IMUL]], <4 x float> %{{.*}}, <4 x float> %{{.*}})
   f += FUNC(f4[0], f4[1]);
 
   int u = 0;
   // CHECK-DAG: [[I0:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 8, i32 0, i8 0, i32 undef)
   // CHECK-DAG: [[I1:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 8, i32 1, i8 0, i32 undef)
   // CHECK: mul i32 [[I0]], [[I1]]
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 349, <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 354, <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 [[UDOT:[0-9]*]], <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <1 x i32>, <1 x i32>)"(i32 [[UMUL:[0-9]*]], <1 x i32> %{{.*}}, <1 x i32> %{{.*}})
   u += FUNC(u1[0], u1[1]);
 
   // CHECK-DAG: [[I00:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 9, i32 0, i8 0, i32 undef)
@@ -122,8 +122,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
 
   // CHECK: [[MUL:%.*]] = mul i32 [[I00]], [[I10]]
   // CHECK: call i32 @dx.op.tertiary.i32(i32 49, i32 [[I01]], i32 [[I11]], i32 [[MUL]])  ; UMad(a,b,c)
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 349, <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 354, <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 [[UDOT]], <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <2 x i32>, <2 x i32>)"(i32 [[UMUL]], <2 x i32> %{{.*}}, <2 x i32> %{{.*}})
   u += FUNC(u2[0], u2[1]);
 
   // CHECK-DAG: [[I00:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 10, i32 0, i8 0, i32 undef)
@@ -136,8 +136,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK: [[PING:%.*]] = mul i32 [[I00]], [[I10]]
   // CHECK: [[PONG:%.*]] = call i32 @dx.op.tertiary.i32(i32 49, i32 [[I01]], i32 [[I11]], i32 [[PING]])  ; UMad(a,b,c)
   // CHECK: [[PING:%.*]] = call i32 @dx.op.tertiary.i32(i32 49, i32 [[I02]], i32 [[I12]], i32 [[PONG]])  ; UMad(a,b,c)
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 349, <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 354, <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 [[UDOT]], <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <3 x i32>, <3 x i32>)"(i32 [[UMUL]], <3 x i32> %{{.*}}, <3 x i32> %{{.*}})
   u += FUNC(u3[0], u3[1]);
 
   // CHECK-DAG: [[I00:%.*]] = call i32 @dx.op.loadInput.i32(i32 4, i32 11, i32 0, i8 0, i32 undef)
@@ -153,8 +153,8 @@ float4 main(int1 i1[2] : IO, int2 i2[2] : IT, int3 i3[2] : IH, int4 i4[2] : IF,
   // CHECK: [[PONG:%.*]] = call i32 @dx.op.tertiary.i32(i32 49, i32 [[I01]], i32 [[I11]], i32 [[PING]])  ; UMad(a,b,c)
   // CHECK: [[PING:%.*]] = call i32 @dx.op.tertiary.i32(i32 49, i32 [[I02]], i32 [[I12]], i32 [[PONG]])  ; UMad(a,b,c)
   // CHECK: [[PONG:%.*]] = call i32 @dx.op.tertiary.i32(i32 49, i32 [[I03]], i32 [[I13]], i32 [[PING]])  ; UMad(a,b,c)
-  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 349, <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
-  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 354, <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
+  // CGLDOT: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 [[UDOT]], <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
+  // CGLMUL: call i32 @"dx.hl.op.rn.i32 (i32, <4 x i32>, <4 x i32>)"(i32 [[UMUL]], <4 x i32> %{{.*}}, <4 x i32> %{{.*}})
   u += FUNC(u4[0], u4[1]);
 
   return float4(i, f, u, 0);


### PR DESCRIPTION
When built without spirv, the CGL tests were offset by 5 because of the missing opcodes. This captures the preliminary opcode and confirms that it matches everywhere it should.