### PR TITLE
Switch from tj-actions/changed-files to step-security/changed-files

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -19,10 +19,10 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           separator: ","
-          fetch_depth: 100 # Fetches only the last 10 commits
+          skip_initial_fetch: true
 
       - name: "Listed files"
         env:


### PR DESCRIPTION
Aligning with upstream LLVM's action definition.