### PR TITLE
Update azure pipelines to gcc-12/g++-12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,13 +73,13 @@ stages:
         Linux_Gcc_Release:
           image: ${{ variables.linux }}
           configuration: Release
-          CC: gcc-12
-          CXX: g++-12
+          CC: gcc-14
+          CXX: g++-14
         Linux_Gcc_Debug:
           image: ${{ variables.linux }}
           configuration: Debug
-          CC: gcc-12
-          CXX: g++-12
+          CC: gcc-14
+          CXX: g++-14
         MacOS_Clang_Release:
           image: ${{ variables.macOS }}
           configuration: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,13 +73,13 @@ stages:
         Linux_Gcc_Release:
           image: ${{ variables.linux }}
           configuration: Release
-          CC: gcc-9
-          CXX: g++-9
+          CC: gcc-12
+          CXX: g++-12
         Linux_Gcc_Debug:
           image: ${{ variables.linux }}
           configuration: Debug
-          CC: gcc-9
-          CXX: g++-9
+          CC: gcc-12
+          CXX: g++-12
         MacOS_Clang_Release:
           image: ${{ variables.macOS }}
           configuration: Release


### PR DESCRIPTION
The new `ubuntu-latest` image based on Ubuntu 24.04 has gcc-12 and does not have gcc-9. This updates to a more recent gcc.

Note: while the Azure images have gcc-14 as well, I've chosen gcc-12 because it is the latest version of gcc available in 24.04's apt repositories. To get newer versions you need to poke at external apt repositories.