### PR TITLE
UB fix: new-delete-type-mismatch in ~CodeGenTypes()

### DIFF
--- a/tools/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -47,7 +47,7 @@ CodeGenTypes::~CodeGenTypes() {
 
   for (llvm::FoldingSet<CGFunctionInfo>::iterator
        I = FunctionInfos.begin(), E = FunctionInfos.end(); I != E; )
-    delete &*I++;
+    ::operator delete(&*I++);
 }
 
 void CodeGenTypes::addRecordTypeName(const RecordDecl *RD,


### PR DESCRIPTION
It is undefined behavior to use `delete` expression on something which was not created with corresponding `new` expression. Switching to explicit global `operator delete()` call to match with `operator new()` call at `CGFunctionInfo::create()`.

This issue is raised by Chromium ClusterFuzz, with ASan enabled. https://crbug.com/410141973