### PR TITLE
[Internal] Remove dead fallthrough statement

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -2819,7 +2819,6 @@ void SROA_Helper::RewriteCall(CallInst *CI) {
         DeadInsts.push_back(CI);
         break;
       }
-        LLVM_FALLTHROUGH;
       default:
         // RayQuery this pointer replacement.
         if (OldVal->getType()->isPointerTy() &&


### PR DESCRIPTION
This PR removes a dead fallthrough statement after a switch-statement's case that is terminated by a break;
This needs to be removed, because the way linux builds dxc in our internal infrastructure, it errors when a dead fallthrough statement is detected.
For context, here is the relevant error:

```
ScalarReplAggregatesHLSL.cpp:2822:9: error: fallthrough annotation in unreachable code [-Werror,-Wimplicit-fallthrough]
        LLVM_FALLTHROUGH;
        ^
... DXC/include/llvm/Support/Compiler.h:224:26: note: expanded from macro 'LLVM_FALLTHROUGH'
#define LLVM_FALLTHROUGH [[fallthrough]]
                         ^
1 error generated.
```