### PR TITLE
Fix compatibility with newer versions of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,16 @@ if(POLICY CMP0022)
   cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
 endif()
 
-if (POLICY CMP0051)
-  # CMake 3.1 and higher include generator expressions of the form
-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
-  # stripped everywhere that access the SOURCES property, so we just
-  # defer to the OLD behavior of not including generator expressions
-  # in the output for now.
-  cmake_policy(SET CMP0051 OLD)
+ # CMake version 3.1.0 removed support for setting Policy CMP0051 to OLD
+if(CMAKE_VERSION VERSION_LESS "3.1.0")
+  if (POLICY CMP0051)
+    # CMake 3.1 and higher include generator expressions of the form
+    # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+    # stripped everywhere that access the SOURCES property, so we just
+    # defer to the OLD behavior of not including generator expressions
+    # in the output for now.
+    cmake_policy(SET CMP0051 OLD)
+  endif()
 endif()
 
 if(CMAKE_VERSION VERSION_LESS 3.1.20141117)

--- a/tools/clang/CMakeLists.txt
+++ b/tools/clang/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 2.8.8)
+  # Support for CMake versions <3.5 is removed in versions >3.20
+if(${CMAKE_VERSION} VERSION_LESS "3.20")
+  cmake_minimum_required(VERSION 2.8.8)
+else()
+  cmake_minimum_required(VERSION 3.5)
+endif()
 
 # FIXME: It may be removed when we use 2.8.12.
 if(CMAKE_VERSION VERSION_LESS 2.8.12)


### PR DESCRIPTION
These changes allow the use of newer versions of CMake while maintaining compatibility with old versions.

Fixes #7237