### PR TITLE
Add constraint to test that requires spirv support

### DIFF
--- a/tools/clang/test/SemaHLSL/attributes/spv.inline.decorate.member.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/spv.inline.decorate.member.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv
 // RUN: %dxc -T ps_6_0 -E main -verify -spirv %s
 
 struct S


### PR DESCRIPTION
This PR adds a // REQUIRES: spirv line to the top of a test that uses spirv.
This prevents failures in dev environments that don't have spirv enabled.