### PR TITLE
Use Wide String variants explicitly for Windows API calls 

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -820,10 +820,10 @@ public:
         return false;
       }
 
-      if (GetModuleHandle("d3d10warp.dll") != NULL) {
-        CHAR szFullModuleFilePath[MAX_PATH] = "";
-        GetModuleFileName(GetModuleHandle("d3d10warp.dll"),
-                          szFullModuleFilePath, sizeof(szFullModuleFilePath));
+      if (GetModuleHandleW(L"d3d10warp.dll") != NULL) {
+        WCHAR szFullModuleFilePath[MAX_PATH] = L"";
+        GetModuleFileNameW(GetModuleHandleW(L"d3d10warp.dll"),
+                           szFullModuleFilePath, sizeof(szFullModuleFilePath));
         WEX::Logging::Log::Comment(WEX::Common::String().Format(
             L"WARP driver loaded from: %S", szFullModuleFilePath));
       }


### PR DESCRIPTION
This PR changes some code in ExecutionTests.cpp to use the wide string variants of Windows API calls explicitly. This is because some internal builds will get confused about which overload to resolve the GetModuleHandle function to. By being explicit, this should eliminate the error that an arg can't be converted to LPCWSTR.

Cherry picked from https://github.com/microsoft/DirectXShaderCompiler/pull/7235