### PR TITLE
Disable code owners in main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @microsoft/hlsl-release
+# Uncomment the next line in release branches after ask-mode begins
+# * @microsoft/hlsl-release


### PR DESCRIPTION
MS just changed policy to enforce code owners across the whole enterprise, which is _not_ what we want. So we need to disable this in main for the time being.