### PR TITLE
[WorkGraph][SM6.9] Implements [MaxRecordPerNode(N)] for NodeOutpurArray

### DIFF
--- a/include/dxc/DXIL/DxilMetadataHelper.h
+++ b/include/dxc/DXIL/DxilMetadataHelper.h
@@ -328,6 +328,7 @@ public:
   static const unsigned kDxilNodeMaxRecordsSharedWithTag = 4;
   static const unsigned kDxilNodeOutputArraySizeTag = 5;
   static const unsigned kDxilNodeAllowSparseNodesTag = 6;
+  static const unsigned kDxilNodeMaxRecordsPerNodeTag = 7;
 
   // Node Record Type
   static const unsigned kDxilNodeRecordSizeTag = 0;

--- a/include/dxc/DXIL/DxilNodeProps.h
+++ b/include/dxc/DXIL/DxilNodeProps.h
@@ -140,6 +140,7 @@ struct NodeIOProperties {
   int MaxRecordsSharedWith = -1;
   unsigned OutputArraySize = 0;
   bool AllowSparseNodes = false;
+  unsigned MaxRecordsPerNode = 0;
 
 public:
   NodeIOProperties() {}

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -280,6 +280,7 @@ RDAT_ENUM_START(NodeAttribKind, uint32_t)
   RDAT_ENUM_VALUE(OutputArraySize, 6)
   RDAT_ENUM_VALUE(AllowSparseNodes, 7)
   RDAT_ENUM_VALUE(RecordAlignmentInBytes, 8)
+  RDAT_ENUM_VALUE(MaxRecordsPerNode, 9)
   RDAT_ENUM_VALUE_NODEF(LastValue)
 RDAT_ENUM_END()
 
@@ -415,6 +416,9 @@ RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
                     getAttribKind() ==
                         hlsl::RDAT::NodeAttribKind::RecordAlignmentInBytes)
       RDAT_VALUE(uint32_t, RecordAlignmentInBytes)
+    RDAT_UNION_ELIF(MaxRecordsPerNode,
+                    getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecordsPerNode)
+      RDAT_VALUE(uint32_t, MaxRecordsPerNode)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 RDAT_STRUCT_END()

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2808,7 +2808,12 @@ DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
     // Required Field
     MDVals.emplace_back(Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsTag));
     MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecords));
-    MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecordsPerNode));
+
+    if (Node.MaxRecordsPerNode) {    
+      MDVals.emplace_back(
+              Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsSharedWithTag));
+      MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecordsPerNode));
+    }
 
     if (Node.OutputArraySize) {
       MDVals.emplace_back(

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2046,7 +2046,7 @@ void DxilMDHelper::DeserializeNodeProps(const MDTuple *pProps, unsigned &idx,
     nodeoutput.AllowSparseNodes = ConstMDToBool(pProps->getOperand(idx++));
     if (pProps->getNumOperands() > idx) {
       nodeoutput.RecordType.alignment =
-          ConstMDToUint32(pProps->getOperand(idx++));      
+          ConstMDToUint32(pProps->getOperand(idx++));
     }
     nodeoutput.MaxRecordsPerNode = ConstMDToUint32(pProps->getOperand(idx++));
   }

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -1985,7 +1985,7 @@ void DxilMDHelper::SerializeNodeProps(SmallVectorImpl<llvm::Metadata *> &MDVals,
     MDVals.push_back(Uint32ToConstMD(nodeoutput.OutputArraySize));
     MDVals.push_back(BoolToConstMD(nodeoutput.AllowSparseNodes));
     MDVals.push_back(Uint32ToConstMD(nodeoutput.RecordType.alignment));
-    MDVals.push_back(Uint32ToConstMD(nodeoutput.MaxRecordsPerNode));
+    MDVals.push_back(Uint32ToConstMD(nodeoutput.MaxRecordsPerNode));    
   }
 }
 
@@ -2044,11 +2044,11 @@ void DxilMDHelper::DeserializeNodeProps(const MDTuple *pProps, unsigned &idx,
     nodeoutput.MaxRecordsSharedWith = ConstMDToInt32(pProps->getOperand(idx++));
     nodeoutput.OutputArraySize = ConstMDToUint32(pProps->getOperand(idx++));
     nodeoutput.AllowSparseNodes = ConstMDToBool(pProps->getOperand(idx++));
-    nodeoutput.MaxRecordsPerNode = ConstMDToUint32(pProps->getOperand(idx++));
     if (pProps->getNumOperands() > idx) {
       nodeoutput.RecordType.alignment =
-          ConstMDToUint32(pProps->getOperand(idx++));
+          ConstMDToUint32(pProps->getOperand(idx++));      
     }
+    nodeoutput.MaxRecordsPerNode = ConstMDToUint32(pProps->getOperand(idx++));
   }
 }
 
@@ -2809,12 +2809,6 @@ DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
     MDVals.emplace_back(Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsTag));
     MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecords));
 
-    if (Node.MaxRecordsPerNode) {    
-      MDVals.emplace_back(
-              Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsPerNodeTag));
-      MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecordsPerNode));
-    }
-
     if (Node.OutputArraySize) {
       MDVals.emplace_back(
           Uint32ToConstMD(DxilMDHelper::kDxilNodeOutputArraySizeTag));
@@ -2840,6 +2834,13 @@ DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
       NodeOpIDVals.emplace_back(Uint32ToConstMD(Node.OutputID.Index));
       MDVals.emplace_back(MDNode::get(m_Ctx, NodeOpIDVals));
     }
+    
+    if (Node.MaxRecordsPerNode) {
+      MDVals.emplace_back(
+          Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsPerNodeTag));
+      MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecordsPerNode));
+    }
+
   } else {
     DXASSERT(Node.Flags.IsInputRecord(), "Invalid NodeIO Kind");
     if (Node.MaxRecords) {

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2811,7 +2811,7 @@ DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
 
     if (Node.MaxRecordsPerNode) {    
       MDVals.emplace_back(
-              Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsSharedWithTag));
+              Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsPerNodeTag));
       MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecordsPerNode));
     }
 

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -1985,6 +1985,7 @@ void DxilMDHelper::SerializeNodeProps(SmallVectorImpl<llvm::Metadata *> &MDVals,
     MDVals.push_back(Uint32ToConstMD(nodeoutput.OutputArraySize));
     MDVals.push_back(BoolToConstMD(nodeoutput.AllowSparseNodes));
     MDVals.push_back(Uint32ToConstMD(nodeoutput.RecordType.alignment));
+    MDVals.push_back(Uint32ToConstMD(nodeoutput.MaxRecordsPerNode));
   }
 }
 
@@ -2043,6 +2044,7 @@ void DxilMDHelper::DeserializeNodeProps(const MDTuple *pProps, unsigned &idx,
     nodeoutput.MaxRecordsSharedWith = ConstMDToInt32(pProps->getOperand(idx++));
     nodeoutput.OutputArraySize = ConstMDToUint32(pProps->getOperand(idx++));
     nodeoutput.AllowSparseNodes = ConstMDToBool(pProps->getOperand(idx++));
+    nodeoutput.MaxRecordsPerNode = ConstMDToUint32(pProps->getOperand(idx++));
     if (pProps->getNumOperands() > idx) {
       nodeoutput.RecordType.alignment =
           ConstMDToUint32(pProps->getOperand(idx++));
@@ -2806,6 +2808,7 @@ DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
     // Required Field
     MDVals.emplace_back(Uint32ToConstMD(DxilMDHelper::kDxilNodeMaxRecordsTag));
     MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecords));
+    MDVals.emplace_back(Uint32ToConstMD(Node.MaxRecordsPerNode));
 
     if (Node.OutputArraySize) {
       MDVals.emplace_back(
@@ -2921,6 +2924,9 @@ NodeIOProperties DxilMDHelper::LoadDxilNodeIOState(const llvm::MDOperand &MDO) {
       MDNode *pNode = cast<MDNode>(MDO.get());
       Node.OutputID.Name = StringMDToString(pNode->getOperand(0));
       Node.OutputID.Index = ConstMDToUint32(pNode->getOperand(1));
+    } break;
+    case DxilMDHelper::kDxilNodeMaxRecordsPerNodeTag: {
+      Node.MaxRecordsPerNode = ConstMDToUint32(MDO);
     } break;
     default:
       m_bExtraMetadata = true;

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1176,6 +1176,12 @@ private:
           nAttrib.AllowSparseNodes = N.AllowSparseNodes;
           nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
         }
+        if (N.MaxRecordsPerNode) {
+          nAttrib = {};
+          nAttrib.AttribKind = (uint32_t)NodeAttribKind::MaxRecordsPerNode;
+          nAttrib.MaxRecords = N.MaxRecordsPerNode;
+          nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
+        }
       } else if (N.Flags.IsInputRecord()) {
         if (N.MaxRecords) {
           nAttrib = {};

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1169,19 +1169,18 @@ private:
               (uint32_t)RDAT::NodeAttribKind::MaxRecordsSharedWith;
           nAttrib.MaxRecordsSharedWith = N.MaxRecordsSharedWith;
           nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
-        }
+        } else if (N.MaxRecordsPerNode >= 0) {
+            nAttrib = {};
+            nAttrib.AttribKind = (uint32_t)NodeAttribKind::MaxRecordsPerNode;
+            nAttrib.MaxRecordsPerNode = N.MaxRecordsPerNode;
+            nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
+         }
         if (N.AllowSparseNodes) {
           nAttrib = {};
           nAttrib.AttribKind = (uint32_t)RDAT::NodeAttribKind::AllowSparseNodes;
           nAttrib.AllowSparseNodes = N.AllowSparseNodes;
           nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
-        }
-        if (N.MaxRecordsPerNode) {
-          nAttrib = {};
-          nAttrib.AttribKind = (uint32_t)NodeAttribKind::MaxRecordsPerNode;
-          nAttrib.MaxRecords = N.MaxRecordsPerNode;
-          nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
-        }
+        }        
       } else if (N.Flags.IsInputRecord()) {
         if (N.MaxRecords) {
           nAttrib = {};

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1169,12 +1169,15 @@ private:
               (uint32_t)RDAT::NodeAttribKind::MaxRecordsSharedWith;
           nAttrib.MaxRecordsSharedWith = N.MaxRecordsSharedWith;
           nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
-        } else if (N.MaxRecordsPerNode >= 0) {
+        } 
+        
+        if (N.MaxRecordsPerNode > 0) {
             nAttrib = {};
             nAttrib.AttribKind = (uint32_t)NodeAttribKind::MaxRecordsPerNode;
             nAttrib.MaxRecordsPerNode = N.MaxRecordsPerNode;
             nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
          }
+
         if (N.AllowSparseNodes) {
           nAttrib = {};
           nAttrib.AttribKind = (uint32_t)RDAT::NodeAttribKind::AllowSparseNodes;

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -477,6 +477,7 @@ bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);
 bool IsHLSLRWNodeInputRecordType(clang::QualType type);
 bool IsHLSLRONodeInputRecordType(clang::QualType type);
 bool IsHLSLNodeOutputType(clang::QualType type);
+bool IsHLSLNodeOutputArrayType(clang::QualType type);
 
 DXIL::NodeIOKind GetNodeIOType(clang::QualType type);
 

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1119,6 +1119,12 @@ def HLSLMaxRecords : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def HLSLMaxRecordsPerNode : InheritableAttr {
+  let Spellings = [CXX11<"", "MaxRecordsPerNode", 2015>];
+  let Args = [IntArgument<"maxCount">];
+  let Documentation = [Undocumented];
+}
+
 def HLSLMaxRecordsSharedWith : InheritableParamAttr {
   let Spellings = [CXX11<"", "maxrecordssharedwith", 2015>];
   let Args = [IdentifierArgument<"Name">];

--- a/tools/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/tools/clang/include/clang/Basic/DiagnosticGroups.td
@@ -805,4 +805,5 @@ def HLSLParameterUsage : DiagGroup<"parameter-usage">;
 def HLSLAvailability: DiagGroup<"hlsl-availability">;
 def HLSLBarrier : DiagGroup<"hlsl-barrier">;
 def HLSLLegacyLiterals : DiagGroup<"hlsl-legacy-literal">;
+def HLSLMaxNodesPerRecordAttr : DiagGroup<"hlsl-require-max-records-per-node">;
 // HLSL Change Ends

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7974,6 +7974,8 @@ def warn_hlsl_legacy_integer_literal_signedness: Warning<
   InGroup<HLSLLegacyLiterals>, DefaultIgnore;
 def err_hlsl_unsupported_semantic_index: Error<
   "'%0' is defined with semantic index %1, but only values 0 through %2 are supported">;
+def warn_hlsl_max_records_per_node_required_attribute: Warning<
+  "MaxRecordsPerNode is a required attribute SM6.9+">, InGroup<HLSLMaxNodesPerRecordAttr>, DefaultError;
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -700,6 +700,15 @@ bool IsHLSLNodeOutputType(clang::QualType type) {
          static_cast<uint32_t>(DXIL::NodeIOFlags::Output);
 }
 
+bool IsHLSLNodeOutputArrayType(clang::QualType type) {
+  return (static_cast<uint32_t>(GetNodeIOType(type)) &
+          (static_cast<uint32_t>(DXIL::NodeIOFlags::Output) |
+           static_cast<uint32_t>(DXIL::NodeIOFlags::NodeArray) |
+           static_cast<uint32_t>(DXIL::NodeIOFlags::RecordGranularityMask))) ==
+          (static_cast<uint32_t>(DXIL::NodeIOFlags::Output) | 
+          static_cast<uint32_t>(DXIL::NodeIOFlags::NodeArray));
+}
+
 bool IsHLSLStructuredBufferType(clang::QualType type) {
   if (const RecordType *RT = type->getAs<RecordType>()) {
     StringRef name = RT->getDecl()->getName();

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2440,10 +2440,7 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
       if (const auto *Attr = parmDecl->getAttr<HLSLMaxRecordsPerNodeAttr>()) {
         node.MaxRecordsPerNode = Attr->getMaxCount();
         DXASSERT(node.MaxRecordsPerNode <= node.MaxRecords,
-                 "MaxRecordsPerNode value should be less than the MaxRecords");
-      } else {
-        //Diags.Report(ArgLoc,
-        //             diag::warn_hlsl_barrier_group_memory_requires_group);
+                 "MaxRecordsPerNode value should be less than or equal to the MaxRecords value");
       }
     }
   }

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2435,14 +2435,18 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
     }
     if (const auto *Attr = parmDecl->getAttr<HLSLMaxRecordsAttr>())
       node.MaxRecords = Attr->getMaxCount();
-    // Check for SM6.9 Attributes
-    if (SM->IsSM69Plus()) {
-      if (const auto *Attr = parmDecl->getAttr<HLSLMaxRecordsPerNodeAttr>()) {
-        node.MaxRecordsPerNode = Attr->getMaxCount();
-        DXASSERT(node.MaxRecordsPerNode <= node.MaxRecords,
+      // Check for SM6.9 Attributes
+     if (SM->IsSM69Plus()) {
+        // Though MaxRecordsPerNode is a required attribute, this requirement
+        // can be overriden, in which case when the attribute is not present
+        // set the value to MaxRecords.
+        node.MaxRecordsPerNode = node.MaxRecords;
+        if (const auto *Attr = parmDecl->getAttr<HLSLMaxRecordsPerNodeAttr>()) {
+          node.MaxRecordsPerNode = Attr->getMaxCount();
+          DXASSERT(node.MaxRecordsPerNode <= node.MaxRecords,
                  "MaxRecordsPerNode value should be less than or equal to the MaxRecords value");
-      }
-    }
+        }
+     }  
   }
 
   if (inputPatchCount > 1) {

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2435,6 +2435,17 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
     }
     if (const auto *Attr = parmDecl->getAttr<HLSLMaxRecordsAttr>())
       node.MaxRecords = Attr->getMaxCount();
+    // Check for SM6.9 Attributes
+    if (SM->IsSM69Plus()) {
+      if (const auto *Attr = parmDecl->getAttr<HLSLMaxRecordsPerNodeAttr>()) {
+        node.MaxRecordsPerNode = Attr->getMaxCount();
+        DXASSERT(node.MaxRecordsPerNode <= node.MaxRecords,
+                 "MaxRecordsPerNode value should be less than the MaxRecords");
+      } else {
+        //Diags.Report(ArgLoc,
+        //             diag::warn_hlsl_barrier_group_memory_requires_group);
+      }
+    }
   }
 
   if (inputPatchCount > 1) {

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -824,6 +824,7 @@ void Parser::ParseGNUAttributeArgs(IdentifierInfo *AttrName,
     case AttributeList::AT_HLSLNodeMaxRecursionDepth:
     case AttributeList::AT_HLSLMaxRecordsSharedWith:
     case AttributeList::AT_HLSLMaxRecords:
+    case AttributeList::AT_HLSLMaxRecordsPerNode:
     case AttributeList::AT_HLSLNodeArraySize:
     case AttributeList::AT_HLSLRootSignature:
     case AttributeList::AT_HLSLOutputControlPoints:

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15984,7 +15984,7 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
         std::string profile = S.getLangOpts().HLSLProfile;
         const ShaderModel *SM = hlsl::ShaderModel::GetByName(profile.c_str());
         if (SM->IsSM69Plus() &&!PD->getAttr<HLSLMaxRecordsPerNodeAttr>()) {
-          S.Diags.Report(FD->getLocation(),
+          S.Diags.Report(PD->getLocation(),
               diag::warn_hlsl_max_records_per_node_required_attribute);
         }
       }
@@ -16006,6 +16006,8 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
     auto *NodeArraySizeAttr = Param->getAttr<HLSLNodeArraySizeAttr>();
     auto *UnboundedSparseNodesAttr =
         Param->getAttr<HLSLUnboundedSparseNodesAttr>();
+    auto *MaxRecordsPerNodeAttr =
+        Param->getAttr<HLSLMaxRecordsPerNodeAttr>();
     // Check any node input is compatible with the node launch type
     if (hlsl::IsHLSLNodeInputType(ParamTy)) {
       InputCount++;
@@ -16036,7 +16038,7 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
       // If node output is not an array, diagnose array only attributes
       if (((uint32_t)GetNodeIOType(ParamTy) &
            (uint32_t)DXIL::NodeIOFlags::NodeArray) == 0) {
-        Attr *ArrayAttrs[] = {NodeArraySizeAttr, UnboundedSparseNodesAttr};
+        Attr *ArrayAttrs[] = {NodeArraySizeAttr, UnboundedSparseNodesAttr, MaxRecordsPerNodeAttr};
         for (auto *A : ArrayAttrs) {
           if (A) {
             S.Diags.Report(A->getLocation(),

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/error_no_max_records_per_node_sm69.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/error_no_max_records_per_node_sm69.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// Test for required attribute 
+
+struct RECORD1
+{
+    uint value;
+    uint value2;
+};
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(128, 1, 1)]
+void node_1_2(
+    [NodeArraySize(128)] [MaxRecords(64)] NodeOutputArray<RECORD1> OutputArray
+)
+{
+}
+// CHECK: error: MaxRecordsPerNode is a required attribute SM6.9+

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/max_records_per_node_sm69.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/max_records_per_node_sm69.hlsl
@@ -1,0 +1,50 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// Tests for [MaxRecordsPerNode] attribute
+
+struct RECORD1
+{
+    uint value;
+    uint value2;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(128, 1, 1)]
+void node_1_0(
+    [NodeArraySize(128)] [MaxRecords(64)] [MaxRecordsPerNode(16)] NodeOutputArray<RECORD1> OutputArray
+)
+{
+}
+// CHECK-NOT: error: MaxRecordsPerNode is a required attribute SM6.9+ [-Whlsl-require-max-records-per-node]
+
+// Test Emission of metadata
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(128, 1, 1)]
+void node_1_1(
+    [NodeArraySize(128)] [MaxRecords(64)] [MaxRecordsPerNode(32)] NodeOutputArray<RECORD1> OutputArray
+)
+{
+}
+// CHECK: define void @node_1_1()
+// CHECK: ret void
+
+// CHECK: !{void ()* @node_1_1, !"node_1_1", null, null, [[NODE_1_1:![0-9]+]]}
+// CHECK: [[NODE_1_1]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !20, i32 16, i32 -1, i32 18, !11, i32 21, [[OUTPUTS:![0-9]+]]
+// CHECK: [[OUTPUTS]] = !{[[OUTPUT1:![0-9]+]]}
+// CHECK: [[OUTPUT1]] = !{i32 1, i32 22, i32 2, !14, i32 3, i32 64, i32 5, i32 128, i32 0, !15, i32 7, i32 32}
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(128, 1, 1)]
+void node_1_2(
+    [NodeArraySize(128)] [MaxRecords(64)] NodeOutputArray<RECORD1> OutputArray
+)
+{
+}
+// CHECK: error: MaxRecordsPerNode is a required attribute SM6.9+ [-Whlsl-require-max-records-per-node]
+

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/override_max_records_per_node_requirement_sm69.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/override_max_records_per_node_requirement_sm69.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T lib_6_9 -Wno-hlsl-require-max-records-per-node %s | FileCheck %s
+
+// Tests for overrriding [MaxRecordsPerNode] attribute requirement with -Wno
+// Test MaxRecordsPerNode set to MaxRecords
+
+struct RECORD1
+{
+    uint value;
+    uint value2;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(128, 1, 1)]
+void node_1_0(
+    [NodeArraySize(128)] [MaxRecords(64)] NodeOutputArray<RECORD1> OutputArray
+)
+{
+}
+
+// CHECK-NOT: error: MaxRecordsPerNode is a required attribute SM6.9+ [-Whlsl-require-max-records-per-node]
+// CHECK: !{void ()* @node_1_0, !"node_1_0", null, null, [[NODE_1_0:![0-9]+]]}
+// CHECK: [[NODE_1_0]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !10, i32 16, i32 -1, i32 18, !11, i32 21, [[OUTPUTS:![0-9]+]]
+// CHECK: [[OUTPUTS]] = !{[[OUTPUT1:![0-9]+]]}
+// CHECK: [[OUTPUT1]] = !{i32 1, i32 22, i32 2, !14, i32 3, i32 [[MAXRECORDS:[0-9]+]], i32 5, i32 128, i32 0, !15, i32 7, i32 [[MAXRECORDS]]}
+


### PR DESCRIPTION
Implements the following spec:
https://github.com/microsoft/hlsl-specs/blob/main/proposals/0025-max-records-per-node.md

Adds some basic Filecheck tests.