### PR TITLE
[SPIRV] Fix constant value in function

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -2000,7 +2000,13 @@ bool EmitVisitor::visit(SpirvIntrinsicInstruction *inst) {
     }
   }
 
-  finalizeInstruction(&mainBinary);
+  auto opcode = static_cast<spv::Op>(inst->getInstruction());
+  if ((opcode == spv::Op::OpSpecConstant || opcode == spv::Op::OpConstant) &&
+      !inst->getInstructionSet()) {
+    finalizeInstruction(&typeConstantBinary);
+  } else {
+    finalizeInstruction(&mainBinary);
+  }
   return true;
 }
 

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicConstantValue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicConstantValue.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -Od -T cs_6_8 -spirv -fcgl %s | FileCheck %s
+
+// CHECK: %spirvIntrinsicType = OpTypeInt 8 0
+using uint8_t [[vk::ext_capability(/* Int8 */ 39)]] =
+    vk::SpirvType</* OpTypeInt */ 21, 8, 8, vk::Literal<vk::integral_constant<uint, 8> >,
+                  vk::Literal<vk::integral_constant<bool, false> > >;
+
+[[vk::ext_instruction(/* OpConstant */ 43)]] uint8_t mkconsant([[vk::ext_literal]] int v);
+
+// CHECK: OpConstant %spirvIntrinsicType 42
+static const uint8_t K = mkconsant(42);
+
+[numthreads(1, 1, 1)] void main() {}


### PR DESCRIPTION
We will get a crash when use spirv intrinsic to create a constant value.
```fundamental
fatal error: generated SPIR-V is invalid: Constant cannot appear in a function declaration
  %spirvIntrinsicType_42 = OpConstant %spirvIntrinsicType 42
```