### PR TITLE
Add UUID compiler extension check on Clang

### DIFF
--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -51,7 +51,8 @@
 #define _countof(a) (sizeof(a) / sizeof(*(a)))
 
 // If it is GCC, there is no UUID support and we must emulate it.
-#ifndef __clang__
+// Clang support depends on the -fms-extensions compiler flag.
+#if !defined(__clang__) || !defined(_MSC_EXTENSIONS)
 #define __EMULATE_UUID 1
 #endif // __clang__
 


### PR DESCRIPTION
Fixes #7248

Fix Clang Compilation on Linux without Microsoft extensions enabled.

## Rationale
Clang support depends on the `-fms-extensions` compiler flag. [[1]](https://clang.llvm.org/docs/UsersManual.html#microsoft-extensions)
If enabled, the `_MSC_EXTENSIONS` macro is defined. [[2]](https://github.com/llvm/llvm-project/blob/19a319667b567a26a20f9829a0ae7e6a5c259cba/clang/lib/Basic/Targets/OSTargets.cpp#L248)