### PR TITLE
Don't pass through to DXIL.dll in DxcCreateInstance for CLSID_DxcValidator

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -87,11 +87,7 @@ static HRESULT ThreadMallocDxcCreateInstance(REFCLSID rclsid, REFIID riid,
   } else if (IsEqualCLSID(rclsid, CLSID_DxcUtils)) {
     hr = CreateDxcUtils(riid, ppv);
   } else if (IsEqualCLSID(rclsid, CLSID_DxcValidator)) {
-    if (DxilLibIsEnabled()) {
-      hr = DxilLibCreateInstance(rclsid, riid, (IUnknown **)ppv);
-    } else {
-      hr = CreateDxcValidator(riid, ppv);
-    }
+    hr = CreateDxcValidator(riid, ppv);
   } else if (IsEqualCLSID(rclsid, CLSID_DxcAssembler)) {
     hr = CreateDxcAssembler(riid, ppv);
   } else if (IsEqualCLSID(rclsid, CLSID_DxcOptimizer)) {


### PR DESCRIPTION
This change removes the code meant to pass through to DXIL.dll when creating a CLSID_DxcValidator object with DxcCreateInstance.

Since the internal validator is now the default, and it will sign shaders, there is no reason to pass through to DXIL.dll when using DxcCreateInstance on DxCompiler.dll.

Testing will come with planned work to include the ability to globally override the default validator to external.