### PR TITLE
Revert ADO pipelines to Ubuntu 22.04 temporarily

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ stages:
 
     variables:
       macOS: macOS-latest
-      linux: Ubuntu-latest
+      linux: Ubuntu-22.04 # FIXME: #7364, DXC does not build correctly with GCC 13+
 
     strategy:
       matrix:


### PR DESCRIPTION
DXC seems to be building inocrrectly with GCC-13 and later, which is causing our pre-merge testing on 24.04 to fail. This will take some time to sort out, so in the meantime I'm reverting to 22.04 on our pipelines.