### PR TITLE
[OMM] Add DXR Entry point test, non-library target test, conforming tests to spec.

### DIFF
--- a/tools/clang/CMakeLists.txt
+++ b/tools/clang/CMakeLists.txt
@@ -1,18 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
-
-# FIXME: It may be removed when we use 2.8.12.
-if(CMAKE_VERSION VERSION_LESS 2.8.12)
-  # Invalidate a couple of keywords.
-  set(cmake_2_8_12_INTERFACE)
-  set(cmake_2_8_12_PRIVATE)
-else()
-  # Use ${cmake_2_8_12_KEYWORD} intead of KEYWORD in target_link_libraries().
-  set(cmake_2_8_12_INTERFACE INTERFACE)
-  set(cmake_2_8_12_PRIVATE PRIVATE)
-  if(POLICY CMP0022)
-    cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
-  endif()
-endif()
+cmake_minimum_required(VERSION 3.5)
 
 # If we are not building as a part of LLVM, build Clang as an
 # standalone project, using LLVM as an external library:

--- a/tools/clang/test/SemaHLSL/rayquery-omm-DXR-entry-point.hlsl
+++ b/tools/clang/test/SemaHLSL/rayquery-omm-DXR-entry-point.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc -T lib_6_3 -validator-version 1.8 -verify %s
+
+// expected-warning@+1{{potential misuse of built-in constant 'RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS' in shader model lib_6_3; introduced in shader model 6.9}}
+RaytracingPipelineConfig1 rpc = { 32, RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS };
+
+RaytracingAccelerationStructure RTAS;
+// DXR entry to test that restricted flags are diagnosed.
+[shader("raygeneration")]
+void main(void) {
+	RayDesc rayDesc;
+
+	// expected-warning@+2{{potential misuse of built-in constant 'RAY_FLAG_FORCE_OMM_2_STATE' in shader model lib_6_3; introduced in shader model 6.9}}
+	// expected-warning@+1{{potential misuse of built-in constant 'RAYQUERY_FLAG_ALLOW_OPACITY_MICROMAPS' in shader model lib_6_3; introduced in shader model 6.9}}
+	RayQuery<RAY_FLAG_FORCE_OMM_2_STATE, RAYQUERY_FLAG_ALLOW_OPACITY_MICROMAPS> rayQuery;
+	// expected-warning@+1{{potential misuse of built-in constant 'RAY_FLAG_FORCE_OMM_2_STATE' in shader model lib_6_3; introduced in shader model 6.9}}
+	rayQuery.TraceRayInline(RTAS, RAY_FLAG_FORCE_OMM_2_STATE, 2, rayDesc);
+}

--- a/tools/clang/test/SemaHLSL/rayquery-omm-type-diag.hlsl
+++ b/tools/clang/test/SemaHLSL/rayquery-omm-type-diag.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -T vs_6_9 -E RayQueryTests -verify %s
-// RUN: %dxc -T vs_6_5 -E RayQueryTests2 -verify %s
+// RUN: %dxc -T vs_6_9 -verify %s
+// RUN: %dxc -T vs_6_5 -verify %s
 
 // validate 2nd template argument flags
 // expected-error@+1{{When using 'RAY_FLAG_FORCE_OMM_2_STATE' in RayFlags, RayQueryFlags must have RAYQUERY_FLAG_ALLOW_OPACITY_MICROMAPS set.}}

--- a/tools/clang/test/SemaHLSL/raytracingpipelineconfig1-no-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/raytracingpipelineconfig1-no-errors.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T ps_6_0 -verify %s
+
+// expected-no-diagnostics
+// No diagnostics expected because this is a non-library target,
+// and SubObjects are ignored on non-library targets.
+
+RaytracingPipelineConfig1 rpc = { 32, RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS };
+
+[shader("pixel")]
+int main(int i : INDEX) : SV_Target {
+  return 1;
+}

--- a/tools/clang/test/SemaHLSL/raytracingpipelineconfig1-no-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/raytracingpipelineconfig1-no-errors.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T ps_6_0 -verify %s
 
 // expected-no-diagnostics
-// No diagnostics expected because this is a non-library target,
+// No diagnostic is expected because this is a non-library target,
 // and SubObjects are ignored on non-library targets.
 
 RaytracingPipelineConfig1 rpc = { 32, RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS };


### PR DESCRIPTION
This PR adds 2 tests that were mentioned in the spec that haven't yet been added.
1. A test that makes sure that restricted flags are diagnosed in DXR entry shaders.
2. A test that makes sure that no diagnostics are emitted when a restricted flag is used for a subobject in a non-library shadaer target.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7282