### PR TITLE
Fix logging of WARP location in ExecTests

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -825,7 +825,7 @@ public:
         GetModuleFileNameW(GetModuleHandleW(L"d3d10warp.dll"),
                            szFullModuleFilePath, sizeof(szFullModuleFilePath));
         WEX::Logging::Log::Comment(WEX::Common::String().Format(
-            L"WARP driver loaded from: %S", szFullModuleFilePath));
+            L"WARP driver loaded from: %ls", szFullModuleFilePath));
       }
 
     } else {


### PR DESCRIPTION
We changed the type of the string to fix a build related issue in another repo that ingests DXC source. When we did that we ended up with an incorrect format character for printing the string. 

Fixed and verified locally that logging is working properly again.