### PR TITLE
Fix assert due to unreachable discard

### DIFF
--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -525,6 +525,10 @@ void CodeGenFunction::EmitGotoStmt(const GotoStmt &S) {
 
 // HLSL Change Begins.
 void CodeGenFunction::EmitDiscardStmt(const DiscardStmt &S) {
+  // Skip unreachable discard.
+  if (!HaveInsertPoint())
+    return;
+
   CGM.getHLSLRuntime().EmitHLSLDiscard(*this);
 }
 // HLSL Change Ends.

--- a/tools/clang/test/DXC/FinishCodeGen/unreachable-discard.hlsl
+++ b/tools/clang/test/DXC/FinishCodeGen/unreachable-discard.hlsl
@@ -10,11 +10,9 @@
 // an unreachable discard.
 
 // CHECK:      define void @main()
-// CHECK:      while.body:
-// CHECK-NEXT: br label %while.body
-// CHECK:      return:
-// CHECK-NEXT: ret void
+// CHECK:      br label %
 // CHECK-NOT:  call void @"dx.hl.op..void (i32, float)"
+// CHECK:      ret void
 
 void main() {
   while (true) {

--- a/tools/clang/test/DXC/FinishCodeGen/unreachable-discard.hlsl
+++ b/tools/clang/test/DXC/FinishCodeGen/unreachable-discard.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc /T ps_6_5 -fcgl %s | FileCheck %s
+
+// Compiling this HLSL would trigger an assertion:
+//    While deleting: void (i32, float)* %dx.hl.op..void (i32, float)
+//    Use still stuck around after Def is destroyed:  call void @"dx.hl.op..void (i32, float)"(i32 120, float -1.000000e+00), !dbg <0x503000001cc8>
+//    Error: assert(use_empty() && "Uses remain when a value is destroyed!")
+//    File: <snip>/src/external/DirectXShaderCompiler/lib/IR/Value.cpp(83)
+//
+// Bug was fixed in CodeGenFunction::EmitDiscardStmt by skipping the emission of
+// an unreachable discard.
+
+// CHECK:      define void @main()
+// CHECK:      while.body:
+// CHECK-NEXT: br label %while.body
+// CHECK:      return:
+// CHECK-NEXT: ret void
+// CHECK-NOT:  call void @"dx.hl.op..void (i32, float)"
+
+void main() {
+  while (true) {
+  }
+  discard;
+}


### PR DESCRIPTION
When emitting discard in an unreachable code context (e.g. after an infinite loop), DXC would assert (if asserts enabled), or trigger a UBSAN failure because the discard instruction would have no parent. When an infinite loop is emitted during CodeGen, the InsertPt is cleared, thus subsequent discard instructions would be created, but no parent set. We skip emitting discard in this case, which follows the same pattern as is done for EmitIfStmt, and EmitSwitchStmt.