### PR TITLE
[SER] Validate %dx.types.HitObject as legal type same as handle

### DIFF
--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -2599,6 +2599,9 @@ static bool ValidateType(Type *Ty, ValidationContext &ValCtx,
       if (ValCtx.HandleTy == Ty)
         return true;
       hlsl::OP *HlslOP = ValCtx.DxilMod.GetOP();
+      // Allow HitObject type.
+      if (ST == HlslOP->GetHitObjectType())
+        return true;
       if (IsDxilBuiltinStructType(ST, HlslOP)) {
         ValCtx.EmitTypeError(Ty, ValidationRule::InstrDxilStructUser);
         Result = false;

--- a/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/maybereorder_od.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/maybereorder_od.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T lib_6_9 -E main %s -Od | FileCheck %s --check-prefix DXIL
+
+// DXIL: %[[HOA:[^ ]+]] = alloca %dx.types.HitObject, align 4
+// DXIL-NEXT: %[[NOP:[^ ]+]] = call %dx.types.HitObject @dx.op.hitObject_MakeNop(i32 266)  ; HitObject_MakeNop()
+// DXIL-NEXT: store %dx.types.HitObject %[[NOP]], %dx.types.HitObject* %[[HOA]]
+// DXIL-NEXT: %[[LD0:[^ ]+]] = load %dx.types.HitObject, %dx.types.HitObject* %[[HOA]]
+// DXIL-NEXT: call void @dx.op.maybeReorderThread(i32 268, %dx.types.HitObject %[[LD0]], i32 undef, i32 0)  ; MaybeReorderThread(hitObject,coherenceHint,numCoherenceHintBitsFromLSB)
+// DXIL-NEXT: %[[LD1:[^ ]+]] = load %dx.types.HitObject, %dx.types.HitObject* %[[HOA]]
+// DXIL-NEXT: call void @dx.op.maybeReorderThread(i32 268, %dx.types.HitObject %[[LD1]], i32 241, i32 3)  ; MaybeReorderThread(hitObject,coherenceHint,numCoherenceHintBitsFromLSB)
+// DXIL-NEXT: %[[NOP2:[^ ]+]] = call %dx.types.HitObject @dx.op.hitObject_MakeNop(i32 266)  ; HitObject_MakeNop()
+// DXIL-NEXT: call void @dx.op.maybeReorderThread(i32 268, %dx.types.HitObject %[[NOP2]], i32 242, i32 7)  ; MaybeReorderThread(hitObject,coherenceHint,numCoherenceHintBitsFromLSB)
+
+[shader("raygeneration")]
+void main() {
+  dx::HitObject hit;
+  dx::MaybeReorderThread(hit);
+  dx::MaybeReorderThread(hit, 0xf1, 3);
+  dx::MaybeReorderThread(0xf2, 7);
+}


### PR DESCRIPTION
Validator did not recognize %dx.types.HitObject as an allowed type. This lead to validation failures in -Od compiles where allocas, loads and stores remain in the generated DXIL:

```
  dxc.exe -T lib_6_9 -Od \tools\clang\test\CodeGenDXIL\hlsl\intrinsics\maybereorder.hlsl
  error: validation errors
  error: Declaration '%dx.types.HitObject = type { i8* }' uses a reserved prefix.
```
Closes #7387