### PR TITLE
[SPIRV] Update submodules and fix test

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/vk.binding.global-struct-of-resource.and.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.global-struct-of-resource.and.array.hlsl
@@ -27,6 +27,7 @@ float4 main() : SV_Target
 // CHECK:   [[x:%[0-9]+]] = OpSampledImage %type_sampled_image [[tex]] [[smp]]
   return Textures[0].Sample(TheStruct.Sampler, float2(0, 0))
 // CHECK: [[tex:%[0-9]+]] = OpLoad %type_2d_image %TheStruct_Texture
+// CHECK: [[smp:%[0-9]+]] = OpLoad %type_sampler %TheStruct_Sampler
 // CHECK:   [[x:%[0-9]+]] = OpSampledImage %type_sampled_image [[tex]] [[smp]]
        + TheStruct.Texture.Sample(TheStruct.Sampler, float2(0, 0));
 }


### PR DESCRIPTION
Updates the submodules. One test is updated because spirv-opt does not
common the load of a sampler anymore to avoid using a value from a
different basic block.
