### PR TITLE
[SER] Basic execution test to build up DXR test infra

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -293,6 +293,7 @@ public:
   TEST_METHOD(SignTest);
   TEST_METHOD(Int64Test);
   TEST_METHOD(LifetimeIntrinsicTest)
+  TEST_METHOD(SERBasicTest);
   TEST_METHOD(WaveIntrinsicsTest);
   TEST_METHOD(WaveIntrinsicsDDITest);
   TEST_METHOD(WaveIntrinsicsInPSTest);
@@ -711,6 +712,226 @@ public:
                                Ty *pInputDataPairs, unsigned inputDataCount);
 
   template <class Ty> const wchar_t *BasicShaderModelTest_GetFormatString();
+
+//= DXR Utility
+//============================================================================
+#define SHADER_ID_SIZE_IN_BYTES 32
+
+#ifndef ROUND_UP
+#define ROUND_UP(v, powerOf2Alignment)                                         \
+  (((v) + (powerOf2Alignment)-1) & ~((powerOf2Alignment)-1))
+#endif
+  struct SceneConsts {
+    DirectX::XMFLOAT4 eye;
+    DirectX::XMFLOAT4 U;
+    DirectX::XMFLOAT4 V;
+    DirectX::XMFLOAT4 W;
+    float sceneScale;
+    unsigned windowSize[2];
+    int rayFlags;
+  };
+
+  struct Instance {
+    D3D12_RAYTRACING_GEOMETRY_TYPE type;
+    DirectX::XMFLOAT4X4 matrix;
+    UINT geometryCount;
+    UINT bottomASIdx;
+    UINT instanceID;
+    UINT mask;
+    UINT flags;
+  };
+
+  class ShaderTable {
+  public:
+    void Init(ID3D12Device *device, int raygenCount, int missCount,
+              int hitGroupCount, int rayTypeCount, int rootTableDwords) {
+      m_rayTypeCount = rayTypeCount;
+      m_raygenCount = raygenCount;
+      m_missCount = missCount * rayTypeCount;
+      m_hitGroupCount = hitGroupCount * rayTypeCount;
+      m_rootTableSizeInBytes = rootTableDwords * 4;
+      m_shaderRecordSizeInBytes =
+          ROUND_UP(m_rootTableSizeInBytes + SHADER_ID_SIZE_IN_BYTES,
+                   D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT);
+      m_missStartIdx = m_raygenCount;
+      m_hitGroupStartIdx = m_missStartIdx + m_missCount;
+
+      const int m_totalSizeInBytes =
+          (m_raygenCount + m_missCount + m_hitGroupCount) *
+          m_shaderRecordSizeInBytes;
+
+      D3D12_RESOURCE_DESC desc = CD3DX12_RESOURCE_DESC::Buffer(
+          m_totalSizeInBytes, D3D12_RESOURCE_FLAG_NONE,
+          std::max(D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT,
+                   D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT));
+      CD3DX12_HEAP_PROPERTIES heap =
+          CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+      VERIFY_SUCCEEDED(device->CreateCommittedResource(
+          &heap, D3D12_HEAP_FLAG_NONE, &desc,
+          D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
+          IID_PPV_ARGS(&m_sbtResource)));
+      m_sbtResource->SetName(L"SBT Resource Heap");
+      CD3DX12_HEAP_PROPERTIES upload =
+          CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+      VERIFY_SUCCEEDED(device->CreateCommittedResource(
+          &upload, D3D12_HEAP_FLAG_NONE, &desc,
+          D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+          IID_PPV_ARGS(&m_sbtUploadResource)));
+      m_sbtUploadResource->SetName(L"SBT Upload Heap");
+
+      VERIFY_SUCCEEDED(
+          m_sbtUploadResource->Map(0, nullptr, (void **)&m_hostPtr));
+    }
+
+    void Upload(ID3D12GraphicsCommandList *cmdlist) {
+      CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+          m_sbtResource, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+          D3D12_RESOURCE_STATE_COPY_DEST);
+      cmdlist->ResourceBarrier(1, &barrier);
+      cmdlist->CopyResource(m_sbtResource, m_sbtUploadResource);
+      CD3DX12_RESOURCE_BARRIER barrier2 = CD3DX12_RESOURCE_BARRIER::Transition(
+          m_sbtResource, D3D12_RESOURCE_STATE_COPY_DEST,
+          D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+      cmdlist->ResourceBarrier(1, &barrier2);
+    }
+
+    int GetShaderRecordSizeInBytes() { return m_shaderRecordSizeInBytes; }
+
+    int GetRaygenShaderRecordIdx(int idx) { return idx; }
+    int GetMissShaderRecordIdx(int idx, int rayType) {
+      return m_missStartIdx + idx * m_rayTypeCount + rayType;
+    }
+    int GetHitGroupShaderRecordIdx(int idx, int rayType) {
+      return m_hitGroupStartIdx + idx * m_rayTypeCount + rayType;
+    }
+
+    void *GetRaygenShaderIdPtr(int idx) {
+      return m_hostPtr +
+             GetRaygenShaderRecordIdx(idx) * m_shaderRecordSizeInBytes;
+    }
+    void *GetMissShaderIdPtr(int idx, int rayType) {
+      return m_hostPtr +
+             GetMissShaderRecordIdx(idx, rayType) * m_shaderRecordSizeInBytes;
+    }
+    void *GetHitGroupShaderIdPtr(int idx, int rayType) {
+      return m_hostPtr + GetHitGroupShaderRecordIdx(idx, rayType) *
+                             m_shaderRecordSizeInBytes;
+    }
+
+    void *GetRaygenRootTablePtr(int idx) {
+      return (char *)GetRaygenShaderIdPtr(idx) + SHADER_ID_SIZE_IN_BYTES;
+    }
+    void *GetMissRootTablePtr(int idx, int rayType) {
+      return (char *)GetMissShaderIdPtr(idx, rayType) + SHADER_ID_SIZE_IN_BYTES;
+    }
+    void *GetHitGroupRootTablePtr(int idx, int rayType) {
+      return (char *)GetHitGroupShaderIdPtr(idx, rayType) +
+             SHADER_ID_SIZE_IN_BYTES;
+    }
+
+    int GetRaygenRangeInBytes() {
+      return m_raygenCount * m_shaderRecordSizeInBytes;
+    }
+    int GetMissRangeInBytes() {
+      return m_missCount * m_shaderRecordSizeInBytes;
+    }
+    int GetHitGroupRangeInBytes() {
+      return m_hitGroupCount * m_shaderRecordSizeInBytes;
+    }
+
+    D3D12_GPU_VIRTUAL_ADDRESS GetRaygenStartGpuVA() {
+      return m_sbtResource->GetGPUVirtualAddress() +
+             GetRaygenShaderRecordIdx(0) * m_shaderRecordSizeInBytes;
+    }
+    D3D12_GPU_VIRTUAL_ADDRESS GetMissStartGpuVA() {
+      return m_sbtResource->GetGPUVirtualAddress() +
+             GetMissShaderRecordIdx(0, 0) * m_shaderRecordSizeInBytes;
+    }
+    D3D12_GPU_VIRTUAL_ADDRESS GetHitGroupStartGpuVA() {
+      return m_sbtResource->GetGPUVirtualAddress() +
+             GetHitGroupShaderRecordIdx(0, 0) * m_shaderRecordSizeInBytes;
+    }
+
+  private:
+    CComPtr<ID3D12Resource> m_sbtResource;
+    CComPtr<ID3D12Resource> m_sbtUploadResource;
+    char *m_hostPtr = nullptr;
+    int m_rayTypeCount = 0;
+    int m_raygenCount = 0;
+    int m_missCount = 0;
+    int m_hitGroupCount = 0;
+    int m_rootTableSizeInBytes = 0;
+    int m_shaderRecordSizeInBytes = 0;
+    int m_missStartIdx = 0;
+    int m_hitGroupStartIdx = 0;
+  };
+
+  //-----------------------------------------------------------------------------
+  void AllocateBuffer(
+      ID3D12Device *pDevice, UINT64 bufferSize, ID3D12Resource **ppResource,
+      bool allowUAV = false,
+      D3D12_RESOURCE_STATES initialResourceState = D3D12_RESOURCE_STATE_COMMON,
+      const wchar_t *resourceName = nullptr) {
+    auto uploadHeapProperties =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(
+        bufferSize, allowUAV ? D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
+                             : D3D12_RESOURCE_FLAG_NONE);
+    VERIFY_SUCCEEDED(pDevice->CreateCommittedResource(
+        &uploadHeapProperties, D3D12_HEAP_FLAG_NONE, &bufferDesc,
+        initialResourceState, nullptr, IID_PPV_ARGS(ppResource)));
+    if (resourceName) {
+      (*ppResource)->SetName(resourceName);
+    }
+  }
+
+  //-----------------------------------------------------------------------------
+  void ReallocScratchResource(ID3D12Device *pDevice,
+                              ID3D12Resource **ppResource, UINT64 nbytes) {
+
+    if (!(*ppResource) || (*ppResource)->GetDesc().Width < nbytes) {
+      AllocateBuffer(pDevice, nbytes, ppResource, true,
+                     D3D12_RESOURCE_STATE_UNORDERED_ACCESS, L"scratchResource");
+    }
+  }
+
+  //-----------------------------------------------------------------------------
+  void AllocateUploadBuffer(ID3D12Device *pDevice, const void *pData,
+                            UINT64 datasize, ID3D12Resource **ppResource,
+                            const wchar_t *resourceName = nullptr) {
+    auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+    auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(datasize);
+    VERIFY_SUCCEEDED(pDevice->CreateCommittedResource(
+        &uploadHeapProperties, D3D12_HEAP_FLAG_NONE, &bufferDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(ppResource)));
+    if (resourceName) {
+      (*ppResource)->SetName(resourceName);
+    }
+    void *pMappedData;
+    VERIFY_SUCCEEDED((*ppResource)->Map(0, nullptr, &pMappedData));
+    memcpy(pMappedData, pData, datasize);
+    (*ppResource)->Unmap(0, nullptr);
+  }
+
+  //-----------------------------------------------------------------------------
+  void AllocateBufferFromUpload(ID3D12Device *pDevice,
+                                ID3D12GraphicsCommandList *pCommandList,
+                                ID3D12Resource *uploadSource,
+                                ID3D12Resource **ppResource,
+                                D3D12_RESOURCE_STATES targetResourceState,
+                                const wchar_t *resourceName = nullptr) {
+    const bool allowUAV =
+        targetResourceState == D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+    AllocateBuffer(pDevice, uploadSource->GetDesc().Width, ppResource, allowUAV,
+                   D3D12_RESOURCE_STATE_COPY_DEST, resourceName);
+    pCommandList->CopyResource(*ppResource, uploadSource);
+    CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+        *ppResource, D3D12_RESOURCE_STATE_COPY_DEST, targetResourceState);
+    pCommandList->ResourceBarrier(1, (const D3D12_RESOURCE_BARRIER *)&barrier);
+  }
+
+  //= DXR Utility
+  //============================================================================
 
   void CompileFromText(LPCSTR pText, LPCWSTR pEntryPoint,
                        LPCWSTR pTargetProfile, ID3DBlob **ppBlob,
@@ -1918,6 +2139,28 @@ public:
                                    LPCWSTR pTargetProfile, LPCWSTR *pOptions,
                                    int numOptions);
 
+  CComPtr<ID3D12Device> CreateDXRDevice(D3D_SHADER_MODEL shaderModel,
+                                        bool skipUnsupported) {
+    CComPtr<ID3D12Device> pDevice;
+    bool bSM_Supported = CreateDevice(&pDevice, shaderModel, skipUnsupported);
+    if (!bSM_Supported) {
+      WEX::Logging::Log::Comment(
+          L"No supported device was found for required shader model.");
+      return nullptr;
+    }
+    if (!DoesDeviceSupportRayTracing(pDevice)) {
+      WEX::Logging::Log::Comment(L"Device does not support DXR.");
+      return nullptr;
+    }
+    return pDevice;
+  }
+
+  CComPtr<ID3D12Resource>
+  RunDXRTest(ID3D12Device *pDevice0, LPCSTR shader, LPCWSTR pTargetProfile,
+             LPCWSTR *pOptions, int numOptions, std::vector<int> &testData,
+             int windowWidth, int windowHeight, int payloadCount = 4,
+             int attributeCount = 2, int maxRecursion = 1);
+
   void SetDescriptorHeap(ID3D12GraphicsCommandList *pCommandList,
                          ID3D12DescriptorHeap *pHeap) {
     ID3D12DescriptorHeap *const pHeaps[1] = {pHeap};
@@ -2440,6 +2683,633 @@ TEST_F(ExecutionTest, LifetimeIntrinsicTest) {
       VERIFY_ARE_EQUAL(values[1], (uint32_t)1);
     }
   }
+}
+
+CComPtr<ID3D12Resource>
+ExecutionTest::RunDXRTest(ID3D12Device *pDevice0, LPCSTR shader,
+                          LPCWSTR pTargetProfile, LPCWSTR *pOptions,
+                          int numOptions, std::vector<int> &testData,
+                          int windowWidth, int windowHeight, int payloadCount,
+                          int attributeCount, int maxRecursion) {
+  CComPtr<ID3D12Device5> pDevice;
+  VERIFY_SUCCEEDED(pDevice0->QueryInterface(IID_PPV_ARGS(&pDevice)));
+
+  FenceObj FO;
+  InitFenceObj(pDevice, &FO);
+
+  // Setup Resources
+  CComPtr<ID3D12Resource> pTestBuffer;
+  CComPtr<ID3D12Resource> pTestBufferRead;
+  CComPtr<ID3D12Resource> pSceneConstantBuffer;
+
+  // Descriptor heap
+  CComPtr<ID3D12DescriptorHeap> pDescriptorHeap;
+  {
+    //
+    // UAV descriptor heap layout:
+    //     0 - test buffer UAV
+    //     1 - vertex buffer SRV
+    //     2 - index buffer SRV
+    //
+    D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc = {};
+    descriptorHeapDesc.NumDescriptors = 3;
+    descriptorHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    descriptorHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    pDevice->CreateDescriptorHeap(&descriptorHeapDesc,
+                                  IID_PPV_ARGS(&pDescriptorHeap));
+    pDescriptorHeap->SetName(L"Descriptor Heap");
+  }
+  int descriptorSize = pDevice->GetDescriptorHandleIncrementSize(
+      D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+
+  // Testbuffer
+  {
+    auto resDesc = CD3DX12_RESOURCE_DESC::Buffer(
+        testData.size() * sizeof(int),
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    auto defaultHeapProperties =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    VERIFY_SUCCEEDED(pDevice->CreateCommittedResource(
+        &defaultHeapProperties, D3D12_HEAP_FLAG_NONE, &resDesc,
+        D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr,
+        IID_PPV_ARGS(&pTestBuffer)));
+    pTestBuffer->SetName(L"Test Buffer");
+
+    const int descriptorIndex = 0;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle =
+        CD3DX12_CPU_DESCRIPTOR_HANDLE(
+            pDescriptorHeap->GetCPUDescriptorHandleForHeapStart(),
+            descriptorIndex, descriptorSize);
+    D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {};
+    UAVDesc.Format = DXGI_FORMAT_UNKNOWN;
+    UAVDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+    UAVDesc.Buffer.FirstElement = 0;
+    UAVDesc.Buffer.NumElements = (UINT)testData.size();
+    UAVDesc.Buffer.StructureByteStride = sizeof(int);
+    UAVDesc.Buffer.CounterOffsetInBytes = 0;
+    UAVDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+    pDevice->CreateUnorderedAccessView(pTestBuffer, nullptr, &UAVDesc,
+                                       cpuDescriptorHandle);
+  }
+
+  // Testbuffer Readback
+  {
+    CD3DX12_HEAP_PROPERTIES readHeap(D3D12_HEAP_TYPE_READBACK);
+    CD3DX12_RESOURCE_DESC readDesc(
+        CD3DX12_RESOURCE_DESC::Buffer(testData.size() * sizeof(int)));
+    pDevice->CreateCommittedResource(&readHeap, D3D12_HEAP_FLAG_NONE, &readDesc,
+                                     D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+                                     IID_PPV_ARGS(&pTestBufferRead));
+  }
+
+  // Create CBV resource (sceneConstantBuffer), index 1
+  {
+    const int descriptorIndex = 1;
+    const UINT constantBufferSize =
+        (sizeof(SceneConsts) +
+         (D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1)) &
+        ~(D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT -
+          1); // must be a multiple 256 bytes
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle =
+        CD3DX12_CPU_DESCRIPTOR_HANDLE(
+            pDescriptorHeap->GetCPUDescriptorHandleForHeapStart(),
+            descriptorIndex, descriptorSize);
+    auto resDesc = CD3DX12_RESOURCE_DESC::Buffer(constantBufferSize);
+    auto uploadHeapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+    pDevice->CreateCommittedResource(&uploadHeapProperties,
+                                     D3D12_HEAP_FLAG_NONE, &resDesc,
+                                     D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                     IID_PPV_ARGS(&pSceneConstantBuffer));
+
+    UINT8 *sceneConstantBufferWO;
+    CD3DX12_RANGE readRange(
+        0, 0); // We do not intend to read from this resource on the CPU.
+    pSceneConstantBuffer->Map(
+        0, &readRange, reinterpret_cast<void **>(&sceneConstantBufferWO));
+
+    // Setup Scene Constants
+    SceneConsts sceneConsts = {
+        {25.f, -25.f, 700.f, 0.f},
+        {536.f, 0.f, 0.f, 0.f},
+        {0.f, 301.f, 0.f, 0.f},
+        {0.f, 0., -699.f, 0.f},
+        100.f,
+        {(unsigned int)windowWidth, (unsigned int)windowHeight},
+        0x00};
+
+    memcpy(sceneConstantBufferWO, &sceneConsts, sizeof(SceneConsts));
+    pSceneConstantBuffer->Unmap(0, nullptr);
+
+    D3D12_CONSTANT_BUFFER_VIEW_DESC desc = {};
+    desc.SizeInBytes = constantBufferSize;
+    desc.BufferLocation = pSceneConstantBuffer->GetGPUVirtualAddress();
+    pDevice->CreateConstantBufferView(&desc, cpuDescriptorHandle);
+  }
+
+  // Local (SBT) root signature
+  CComPtr<ID3D12RootSignature> pLocalRootSignature;
+  {
+    CD3DX12_DESCRIPTOR_RANGE bufferRanges[1];
+    CD3DX12_ROOT_PARAMETER rootParameters[1];
+    bufferRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2, 1, 0,
+                         2); // vertexBuffer(t1), indexBuffer(t2)
+    rootParameters[0].InitAsDescriptorTable(
+        _countof(bufferRanges), bufferRanges, D3D12_SHADER_VISIBILITY_ALL);
+
+    CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+    rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 0, nullptr,
+                           D3D12_ROOT_SIGNATURE_FLAG_LOCAL_ROOT_SIGNATURE);
+    CComPtr<ID3DBlob> signature;
+    CComPtr<ID3DBlob> error;
+    VERIFY_SUCCEEDED(D3D12SerializeRootSignature(
+        &rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+    VERIFY_SUCCEEDED(pDevice->CreateRootSignature(
+        0, signature->GetBufferPointer(), signature->GetBufferSize(),
+        IID_PPV_ARGS(&pLocalRootSignature)));
+    pLocalRootSignature->SetName(L"Local Root Signature");
+  }
+
+  // Global root signature
+  CComPtr<ID3D12RootSignature> pGlobalRootSignature;
+  {
+    CD3DX12_DESCRIPTOR_RANGE bufferRanges[1];
+    CD3DX12_ROOT_PARAMETER rootParameters[3];
+    bufferRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1,
+                         0); // testBuffer(u0)
+    rootParameters[0].InitAsShaderResourceView(
+        0, 0, D3D12_SHADER_VISIBILITY_ALL);        // accelStruct(t0)
+    rootParameters[1].InitAsConstantBufferView(0); // sceneConstants(b0)
+    rootParameters[2].InitAsDescriptorTable(
+        _countof(bufferRanges), bufferRanges, D3D12_SHADER_VISIBILITY_ALL);
+
+    CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+    rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 0, nullptr,
+                           D3D12_ROOT_SIGNATURE_FLAG_NONE);
+    CComPtr<ID3DBlob> signature;
+    CComPtr<ID3DBlob> error;
+    VERIFY_SUCCEEDED(D3D12SerializeRootSignature(
+        &rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+    VERIFY_SUCCEEDED(pDevice->CreateRootSignature(
+        0, signature->GetBufferPointer(), signature->GetBufferSize(),
+        IID_PPV_ARGS(&pGlobalRootSignature)));
+    pGlobalRootSignature->SetName(L"Global Root Signature");
+  }
+
+  // Create command queue.
+  CComPtr<ID3D12CommandQueue> pCommandQueue;
+  CreateCommandQueue(pDevice, L"RunPAQTest Command Queue", &pCommandQueue,
+                     D3D12_COMMAND_LIST_TYPE_DIRECT);
+
+  // Compile raygen shader.
+  CComPtr<ID3DBlob> pShaderLib;
+  CompileFromText(shader, L"raygen", pTargetProfile, &pShaderLib, pOptions,
+                  numOptions);
+
+  // Describe and create the RT pipeline state object (RTPSO).
+  CD3DX12_STATE_OBJECT_DESC stateObjectDesc(
+      D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE);
+  auto lib = stateObjectDesc.CreateSubobject<CD3DX12_DXIL_LIBRARY_SUBOBJECT>();
+  CD3DX12_SHADER_BYTECODE byteCode(pShaderLib);
+  lib->SetDXILLibrary(&byteCode);
+  lib->DefineExport(L"raygen");
+  lib->DefineExport(L"closesthit");
+  lib->DefineExport(L"anyhit");
+  lib->DefineExport(L"miss");
+
+  stateObjectDesc.CreateSubobject<CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT>()
+      ->Config(payloadCount * sizeof(float), attributeCount * sizeof(float));
+  stateObjectDesc
+      .CreateSubobject<CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT>()
+      ->Config(maxRecursion);
+
+  // Set Global Root Signature subobject.
+  auto globalRootSigSubObj =
+      stateObjectDesc
+          .CreateSubobject<CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT>();
+  globalRootSigSubObj->SetRootSignature(pGlobalRootSignature);
+  auto exports = stateObjectDesc.CreateSubobject<
+      CD3DX12_SUBOBJECT_TO_EXPORTS_ASSOCIATION_SUBOBJECT>();
+  exports->SetSubobjectToAssociate(*globalRootSigSubObj);
+  exports->AddExport(L"raygen");
+  exports->AddExport(L"closesthit");
+  exports->AddExport(L"anyhit");
+  exports->AddExport(L"miss");
+
+  auto hitGroup =
+      stateObjectDesc.CreateSubobject<CD3DX12_HIT_GROUP_SUBOBJECT>();
+  hitGroup->SetHitGroupExport(L"HitGroup");
+  hitGroup->SetClosestHitShaderImport(L"closesthit");
+  hitGroup->SetAnyHitShaderImport(L"anyhit");
+
+  CComPtr<ID3D12StateObject> pStateObject;
+  CComPtr<ID3D12StateObjectProperties> pStateObjectProperties;
+  VERIFY_SUCCEEDED(
+      pDevice->CreateStateObject(stateObjectDesc, IID_PPV_ARGS(&pStateObject)));
+  VERIFY_SUCCEEDED(pStateObject->QueryInterface(&pStateObjectProperties));
+  stateObjectDesc.CreateSubobject<CD3DX12_LOCAL_ROOT_SIGNATURE_SUBOBJECT>()
+      ->SetRootSignature(pLocalRootSignature);
+  stateObjectDesc.CreateSubobject<CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT>()
+      ->SetRootSignature(pGlobalRootSignature);
+
+  // Create SBT
+  ShaderTable shaderTable;
+  shaderTable.Init(pDevice,
+                   1, // raygen count
+                   1, // miss count
+                   1, // hit group count
+                   1, // ray type count
+                   2  // dwords per root table
+  );
+
+  memcpy(shaderTable.GetRaygenShaderIdPtr(0),
+         pStateObjectProperties->GetShaderIdentifier(L"raygen"),
+         SHADER_ID_SIZE_IN_BYTES);
+  memcpy(shaderTable.GetMissShaderIdPtr(0, 0),
+         pStateObjectProperties->GetShaderIdentifier(L"miss"),
+         SHADER_ID_SIZE_IN_BYTES);
+  memcpy(shaderTable.GetHitGroupShaderIdPtr(0, 0),
+         pStateObjectProperties->GetShaderIdentifier(L"HitGroup"),
+         SHADER_ID_SIZE_IN_BYTES);
+
+  auto tbl = pDescriptorHeap->GetGPUDescriptorHandleForHeapStart().ptr;
+  memcpy(shaderTable.GetHitGroupRootTablePtr(0, 0), &tbl, 8);
+
+  // Create a command allocator and list.
+  CComPtr<ID3D12CommandAllocator> pCommandAllocator;
+  CComPtr<ID3D12GraphicsCommandList4> pCommandList;
+  VERIFY_SUCCEEDED(pDevice->CreateCommandAllocator(
+      D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&pCommandAllocator)));
+  VERIFY_SUCCEEDED(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
+                                              pCommandAllocator, nullptr,
+                                              IID_PPV_ARGS(&pCommandList)));
+  pCommandList->SetName(L"ExecutionTest::RunDXRTest Command List");
+
+  pCommandList->Close();
+  ExecuteCommandList(pCommandQueue, pCommandList);
+  WaitForSignal(pCommandQueue, FO);
+
+  VERIFY_SUCCEEDED(pCommandAllocator->Reset());
+  VERIFY_SUCCEEDED(pCommandList->Reset(pCommandAllocator, nullptr));
+
+  // Create scene geometry.
+  CComPtr<ID3D12Resource> vertexBuffer;
+  CComPtr<ID3D12Resource> vertexBufferUpload;
+  CComPtr<ID3D12Resource> indexBuffer;
+  CComPtr<ID3D12Resource> indexBufferUpload;
+  CComPtr<ID3D12Resource> scratchResource;
+  CComPtr<ID3D12Resource> blasResource;
+  CComPtr<ID3D12Resource> tlasResource;
+  CComPtr<ID3D12Resource> instanceDescs;
+
+  // Define a Quad
+  const float verts[] = {
+      -50.5f, 50.5f,  0.5f, // top left
+      50.5f,  -50.5f, 0.5f, // bottom right
+      -50.5f, -50.5f, 0.5f, // bottom left
+      50.5f,  50.5f,  0.5f  // top right
+  };
+  const int indices[] = {
+      0, 1, 2, // first triangle
+      0, 3, 1  // second triangle
+  };
+
+  const UINT64 vertexDataSize = sizeof(verts);
+  const UINT64 indexDataSize = sizeof(indices);
+
+  AllocateUploadBuffer(pDevice, verts, vertexDataSize, &vertexBufferUpload,
+                       L"vertexBufferUpload");
+  AllocateUploadBuffer(pDevice, indices, indexDataSize, &indexBufferUpload,
+                       L"indexBufferUpload");
+
+  AllocateBufferFromUpload(
+      pDevice, pCommandList, vertexBufferUpload, &vertexBuffer,
+      D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, L"vertexBuffer");
+  AllocateBufferFromUpload(
+      pDevice, pCommandList, indexBufferUpload, &indexBuffer,
+      D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, L"indexBuffer");
+
+  {
+    const int descriptorIndex = 1;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle =
+        CD3DX12_CPU_DESCRIPTOR_HANDLE(
+            pDescriptorHeap->GetCPUDescriptorHandleForHeapStart(),
+            descriptorIndex, descriptorSize);
+    D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+    srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srvDesc.Buffer.NumElements =
+        UINT(vertexDataSize / sizeof(DirectX::XMFLOAT3));
+    srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+    srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+    srvDesc.Buffer.StructureByteStride = sizeof(DirectX::XMFLOAT3);
+    pDevice->CreateShaderResourceView(vertexBuffer, &srvDesc,
+                                      cpuDescriptorHandle);
+  }
+  {
+    const int descriptorIndex = 2;
+    D3D12_CPU_DESCRIPTOR_HANDLE cpuDescriptorHandle =
+        CD3DX12_CPU_DESCRIPTOR_HANDLE(
+            pDescriptorHeap->GetCPUDescriptorHandleForHeapStart(),
+            descriptorIndex, descriptorSize);
+    D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+    srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srvDesc.Buffer.NumElements = UINT(indexDataSize / sizeof(int));
+    srvDesc.Format = DXGI_FORMAT_UNKNOWN;
+    srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
+    srvDesc.Buffer.StructureByteStride = sizeof(int);
+    pDevice->CreateShaderResourceView(indexBuffer, &srvDesc,
+                                      cpuDescriptorHandle);
+  }
+
+  pCommandList->Close();
+  ExecuteCommandList(pCommandQueue, pCommandList);
+  WaitForSignal(pCommandQueue, FO);
+
+  VERIFY_SUCCEEDED(pCommandAllocator->Reset());
+  VERIFY_SUCCEEDED(pCommandList->Reset(pCommandAllocator, nullptr));
+
+  // Build BLAS.
+  {
+    D3D12_RAYTRACING_GEOMETRY_DESC geometryDesc = {};
+    geometryDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+    geometryDesc.Triangles.IndexBuffer = indexBuffer->GetGPUVirtualAddress();
+    geometryDesc.Triangles.IndexCount =
+        static_cast<UINT>(indexBuffer->GetDesc().Width) / sizeof(int);
+    geometryDesc.Triangles.IndexFormat = DXGI_FORMAT_R32_UINT;
+    geometryDesc.Triangles.Transform3x4 = 0;
+    geometryDesc.Triangles.VertexFormat = DXGI_FORMAT_R32G32B32_FLOAT;
+    geometryDesc.Triangles.VertexCount =
+        static_cast<UINT>(vertexBuffer->GetDesc().Width) /
+        sizeof(DirectX::XMFLOAT3);
+    geometryDesc.Triangles.VertexBuffer.StartAddress =
+        vertexBuffer->GetGPUVirtualAddress();
+    geometryDesc.Triangles.VertexBuffer.StrideInBytes =
+        sizeof(DirectX::XMFLOAT3);
+    geometryDesc.Flags =
+        D3D12_RAYTRACING_GEOMETRY_FLAG_NONE; // Non-opaque to trigger anyhit.
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags =
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
+
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS accelInputs = {};
+    accelInputs.Type =
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+    accelInputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+    accelInputs.pGeometryDescs = &geometryDesc;
+    accelInputs.NumDescs = 1;
+    accelInputs.Flags = buildFlags;
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo = {};
+    pDevice->GetRaytracingAccelerationStructurePrebuildInfo(&accelInputs,
+                                                            &prebuildInfo);
+
+    ReallocScratchResource(pDevice, &scratchResource,
+                           prebuildInfo.ScratchDataSizeInBytes);
+    AllocateBuffer(
+        pDevice, prebuildInfo.ResultDataMaxSizeInBytes, &blasResource, true,
+        D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, L"BLAS");
+
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc = {};
+    buildDesc.Inputs = accelInputs;
+    buildDesc.ScratchAccelerationStructureData =
+        scratchResource->GetGPUVirtualAddress();
+    buildDesc.DestAccelerationStructureData =
+        blasResource->GetGPUVirtualAddress();
+
+    pCommandList->BuildRaytracingAccelerationStructure(&buildDesc, 0, 0);
+    CD3DX12_RESOURCE_BARRIER barrier =
+        CD3DX12_RESOURCE_BARRIER::UAV(blasResource);
+    pCommandList->ResourceBarrier(1, (const D3D12_RESOURCE_BARRIER *)&barrier);
+  }
+
+  pCommandList->Close();
+  ExecuteCommandList(pCommandQueue, pCommandList);
+  WaitForSignal(pCommandQueue, FO);
+
+  VERIFY_SUCCEEDED(pCommandAllocator->Reset());
+  VERIFY_SUCCEEDED(pCommandList->Reset(pCommandAllocator, nullptr));
+
+  // Build TLAS.
+  {
+    D3D12_RAYTRACING_INSTANCE_DESC instanceDesc = {};
+    instanceDesc.Transform[0][0] = instanceDesc.Transform[1][1] =
+        instanceDesc.Transform[2][2] = 1;
+    instanceDesc.InstanceMask = 1;
+    instanceDesc.AccelerationStructure = blasResource->GetGPUVirtualAddress();
+    AllocateUploadBuffer(pDevice, &instanceDesc, sizeof(instanceDesc),
+                         &instanceDescs, L"instanceDescs");
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS buildFlags =
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS accelInputs = {};
+    accelInputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+    accelInputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+    accelInputs.NumDescs = 1;
+    accelInputs.Flags = buildFlags;
+    accelInputs.InstanceDescs = instanceDescs->GetGPUVirtualAddress();
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo = {};
+    pDevice->GetRaytracingAccelerationStructurePrebuildInfo(&accelInputs,
+                                                            &prebuildInfo);
+
+    AllocateBuffer(
+        pDevice, prebuildInfo.ResultDataMaxSizeInBytes, &tlasResource, true,
+        D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, L"TLAS");
+
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc = {};
+    buildDesc.Inputs = accelInputs;
+    buildDesc.ScratchAccelerationStructureData =
+        scratchResource->GetGPUVirtualAddress();
+    buildDesc.DestAccelerationStructureData =
+        tlasResource->GetGPUVirtualAddress();
+
+    pCommandList->BuildRaytracingAccelerationStructure(&buildDesc, 0, 0);
+    CD3DX12_RESOURCE_BARRIER barrier =
+        CD3DX12_RESOURCE_BARRIER::UAV(tlasResource);
+    pCommandList->ResourceBarrier(1, (const D3D12_RESOURCE_BARRIER *)&barrier);
+  }
+
+  shaderTable.Upload(pCommandList);
+
+  ID3D12DescriptorHeap *const pHeaps[1] = {pDescriptorHeap};
+  pCommandList->SetDescriptorHeaps(1, pHeaps);
+  pCommandList->SetComputeRootSignature(pGlobalRootSignature);
+  pCommandList->SetComputeRootShaderResourceView(
+      0, tlasResource->GetGPUVirtualAddress());
+  pCommandList->SetComputeRootConstantBufferView(
+      1, pSceneConstantBuffer->GetGPUVirtualAddress());
+  pCommandList->SetComputeRootDescriptorTable(
+      2, pDescriptorHeap->GetGPUDescriptorHandleForHeapStart());
+
+  D3D12_DISPATCH_RAYS_DESC dispatchDesc = {};
+  dispatchDesc.RayGenerationShaderRecord.StartAddress =
+      shaderTable.GetRaygenStartGpuVA();
+  dispatchDesc.RayGenerationShaderRecord.SizeInBytes =
+      shaderTable.GetRaygenRangeInBytes();
+  dispatchDesc.MissShaderTable.StartAddress = shaderTable.GetMissStartGpuVA();
+  dispatchDesc.MissShaderTable.SizeInBytes = shaderTable.GetMissRangeInBytes();
+  dispatchDesc.MissShaderTable.StrideInBytes =
+      shaderTable.GetShaderRecordSizeInBytes();
+  dispatchDesc.HitGroupTable.StartAddress = shaderTable.GetHitGroupStartGpuVA();
+  dispatchDesc.HitGroupTable.SizeInBytes =
+      shaderTable.GetHitGroupRangeInBytes();
+  dispatchDesc.HitGroupTable.StrideInBytes =
+      shaderTable.GetShaderRecordSizeInBytes();
+  dispatchDesc.Width = windowWidth;
+  dispatchDesc.Height = windowHeight;
+  dispatchDesc.Depth = 1;
+  pCommandList->SetPipelineState1(pStateObject);
+  pCommandList->DispatchRays(&dispatchDesc);
+
+  pCommandList->Close();
+  ExecuteCommandList(pCommandQueue, pCommandList);
+  WaitForSignal(pCommandQueue, FO);
+
+  VERIFY_SUCCEEDED(pCommandAllocator->Reset());
+  VERIFY_SUCCEEDED(pCommandList->Reset(pCommandAllocator, nullptr));
+
+  // Copy the testBuffer contents to CPU
+  D3D12_RESOURCE_BARRIER barriers[1];
+  barriers[0] = CD3DX12_RESOURCE_BARRIER::Transition(
+      pTestBuffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+      D3D12_RESOURCE_STATE_COPY_SOURCE);
+  pCommandList->ResourceBarrier(1, barriers);
+  pCommandList->CopyResource(pTestBufferRead, pTestBuffer);
+  barriers[0] = CD3DX12_RESOURCE_BARRIER::Transition(
+      pTestBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE,
+      D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+  pCommandList->ResourceBarrier(1, barriers);
+
+  pCommandList->Close();
+  ExecuteCommandList(pCommandQueue, pCommandList);
+  WaitForSignal(pCommandQueue, FO);
+
+  // Copy the shader test data into 'testData'.
+  MappedData data(pTestBufferRead, (UINT32)testData.size() * sizeof(int));
+  const int *pData = (int *)data.data();
+
+  for (int i = 0; i < testData.size(); i++) {
+    testData[i] = *pData++;
+  }
+
+  return pTestBufferRead;
+}
+
+TEST_F(ExecutionTest, SERBasicTest) {
+  // Test SER
+  static const char *pShader = R"(
+struct SceneConstants
+{
+    float4 eye;
+    float4 U;
+    float4 V;
+    float4 W;
+    float sceneScale;
+    uint2 windowSize;
+    int rayFlags;
+};
+
+struct[raypayload] PerRayData
+{
+    uint visited : read(anyhit,closesthit,miss,caller) : write(anyhit,miss,closesthit,caller);
+};
+
+struct Attrs
+{
+    float2 barycentrics : BARYCENTRICS;
+};
+
+// reordercoherent // Requires #7250
+RWStructuredBuffer<int> testBuffer : register(u0);
+RaytracingAccelerationStructure topObject : register(t0);
+ConstantBuffer<SceneConstants> sceneConstants : register(b0);
+
+RayDesc ComputeRay()
+{
+    uint2   launchIndex = DispatchRaysIndex().xy;
+    uint2   launchDim = DispatchRaysDimensions().xy;
+
+    float2 d = float2(DispatchRaysIndex().xy) / float2(DispatchRaysDimensions().xy) * 2.0f - 1.0f;
+    RayDesc ray;
+    ray.Origin = sceneConstants.eye.xyz;
+    ray.Direction = normalize(d.x*sceneConstants.U.xyz + d.y*sceneConstants.V.xyz + sceneConstants.W.xyz);
+    ray.TMin = 0;
+    ray.TMax = 1e18;
+
+    return ray;
+}
+
+[shader("raygeneration")]
+void raygen()
+{
+    uint2   launchIndex = DispatchRaysIndex().xy;
+    uint2   launchDim = DispatchRaysDimensions().xy;
+
+    RayDesc ray = ComputeRay();
+
+    PerRayData payload;
+    payload.visited = 0;
+
+    // SER Test
+    dx::HitObject hitObject;
+#if 1
+    // TODO: Actual testing once more SER functionality has landed in 'main'
+    TraceRay(topObject, RAY_FLAG_NONE, 0xFF, 0, 1, 0, ray, payload);
+#else
+    // Requires #7256, #7278
+    dx::HitObject hitObject = dx::HitObject::TraceRay(topObject, RAY_FLAG_NONE, 0xFF, 0, 1, 0, ray, payload);
+    dx::MaybeReorderThread(hitObject); // PR #7256
+    dx::HitObject::Invoke(hitObject, payload); // PR #7278
+#endif
+
+  int id = launchIndex.x + launchIndex.y * launchDim.x;
+  testBuffer[id] = payload.visited;
+}
+
+[shader("miss")]
+void miss(inout PerRayData payload)
+{
+  payload.visited |= 2U;
+}
+
+[shader("anyhit")]
+void anyhit(inout PerRayData payload, in Attrs attrs)
+{
+  payload.visited |= 1U;
+}
+
+[shader("closesthit")]
+void closesthit(inout PerRayData payload, in Attrs attrs)
+{
+  payload.visited |= 4U;
+}
+
+)";
+
+  CComPtr<ID3D12Device> pDevice = CreateDXRDevice(D3D_SHADER_MODEL_6_9, false);
+  if (!pDevice) {
+    WEX::Logging::Log::Comment(
+        L"SERBasicTest requires device support for shader model 6.9+ and DXR");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+
+  // Initialize test data.
+  const int windowSize = 64;
+  std::vector<int> testData(windowSize * windowSize, 0);
+  LPCWSTR args[] = {L"-HV 2021", L"-Vd"};
+
+  RunDXRTest(pDevice, pShader, L"lib_6_9", args, _countof(args), testData,
+             windowSize, windowSize);
+  std::map<int, int> histo;
+  for (int val : testData) {
+    ++histo[val];
+  }
+  VERIFY_ARE_EQUAL(histo.size(), 2);
+  VERIFY_ARE_EQUAL(histo[2], 4030);
+  VERIFY_ARE_EQUAL(histo[5], 66);
 }
 
 TEST_F(ExecutionTest, BasicComputeTest) {


### PR DESCRIPTION
- Adds `CreateDXRDevice` and `RunDXRTest` helpers for triangle dxr tests. Will extend this to procedural in followups.
- Adds a trivial `SERBasicTest`. As SER functionality is still missing in DXC, this only uses the `dx::HitObject` type.
