### PR TITLE
[Cherry Pick] Use internal validator for execution test that requires SM 6.8 

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -11641,20 +11641,23 @@ void ExecuteWaveSizeRangeInstance(UINT minWaveSize, UINT maxWaveSize,
       })";
 
   // format compiler args
-  char compilerOptions[64];
+  char compilerOptions[70];
   if (usePreferred) {
     // putting spaces in between the %d's below will cause compilation issues.
-    VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
-                             "-D WAVE_SIZE_ATTR=[wavesize(%d,%d,%d)]",
-                             minShaderWaveSize, maxShaderWaveSize,
-                             prefShaderWaveSize) != -1);
+    VERIFY_IS_TRUE(
+        sprintf_s(
+            compilerOptions, sizeof(compilerOptions),
+            "-D WAVE_SIZE_ATTR=[wavesize(%d,%d,%d)] -select-validator internal",
+            minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize) != -1);
     LogCommentFmt(L"Verifying wave size range test results for (min, max, "
                   L"preferred): (%d, %d, %d)",
                   minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize);
   } else {
-    VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
-                             "-D WAVE_SIZE_ATTR=[wavesize(%d,%d)]",
-                             minShaderWaveSize, maxShaderWaveSize) != -1);
+    VERIFY_IS_TRUE(
+        sprintf_s(
+            compilerOptions, sizeof(compilerOptions),
+            "-D WAVE_SIZE_ATTR=[wavesize(%d,%d)] -select-validator internal",
+            minShaderWaveSize, maxShaderWaveSize) != -1);
     LogCommentFmt(
         L"Verifying wave size range test results for (min, max): (%d, %d)",
         minShaderWaveSize, maxShaderWaveSize);


### PR DESCRIPTION
This PR modifies WaveSizeRange test which depends on shader model 6.8.
The compiler needs -select-validator internal.
This will allow the tests to be run in different testing environments when an external validator that isn't sufficient is available.

Cherry pick of https://github.com/microsoft/DirectXShaderCompiler/pull/7309