### PR TITLE
Update clang-format-checker.yml

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -15,14 +15,15 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0 # Fetch all history
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v41
         with:
           separator: ","
-          fetch_depth: 100 # Fetches only the last 10 commits
+          fetch_depth: 100 # Fetches only the last 100 commits
 
       - name: "Listed files"
         env:
@@ -88,7 +89,8 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0 # Fetch all history
           path: build/main_src
 
       - name: Setup Python env
@@ -115,7 +117,7 @@ jobs:
       - name: Fetch LLVM sources for head
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0 # Fetch all history
           ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
           repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
 

--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
+        uses: tj-actions/changed-files@v41
         with:
           separator: ","
           # skip_initial_fetch: true

--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -23,7 +23,8 @@ jobs:
         uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           separator: ","
-          skip_initial_fetch: true
+          # skip_initial_fetch: true
+          fetch_depth: 100 # Fetches only the last 100 commits
 
       - name: "Listed files"
         env:


### PR DESCRIPTION
The github action for clang-format-checker started failing with "Error: Similar commit hashes detected: previous sha: 3ddf29bd4384cd2b81a6b04c71ca9e8f3160714f is equivalent to the current sha: 3ddf29bd4384cd2b81a6b04c71ca9e8f3160714f."