### PR TITLE
Make Event Tracing for Windows optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,13 @@ mark_as_advanced(DXC_DISABLE_ALLOCATOR_OVERRIDES)
 option(DXC_CODEGEN_EXCEPTIONS_TRAP "An exception in code generation generates a trap, ending the compiler process" OFF)
 mark_as_advanced(DXC_CODEGEN_EXCEPTIONS_TRAP)
 
+option(DXC_ENABLE_ETW "Compile with ETW Tracing" ON)
+mark_as_advanced(DXC_ENABLE_ETW)
+
+if(DXC_ENABLE_ETW)
+  add_compile_definitions(DXC_ENABLE_ETW)
+endif()
+
 # adjust link option to enable debugging from kernel mode; not compatible with incremental linking
 if(NOT CMAKE_VERSION VERSION_LESS "3.13" AND MSVC AND NOT CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64EC")
   add_link_options(/DEBUGTYPE:CV,FIXUP,PDATA /INCREMENTAL:NO)

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -197,19 +197,8 @@
 #define OutputDebugStringA(msg) fputs(msg, stderr)
 #define OutputDebugFormatA(...) fprintf(stderr, __VA_ARGS__)
 
-// Event Tracing for Windows (ETW) provides application programmers the ability
-// to start and stop event tracing sessions, instrument an application to
-// provide trace events, and consume trace events.
-#define DxcEtw_DXCompilerCreateInstance_Start()
-#define DxcEtw_DXCompilerCreateInstance_Stop(hr)
-#define DxcEtw_DXCompilerCompile_Start()
-#define DxcEtw_DXCompilerCompile_Stop(hr)
-#define DxcEtw_DXCompilerDisassemble_Start()
-#define DxcEtw_DXCompilerDisassemble_Stop(hr)
-#define DxcEtw_DXCompilerPreprocess_Start()
-#define DxcEtw_DXCompilerPreprocess_Stop(hr)
-#define DxcEtw_DxcValidation_Start()
-#define DxcEtw_DxcValidation_Stop(hr)
+// I have no idea if I don't break something like INSTALL targets, requires CI tests
+#include "WinEtwAdapter.h"
 
 #define UInt32Add UIntAdd
 #define Int32ToUInt32 IntToUInt

--- a/include/dxc/WinEtwAdapter.h
+++ b/include/dxc/WinEtwAdapter.h
@@ -1,0 +1,33 @@
+//===- WinEtwAdapter.h - Windows ETW Adapter, stub -*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_WIN_ETW_ADAPTER_H
+#define LLVM_SUPPORT_WIN_ETW_ADAPTER_H
+
+// Event Tracing for Windows (ETW) provides application programmers the ability
+// to start and stop event tracing sessions, instrument an application to
+// provide trace events, and consume trace events.
+#define EventRegisterMicrosoft_Windows_DXCompiler_API()
+#define EventUnregisterMicrosoft_Windows_DXCompiler_API()
+#define DxcEtw_DXCompilerCreateInstance_Start()
+#define DxcEtw_DXCompilerCreateInstance_Stop(hr)
+#define DxcEtw_DXCompilerInitialization_Start()
+#define DxcEtw_DXCompilerInitialization_Stop(hr)
+#define DxcEtw_DXCompilerShutdown_Start()
+#define DxcEtw_DXCompilerShutdown_Stop(hr)
+#define DxcEtw_DXCompilerCompile_Start()
+#define DxcEtw_DXCompilerCompile_Stop(hr)
+#define DxcEtw_DXCompilerDisassemble_Start()
+#define DxcEtw_DXCompilerDisassemble_Stop(hr)
+#define DxcEtw_DXCompilerPreprocess_Start()
+#define DxcEtw_DXCompilerPreprocess_Stop(hr)
+#define DxcEtw_DxcValidation_Start()
+#define DxcEtw_DxcValidation_Stop(hr)
+
+#endif // LLVM_SUPPORT_WIN_ETW_ADAPTER_H

--- a/projects/dxilconv/tools/dxilconv/dxilconv.cpp
+++ b/projects/dxilconv/tools/dxilconv/dxilconv.cpp
@@ -23,7 +23,11 @@
 #include "dxc/config.h"
 #include "dxc/dxcisense.h"
 #include "dxc/dxctools.h"
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 
 #include "DxbcConverter.h"
 

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -128,7 +128,8 @@ endif (MSVC)
 
 add_clang_library(dxcompiler SHARED ${SOURCES})
 add_dependencies(dxcompiler TablegenHLSLOptions) 
-if (MSVC)
+
+if (MSVC AND DXC_ENABLE_ETW)
   # No DxcEtw on non-Windows platforms.
   add_dependencies(dxcompiler DxcEtw)
 endif()

--- a/tools/clang/tools/dxcompiler/DXCompiler.cpp
+++ b/tools/clang/tools/dxcompiler/DXCompiler.cpp
@@ -17,7 +17,11 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ManagedStatic.h"
 #ifdef LLVM_ON_WIN32
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #endif
 #include "dxillib.h"
 

--- a/tools/clang/tools/dxcompiler/DXCompiler.rc
+++ b/tools/clang/tools/dxcompiler/DXCompiler.rc
@@ -11,4 +11,6 @@
 #define VER_ORIGINALFILENAME_STR      "DXCompiler.dll"
 
 // #include <common.ver>
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.rc"
+#endif

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -22,7 +22,11 @@
 #include "dxc/dxcisense.h"
 #include "dxc/dxctools.h"
 #ifdef _WIN32
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #endif
 #include "dxc/DxilContainer/DxcContainerBuilder.h"
 #include "dxillib.h"

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -51,7 +51,11 @@
 #include "dxc/Support/microcom.h"
 
 #ifdef _WIN32
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #endif
 #include "dxcompileradapter.h"
 #include "dxcshadersourceinfo.h"

--- a/tools/clang/tools/dxcvalidator/dxcvalidator.cpp
+++ b/tools/clang/tools/dxcvalidator/dxcvalidator.cpp
@@ -27,7 +27,11 @@
 #include "dxc/Support/dxcapi.impl.h"
 
 #ifdef _WIN32
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #endif
 
 using namespace llvm;

--- a/tools/clang/tools/dxildll/dxildll.cpp
+++ b/tools/clang/tools/dxildll/dxildll.cpp
@@ -23,8 +23,12 @@
 #include "llvm/Support/ManagedStatic.h"
 #include <algorithm>
 #ifdef _WIN32
+#ifdef DXC_ENABLE_ETW
 #include "Tracing/DxcRuntimeEtw.h"
 #include "dxc/Tracing/dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #endif
 
 #include "dxc/dxcisense.h"

--- a/tools/clang/tools/dxrfallbackcompiler/DXCompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/DXCompiler.cpp
@@ -14,7 +14,11 @@
 #include "dxc/Support/Global.h"
 #include "dxc/Support/HLSLOptions.h"
 #include "dxc/config.h"
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #include "dxillib.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ManagedStatic.h"

--- a/tools/clang/tools/dxrfallbackcompiler/DXCompiler.rc
+++ b/tools/clang/tools/dxrfallbackcompiler/DXCompiler.rc
@@ -11,4 +11,6 @@
 #define VER_ORIGINALFILENAME_STR      "DxrFallbackCompiler.dll"
 
 // #include <common.ver>
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.rc"
+#endif

--- a/tools/clang/tools/dxrfallbackcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcapi.cpp
@@ -16,7 +16,11 @@
 #include "dxc/Support/Global.h"
 #include "dxc/dxcdxrfallbackcompiler.h"
 #include "dxc/dxctools.h"
+#ifdef DXC_ENABLE_ETW
 #include "dxcetw.h"
+#else
+#include "dxc/WinEtwAdapter.h"
+#endif // DXC_ENABLE_ETW
 #include <memory>
 
 HRESULT CreateDxcDxrFallbackCompiler(REFIID riid, LPVOID *ppv);


### PR DESCRIPTION
The Microsoft [Message Compiler](https://github.com/microsoft/DirectXShaderCompiler/blob/206b77577d15fc5798eb7ad52290388539b7146d/include/dxc/Tracing/CMakeLists.txt#L9) dependency in the build system makes it impossible to build the project on Windows Nano Server, due to COM not being available in that distribution.

This PR resolves the issue by patching the build system to make ETW optional. It disables the tracing when DXC_ENABLE_ETW is turned off, using the same logic already applied when building for non-Windows platforms. When disabled, the code falls back to empty stubs.

This PR is a work in progress - currently, only the `dxcompiler` target has been built with MSVC 14.42.34433 and WinSDK 22621.  A few links in case:

- Github Actions with the `dxcompiler` [build log](<https://github.com/Devsh-Graphics-Programming/docker-nanoserver-msvc-winsdk/actions/runs/14140589980/job/39621197973#step:12:9102>) (Nano Server LTSC2022 container)
- System environment Dockerfile [setup](<https://github.com/Devsh-Graphics-Programming/docker-nanoserver-msvc-winsdk/blob/docker-backwards/Dockerfile#L13>) 
- CMake [toolchain file](<https://github.com/Devsh-Graphics-Programming/docker-nanoserver-msvc-winsdk/blob/docker-backwards/cmake/winsdk-msvc-toolchain.cmake>)
-  CMake [configuration options](<https://github.com/Devsh-Graphics-Programming/docker-nanoserver-msvc-winsdk/blob/docker-backwards/tests/3rdparty/CMakeLists.txt#L29>)

The ETW manifest (`dxcetw.man`) is the only input for mc.exe. Its output includes a header and some .bin files (e.g., MSG00001.bin, dxcetwTEMP.bin after some copies in the custom command) but only the header (`dxcetw.h`) seems to be functionally required for building and please correct me if I'm wrong. The .bin files are generated and marked in CMake as GENERATED but

- they are not referenced in any resource .rc or included in any target
- their presence appears to be unused: search [1](<https://github.com/search?q=repo%3Amicrosoft%2FDirectXShaderCompiler+MSG00001&type=code>), [2](<https://github.com/search?q=repo%3Amicrosoft%2FDirectXShaderCompiler+dxcetwTEMP&type=code>), [3](<https://github.com/search?q=repo%3Amicrosoft%2FDirectXShaderCompiler+dxcetw&type=code>)

so, would it make sense to commit the generated header directly into version control instead? It seems to be fully deterministic