### PR TITLE
Update LongVector Execution tests to now use XML 

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -279,6 +279,7 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS4 {
 
 // Virtual class to compute the expected result given a set of inputs
 struct TableParameter;
+class TableParameterHandler; // Forward declaration
 
 class ExecutionTest {
 public:
@@ -507,115 +508,15 @@ public:
                        L"Table:ShaderOpArithTable.xml#PackUnpackOpTable")
   END_TEST_METHOD()
 
-  // bool binary ops
-  TEST_METHOD(LongVector_ScalarAdd_bool)
-  TEST_METHOD(LongVector_ScalarMultiply_bool)
-  TEST_METHOD(LongVector_Multiply_bool)
-  TEST_METHOD(LongVector_Add_bool)
-  TEST_METHOD(LongVector_Min_bool)
-  TEST_METHOD(LongVector_Max_bool)
-  // bool unary ops
-  // Note that clamp doesn't make sense for bools.
-  TEST_METHOD(LongVector_Initialize_bool);
+  BEGIN_TEST_METHOD(LongVector_BinaryOpTest)
+  TEST_METHOD_PROPERTY(L"DataSource",
+                       L"Table:ShaderOpArithTable.xml#LongVectorBinaryOpTable")
+  END_TEST_METHOD()
 
-  // float16 (half) binary ops
-  TEST_METHOD(LongVector_ScalarAdd_float16)
-  TEST_METHOD(LongVector_ScalarMultiply_float16)
-  TEST_METHOD(LongVector_Multiply_float16)
-  TEST_METHOD(LongVector_Add_float16)
-  TEST_METHOD(LongVector_Min_float16)
-  TEST_METHOD(LongVector_Max_float16)
-  // float16 (half) unary ops
-  TEST_METHOD(LongVector_Clamp_float16);
-  TEST_METHOD(LongVector_Initialize_float16);
-
-  // float32 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_float32)
-  TEST_METHOD(LongVector_ScalarMultiply_float32)
-  TEST_METHOD(LongVector_Multiply_float32)
-  TEST_METHOD(LongVector_Add_float32)
-  TEST_METHOD(LongVector_Min_float32)
-  TEST_METHOD(LongVector_Max_float32)
-  // float32 unary ops
-  TEST_METHOD(LongVector_Clamp_float32);
-  TEST_METHOD(LongVector_Initialize_float32);
-
-  // float64 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_float64)
-  TEST_METHOD(LongVector_ScalarMultiply_float64)
-  TEST_METHOD(LongVector_Multiply_float64)
-  TEST_METHOD(LongVector_Add_float64)
-  TEST_METHOD(LongVector_Min_float64)
-  TEST_METHOD(LongVector_Max_float64)
-  // float64 unary ops
-  TEST_METHOD(LongVector_Clamp_float64);
-  TEST_METHOD(LongVector_Initialize_float64);
-
-  // int16 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_int16)
-  TEST_METHOD(LongVector_ScalarMultiply_int16)
-  TEST_METHOD(LongVector_Multiply_int16)
-  TEST_METHOD(LongVector_Add_int16)
-  TEST_METHOD(LongVector_Min_int16)
-  TEST_METHOD(LongVector_Max_int16)
-  // int16 unary ops
-  TEST_METHOD(LongVector_Clamp_int16);
-  TEST_METHOD(LongVector_Initialize_int16);
-
-  // int32 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_int32)
-  TEST_METHOD(LongVector_ScalarMultiply_int32)
-  TEST_METHOD(LongVector_Multiply_int32)
-  TEST_METHOD(LongVector_Add_int32)
-  TEST_METHOD(LongVector_Min_int32)
-  TEST_METHOD(LongVector_Max_int32)
-  // int32 unary ops
-  TEST_METHOD(LongVector_Clamp_int32);
-  TEST_METHOD(LongVector_Initialize_int32);
-
-  // int64 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_int64)
-  TEST_METHOD(LongVector_ScalarMultiply_int64)
-  TEST_METHOD(LongVector_Multiply_int64)
-  TEST_METHOD(LongVector_Add_int64)
-  TEST_METHOD(LongVector_Min_int64)
-  TEST_METHOD(LongVector_Max_int64)
-  // int64 unary ops
-  TEST_METHOD(LongVector_Clamp_int64);
-  TEST_METHOD(LongVector_Initialize_int64);
-
-  // uint16 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_uint16)
-  TEST_METHOD(LongVector_ScalarMultiply_uint16)
-  TEST_METHOD(LongVector_Multiply_uint16)
-  TEST_METHOD(LongVector_Add_uint16)
-  TEST_METHOD(LongVector_Min_uint16)
-  TEST_METHOD(LongVector_Max_uint16)
-  // uint16 unary ops
-  TEST_METHOD(LongVector_Clamp_uint16);
-  TEST_METHOD(LongVector_Initialize_uint16);
-
-  // uint32 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_uint32)
-  TEST_METHOD(LongVector_ScalarMultiply_uint32)
-  TEST_METHOD(LongVector_Multiply_uint32)
-  TEST_METHOD(LongVector_Add_uint32)
-  TEST_METHOD(LongVector_Min_uint32)
-  TEST_METHOD(LongVector_Max_uint32)
-  // uint32 unary ops
-  TEST_METHOD(LongVector_Clamp_uint32);
-  TEST_METHOD(LongVector_Initialize_uint32);
-
-  // uint64 binary ops
-  TEST_METHOD(LongVector_ScalarAdd_uint64)
-  TEST_METHOD(LongVector_ScalarMultiply_uint64)
-  TEST_METHOD(LongVector_Multiply_uint64)
-  TEST_METHOD(LongVector_Add_uint64)
-  TEST_METHOD(LongVector_Min_uint64)
-  TEST_METHOD(LongVector_Max_uint64)
-  // uint64 unary ops
-  TEST_METHOD(LongVector_Clamp_uint64);
-  TEST_METHOD(LongVector_Initialize_uint64);
+  BEGIN_TEST_METHOD(LongVector_UnaryOpTest)
+  TEST_METHOD_PROPERTY(L"DataSource",
+                       L"Table:ShaderOpArithTable.xml#LongVectorUnaryOpTable")
+  END_TEST_METHOD()
 
   dxc::DxcDllSupport m_support;
 
@@ -826,9 +727,14 @@ public:
                                const char *pShaderModelStr, const char *pShader,
                                Ty *pInputDataPairs, unsigned inputDataCount);
 
+  template <typename T>
+  void LongVectorOpTestDispatchByDataType(T OpType, std::wstring DataType, TableParameterHandler &Handler);
+
+  template <typename T, typename U> 
+  void LongVectorOpTestDispatchByVectorSize(U OpType, TableParameterHandler &Handler);
+
   template <typename T, std::size_t N>
   void LongVectorOpTestBase(LongVectorOpTestConfig<T> &TestConfig);
-  template <typename T> void LongVectorOpTestBase(LongVectorOpType OpType);
 
   template <class Ty> const wchar_t *BasicShaderModelTest_GetFormatString();
 
@@ -6580,6 +6486,20 @@ static TableParameter PackUnpackOpParameters[] = {
     {L"Validation.Input", TableParameter::UINT32_TABLE, true},
 };
 
+static TableParameter LongVectorBinaryOpParameters[] = {
+  {L"DataType", TableParameter::STRING, true},
+  {L"OpTypeEnum", TableParameter::STRING, true},
+  {L"InputValueSetName1", TableParameter::STRING, false},
+  {L"InputValueSetName2", TableParameter::STRING, false},
+};
+
+static TableParameter LongVectorUnaryOpParameters[] = {
+  {L"DataType", TableParameter::STRING, true},
+  {L"OpTypeEnum", TableParameter::STRING, true},
+  {L"InputValueSetName1", TableParameter::STRING, false},
+  {L"InputArgsName", TableParameter::STRING, false},
+};
+
 static bool IsHexString(PCWSTR str, uint16_t *value) {
   std::wstring wString(str);
   wString.erase(std::remove(wString.begin(), wString.end(), L' '),
@@ -11216,486 +11136,93 @@ TEST_F(ExecutionTest, PackUnpackTest) {
   }
 }
 
-TEST_F(ExecutionTest, LongVector_ScalarAdd_bool) {
+TEST_F(ExecutionTest, LongVector_BinaryOpTest) {
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_bool) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_bool) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_bool) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_bool) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_bool) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarAdd_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_ScalarAdd);
-}
-
-TEST_F(ExecutionTest, LongVector_ScalarMultiply_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_ScalarMultiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Multiply_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_Multiply);
-}
-
-TEST_F(ExecutionTest, LongVector_Add_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_Add);
-}
-
-TEST_F(ExecutionTest, LongVector_Min_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_Min);
-}
-
-TEST_F(ExecutionTest, LongVector_Max_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_Max);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_bool) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLBool_t>(LongVectorOpType_Initialize);
-}
-
-TEST_F(ExecutionTest, LongVector_Clamp_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_Clamp);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_float16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<HLSLHalf_t>(LongVectorOpType_Initialize);
-}
-
-TEST_F(ExecutionTest, LongVector_Clamp_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_Clamp);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_float32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<float>(LongVectorOpType_Initialize);
-}
-
-TEST_F(ExecutionTest, LongVector_Clamp_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_Clamp);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_float64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<double>(LongVectorOpType_Initialize);
-}
 
-TEST_F(ExecutionTest, LongVector_Clamp_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_Clamp);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_int16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int16_t>(LongVectorOpType_Initialize);
-}
-
-TEST_F(ExecutionTest, LongVector_Clamp_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_Clamp);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_int32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int32_t>(LongVectorOpType_Initialize);
-}
-
-TEST_F(ExecutionTest, LongVector_Clamp_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_Clamp);
-}
+  using namespace WEX::Common;
 
-TEST_F(ExecutionTest, LongVector_Initialize_int64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<int64_t>(LongVectorOpType_Initialize);
-}
-
-TEST_F(ExecutionTest, LongVector_Clamp_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_Clamp);
-}
-
-TEST_F(ExecutionTest, LongVector_Initialize_uint16) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint16_t>(LongVectorOpType_Initialize);
-}
+  const int TableSize = sizeof(LongVectorBinaryOpParameters) / sizeof(TableParameter);
+  TableParameterHandler Handler(LongVectorBinaryOpParameters, TableSize);
 
-TEST_F(ExecutionTest, LongVector_Clamp_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_Clamp);
-}
+  std::wstring DataType(Handler.GetTableParamByName(L"DataType")->m_str);
+  std::wstring OpTypeString(Handler.GetTableParamByName(L"OpTypeEnum")->m_str);
 
-TEST_F(ExecutionTest, LongVector_Initialize_uint32) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint32_t>(LongVectorOpType_Initialize);
+  auto OpType = GetLongVectorBinaryOpType(OpTypeString);
+  LongVectorOpTestDispatchByDataType(OpType, DataType, Handler);
 }
 
-TEST_F(ExecutionTest, LongVector_Clamp_uint64) {
+TEST_F(ExecutionTest, LongVector_UnaryOpTest) {
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_Clamp);
-}
 
-TEST_F(ExecutionTest, LongVector_Initialize_uint64) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  LongVectorOpTestBase<uint64_t>(LongVectorOpType_Initialize);
+  const int TableSize = sizeof(LongVectorUnaryOpParameters) / sizeof(TableParameter);
+  TableParameterHandler Handler(LongVectorUnaryOpParameters, TableSize);
+  
+  std::wstring DataType(Handler.GetTableParamByName(L"DataType")->m_str);
+  std::wstring OpTypeString(Handler.GetTableParamByName(L"OpTypeEnum")->m_str);
+  
+  auto OpType = GetLongVectorUnaryOpType(OpTypeString);
+  LongVectorOpTestDispatchByDataType(OpType, DataType, Handler);
 }
 
 template <typename T>
-void ExecutionTest::LongVectorOpTestBase(LongVectorOpType opType) {
+void ExecutionTest::LongVectorOpTestDispatchByDataType(T OpType, std::wstring DataType, TableParameterHandler &Handler) {
+  using namespace WEX::Common;
+
+  if(DataType == L"bool")
+    LongVectorOpTestDispatchByVectorSize<HLSLBool_t>(OpType, Handler);
+  else if(DataType == L"int16")
+    LongVectorOpTestDispatchByVectorSize<int16_t>(OpType, Handler);
+  else if(DataType == L"int32")
+    LongVectorOpTestDispatchByVectorSize<int32_t>(OpType, Handler);
+  else if(DataType == L"int64")
+    LongVectorOpTestDispatchByVectorSize<int64_t>(OpType, Handler);
+  else if(DataType == L"uint16")
+    LongVectorOpTestDispatchByVectorSize<uint16_t>(OpType, Handler);
+  else if(DataType == L"uint32")
+    LongVectorOpTestDispatchByVectorSize<uint32_t>(OpType, Handler);
+  else if(DataType == L"uint64")
+    LongVectorOpTestDispatchByVectorSize<uint64_t>(OpType, Handler);
+  else if(DataType == L"float16")
+    LongVectorOpTestDispatchByVectorSize<HLSLHalf_t>(OpType, Handler);
+  else if(DataType == L"float32")
+    LongVectorOpTestDispatchByVectorSize<float>(OpType, Handler);
+  else if(DataType == L"float64")
+    LongVectorOpTestDispatchByVectorSize<double>(OpType, Handler);
+  else
+    VERIFY_FAIL(String().Format(L"DataType: %s is not recognized.", DataType.c_str()));
+}
+
+template <typename T, typename U>
+void ExecutionTest::LongVectorOpTestDispatchByVectorSize(U opType, TableParameterHandler &Handler) {
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
   LongVectorOpTestConfig<T> TestConfig(opType);
+
+  // InputValueSetName1 is optional. So the string may be empty. An empty
+  // string will result in the default value set for this DataType being used.
+  std::wstring InputValueSet1(Handler.GetTableParamByName(L"InputValueSetName1")->m_str);
+  if(!InputValueSet1.empty()) {
+    TestConfig.SetInputValueSet1(InputValueSet1);
+  }
+
+  // InputValueSetName2 is optional. So the string may be empty. An empty
+  // string will result in the default value set for this DataType being used.
+  if(TestConfig.IsBinaryOp()) {
+    std::wstring InputValueSet2(Handler.GetTableParamByName(L"InputValueSetName2")->m_str);
+    if(!InputValueSet1.empty()) {
+      TestConfig.SetInputValueSet2(InputValueSet2);
+    }
+  }
+
+  if(TestConfig.HasInputArguments()){
+    std::wstring InputArgsName(Handler.GetTableParamByName(L"InputArgsName")->m_str);
+    if(!InputArgsName.empty()) {
+      TestConfig.SetInputArgsArrayName(InputArgsName);
+    }
+  }
 
   LongVectorOpTestBase<T, 3>(TestConfig);
   LongVectorOpTestBase<T, 4>(TestConfig);
@@ -11716,200 +11243,144 @@ void ExecutionTest::LongVectorOpTestBase(
 
   LogCommentFmt(L"Running LongVectorOpTestBase<%S, %zu>", typeid(T).name(), N);
 
+  bool LogInputs = false;
+  WEX::TestExecution::RuntimeParameters::TryGetValue(L"LongVectorLogInputs", LogInputs);
+
   CComPtr<ID3D12Device> D3DDevice;
   if (!CreateDevice(&D3DDevice, D3D_SHADER_MODEL_6_9)) {
 #ifdef _HLK_CONF
     LogErrorFmtThrow(L"Device does not support SM 6.9. Can't run these tests.");
-  }
 #else
     WEX::Logging::Log::Comment(
         "Device does not support SM 6.9. Can't run these tests.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
     return;
 #endif
-}
-
-DeterministicNumberGenerator<T> NumberGenerator(1337);
-std::array<T, N> InputVector1;
-std::array<T, N> InputVector2;
-std::array<T, 1> ScalarInput;
-ScalarInput[0] = NumberGenerator.generate();
-const bool IsVectorBinaryOp = TestConfig.IsBinaryOp && !TestConfig.IsScalarOp;
-
-// Fill the vector inputs with values.
-for (size_t Index = 0; Index < N; Index++) {
-  // Always generate input.
-  InputVector1[Index] = NumberGenerator.generate();
-
-  if (IsVectorBinaryOp)
-    InputVector2[Index] = NumberGenerator.generate();
-}
-
-// We pass these values into the shader and they're requried to compile. So
-// they need to set to something.
-T ClampArgMin = 0;
-T ClampArgMax = 0;
-if (TestConfig.OpType == LongVectorOpType_Clamp) {
-  if constexpr (std::is_same_v<T, HLSLBool_t>) {
-    // Attempting to generate a clamp value for HLSLBool_t will result in an
-    // infinite loop in the below while. We don't have a test case for clamp
-    // with bools anyways. But adding this check to prevent the mistake.
-    LogErrorFmtThrow(L"Clamp is not supported for HLSLBool_t.");
   }
 
-  ClampArgMin = NumberGenerator.generate();
-  ClampArgMax = NumberGenerator.generate();
-  while (ClampArgMin >= ClampArgMax) {
-    // Generate a new value for ClampArgMin. It needs to be smaller than
-    // or equal to ClampArgMax.
-    ClampArgMax = NumberGenerator.generate();
-  }
-}
+  std::array<T, N> InputVector1;
+  std::array<T, N> InputVector2; // May be unused, but must be defined.
+  std::array<T, 1> ScalarInput; // May be unused, but must be defined.
+  std::vector<T> InputArgsArray = {};
+  const bool IsVectorBinaryOp = TestConfig.IsBinaryOp() && !TestConfig.IsScalarOp();
 
-std::array<T, N> ExpectedVector;
-for (size_t Index = 0; Index < N; Index++) {
-  if (TestConfig.IsBinaryOp) {
-    T Input1 = InputVector1[Index];
-    T Input2 = TestConfig.IsScalarOp ? ScalarInput[0] : InputVector2[Index];
-    if (TestConfig.OperatorString == "*") {
-      ExpectedVector[Index] = Input1 * Input2;
-    } else if (TestConfig.OperatorString == "+") {
-      ExpectedVector[Index] = Input1 + Input2;
-    } else if (TestConfig.OperatorString == ",") {
-      if (TestConfig.OpType == LongVectorOpType_Min)
-        ExpectedVector[Index] = std::min<T>(Input1, Input2);
-      else if (TestConfig.OpType == LongVectorOpType_Max)
-        ExpectedVector[Index] = std::max<T>(Input1, Input2);
-      else
-        LogErrorFmtThrow(L"Unrecognized Binary LongVectorOpType: %d",
-                         TestConfig.OpType);
-    } else {
-      LogErrorFmtThrow(
-          L"Don't know how to compute expected value for operatorString: %s",
-          TestConfig.OperatorString.c_str());
-    }
-  } else // Unary op logic
-  {
-    if (TestConfig.OpType == LongVectorOpType_Clamp) {
-      ExpectedVector[Index] =
-          std::clamp(InputVector1[Index], ClampArgMin, ClampArgMax);
-    } else if (TestConfig.OpType = LongVectorOpType_Initialize) {
-      ExpectedVector[Index] = InputVector1[Index];
-    } else {
-      LogErrorFmtThrow(L"Unrecognized Unary LongVectorOpType: %d",
-                       TestConfig.OpType);
+  std::vector<T> InputVector1ValueSet = TestConfig.GetInputValueSet1();
+  std::vector<T> InputVector2ValueSet = TestConfig.IsBinaryOp() ? TestConfig.GetInputValueSet2() : std::vector<T>();
+
+  if(TestConfig.IsScalarOp())
+    // Scalar ops are always binary ops. So InputVector2ValueSet is initialized
+    // with values above.
+    ScalarInput[0] = InputVector2ValueSet[0];
+
+  // Fill the input vectors with values from the value set. Repeat the values
+  // when we reach the end of the value set.
+  for (size_t Index = 0; Index < N; Index++) {
+    InputVector1[Index] = InputVector1ValueSet[Index % InputVector1ValueSet.size()];
+
+    if (IsVectorBinaryOp)
+      InputVector2[Index] = InputVector2ValueSet[Index % InputVector2ValueSet.size()];
+  }
+
+  if (TestConfig.HasInputArguments()) {
+    InputArgsArray = TestConfig.GetInputArgsArray();
+  }
+
+  std::array<T, N> ExpectedVector;
+  if(IsVectorBinaryOp)
+    ExpectedVector = ComputeExpectedValues(InputVector1, InputVector2, TestConfig);
+  else if (TestConfig.IsScalarOp())
+    ExpectedVector = ComputeExpectedValues(InputVector1, ScalarInput[0], TestConfig);
+  else // Must be a unary op
+    ExpectedVector = ComputeExpectedValues(InputVector1, TestConfig);
+
+  if(LogInputs){
+    LogLongVector<T, N>(InputVector1, L"InputVector1");
+
+    if(IsVectorBinaryOp)
+      LogLongVector<T, N>(InputVector2, L"InputVector2");
+    else if (TestConfig.IsScalarOp())
+      LogLongVector<T, 1>(ScalarInput, L"ScalarInput");
+
+    if(TestConfig.GetUnaryOpType() == LongVectorUnaryOpType_Clamp) {
+      LogScalar(InputArgsArray[0], L"ClampArgMin");
+      LogScalar(InputArgsArray[1], L"ClampArgMax");
     }
   }
-}
 
-// Set up the compiler options string.
-std::stringstream CompilerOptions("");
-std::string HLSLType = TestConfig.GetHLSLTypeString();
-CompilerOptions << "-DTYPE=";
-CompilerOptions << HLSLType;
-CompilerOptions << " -DNUM=";
-CompilerOptions << N;
-const bool Is16BitType =
-    (HLSLType == "int16_t" || HLSLType == "uint16_t" || HLSLType == "half");
-CompilerOptions << (Is16BitType ? " -enable-16bit-types" : "");
-CompilerOptions << " -DOPERATOR=";
-CompilerOptions << TestConfig.OperatorString;
-if (TestConfig.IsBinaryOp) {
-  CompilerOptions << " -DOPERAND2=";
-  CompilerOptions << (TestConfig.IsScalarOp ? "InputScalar" : "InputVector2");
+  // We have to construct the string outside of the lambda. Otherwise it's
+  // cleaned up when the lambda finishes executing but before the shader runs.
+  std::string CompilerOptionsString = TestConfig.GetCompilerOptionsString(N);
 
-  if (TestConfig.IsScalarOp) {
-    CompilerOptions << " -DIS_SCALAR_OP=1";
-  } else {
-    CompilerOptions << " -DIS_BINARY_VECTOR_OP=1";
-  }
-  CompilerOptions << " -DFUNC=";
-  CompilerOptions << TestConfig.IntrinsicString;
-} else {
-  CompilerOptions << " -DFUNC=";
-  CompilerOptions << TestConfig.IntrinsicString;
-  CompilerOptions << " -DOPERAND2=";
-  switch (TestConfig.OpType) {
-  case LongVectorOpType_Clamp:
-    CompilerOptions << "ClampArgMinMax";
-    CompilerOptions << " -DFUNC_CLAMP=1";
-    break;
-  case LongVectorOpType_Initialize:
-    CompilerOptions << " -DFUNC_INITIALIZE=1";
-    break;
-  }
-}
+  // The name of the shader we want to use in ShaderOpArith.xml. Could also add
+  // logic to set this name in ShaderOpArithTable.xml so we can use different
+  // shaders for different tests.
+  LPCSTR ShaderName = "LongVectorOp";
+  // ShaderOpArith.xml defines the input/output resources and the shader source.
+  CComPtr<IStream> TestXML;
+  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &TestXML);
 
-// We have to construct the string outside of the lambda. Otherwise it's
-// cleaned up when the lambda finishes executing but before the shader runs.
-std::string CompilerOptionsString = CompilerOptions.str();
+  // RunShaderOpTest is a helper function that handles resource creation
+  // and setup. It also handles the shader compilation and execution. It takes a
+  // callback that is called when the shader is compiled, but before it is
+  // executed.
+  std::shared_ptr<ShaderOpTestResult> TestResult = RunShaderOpTest(
+      D3DDevice, m_support, TestXML, ShaderName,
+      [&](LPCSTR Name, std::vector<BYTE> &ShaderData, st::ShaderOp *ShaderOp) {
+        LogCommentFmt(L"RunShaderOpTest CallBack. Resource Name: %S", Name);
 
-// ShaderOpArith.xml defines the input/output resources and the shader source.
-CComPtr<IStream> TestXML;
-ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &TestXML);
+        // This callback is called once for each resource defined for
+        // "LongVectorOp" in ShaderOpArith.xml. All callbacks are fired for each
+        // resource. We determine whether they are applicable to the test case
+        // when they run.
 
-// RunShaderOpTest is a helper function that handles resource creation
-// and setup. It also handles the shader compilation and execution. It takes a
-// callback that is called when the shader is compiled, but before it is
-// executed.
-std::shared_ptr<ShaderOpTestResult> TestResult = RunShaderOpTest(
-    D3DDevice, m_support, TestXML, "LongVectorOp",
-    [&](LPCSTR Name, std::vector<BYTE> &ShaderData, st::ShaderOp *ShaderOp) {
-      LogCommentFmt(L"RunShaderOpTest CallBack. Resource Name: %S", Name);
+        // Process the callback for the OutputVector resource.
+        if (0 == _stricmp(Name, "OutputVector")) {
+          // We only need to set the compiler options string once. So this is a
+          // convenient place to do it.
+          ShaderOp->Shaders.at(0).Arguments = CompilerOptionsString.c_str();
 
-      // This callback is called once for each resource defined for
-      // "LongVectorOp" in ShaderOpArith.xml. All callbacks are fired for each
-      // resource. We determine whether they are applicable to the test case
-      // when they run.
-
-      // Process the callback for the OutputVector resource.
-      if (0 == _stricmp(Name, "OutputVector")) {
-        // We only need to set the compiler options string once. So this is a
-        // convenient place to do it.
-        ShaderOp->Shaders.at(0).Arguments = CompilerOptionsString.c_str();
-
-        return;
-      }
-
-      // Process the callback for the InputFuncArgs resource.
-      if (0 == _stricmp(Name, "InputFuncArgs")) {
-        if (TestConfig.IsScalarOp) {
-          FillShaderBufferFromLongVectorData<T, 1>(ShaderData, ScalarInput);
-        } else if (TestConfig.OpType == LongVectorOpType_Clamp) {
-          std::array<T, 2> ClampArgs = {ClampArgMin, ClampArgMax};
-          FillShaderBufferFromLongVectorData<T, 2>(ShaderData, ClampArgs);
+          return;
         }
 
-        return;
-      }
+        // Process the callback for the InputFuncArgs resource.
+        if (0 == _stricmp(Name, "InputFuncArgs")) {
+          if (TestConfig.IsScalarOp()) {
+            FillShaderBufferFromLongVectorData<T, 1>(ShaderData, ScalarInput);
+          } else if (TestConfig.GetUnaryOpType() == LongVectorUnaryOpType_Clamp) {
+            std::array<T, 2> ClampArgs = {InputArgsArray[0], InputArgsArray[1]};
+            FillShaderBufferFromLongVectorData<T, 2>(ShaderData, ClampArgs);
+          }
 
-      // Process the callback for the InputVector1 resource.
-      if (0 == _stricmp(Name, "InputVector1")) {
-        FillShaderBufferFromLongVectorData<T, N>(ShaderData, InputVector1);
-        return;
-      }
-
-      // Process the callback for the InputVector2 resource.
-      if (0 == _stricmp(Name, "InputVector2")) {
-        if (IsVectorBinaryOp) {
-          FillShaderBufferFromLongVectorData<T, N>(ShaderData, InputVector2);
+          return;
         }
-        return;
-      }
 
-      LogErrorFmtThrow(
-          L"RunShaderOpTest CallBack. Unexpected Resource Name: %S", Name);
-    });
+        // Process the callback for the InputVector1 resource.
+        if (0 == _stricmp(Name, "InputVector1")) {
+          FillShaderBufferFromLongVectorData<T, N>(ShaderData, InputVector1);
+          return;
+        }
 
-// Map the data from GPU to CPU memory so we can verify our expectations.
-MappedData ShaderOutData;
-TestResult->Test->GetReadBackData("OutputVector", &ShaderOutData);
+        // Process the callback for the InputVector2 resource.
+        if (0 == _stricmp(Name, "InputVector2")) {
+          if (IsVectorBinaryOp) {
+            FillShaderBufferFromLongVectorData<T, N>(ShaderData, InputVector2);
+          }
+          return;
+        }
 
-std::array<T, N> OutputVector;
-FillLongVectorDataFromShaderBuffer<T, N>(ShaderOutData, OutputVector);
+        LogErrorFmtThrow(
+            L"RunShaderOpTest CallBack. Unexpected Resource Name: %S", Name);
+      });
 
-VERIFY_SUCCEEDED(DoArraysMatch<T>(OutputVector, ExpectedVector,
-                                  TestConfig.Tolerance));
+  // Map the data from GPU to CPU memory so we can verify our expectations.
+  MappedData ShaderOutData;
+  TestResult->Test->GetReadBackData("OutputVector", &ShaderOutData);
+
+  std::array<T, N> OutputVector;
+  FillLongVectorDataFromShaderBuffer<T, N>(ShaderOutData, OutputVector);
+
+  VERIFY_SUCCEEDED(DoArraysMatch<T>(OutputVector, ExpectedVector,
+                                    TestConfig.GetTolerance()));
 }
 
 // This test expects a <pShader> that retrieves a signal value from each of a

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <map>
+#include <vector>
+#include <string>
+
+static const std::map<std::wstring, std::vector<bool>> DefaultInputValueSet_bool = {
+    {L"DefaultInputValueSet1", {false, true, false, false, false, false, true, true, true, true}},
+    {L"DefaultInputValueSet2", {true, false, false, false, false, true, true, true, false, false}},
+};
+
+static const std::map<std::wstring, std::vector<int16_t>> DefaultInputValueSet_int16 = {
+    {L"DefaultInputValueSet1", {-6, 1, 7, 3, 8, 4, -3, 8, 8, -2}},
+    {L"DefaultInputValueSet2", {5, -6, -3, -2, 9, 3, 1, -3, -7, 2}},
+    {L"DefaultClampArgs", {-1 , 1}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<int32_t>> DefaultInputValueSet_int32 = {
+    {L"DefaultInputValueSet1", {-6, 1, 7, 3, 8, 4, -3, 8, 8, -2}},
+    {L"DefaultInputValueSet2", {5, -6, -3, -2, 9, 3, 1, -3, -7, 2}},
+    {L"DefaultClampArgs", {-1 , 1}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<int64_t>> DefaultInputValueSet_int64 = {
+    {L"DefaultInputValueSet1", {-6, 11, 7, 3, 8, 4, -3, 8, 8, -2}},
+    {L"DefaultInputValueSet2", {5, -1337, -3, -2, 9, 3, 1, -3, 501, 2}},
+    {L"DefaultClampArgs", {-1 , 1}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<uint16_t>> DefaultInputValueSet_uint16 = {
+    {L"DefaultInputValueSet1", {1, 699, 3, 1023, 5, 6, 0, 8, 9, 10}},
+    {L"DefaultInputValueSet2", {2, 111, 3, 4, 5, 9, 21, 8, 9, 10}},
+    {L"DefaultClampArgs", {1 , 2}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<uint32_t>> DefaultInputValueSet_uint32 = {
+    {L"DefaultInputValueSet1", {1, 2, 3, 4, 5, 0, 7, 8, 9, 10}},
+    {L"DefaultInputValueSet2", {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+    {L"DefaultClampArgs", {1 , 2}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<uint64_t>> DefaultInputValueSet_uint64 = {
+    {L"DefaultInputValueSet1", {1, 2, 3, 4, 5, 0, 7, 1000, 9, 10}},
+    {L"DefaultInputValueSet2", {1, 2, 1337, 4, 5, 6, 7, 8, 9, 10}},
+    {L"DefaultClampArgs", {1 , 2}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<float>> DefaultInputValueSet_float16 = {
+    {L"DefaultInputValueSet1", {1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0}},
+    {L"DefaultInputValueSet2", {1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0}},
+    {L"DefaultClampArgs", {-1.0 , 1.0}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<float>> DefaultInputValueSet_float32 = {
+    {L"DefaultInputValueSet1", {1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0}},
+    {L"DefaultInputValueSet2", {1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0}},
+    {L"DefaultClampArgs", {-1.0 , 1.0}} // Min, Max values for clamp
+};
+
+static const std::map<std::wstring, std::vector<double>> DefaultInputValueSet_float64 = {
+    {L"DefaultInputValueSet1", {1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0}},
+    {L"DefaultInputValueSet2", {1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0}},
+    {L"DefaultClampArgs", {-1.0 , 1.0}} // Min, Max values for clamp
+};

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -11,133 +11,139 @@
 #include <DirectXPackedVector.h>
 
 #include <Verify.h>
-
-template <typename T> struct LongVectorOpTestConfig; // Forward declaration
-enum LongVectorOpType;                               // Forward declaration
+#include "LongVectorTestData.h"
 
 // A helper struct because C++ bools are 1 byte and HLSL bools are 4 bytes.
 // Take int32_t as a constuctor argument and convert it to bool when needed.
 // Comparisons cast to a bool because we only care if the bool representation is
 // true or false.
 struct HLSLBool_t {
-  HLSLBool_t() : val(0) {}
-  HLSLBool_t(int32_t val) : val(val) {}
-  HLSLBool_t(bool val) : val(val) {}
-  HLSLBool_t(const HLSLBool_t &other) : val(other.val) {}
+  HLSLBool_t() : Val(0) {}
+  HLSLBool_t(int32_t Val) : Val(Val) {}
+  HLSLBool_t(bool Val) : Val(Val) {}
+  HLSLBool_t(const HLSLBool_t &Other) : Val(Other.Val) {}
 
-  bool operator==(const HLSLBool_t &other) const {
-    return static_cast<bool>(val) == static_cast<bool>(other.val);
+  bool operator==(const HLSLBool_t &Other) const {
+    return static_cast<bool>(Val) == static_cast<bool>(Other.Val);
   }
 
-  bool operator!=(const HLSLBool_t &other) const {
-    return static_cast<bool>(val) != static_cast<bool>(other.val);
+  bool operator!=(const HLSLBool_t &Other) const {
+    return static_cast<bool>(Val) != static_cast<bool>(Other.Val);
   }
 
-  bool operator<(const HLSLBool_t &other) const { return val < other.val; }
+  bool operator<(const HLSLBool_t &Other) const { return Val < Other.Val; }
 
-  bool operator>(const HLSLBool_t &other) const { return val > other.val; }
+  bool operator>(const HLSLBool_t &Other) const { return Val > Other.Val; }
 
-  bool operator<=(const HLSLBool_t &other) const { return val <= other.val; }
+  bool operator<=(const HLSLBool_t &Other) const { return Val <= Other.Val; }
 
-  bool operator>=(const HLSLBool_t &other) const { return val >= other.val; }
+  bool operator>=(const HLSLBool_t &Other) const { return Val >= Other.Val; }
 
-  HLSLBool_t operator*(const HLSLBool_t &other) const {
-    return HLSLBool_t(val * other.val);
+  HLSLBool_t operator*(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val * Other.Val);
   }
 
-  HLSLBool_t operator+(const HLSLBool_t &other) const {
-    return HLSLBool_t(val + other.val);
+  HLSLBool_t operator+(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val + Other.Val);
   }
 
   // So we can construct std::wstrings using std::wostream
-  friend std::wostream &operator<<(std::wostream &os, const HLSLBool_t &obj) {
-    os << static_cast<bool>(obj.val);
-    return os;
+  friend std::wostream &operator<<(std::wostream &Os, const HLSLBool_t &Obj) {
+    Os << static_cast<bool>(Obj.Val);
+    return Os;
   }
 
   // So we can construct std::strings using std::ostream
-  friend std::ostream &operator<<(std::ostream &os, const HLSLBool_t &obj) {
-    os << static_cast<bool>(obj.val);
-    return os;
+  friend std::ostream &operator<<(std::ostream &Os, const HLSLBool_t &Obj) {
+    Os << static_cast<bool>(Obj.Val);
+    return Os;
   }
 
-  int32_t val = 0;
+  int32_t Val = 0;
 };
 
 //  No native float16 type in C++ until C++23 . So we use uint16_t to represent
 //  it. Simple little wrapping struct to help handle the right behavior.
 struct HLSLHalf_t {
-  HLSLHalf_t() : val(0) {}
-  HLSLHalf_t(DirectX::PackedVector::HALF val) : val(val) {}
-  HLSLHalf_t(const HLSLHalf_t &other) : val(other.val) {}
-
-  bool operator==(const HLSLHalf_t &other) const { return val == other.val; }
-
-  bool operator<(const HLSLHalf_t &other) const {
-    return DirectX::PackedVector::XMConvertHalfToFloat(val) <
-           DirectX::PackedVector::XMConvertHalfToFloat(other.val);
+  HLSLHalf_t() : Val(0) {}
+  HLSLHalf_t(DirectX::PackedVector::HALF Val) : Val(Val) {}
+  HLSLHalf_t(const HLSLHalf_t &Other) : Val(Other.Val) {}
+  HLSLHalf_t(const float F) {
+    Val = DirectX::PackedVector::XMConvertFloatToHalf(F);
+  }
+  HLSLHalf_t(const int I) {
+    VERIFY_IS_TRUE(I == 0, L"HLSLHalf_t constructor with int override only meant for cases when initializing to 0.");
+    const float F = static_cast<float>(I);
+    Val = DirectX::PackedVector::XMConvertFloatToHalf(F);
   }
 
-  bool operator>(const HLSLHalf_t &other) const {
-    return DirectX::PackedVector::XMConvertHalfToFloat(val) >
-           DirectX::PackedVector::XMConvertHalfToFloat(other.val);
+  bool operator==(const HLSLHalf_t &Other) const { return Val == Other.Val; }
+
+  bool operator<(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) <
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+  }
+
+  bool operator>(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) >
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
   }
 
   // Used by tolerance checks in the tests.
-  bool operator>(float d) const {
-    float a = DirectX::PackedVector::XMConvertHalfToFloat(val);
-    return a > d;
+  bool operator>(float F) const {
+    float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    return A > F;
   }
 
-  bool operator<(float d) const {
-    float a = DirectX::PackedVector::XMConvertHalfToFloat(val);
-    return a < d;
+  bool operator<(float F) const {
+    float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    return A < F;
   }
 
-  bool operator<=(const HLSLHalf_t &other) const {
-    return DirectX::PackedVector::XMConvertHalfToFloat(val) <=
-           DirectX::PackedVector::XMConvertHalfToFloat(other.val);
+  bool operator<=(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) <=
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
   }
 
-  bool operator>=(const HLSLHalf_t &other) const {
-    return DirectX::PackedVector::XMConvertHalfToFloat(val) >=
-           DirectX::PackedVector::XMConvertHalfToFloat(other.val);
+  bool operator>=(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) >=
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
   }
 
-  bool operator!=(const HLSLHalf_t &other) const { return val != other.val; }
+  bool operator!=(const HLSLHalf_t &Other) const { return Val != Other.Val; }
 
-  HLSLHalf_t operator*(const HLSLHalf_t &other) const {
-    float a = DirectX::PackedVector::XMConvertHalfToFloat(val);
-    float b = DirectX::PackedVector::XMConvertHalfToFloat(other.val);
-    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(a * b));
+  HLSLHalf_t operator*(const HLSLHalf_t &Other) const {
+    float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A * B));
   }
 
-  HLSLHalf_t operator+(const HLSLHalf_t &other) const {
-    float a = DirectX::PackedVector::XMConvertHalfToFloat(val);
-    float b = DirectX::PackedVector::XMConvertHalfToFloat(other.val);
-    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(a + b));
+  HLSLHalf_t operator+(const HLSLHalf_t &Other) const {
+    float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A + B));
   }
 
-  HLSLHalf_t operator-(const HLSLHalf_t &other) const {
-    float a = DirectX::PackedVector::XMConvertHalfToFloat(val);
-    float b = DirectX::PackedVector::XMConvertHalfToFloat(other.val);
-    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(a - b));
-  }
-
-  // So we can construct std::wstrings using std::wostream
-  friend std::wostream &operator<<(std::wostream &os, const HLSLHalf_t &obj) {
-    os << DirectX::PackedVector::XMConvertHalfToFloat(obj.val);
-    return os;
+  HLSLHalf_t operator-(const HLSLHalf_t &Other) const {
+    float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A - B));
   }
 
   // So we can construct std::wstrings using std::wostream
-  friend std::ostream &operator<<(std::ostream &os, const HLSLHalf_t &obj) {
-    os << DirectX::PackedVector::XMConvertHalfToFloat(obj.val);
-    return os;
+  friend std::wostream &operator<<(std::wostream &Os, const HLSLHalf_t &Obj) {
+    Os << DirectX::PackedVector::XMConvertHalfToFloat(Obj.Val);
+    return Os;
+  }
+
+  // So we can construct std::wstrings using std::wostream
+  friend std::ostream &operator<<(std::ostream &Os, const HLSLHalf_t &Obj) {
+    Os << DirectX::PackedVector::XMConvertHalfToFloat(Obj.Val);
+    return Os;
   }
 
   // HALF is an alias to uint16_t
-  DirectX::PackedVector::HALF val = 0;
+  DirectX::PackedVector::HALF Val = 0;
 };
 
 // Helper to fill the shader buffer based on type. Convenient to be used when
@@ -157,12 +163,12 @@ void FillShaderBufferFromLongVectorData(std::vector<BYTE> &ShaderBuffer,
     DirectX::PackedVector::HALF *ShaderBufferPtr =
         reinterpret_cast<DirectX::PackedVector::HALF *>(ShaderBuffer.data());
     for (size_t i = 0; i < N; ++i) {
-      ShaderBufferPtr[i] = TestData[i].val;
+      ShaderBufferPtr[i] = TestData[i].Val;
     }
   } else if constexpr (std::is_same_v<T, HLSLBool_t>) {
     int32_t *ShaderBufferPtr = reinterpret_cast<int32_t *>(ShaderBuffer.data());
     for (size_t i = 0; i < N; ++i) {
-      ShaderBufferPtr[i] = TestData[i].val;
+      ShaderBufferPtr[i] = TestData[i].Val;
     }
   } else {
     T *ShaderBufferPtr = reinterpret_cast<T *>(ShaderBuffer.data());
@@ -199,68 +205,216 @@ void FillLongVectorDataFromShaderBuffer(MappedData &ShaderBuffer,
   }
 }
 
-enum LongVectorOpType {
-  LongVectorOpType_ScalarAdd,
-  LongVectorOpType_ScalarMultiply,
-  LongVectorOpType_Multiply,
-  LongVectorOpType_Add,
-  LongVectorOpType_Min,
-  LongVectorOpType_Max,
-  LongVectorOpType_Clamp,
-  LongVectorOpType_Initialize,
-  LongVectorOpType_UnInitialized
+enum LongVectorBinaryOpType {
+  LongVectorBinaryOpType_ScalarAdd,
+  LongVectorBinaryOpType_ScalarMultiply,
+  LongVectorBinaryOpType_Multiply,
+  LongVectorBinaryOpType_Add,
+  LongVectorBinaryOpType_Min,
+  LongVectorBinaryOpType_Max,
+  LongVectorBinaryOpType_ScalarMin,
+  LongVectorBinaryOpType_ScalarMax,
+  LongVectorBinaryOpType_EnumValueCount
 };
 
+struct LongVectorOpTypeStringToEnumValue {
+  std::wstring OpTypeString;
+  uint32_t OpTypeValue;
+};
+
+template <typename T>
+T GetLongVectorOpType(const LongVectorOpTypeStringToEnumValue* Values, const std::wstring &OpTypeString, std::size_t Length) {
+  for(size_t i = 0; i < Length; i++) {
+    if (Values[i].OpTypeString == OpTypeString) {
+      return static_cast<T>(Values[i].OpTypeValue);
+    }
+  }
+
+  LogErrorFmtThrow(L"Invalid LongVectorOpType string: %s", OpTypeString.c_str());
+
+  if(std::is_same_v<T, LongVectorBinaryOpType>)
+    return static_cast<T>(LongVectorBinaryOpType_EnumValueCount);
+  else if (std::is_same_v<T, LongVectorUnaryOpType>)
+    return static_cast<T>(LongVectorUnaryOpType_EnumValueCount);
+}
+
+static const LongVectorOpTypeStringToEnumValue LongVectorBinaryOpTypeStringToEnumMap[] = {
+    {L"LongVectorBinaryOpType_ScalarAdd", LongVectorBinaryOpType_ScalarAdd},
+    {L"LongVectorBinaryOpType_ScalarMultiply",
+     LongVectorBinaryOpType_ScalarMultiply},
+    {L"LongVectorBinaryOpType_Multiply", LongVectorBinaryOpType_Multiply},
+    {L"LongVectorBinaryOpType_Add", LongVectorBinaryOpType_Add},
+    {L"LongVectorBinaryOpType_Min", LongVectorBinaryOpType_Min},
+    {L"LongVectorBinaryOpType_Max", LongVectorBinaryOpType_Max},
+    {L"LongVectorBinaryOpType_ScalarMin", LongVectorBinaryOpType_ScalarMin},
+    {L"LongVectorBinaryOpType_ScalarMax", LongVectorBinaryOpType_ScalarMax},
+};
+
+static_assert(
+    _countof(LongVectorBinaryOpTypeStringToEnumMap) ==
+    LongVectorBinaryOpType_EnumValueCount,
+    "LongVectorBinaryOpTypeStringToEnumMap size mismatch. Did you add a new enum value?");
+
+LongVectorBinaryOpType GetLongVectorBinaryOpType(
+    const std::wstring &OpTypeString) {
+  return GetLongVectorOpType<LongVectorBinaryOpType>(
+      LongVectorBinaryOpTypeStringToEnumMap, OpTypeString, std::size(LongVectorBinaryOpTypeStringToEnumMap));
+}
+
+enum LongVectorUnaryOpType {
+  LongVectorUnaryOpType_Clamp,
+  LongVectorUnaryOpType_Initialize,
+  LongVectorUnaryOpType_EnumValueCount
+};
+
+static const LongVectorOpTypeStringToEnumValue LongVectorUnaryOpTypeStringToEnumMap[] = {
+  {L"LongVectorUnaryOpType_Clamp", LongVectorUnaryOpType_Clamp},
+  {L"LongVectorUnaryOpType_Initialize", LongVectorUnaryOpType_Initialize},
+};
+
+static_assert(
+  _countof(LongVectorUnaryOpTypeStringToEnumMap) ==
+  LongVectorUnaryOpType_EnumValueCount,
+  "LongVectorUnaryOpTypeStringToEnumMap size mismatch. Did you add a new enum value?");
+
+LongVectorUnaryOpType GetLongVectorUnaryOpType(const std::wstring &OpTypeString) {
+  return GetLongVectorOpType<LongVectorUnaryOpType>(LongVectorUnaryOpTypeStringToEnumMap, OpTypeString, std::size(LongVectorUnaryOpTypeStringToEnumMap));
+}
+
+template <typename T>
+std::vector<T> GetInputValueSetByKey(std::wstring Key) {
+
+  if constexpr (std::is_same_v<T, HLSLBool_t>)
+    return std::vector<T>(DefaultInputValueSet_bool.at(Key).begin(),
+                        DefaultInputValueSet_bool.at(Key).end());
+  else if constexpr (std::is_same_v<T, HLSLHalf_t>)
+    return std::vector<T>(DefaultInputValueSet_float16.at(Key).begin(),
+                        DefaultInputValueSet_float16.at(Key).end());
+  else if constexpr (std::is_same_v<T, float>)
+    return std::vector<T>(DefaultInputValueSet_float32.at(Key).begin(),
+                        DefaultInputValueSet_float32.at(Key).end());
+  else if constexpr (std::is_same_v<T, double>)
+    return std::vector<T>(DefaultInputValueSet_float64.at(Key).begin(),
+                        DefaultInputValueSet_float64.at(Key).end());
+  else if constexpr (std::is_same_v<T, int16_t>)
+    return std::vector<T>(DefaultInputValueSet_int16.at(Key).begin(),
+                        DefaultInputValueSet_int16.at(Key).end());
+  else if constexpr (std::is_same_v<T, int32_t>)
+    return std::vector<T>(DefaultInputValueSet_int32.at(Key).begin(),
+                        DefaultInputValueSet_int32.at(Key).end());
+  else if constexpr (std::is_same_v<T, int64_t>)
+    return std::vector<T>(DefaultInputValueSet_int64.at(Key).begin(),
+                        DefaultInputValueSet_int64.at(Key).end());
+  else if constexpr (std::is_same_v<T, uint16_t>)
+    return std::vector<T>(DefaultInputValueSet_uint16.at(Key).begin(),
+                        DefaultInputValueSet_uint16.at(Key).end());
+  else if constexpr (std::is_same_v<T, uint32_t>)
+    return std::vector<T>(DefaultInputValueSet_uint32.at(Key).begin(),
+                        DefaultInputValueSet_uint32.at(Key).end());
+  else if constexpr (std::is_same_v<T, uint64_t>)
+    return std::vector<T>(DefaultInputValueSet_uint64.at(Key).begin(),
+                        DefaultInputValueSet_uint64.at(Key).end());
+
+  VERIFY_FAIL("GetInputValueSetByKey() Unsupported type.");
+  return std::vector<T>();
+}
+
 // Used to pass into LongVectorOpTestBase
-template <typename T> struct LongVectorOpTestConfig {
+template <typename T> class LongVectorOpTestConfig {
+public:
   LongVectorOpTestConfig() = default;
 
-  LongVectorOpTestConfig(LongVectorOpType OpType) : OpType(OpType) {
-    IntrinsicString = "";
+  LongVectorOpTestConfig(LongVectorUnaryOpType OpType) : UnaryOpType_(OpType) {
+    IntrinsicString_ = "";
 
     if (IsFloatingPointType())
-      Tolerance = 1;
+      Tolerance_ = 1;
 
     switch (OpType) {
-    case LongVectorOpType_ScalarAdd:
-      OperatorString = "+";
-      IsScalarOp = true;
+    case LongVectorUnaryOpType_Clamp:
+      OperatorString_ = ",";
+      IntrinsicString_ = "TestClamp";
       break;
-    case LongVectorOpType_ScalarMultiply:
-      OperatorString = "*";
-      IsScalarOp = true;
-      break;
-    case LongVectorOpType_Multiply:
-      OperatorString = "*";
-      break;
-    case LongVectorOpType_Add:
-      OperatorString = "+";
-      break;
-    case LongVectorOpType_Min:
-      OperatorString = ",";
-      IntrinsicString = "min";
-      break;
-    case LongVectorOpType_Max:
-      OperatorString = ",";
-      IntrinsicString = "max";
-      break;
-    case LongVectorOpType_Clamp:
-      OperatorString = ",";
-      IntrinsicString = "TestClamp";
-      IsBinaryOp = false;
-      break;
-    case LongVectorOpType_Initialize:
-      IntrinsicString = "TestInitialize";
-      IsBinaryOp = false;
+    case LongVectorUnaryOpType_Initialize:
+      IntrinsicString_ = "TestInitialize";
       break;
     default:
-      VERIFY_FAIL("Invalid LongVectorOpType");
+      VERIFY_FAIL("Invalid LongVectorBinaryOpType");
+    }
+  }
+
+  LongVectorOpTestConfig(LongVectorBinaryOpType OpType) : BinaryOpType_(OpType) {
+    IntrinsicString_ = "";
+
+    if (IsFloatingPointType())
+      Tolerance_ = 1;
+
+    switch (OpType) {
+    case LongVectorBinaryOpType_ScalarAdd:
+      OperatorString_ = "+";
+      break;
+    case LongVectorBinaryOpType_ScalarMultiply:
+      OperatorString_ = "*";
+      break;
+    case LongVectorBinaryOpType_Multiply:
+      OperatorString_ = "*";
+      break;
+    case LongVectorBinaryOpType_Add:
+      OperatorString_ = "+";
+      break;
+    case LongVectorBinaryOpType_Min:
+      OperatorString_ = ",";
+      IntrinsicString_ = "min";
+      break;
+    case LongVectorBinaryOpType_Max:
+      OperatorString_ = ",";
+      IntrinsicString_ = "max";
+      break;
+    case LongVectorBinaryOpType_ScalarMin:
+      OperatorString_ = ",";
+      IntrinsicString_ = "min";
+      break;
+    case LongVectorBinaryOpType_ScalarMax:
+      OperatorString_ = ",";
+      IntrinsicString_ = "max";
+      break;
+    default:
+      VERIFY_FAIL("Invalid LongVectorBinaryOpType");
     }
   }
 
   bool IsFloatingPointType() const {
     return std::is_same_v<T, float> || std::is_same_v<T, double> ||
            std::is_same_v<T, HLSLHalf_t>;
+  }
+
+  bool IsBinaryOp() const {
+    return BinaryOpType_ != LongVectorBinaryOpType_EnumValueCount;
+  }
+
+  bool IsUnaryOp() const {
+    return UnaryOpType_ != LongVectorUnaryOpType_EnumValueCount;
+  }
+
+  bool IsScalarOp() const {
+    switch(BinaryOpType_) {
+      case LongVectorBinaryOpType_ScalarAdd:
+      case LongVectorBinaryOpType_ScalarMultiply:
+      case LongVectorBinaryOpType_ScalarMin:
+      case LongVectorBinaryOpType_ScalarMax:
+        return true;
+      default:
+        return false;
+    };
+  }
+
+  bool HasInputArguments() const {
+    switch(UnaryOpType_) {
+      case LongVectorUnaryOpType_Clamp:
+        return true;
+      default:
+        return false;
+    }
   }
 
   // A helper to get the hlsl type as a string for a given C++ type.
@@ -293,108 +447,216 @@ template <typename T> struct LongVectorOpTestConfig {
     return "UnknownType";
   }
 
+  T ComputeExpectedValue(const T &A, const T &B) const{
+    if (IsBinaryOp()) {
+      switch (BinaryOpType_) {
+      case LongVectorBinaryOpType_ScalarAdd:
+        return A + B;
+      case LongVectorBinaryOpType_ScalarMultiply:
+        return A * B;
+      case LongVectorBinaryOpType_Multiply:
+        return A * B;
+      case LongVectorBinaryOpType_Add:
+        return A + B;
+      case LongVectorBinaryOpType_Min:
+        return std::min(A, B);
+      case LongVectorBinaryOpType_Max:
+        return std::max(A, B);
+      case LongVectorBinaryOpType_ScalarMin:
+        return std::min(A, B);
+      case LongVectorBinaryOpType_ScalarMax:
+        return std::max(A, B);
+      default:
+        LogErrorFmtThrow(L"Unknown LongVectorBinaryOpType: %d", BinaryOpType_);
+      }
+    } else {
+      LogErrorFmtThrow(L"ComputeExpectedValue(const T &A, const T &B) called for a unary op.: %d", UnaryOpType_);
+    }
+
+    return T();
+  }
+
+  T ComputeExpectedValue(const T &A) const{
+    if (IsUnaryOp()) {
+      switch (UnaryOpType_) {
+      case LongVectorUnaryOpType_Clamp: {
+        std::vector<T> ArgsArray = GetInputArgsArray();
+        T Min = ArgsArray[0];
+        T Max = ArgsArray[1];
+        return std::clamp(A, Min, Max);
+      }
+      case LongVectorUnaryOpType_Initialize:
+        return A;
+      default:
+        LogErrorFmtThrow(L"Unknown LongVectorUnaryOpType :%d", UnaryOpType_);
+      }
+    } else {
+      LogErrorFmtThrow(L"ComputeExpectedValue(const T &A) called for a binary op: %d", BinaryOpType_);
+    }
+
+    return T();
+  }
+
+  void SetInputArgsArrayName(std::wstring InputArgsArrayName) {
+    InputArgsArrayName_ = InputArgsArrayName;
+  }
+
+  void SetInputValueSet1(std::wstring InputValueSetName) {
+    InputValueSetName1_ = InputValueSetName;
+  }
+
+  void SetInputValueSet2(std::wstring InputValueSetName) {
+    InputValueSetName2_ = InputValueSetName;
+  }
+
+  std::vector<T> GetInputValueSet1() {
+    return GetInputValueSet(1);
+  }
+
+  std::vector<T> GetInputValueSet2() {
+    return GetInputValueSet(2);
+  }
+
+  std::vector<T> GetInputArgsArray() const{
+
+    std::vector<T> InputArgs;
+
+    std::wstring InputArgsArrayName = InputArgsArrayName_;
+
+    if(UnaryOpType_ == LongVectorUnaryOpType_Clamp && InputArgsArrayName == L"") {
+      InputArgsArrayName = L"DefaultClampArgs";
+    }
+
+    if (InputArgsArrayName.empty())
+      VERIFY_FAIL("No args array name set.");
+
+    if(std::is_same_v<T, HLSLBool_t> && UnaryOpType_ == LongVectorUnaryOpType_Clamp)
+      VERIFY_FAIL("Clamp is not supported for bools.");
+    else
+      return GetInputValueSetByKey<T>(InputArgsArrayName);
+
+    VERIFY_FAIL("Invalid type for args array.");
+    return std::vector<T>();
+  }
+
+  LongVectorBinaryOpType GetBinaryOpType() const {
+    return BinaryOpType_;
+  }
+
+  LongVectorUnaryOpType GetUnaryOpType() const {
+    return UnaryOpType_;
+  }
+
+  float GetTolerance() const {
+    return Tolerance_;
+  }
+
+  std::string GetCompilerOptionsString(size_t VectorSize) {
+    std::stringstream CompilerOptions("");
+    std::string HLSLType = GetHLSLTypeString();
+    CompilerOptions << "-DTYPE=";
+    CompilerOptions << HLSLType;
+    CompilerOptions << " -DNUM=";
+    CompilerOptions << VectorSize;
+    const bool Is16BitType =
+        (HLSLType == "int16_t" || HLSLType == "uint16_t" || HLSLType == "half");
+    CompilerOptions << (Is16BitType ? " -enable-16bit-types" : "");
+    CompilerOptions << " -DOPERATOR=";
+    CompilerOptions << OperatorString_;
+
+    if (IsBinaryOp()) {
+      CompilerOptions << " -DOPERAND2=";
+      CompilerOptions << (IsScalarOp() ? "InputScalar" : "InputVector2");
+  
+      if (IsScalarOp())
+        CompilerOptions << " -DIS_SCALAR_OP=1";
+      else
+        CompilerOptions << " -DIS_BINARY_VECTOR_OP=1";
+
+      CompilerOptions << " -DFUNC=";
+      CompilerOptions << IntrinsicString_;
+    } else { // Unary Op
+      CompilerOptions << " -DFUNC=";
+      CompilerOptions << IntrinsicString_;
+      CompilerOptions << " -DOPERAND2=";
+
+      switch (GetUnaryOpType()) {
+      case LongVectorUnaryOpType_Clamp:
+        CompilerOptions << "ClampArgMinMax";
+        CompilerOptions << " -DFUNC_CLAMP=1";
+        break;
+      case LongVectorUnaryOpType_Initialize:
+        CompilerOptions << " -DFUNC_INITIALIZE=1";
+        break;
+      }
+    }
+
+    return CompilerOptions.str();
+  }
+
+private:
+  std::vector<T> GetInputValueSet(size_t ValueSetIndex) {
+    if(ValueSetIndex ==2 && !IsBinaryOp())
+      VERIFY_FAIL("ValueSetindex==2 is only valid for binary ops.");
+
+    std::wstring InputValueSetName = L"";
+    if(ValueSetIndex == 1)
+      InputValueSetName = InputValueSetName1_;
+    else if (ValueSetIndex == 2)
+      InputValueSetName = InputValueSetName2_;
+    else
+      VERIFY_FAIL("Invalid ValueSetIndex");
+
+    return GetInputValueSetByKey<T>(InputValueSetName);
+  }
+
   // To be used for the value of -DOPERATOR
-  std::string OperatorString;
+  std::string OperatorString_;
   // To be used for the value of -DFUNC
-  std::string IntrinsicString;
+  std::string IntrinsicString_;
   // Optional, can be used to override shader code.
-  bool IsScalarOp = false;
-  bool IsBinaryOp = true;
-  float Tolerance = 0.0;
-  LongVectorOpType OpType = LongVectorOpType_UnInitialized;
+  float Tolerance_ = 0.0;
+  LongVectorBinaryOpType BinaryOpType_ = LongVectorBinaryOpType_EnumValueCount;
+  LongVectorUnaryOpType UnaryOpType_ = LongVectorUnaryOpType_EnumValueCount;
+  std::wstring InputValueSetName1_ = L"DefaultInputValueSet1";
+  std::wstring InputValueSetName2_ = L"DefaultInputValueSet2";
+  std::wstring InputArgsArrayName_ = L""; // No default args array
 };
 
-template <typename T> struct LongVectorTestTraits {
-  std::uniform_int_distribution<T> UD = std::uniform_int_distribution(
-      std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
-};
+template <typename T> bool DoValuesMatch(T A, T B, float Tolerance) {
+    if (Tolerance == 0.0f)
+      return A == B;
 
-template <> struct LongVectorTestTraits<HLSLHalf_t> {
-  // Float values for this were taken from Microsoft online documentation for
-  // the DirectX HALF data type. HALF is equivalent to IEEE 754 binary 16
-  // format.
-  std::uniform_int_distribution<DirectX::PackedVector::HALF> UD =
-      std::uniform_int_distribution(
-          DirectX::PackedVector::XMConvertFloatToHalf(float(6.10e-5f)),
-          DirectX::PackedVector::XMConvertFloatToHalf(float(65504.0f)));
-};
+    T Diff = A > B ? A - B : B - A;
+    return Diff > Tolerance;
+  }
 
-template <> struct LongVectorTestTraits<HLSLBool_t> {
-  std::uniform_int_distribution<uint16_t> UD =
-      std::uniform_int_distribution<uint16_t>(0u, 1u);
-};
+inline bool DoValuesMatch(HLSLBool_t A, HLSLBool_t B, float) {
+  return A == B; 
+}
 
-template <> struct LongVectorTestTraits<float> {
-  //  The ranges for generation. A std::uniform_real_distribution can only
-  //  have a range that is equal to the types largest value. This is due to
-  //  precision issues. So instead we define some large values.
-  std::uniform_real_distribution<float> UD =
-      std::uniform_real_distribution(-1e20f, 1e20f);
-};
+inline bool DoValuesMatch(HLSLHalf_t A, HLSLHalf_t B, float Tolerance) {
+  return CompareHalfULP(A.Val, B.Val, Tolerance);
+}
 
-template <> struct LongVectorTestTraits<double> {
-  //  The ranges for generation. A std::uniform_real_distribution can only
-  //  have a range that is equal to the types largest value. This is due to
-  //  precision issues. So instead we define some large values.
-  std::uniform_real_distribution<double> UD =
-      std::uniform_real_distribution(-1e100, 1e100);
-};
+inline bool DoValuesMatch(float A, float B, float Tolerance) {
+  const int IntTolerance = static_cast<int>(Tolerance);
+  return CompareFloatULP(A, B, IntTolerance);
+}
 
-template <typename T> class DeterministicNumberGenerator {
-  // Mersenne Twister 'random' number generator. Generated numbers are based
-  // on the seed value and are deterministic for any given seed.
-  std::mt19937 Generator;
-
-  LongVectorTestTraits<T> UD;
-
-public:
-  DeterministicNumberGenerator(unsigned SeedValue) : Generator(SeedValue) {}
-
-  T generate() { return UD.UD(Generator); }
-};
+inline bool DoValuesMatch(double A, double B, float Tolerance) {
+  const int64_t IntTolerance = static_cast<int64_t>(Tolerance);
+  return CompareDoubleULP(A, B, IntTolerance);
+}
 
 template <typename T, std::size_t N>
 bool DoArraysMatch(const std::array<T, N> &ActualValues,
                    const std::array<T, N> &ExpectedValues, float Tolerance) {
   // Stash mismatched indexes for easy failure logging later
   std::vector<size_t> MismatchedIndexes;
-  for (size_t Index = 0; Index < N; ++Index) {
-    if constexpr (std::is_same_v<T, HLSLBool_t>) {
-      // Compiler was very picky and wanted an explicit case for any T that
-      // doesn't implement the operators in the below else. ( > and -). It
-      // wouldn't accept putting this constexpr as an or case with other
-      // statements.
-      if (ActualValues[Index] != ExpectedValues[Index]) {
-        MismatchedIndexes.push_back(Index);
-      }
-    } else if constexpr (std::is_same_v<T, HLSLHalf_t>) {
-      const DirectX::PackedVector::HALF a = ActualValues[Index].val;
-      const DirectX::PackedVector::HALF b = ExpectedValues[Index].val;
-      if (!CompareHalfULP(a, b, Tolerance)) {
-        MismatchedIndexes.push_back(Index);
-      }
-    } else if constexpr (std::is_same_v<T, float>) {
-      const int IntTolerance = static_cast<int>(Tolerance);
-      if (!CompareFloatULP(ActualValues[Index], ExpectedValues[Index],
-                           IntTolerance)) {
-        MismatchedIndexes.push_back(Index);
-      }
-    } else if constexpr (std::is_same_v<T, double>) {
-      const int64_t IntTolerance = static_cast<int64_t>(Tolerance);
-      if (!CompareDoubleULP(ActualValues[Index], ExpectedValues[Index],
-                            IntTolerance)) {
-        MismatchedIndexes.push_back(Index);
-      }
-    } else if (Tolerance == 0 && ActualValues[Index] != ExpectedValues[Index]) {
-      MismatchedIndexes.push_back(Index);
-    } else {
-      T Diff = ActualValues[Index] > ExpectedValues[Index]
-                   ? ActualValues[Index] - ExpectedValues[Index]
-                   : ExpectedValues[Index] - ActualValues[Index];
-      if (Diff > Tolerance) {
-        MismatchedIndexes.push_back(Index);
-      }
-    }
+  for (size_t i = 0; i < N; ++i) {
+    if (!DoValuesMatch(ActualValues[i], ExpectedValues[i], Tolerance))
+      MismatchedIndexes.push_back(i);
   }
 
   if (MismatchedIndexes.empty())
@@ -411,4 +673,78 @@ bool DoArraysMatch(const std::array<T, N> &ActualValues,
   }
 
   return false;
+}
+
+template <typename T, std::size_t N> 
+std::array<T, N> ComputeExpectedValues(const std::array<T, N> &InputVector1, const std::array<T, N> &InputVector2, const LongVectorOpTestConfig<T> &Config) {
+
+  VERIFY_IS_TRUE(Config.IsBinaryOp(), L"ComputeExpectedValues() called with a non-binary op config.");
+
+  std::array<T, N> ExpectedValues = {};
+
+  for(size_t i = 0; i < N; ++i) {
+    ExpectedValues[i] = Config.ComputeExpectedValue(InputVector1[i], InputVector2[i]);
+  }
+
+  return ExpectedValues;
+}
+
+template <typename T, std::size_t N> 
+std::array<T, N> ComputeExpectedValues(const std::array<T, N> &InputVector1, const T &ScalarInput, const LongVectorOpTestConfig<T> &Config) {
+
+  VERIFY_IS_TRUE(Config.IsScalarOp(), L"ComputeExpectedValues() called with a non-binary non-scalar op config.");
+
+  std::array<T, N> ExpectedValues = {};
+
+  for(size_t i = 0; i < N; ++i) {
+    ExpectedValues[i] = Config.ComputeExpectedValue(InputVector1[i], ScalarInput);
+  }
+
+  return ExpectedValues;
+}
+
+template <typename T, std::size_t N> 
+std::array<T, N> ComputeExpectedValues(const std::array<T, N> &InputVector1, const LongVectorOpTestConfig<T> &Config) {
+
+  VERIFY_IS_TRUE(Config.IsUnaryOp(), L"ComputeExpectedValues() called with a non-unary op config.");
+
+  std::array<T, N> ExpectedValues = {};
+
+  for(size_t i = 0; i < N; ++i) {
+    ExpectedValues[i] = Config.ComputeExpectedValue(InputVector1[i]);
+  }
+
+  return ExpectedValues;
+}
+
+template <typename T, std::size_t N>
+void LogLongVector(const std::array<T, N> &Values, std::wstring Name) {
+  WEX::Logging::Log::Comment(WEX::Common::String().Format(
+      L"LongVector Name: %s", Name.c_str()));
+  
+  const size_t LoggingWidth = 40;
+
+  std::wstringstream Wss(L"LongVector Values: ");
+  Wss << L"[";
+  for (size_t i = 0; i < N; i++)
+  {
+    if(i % LoggingWidth == 0 && i != 0)
+      Wss << L"\n ";
+    Wss << Values[i];
+    if(i != N - 1)
+      Wss << L", ";
+  }
+  Wss << L" ]";
+
+  WEX::Logging::Log::Comment(Wss.str().c_str());
+}
+
+template <typename T>
+void LogScalar(const T &Value, std::wstring Name) {
+  WEX::Logging::Log::Comment(WEX::Common::String().Format(
+      L"Scalar Name: %s", Name.c_str()));
+
+  std::wstringstream Wss(L"Scalar Value: ");
+  Wss << Value;
+  WEX::Logging::Log::Comment(Wss.str().c_str());
 }

--- a/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
@@ -7524,4 +7524,648 @@
             </Parameter>
         </Row>
     </Table>
+    <Table Id="LongVectorBinaryOpTable">
+        <ParameterTypes>
+          <!-- InputValueSetName1 is optional. If no value is provided use the
+          default value set for the data type. This string is meant to be a
+          key value for the the array of std::pairs defined in
+          LongVectorTestData.h for the applicable DataType-->
+          <ParameterType Name="InputValueSetName1">String</ParameterType>
+          <!-- InputValueSetName2 is optional. Same as InputValueSetName1 -->
+          <ParameterType Name="InputValueSetName2">String</ParameterType>
+          <ParameterType Name="DataType">String</ParameterType>
+          <ParameterType Name="OpTypeEnum">String</ParameterType>
+        </ParameterTypes>
+        <!-- LongVectorBinaryOpTypeTable DataType: bool -->
+        <Row Name="ScalarAdd_bool">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <Row Name="Add_bool">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_bool">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <Row Name="Subtract_bool">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: int16 -->
+        <Row Name="ScalarAdd_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Add_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Subtract_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Multiply_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Divide_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Modulus_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="ScalarMin_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Min_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="ScalarMax_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <Row Name="Max_int16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">int16</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: int32 -->
+        <Row Name="ScalarAdd_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Add_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Subtract_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Multiply_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Divide_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Modulus_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="ScalarMin_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Min_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="ScalarMax_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <Row Name="Max_int32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">int32</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: int64 -->
+        <Row Name="ScalarAdd_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Add_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Subtract_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Multiply_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Divide_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Modulus_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="ScalarMin_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Min_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="ScalarMax_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <Row Name="Max_int64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">int64</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: uint16 -->
+        <Row Name="ScalarAdd_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Add_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Subtract_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Multiply_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Divide_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Modulus_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="ScalarMin_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Min_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="ScalarMax_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <Row Name="Max_uint16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">uint16</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: uint32 -->
+        <Row Name="ScalarAdd_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Add_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Subtract_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Multiply_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Divide_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Modulus_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="ScalarMin_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Min_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="ScalarMax_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <Row Name="Max_uint32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">uint32</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: uint64 -->
+        <Row Name="ScalarAdd_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Add_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Subtract_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Multiply_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Divide_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Modulus_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="ScalarMin_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Min_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="ScalarMax_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <Row Name="Max_uint64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">uint64</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: float16 -->
+        <Row Name="ScalarAdd_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Add_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Subtract_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Multiply_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Divide_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Modulus_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarMin_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Min_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarMax_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Max_float16">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: float32 -->
+        <Row Name="ScalarAdd_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Add_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Subtract_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Multiply_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Divide_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Modulus_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarMin_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Min_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarMax_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Max_float32">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: float64 -->
+        <Row Name="ScalarAdd_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Add_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Subtract_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Multiply_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Divide_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Modulus_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="ScalarMin_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Min_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="ScalarMax_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+        <Row Name="Max_float64">
+          <Parameter Name="OpTypeEnum">LongVectorBinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">float64</Parameter>
+        </Row>
+    </Table>
+    <Table Id="LongVectorUnaryOpTable">
+      <ParameterTypes>
+        <!-- InputValueSetName1 is optional. If no value is provided use the
+        default value set for the data type. This string is meant to be a key
+        value for the the array of std::pairs defined in LongVectorTestData.h
+        for the applicable DataType-->
+        <ParameterType Name="InputValueSetName1">String</ParameterType>
+        <!-- InputArgsName is optional and is also a key to the array of
+        std::pairs defined in LongVectorTestData.h for the applicable DataType.
+        Used for args like min and max in clamp-->
+        <ParameterType Name="InputArgsName">String</ParameterType>
+        <ParameterType Name="DataType">String</ParameterType>
+        <ParameterType Name="OpTypeEnum">String</ParameterType>
+      </ParameterTypes>
+      <!-- LongVectorUnaryOpTypeTable DataType: bool -->
+      <Row Name="Initialize_bool">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: int16 -->
+      <Row Name="Clamp_int16">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="Initialize_int16">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: int32 -->
+      <Row Name="Clamp_int32">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="Initialize_int32">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: int64 -->
+      <Row Name="Clamp_int64">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="Initialize_int64">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: uint16 -->
+      <Row Name="Clamp_uint16">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="Initialize_uint16">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: uint32 -->
+      <Row Name="Clamp_uint32">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="Initialize_uint32">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: uint64 -->
+      <Row Name="Clamp_uint64">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="Initialize_uint64">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: float16 -->
+      <Row Name="Clamp_float16">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Initialize_float16">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: float32 -->
+      <Row Name="Clamp_float32">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Initialize_float32">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: float64 -->
+      <Row Name="Clamp_float64">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Clamp</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="Initialize_float64">
+        <Parameter Name="OpTypeEnum">LongVectorUnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+    </Table>
 </Data>


### PR DESCRIPTION
This change is mainly focused on swapping to use the XML and statically defined values. Opting to stage this for review in smaller chunk while I iterate on adding the additional test cases.

1. Update the LongVector exec tests to use the ShaderOpArithTable.xml TEAF table file for test entry points. This aligns with existing HLK tests.
2. Some light code cleanup.
3. Hard coded value sets in LongVectorTestData.h. Value sets give us a simple way to generate larger arrays from a smaller set of statically defined values. At a later point we can add logic to produce value sets at build time in this same header by consuming from a YAML file used in the offload test suite.