### PR TITLE
Add staging branches to azure pipeline testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,12 @@
 trigger:
   - main
   - release*
+  - staging*
 
 pr: 
   - main
   - release*
+  - staging*
   
 resources:
 - repo: self


### PR DESCRIPTION
The name matches for azure pipelines to run excluded staging branches. This adds them in.

Not sure this is desired, but it's here if we want it.