### PR TITLE
Change default validation behavior

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -115,7 +115,7 @@ struct RewriterOpts {
 };
 
 enum class ValidatorSelection : int {
-  Auto,        // Try internal validator; fallback to DXIL.dll
+  Auto,        // Force internal validator (even if DXIL.dll is present)
   Internal,    // Force internal validator (even if DXIL.dll is present)
   External,    // Use DXIL.dll, failing compilation if not available
   Invalid = -1 // Invalid

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -115,7 +115,7 @@ struct RewriterOpts {
 };
 
 enum class ValidatorSelection : int {
-  Auto,        // Try DXIL.dll; fallback to internal validator
+  Auto,        // Try internal validator; fallback to DXIL.dll
   Internal,    // Force internal validator (even if DXIL.dll is present)
   External,    // Use DXIL.dll, failing compilation if not available
   Invalid = -1 // Invalid

--- a/tools/clang/tools/dxcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxcompiler/dxcutil.cpp
@@ -58,8 +58,10 @@ bool CreateValidator(CComPtr<IDxcValidator> &pValidator,
   bool bExternal =
       SelectValidator == hlsl::options::ValidatorSelection::External;
 
-  if (!bExternal)
+  if (!bExternal) {
     IFT(CreateDxcValidator(IID_PPV_ARGS(&pValidator)));
+    bInternalValidator = true;
+  }
 
   if (pValidator == nullptr && DxilLibIsEnabled()) {
     IFTBOOL(!bInternal, DXC_E_VALIDATOR_MISSING);

--- a/tools/clang/tools/dxcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxcompiler/dxcutil.cpp
@@ -70,11 +70,8 @@ bool CreateValidator(CComPtr<IDxcValidator> &pValidator,
     // if external was explicitly specified, but no
     // external validator could be found (no DXIL.dll), then error
     IFTBOOL(!DxilLibIsEnabled(), DXC_E_VALIDATOR_MISSING);
-    DxilLibCreateInstance(CLSID_DxcValidator, &pValidator);
+    IFT(DxilLibCreateInstance(CLSID_DxcValidator, &pValidator));
 
-    // if external was explicitly specified, but the validator
-    // failed to be created, then error.
-    IFTBOOL(pValidator, DXC_E_VALIDATOR_MISSING);
     return false;
   }
 

--- a/tools/clang/tools/dxcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxcompiler/dxcutil.cpp
@@ -52,19 +52,20 @@ namespace {
 bool CreateValidator(CComPtr<IDxcValidator> &pValidator,
                      hlsl::options::ValidatorSelection SelectValidator =
                          hlsl::options::ValidatorSelection::Auto) {
+  bool bInternalValidator = false;
   bool bInternal =
       SelectValidator == hlsl::options::ValidatorSelection::Internal;
   bool bExternal =
       SelectValidator == hlsl::options::ValidatorSelection::External;
-  if (!bInternal && DxilLibIsEnabled())
-    DxilLibCreateInstance(CLSID_DxcValidator, &pValidator);
 
-  bool bInternalValidator = false;
-  if (pValidator == nullptr) {
-    IFTBOOL(!bExternal, DXC_E_VALIDATOR_MISSING);
+  if (!bExternal)
     IFT(CreateDxcValidator(IID_PPV_ARGS(&pValidator)));
-    bInternalValidator = true;
+
+  if (pValidator == nullptr && DxilLibIsEnabled()) {
+    IFTBOOL(!bInternal, DXC_E_VALIDATOR_MISSING);
+    DxilLibCreateInstance(CLSID_DxcValidator, &pValidator);
   }
+
   return bInternalValidator;
 }
 

--- a/tools/clang/tools/dxcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxcompiler/dxcutil.cpp
@@ -69,7 +69,7 @@ bool CreateValidator(CComPtr<IDxcValidator> &pValidator,
   if (bExternal) {
     // if external was explicitly specified, but no
     // external validator could be found (no DXIL.dll), then error
-    IFTBOOL(!DxilLibIsEnabled(), DXC_E_VALIDATOR_MISSING);
+    IFTBOOL(DxilLibIsEnabled(), DXC_E_VALIDATOR_MISSING);
     IFT(DxilLibCreateInstance(CLSID_DxcValidator, &pValidator));
 
     return false;


### PR DESCRIPTION
This PR changes the default validation behavior to use the internal validator by default.
If no options are specified, the internal validator will be used, and if it fails, then compilation fails.
The external validator can still be run but must be explicitly chosen.
Specifying internal works just as before.

There is plenty of testing and infrastructure that needs to be added to verify this change, but that needs to be added in a separate change. This change is step 1.

Addresses https://github.com/microsoft/DirectXShaderCompiler/issues/7389