### PR TITLE
Add /bigobj compile option to MSVC build (#7228)

### DIFF
--- a/tools/clang/tools/libclang/CMakeLists.txt
+++ b/tools/clang/tools/libclang/CMakeLists.txt
@@ -119,6 +119,7 @@ if(MSVC)
   # Each functions is exported as "dllexport" in include/clang-c.
   # KB835326
   set(LLVM_EXPORTED_SYMBOL_FILE)
+  add_compile_options(/bigobj)
 endif()
 
 # HLSL Change Starts


### PR DESCRIPTION
When targeting arm64 Debug, this error is detected:
libclang\dxcrewriteunused.cpp(1,1): error C1128: number of sections exceeded object file format limit: compile with /bigobj
This PR adds a compile option for the folder that contains dxcrewriteunused.cpp, so that the limit on the number of sections is increased, and compilation may succeed.

Cherry picked from https://github.com/microsoft/DirectXShaderCompiler/pull/7228