### PR TITLE
Add missing diagnostic argument

### DIFF
--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -3504,12 +3504,14 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
       Ty = Context.LitIntTy;
       if (Literal.GetIntegerValue(ResultVal)) {
         // If this value didn't fit into 64-bit literal int, report error.
-        Diag(Tok.getLocation(), diag::err_integer_literal_too_large);
+        Diag(Tok.getLocation(), diag::err_integer_literal_too_large)
+            << /* Unsigned */ 1;
       }
     } else {
 
       if (Literal.GetIntegerValue(ResultVal)) {
-        Diag(Tok.getLocation(), diag::err_integer_literal_too_large);
+        Diag(Tok.getLocation(), diag::err_integer_literal_too_large)
+            << /* Unsigned */ 1;
       }
       if (Literal.isLongLong) {
         if (Literal.isUnsigned)

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/integer_literal_too_large.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/integer_literal_too_large.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T lib_6_6 %s | FileCheck %s
+
+// A diagnostic is generated for an integer literal that is too large to be
+// represented by any integer type - an argument indicates whether the  text
+// contains "signed". That argument was missing in HLSL specific code within
+// Sema::ActOnNumericConstant() which resulted in an assert being raised if
+// the diagnostic was generated in an assert enabled DXC and a random string
+// being inserted in a non-assert enabled DXC.
+
+// CHECK: integer literal is too large to be represented in any integer type
+int a = 98765432109876543210;
+
+// CHECK: integer literal is too large to be represented in any integer type
+uint b = 98765432109876543210U;


### PR DESCRIPTION
Two instances of the err_integer_literal_too_large diagnostic in HLSL specific code within Sema::ActOnNumericConstant() had a missing argument. When these diagnostics were raised this caused an assert in an assert enabled DXC, and random corruption of the diagnostic text in a non-assert enabled DXC.

The trivial fix is to supply the required argument.

Fixes #7425