### PR TITLE
Make dxcompiler target build with Clang 19.1.1

### DIFF
--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -34,7 +34,7 @@ protected:
     m_dll = LoadLibraryA(dllName);
     if (m_dll == nullptr)
       return HRESULT_FROM_WIN32(GetLastError());
-    m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
+    m_createFn = reinterpret_cast<DxcCreateInstanceProc>(reinterpret_cast<void *>(GetProcAddress(m_dll, fnName)));
 
     if (m_createFn == nullptr) {
       HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
@@ -64,7 +64,7 @@ protected:
       fnName2[s] = '2';
       fnName2[s + 1] = '\0';
 #ifdef _WIN32
-      m_createFn2 = (DxcCreateInstance2Proc)GetProcAddress(m_dll, fnName2);
+      m_createFn2 = reinterpret_cast<DxcCreateInstance2Proc>(reinterpret_cast<void *>(GetProcAddress(m_dll, fnName2)));
 #else
       m_createFn2 = (DxcCreateInstance2Proc)::dlsym(m_dll, fnName2);
 #endif

--- a/include/llvm/CodeGen/SchedulerRegistry.h
+++ b/include/llvm/CodeGen/SchedulerRegistry.h
@@ -40,7 +40,7 @@ public:
   static MachinePassRegistry Registry;
 
   RegisterScheduler(const char *N, const char *D, FunctionPassCtor C)
-  : MachinePassRegistryNode(N, D, (MachinePassCtor)C)
+      : MachinePassRegistryNode(N, D, reinterpret_cast<MachinePassCtor>(reinterpret_cast<void *>(C)))
   { Registry.Add(this); }
   ~RegisterScheduler() { Registry.Remove(this); }
 
@@ -54,10 +54,10 @@ public:
     return (RegisterScheduler *)Registry.getList();
   }
   static FunctionPassCtor getDefault() {
-    return (FunctionPassCtor)Registry.getDefault();
+    return reinterpret_cast<FunctionPassCtor>(reinterpret_cast<void *>(Registry.getDefault()));
   }
   static void setDefault(FunctionPassCtor C) {
-    Registry.setDefault((MachinePassCtor)C);
+    Registry.setDefault(reinterpret_cast<MachinePassCtor>(reinterpret_cast<void *>(C)));
   }
   static void setListener(MachinePassRegistryListener *L) {
     Registry.setListener(L);

--- a/lib/IR/Core.cpp
+++ b/lib/IR/Core.cpp
@@ -90,7 +90,8 @@ void LLVMContextSetDiagnosticHandler(LLVMContextRef C,
                                      LLVMDiagnosticHandler Handler,
                                      void *DiagnosticContext) {
   unwrap(C)->setDiagnosticHandler(
-      LLVM_EXTENSION reinterpret_cast<LLVMContext::DiagnosticHandlerTy>(Handler),
+      reinterpret_cast<LLVMContext::DiagnosticHandlerTy>(
+          reinterpret_cast<void *>(Handler)),
       DiagnosticContext);
 }
 

--- a/lib/MSSupport/MSFileSystemImpl.cpp
+++ b/lib/MSSupport/MSFileSystemImpl.cpp
@@ -322,8 +322,9 @@ typedef BOOLEAN(WINAPI *PtrCreateSymbolicLinkW)(
     /*__in*/ DWORD dwFlags);
 
 PtrCreateSymbolicLinkW create_symbolic_link_api =
-    PtrCreateSymbolicLinkW(::GetProcAddress(::GetModuleHandleW(L"Kernel32.dll"),
-                                            "CreateSymbolicLinkW"));
+    PtrCreateSymbolicLinkW(reinterpret_cast<void *>(::GetProcAddress(
+        ::GetModuleHandleW(L"Kernel32.dll"),
+                                            "CreateSymbolicLinkW")));
 } // namespace
 #endif
 

--- a/lib/Support/Windows/RWMutex.inc
+++ b/lib/Support/Windows/RWMutex.inc
@@ -49,21 +49,16 @@ static bool loadSRW() {
     sChecked = true;
 
     if (HMODULE hLib = ::GetModuleHandleW(L"Kernel32.dll")) {
-      fpInitializeSRWLock =
-        (VOID (WINAPI *)(PSRWLOCK))::GetProcAddress(hLib,
-                                               "InitializeSRWLock");
-      fpAcquireSRWLockExclusive =
-        (VOID (WINAPI *)(PSRWLOCK))::GetProcAddress(hLib,
-                                               "AcquireSRWLockExclusive");
-      fpAcquireSRWLockShared =
-        (VOID (WINAPI *)(PSRWLOCK))::GetProcAddress(hLib,
-                                               "AcquireSRWLockShared");
-      fpReleaseSRWLockExclusive =
-        (VOID (WINAPI *)(PSRWLOCK))::GetProcAddress(hLib,
-                                               "ReleaseSRWLockExclusive");
-      fpReleaseSRWLockShared =
-        (VOID (WINAPI *)(PSRWLOCK))::GetProcAddress(hLib,
-                                               "ReleaseSRWLockShared");
+      fpInitializeSRWLock = reinterpret_cast<VOID (WINAPI *)(PSRWLOCK)>(
+          reinterpret_cast<void *>(::GetProcAddress(hLib, "InitializeSRWLock")));
+      fpAcquireSRWLockExclusive = reinterpret_cast<VOID (WINAPI *)(PSRWLOCK)>(
+          reinterpret_cast<void *>(::GetProcAddress(hLib, "AcquireSRWLockExclusive")));
+      fpAcquireSRWLockShared = reinterpret_cast<VOID (WINAPI *)(PSRWLOCK)>(
+          reinterpret_cast<void *>(::GetProcAddress(hLib, "AcquireSRWLockShared")));
+      fpReleaseSRWLockExclusive = reinterpret_cast<VOID (WINAPI *)(PSRWLOCK)>(
+          reinterpret_cast<void *>(::GetProcAddress(hLib, "ReleaseSRWLockExclusive")));
+      fpReleaseSRWLockShared = reinterpret_cast<VOID (WINAPI *)(PSRWLOCK)>(
+          reinterpret_cast<void *>(::GetProcAddress(hLib, "ReleaseSRWLockShared")));
 
       if (fpInitializeSRWLock != NULL) {
         sHasSRW = true;
@@ -72,6 +67,7 @@ static bool loadSRW() {
   }
   return sHasSRW;
 }
+
 
 RWMutexImpl::RWMutexImpl() {
   // TODO: harden to allocation failures - HLSL Change


### PR DESCRIPTION
Fixed clang 19.1.1 (Visual Studio) build. There were issues with function type casts after invoking ::GetProcAddress to get a function pointer (FARPROC -> desired type).