### PR TITLE
[SPIRV] Remove patch decoration from gl_TessCoord (#7187)

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3522,7 +3522,8 @@ SpirvVariable *DeclResultIdMapper::createSpirvInterfaceVariable(
       // Decorate with PerPrimitiveNV for per-primitive out variables.
       spvBuilder.decoratePerPrimitiveNV(varInstr,
                                         varInstr->getSourceLocation());
-    } else {
+    } else if (stageVar.getSemanticInfo().getKind() !=
+               hlsl::Semantic::Kind::DomainLocation) {
       spvBuilder.decoratePatch(varInstr, varInstr->getSourceLocation());
     }
   }

--- a/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
@@ -96,7 +96,6 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // CHECK-NEXT:                OpDecorate %in_var_TANVCORNER Patch
 // CHECK-NEXT:                OpDecorate %in_var_TANWEIGHTS Patch
 // CHECK-NEXT:                OpDecorate %gl_TessCoord BuiltIn TessCoord
-// CHECK-NEXT:                OpDecorate %gl_TessCoord Patch
 // CHECK-NEXT:                OpDecorate %gl_Position BuiltIn Position
 // CHECK-NEXT:                OpDecorate %in_var_BEZIERPOS Location 0
 // CHECK-NEXT:                OpDecorate %in_var_TANGENT Location 1

--- a/tools/clang/test/CodeGenSPIRV/semantic.domain-location.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.domain-location.ds.hlsl
@@ -4,7 +4,6 @@
 // CHECK-SAME: %gl_TessCoord
 
 // CHECK: OpDecorate %gl_TessCoord BuiltIn TessCoord
-// CHECK: OpDecorate %gl_TessCoord Patch
 
 // CHECK: %gl_TessCoord = OpVariable %_ptr_Input_v3float Input
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
@@ -85,7 +85,6 @@ struct DsOut {
 // CHECK: OpDecorateString %gl_PointSize UserSemantic "PSIZE"
 // CHECK: OpDecorate %gl_TessCoord BuiltIn TessCoord
 // CHECK: OpDecorateString %gl_TessCoord UserSemantic "SV_DomainLocation"
-// CHECK: OpDecorate %gl_TessCoord Patch
 // CHECK: OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
 // CHECK: OpDecorateString %gl_TessLevelOuter UserSemantic "SV_TessFactor"
 // CHECK: OpDecorate %gl_TessLevelOuter Patch


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7187.  gl_TessCoord is not a per-patch builtin and therefore the SPIRV should not be decorated with Patch.  This is clear in the GLSL specification, and a SPIRV spec clarification is online here: https://gitlab.khronos.org/spirv/SPIR-V/-/issues/819