### PR TITLE
[CoopVec] Add multi-layer support for ExecutionTest::CoopVec_Mul

### DIFF
--- a/tools/clang/unittests/HLSLExec/CoopVec.h
+++ b/tools/clang/unittests/HLSLExec/CoopVec.h
@@ -749,12 +749,13 @@ public:
                        const TestVector &Bias, bool HasBias,
                        D3D12_LINEAR_ALGEBRA_DATATYPE MatrixInterpretation,
                        D3D12_LINEAR_ALGEBRA_DATATYPE InputType) {
-    bool IsFP32 = false;
+    // The CPU reference matrix is FP32 for all FP interpretations.
+    bool IsMatrixFP32 = false;
     switch (MatrixInterpretation) {
     case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16:
     case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3:
     case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E5M2:
-      IsFP32 = true;
+      IsMatrixFP32 = true;
       break;
     default:
       break;
@@ -763,7 +764,7 @@ public:
     TestVector ResultVec(InputVector.getNumVectors(), Matrix.getNumVectors(),
                          sizeof(float));
 
-    if (IsFP32) {
+    if (IsMatrixFP32) {
       for (int VecIdx = 0; VecIdx < InputVector.getNumVectors(); ++VecIdx) {
         const DirectX::PackedVector::HALF *InputBiasFP16 =
             Bias.getVector<DirectX::PackedVector::HALF>(0);

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -12149,6 +12149,14 @@ void ExecutionTest::runCoopVecMulTestConfig(
       {32, 8, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
       {16, 16, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
       {16, 16, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
       {16, 16, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
@@ -12157,6 +12165,14 @@ void ExecutionTest::runCoopVecMulTestConfig(
       {32, 8, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
       {16, 16, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
       {16, 16, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
       {16, 16, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
@@ -12165,6 +12181,14 @@ void ExecutionTest::runCoopVecMulTestConfig(
       {32, 8, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
       {16, 16, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
        false},
       {16, 16, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
@@ -12180,6 +12204,22 @@ void ExecutionTest::runCoopVecMulTestConfig(
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
        false},
       {32, 8, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {17, 63, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {17, 63, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {1, 1, 16, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
        true},
   };
 
@@ -12280,18 +12320,15 @@ void ExecutionTest::runCoopVecMulSubtest(
   // FIXME: This does not capture all cases, but is sufficient for the preview
   // feature set
   if (MulProps.MatrixInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8) {
-    int32_t *InputBiasI32 = (int32_t *)InputBias.getBuffer();
-    float *InputVectorF32 = (float *)InputVector.getBuffer();
-
     for (int ThreadIdx = 0; ThreadIdx < Config.NumThreads; ++ThreadIdx) {
+      int32_t *InputBiasI32 = InputBias.getVector<int32_t>(0);
       for (int OutputIdx = 0; OutputIdx < Config.OutputPerThread; ++OutputIdx) {
         int Acc = 0;
 
         for (int InputIdx = 0; InputIdx < Config.InputPerThread; ++InputIdx) {
           int InputElem;
           if (MulProps.InputType == D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32) {
-            InputElem = (int)
-                InputVectorF32[ThreadIdx * Config.InputPerThread + InputIdx];
+            InputElem = (int)InputVector.getVector<float>(ThreadIdx)[InputIdx];
           } else {
             InputElem = InputVector.getVector<int8_t>(ThreadIdx)[InputIdx];
           }
@@ -12315,22 +12352,21 @@ void ExecutionTest::runCoopVecMulSubtest(
                  D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3 ||
              MulProps.MatrixInterpretation ==
                  D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E5M2) {
-    DirectX::PackedVector::HALF *InputVectorFP16 =
-        (DirectX::PackedVector::HALF *)InputVector.getBuffer();
-    DirectX::PackedVector::HALF *InputBiasFP16 =
-        (DirectX::PackedVector::HALF *)InputBias.getBuffer();
-
     // The CPU reference matrix is float
     std::vector<float> InputMatrixFP32(InputMatrix.size() / sizeof(float));
     std::memcpy(InputMatrixFP32.data(), InputMatrix.data(), InputMatrix.size());
 
     for (int ThreadIdx = 0; ThreadIdx < Config.NumThreads; ++ThreadIdx) {
+      DirectX::PackedVector::HALF *InputVectorFP16 =
+          InputVector.getVector<DirectX::PackedVector::HALF>(ThreadIdx);
+      DirectX::PackedVector::HALF *InputBiasFP16 =
+          InputBias.getVector<DirectX::PackedVector::HALF>(0);
       for (int OutputIdx = 0; OutputIdx < Config.OutputPerThread; ++OutputIdx) {
         float Acc = 0;
 
         for (int InputIdx = 0; InputIdx < Config.InputPerThread; ++InputIdx) {
-          float const InputElem = ConvertFloat16ToFloat32(
-              InputVectorFP16[ThreadIdx * Config.InputPerThread + InputIdx]);
+          float const InputElem =
+              ConvertFloat16ToFloat32(InputVectorFP16[InputIdx]);
           float const MatrixElem =
               InputMatrixFP32[OutputIdx * Config.InputPerThread + InputIdx];
           Acc += InputElem * MatrixElem;
@@ -12365,7 +12401,7 @@ void main(uint threadIdx : SV_GroupThreadID)
   using namespace dx::linalg;
 
   uint inputOffset = (threadIdx * INPUT_VECTOR_STRIDE);
-  vector<INPUT_DATA_TYPE, INPUT_PER_THREAD / INPUT_DIVISOR> input = InputVector.Load<vector<INPUT_DATA_TYPE, INPUT_PER_THREAD / INPUT_DIVISOR> >(inputOffset);
+  vector<INPUT_DATA_TYPE, INPUT_VECTOR_NUM_ELEMENTS> input = InputVector.Load<vector<INPUT_DATA_TYPE, INPUT_VECTOR_NUM_ELEMENTS> >(inputOffset);
 
   MatrixRef<MATRIX_DATA_TYPE_ENUM, OUTPUT_PER_THREAD, INPUT_PER_THREAD, HLSL_MATRIX_LAYOUT, /*transpose*/false> mat = { InputMatrix, 0, STRIDE };
 
@@ -12439,8 +12475,9 @@ void main(uint threadIdx : SV_GroupThreadID)
     auto StrideDefine = CreateDefineFromInt(L"STRIDE", Stride);
     auto InputDataTypeDefine =
         CreateDefineFromString(L"INPUT_DATA_TYPE", InputDataType);
-    auto InputDivisorDefine =
-        CreateDefineFromInt(L"INPUT_DIVISOR", InputDivisor);
+    auto InputDivisorDefine = CreateDefineFromInt(
+        L"INPUT_VECTOR_NUM_ELEMENTS",
+        (Config.InputPerThread + InputDivisor - 1) / InputDivisor);
     auto AccumDataTypeDefine =
         CreateDefineFromString(L"ACCUM_DATA_TYPE", AccumDataType);
     auto InputInterpretationEnumDefine = CreateDefineFromString(
@@ -12596,11 +12633,12 @@ void main(uint threadIdx : SV_GroupThreadID)
           &ConvertInfo.DestInfo);
     }
 
+    int SRVSize = (ConvertInfo.DestInfo.DestSize + 15) / 16 * 16;
+
     // Create resource to hold matrix copy
-    CreateTestResources(
-        D3DDevice, CommandList, nullptr, 0,
-        CD3DX12_RESOURCE_DESC::Buffer(ConvertInfo.DestInfo.DestSize),
-        &ConvertedMatrixResource, nullptr);
+    CreateTestResources(D3DDevice, CommandList, nullptr, SRVSize,
+                        CD3DX12_RESOURCE_DESC::Buffer(SRVSize),
+                        &ConvertedMatrixResource, nullptr);
 
     // Set up data descriptors
     ConvertInfo.DataDesc.DestVA =
@@ -12613,13 +12651,7 @@ void main(uint threadIdx : SV_GroupThreadID)
         __uuidof(ID3D12GraphicsCommandList11), (void **)&CommandList11));
     CommandList11->ConvertLinearAlgebraMatrix(&ConvertInfo, 1);
 
-    // This increments baseHandle
-    if ((ConvertInfo.DestInfo.DestSize % 4) != 0) {
-      WEX::Logging::Log::Error(L"DestSize is not aligned to 4 bytes");
-      return;
-    }
-    CreateRawSRV(D3DDevice, BaseHandle,
-                 ConvertInfo.DestInfo.DestSize / sizeof(int32_t),
+    CreateRawSRV(D3DDevice, BaseHandle, SRVSize / sizeof(int32_t),
                  ConvertedMatrixResource);
   }
 

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -789,7 +789,7 @@ public:
     int InputPerThread;
     int OutputPerThread;
     int NumThreads;
-    int NumLevels;
+    int NumLayers;
     D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT MatrixLayout;
     bool Bias;
   };
@@ -12221,6 +12221,88 @@ void ExecutionTest::runCoopVecMulTestConfig(
        false},
       {1, 1, 32, 1, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
        true},
+
+      // NumLayers=2 tests
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, false},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, true},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, false},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR, true},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, false},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL, true},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {16, 16, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {16, 16, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {32, 8, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {32, 8, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {17, 63, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {17, 63, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {1, 1, 16, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       false},
+      {1, 1, 32, 2, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
+       true},
   };
 
   for (auto Config : TestConfigs) {
@@ -12231,6 +12313,21 @@ void ExecutionTest::runCoopVecMulTestConfig(
         (Config.MatrixLayout == D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR ||
          Config.MatrixLayout ==
              D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR)) {
+      continue;
+    }
+
+    if (Config.NumLayers > 1 &&
+        (MulProps.InputInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8 ||
+         MulProps.InputInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8 ||
+         MulProps.InputInterpretation ==
+             D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8_T4_PACKED ||
+         MulProps.InputInterpretation ==
+             D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8_T4_PACKED) &&
+        (MulProps.BiasInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_SINT32 ||
+         MulProps.BiasInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_UINT32)) {
+      // We do not support multi-layer tests with packed types as input with
+      // full-precision integer bias Supporting this in the current framework
+      // would require repacking the accumulator vectors
       continue;
     }
 
@@ -12250,9 +12347,9 @@ void ExecutionTest::runCoopVecMulSubtest(
 
   LogCommentFmt(
       L"Running test for InputPerThread: %d, OutputPerThread: %d, NumThreads: "
-      L"%d, NumLevels: %d, Bias: %s, MatrixLayout: %s",
+      L"%d, NumLayers: %d, Bias: %s, MatrixLayout: %s",
       Config.InputPerThread, Config.OutputPerThread, Config.NumThreads,
-      Config.NumLevels, Config.Bias ? L"true" : L"false",
+      Config.NumLayers, Config.Bias ? L"true" : L"false",
       CoopVecHelpers::MatrixLayoutToFilterString(Config.MatrixLayout).c_str());
 
   const int OutputBufferSize = (Config.OutputPerThread * Config.NumThreads * 4);
@@ -12261,8 +12358,8 @@ void ExecutionTest::runCoopVecMulSubtest(
   CComPtr<ID3D12RootSignature> RootSignature;
   {
     CD3DX12_DESCRIPTOR_RANGE Ranges[2];
-    Ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 3, 0,
-                   0); // InputVector, InputMatrix, InputBias
+    Ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 2 + Config.NumLayers, 0,
+                   0); // InputVector, InputBias, InputMatrices[]
     Ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0); // OutputBuffer
     CreateRootSignatureFromRanges(D3DDevice, &RootSignature, Ranges, 2, nullptr,
                                   0);
@@ -12273,7 +12370,7 @@ void ExecutionTest::runCoopVecMulSubtest(
   {
     D3D12_DESCRIPTOR_HEAP_DESC Desc = {};
     Desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-    Desc.NumDescriptors = 4;
+    Desc.NumDescriptors = 3 + Config.NumLayers;
     Desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     VERIFY_SUCCEEDED(
         D3DDevice->CreateDescriptorHeap(&Desc, IID_PPV_ARGS(&DescriptorHeap)));
@@ -12281,106 +12378,35 @@ void ExecutionTest::runCoopVecMulSubtest(
   CD3DX12_CPU_DESCRIPTOR_HANDLE BaseHandle(
       DescriptorHeap->GetCPUDescriptorHandleForHeapStart());
 
-  // Setup input data
-  auto ExpectedOutputBuffer =
-      std::make_unique<float[]>(Config.OutputPerThread * Config.NumThreads);
-
-  std::vector<uint8_t> InputMatrix;
-  if (MulProps.MatrixInterpretation ==
-          D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8_T4_PACKED ||
-      MulProps.MatrixInterpretation ==
-          D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8_T4_PACKED ||
-      MulProps.MatrixInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8 ||
-      MulProps.MatrixInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8) {
-    InputMatrix = CoopVecHelpers::CreateAllOnesInputMatrix<int8_t>(
-        Config.InputPerThread, Config.OutputPerThread);
-  } else if (MulProps.MatrixInterpretation ==
-                 D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16 ||
-             MulProps.MatrixInterpretation ==
-                 D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3 ||
-             MulProps.MatrixInterpretation ==
-                 D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E5M2) {
-    // Matrix source data is fp32, which gets converted to fp16 during matrix
-    // conversion
-    InputMatrix = CoopVecHelpers::CreateAllOnesInputMatrix<float>(
-        Config.InputPerThread, Config.OutputPerThread);
-  } else {
-    WEX::Logging::Log::Error(L"Unsupported matrix data type");
-    return;
+  // Our input matrix is really a set of row vectors, which we can represent
+  // as a TestVector.
+  std::vector<::CoopVecHelpers::TestVector> InputMatrices;
+  for (int I = 0; I < Config.NumLayers - 1; ++I) {
+    // Each layer except the last is InputPerThread x InputPerThread
+    InputMatrices.push_back(
+        ::CoopVecHelpers::TestVector::createAllOnesTestMatrix(
+            Config.InputPerThread, Config.InputPerThread,
+            MulProps.MatrixInterpretation));
   }
+  // Last layer, matrix size is OutputPerThread x InputPerThread
+  InputMatrices.push_back(::CoopVecHelpers::TestVector::createAllOnesTestMatrix(
+      Config.OutputPerThread, Config.InputPerThread,
+      MulProps.MatrixInterpretation));
 
   auto InputVector = CoopVecHelpers::TestVector::createSimpleTestVector(
       Config.NumThreads, Config.InputPerThread, MulProps.InputType,
       MulProps.InputInterpretation);
   auto InputBias = CoopVecHelpers::TestVector::createSimpleTestVector(
-      1, Config.OutputPerThread, MulProps.BiasInterpretation,
-      MulProps.BiasInterpretation);
+      1, std::max(Config.OutputPerThread, Config.InputPerThread),
+      MulProps.BiasInterpretation, MulProps.BiasInterpretation);
 
   // Calculate reference output
-  // FIXME: This does not capture all cases, but is sufficient for the preview
-  // feature set
-  if (MulProps.MatrixInterpretation == D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8) {
-    for (int ThreadIdx = 0; ThreadIdx < Config.NumThreads; ++ThreadIdx) {
-      int32_t *InputBiasI32 = InputBias.getVector<int32_t>(0);
-      for (int OutputIdx = 0; OutputIdx < Config.OutputPerThread; ++OutputIdx) {
-        int Acc = 0;
-
-        for (int InputIdx = 0; InputIdx < Config.InputPerThread; ++InputIdx) {
-          int InputElem;
-          if (MulProps.InputType == D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32) {
-            InputElem = (int)InputVector.getVector<float>(ThreadIdx)[InputIdx];
-          } else {
-            InputElem = InputVector.getVector<int8_t>(ThreadIdx)[InputIdx];
-          }
-          int const MatrixElem =
-              InputMatrix[OutputIdx * Config.InputPerThread + InputIdx];
-          Acc += InputElem * MatrixElem;
-        }
-
-        if (Config.Bias) {
-          Acc += InputBiasI32[OutputIdx];
-        }
-
-        float Result = float(Acc);
-        ExpectedOutputBuffer[ThreadIdx * Config.OutputPerThread + OutputIdx] =
-            Result;
-      }
-    }
-  } else if (MulProps.MatrixInterpretation ==
-                 D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16 ||
-             MulProps.MatrixInterpretation ==
-                 D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3 ||
-             MulProps.MatrixInterpretation ==
-                 D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E5M2) {
-    // The CPU reference matrix is float
-    std::vector<float> InputMatrixFP32(InputMatrix.size() / sizeof(float));
-    std::memcpy(InputMatrixFP32.data(), InputMatrix.data(), InputMatrix.size());
-
-    for (int ThreadIdx = 0; ThreadIdx < Config.NumThreads; ++ThreadIdx) {
-      DirectX::PackedVector::HALF *InputVectorFP16 =
-          InputVector.getVector<DirectX::PackedVector::HALF>(ThreadIdx);
-      DirectX::PackedVector::HALF *InputBiasFP16 =
-          InputBias.getVector<DirectX::PackedVector::HALF>(0);
-      for (int OutputIdx = 0; OutputIdx < Config.OutputPerThread; ++OutputIdx) {
-        float Acc = 0;
-
-        for (int InputIdx = 0; InputIdx < Config.InputPerThread; ++InputIdx) {
-          float const InputElem =
-              ConvertFloat16ToFloat32(InputVectorFP16[InputIdx]);
-          float const MatrixElem =
-              InputMatrixFP32[OutputIdx * Config.InputPerThread + InputIdx];
-          Acc += InputElem * MatrixElem;
-        }
-
-        if (Config.Bias) {
-          Acc += ConvertFloat16ToFloat32(InputBiasFP16[OutputIdx]);
-        }
-
-        float Result = Acc;
-        ExpectedOutputBuffer[ThreadIdx * Config.OutputPerThread + OutputIdx] =
-            Result;
-      }
-    }
+  auto ExpectedOutput = InputVector;
+  for (int I = 0; I < Config.NumLayers; ++I) {
+    ExpectedOutput = ::CoopVecHelpers::TestVector::matrixVectorMultiply(
+        InputMatrices[I], ExpectedOutput, InputBias, Config.Bias,
+        MulProps.MatrixInterpretation,
+        I == 0 ? MulProps.InputType : D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32);
   }
 
   // Create the compute pipeline state for the CoopVec shader
@@ -12391,7 +12417,7 @@ void ExecutionTest::runCoopVecMulSubtest(
 
 ByteAddressBuffer InputVector : register(t0);
 ByteAddressBuffer InputBias : register(t1);
-ByteAddressBuffer InputMatrix : register(t2);
+ByteAddressBuffer InputMatrix[NUM_LAYERS] : register(t2);
 RWByteAddressBuffer OutputBuffer: register(u0);
 
 [shader("compute")]
@@ -12402,25 +12428,57 @@ void main(uint threadIdx : SV_GroupThreadID)
 
   uint inputOffset = (threadIdx * INPUT_VECTOR_STRIDE);
   vector<INPUT_DATA_TYPE, INPUT_VECTOR_NUM_ELEMENTS> input = InputVector.Load<vector<INPUT_DATA_TYPE, INPUT_VECTOR_NUM_ELEMENTS> >(inputOffset);
+  VectorRef<BIAS_INTERPRETATION_ENUM> biasVec = { InputBias, 0 };
 
-  MatrixRef<MATRIX_DATA_TYPE_ENUM, OUTPUT_PER_THREAD, INPUT_PER_THREAD, HLSL_MATRIX_LAYOUT, /*transpose*/false> mat = { InputMatrix, 0, STRIDE };
+  vector<ACCUM_DATA_TYPE, OUTPUT_PER_THREAD> output;
+)";
 
-  vector<ACCUM_DATA_TYPE, OUTPUT_PER_THREAD> accum;
+    if (Config.NumLayers == 1) {
+      ShaderSource += R"(
+  MatrixRef<MATRIX_DATA_TYPE_ENUM, OUTPUT_PER_THREAD, INPUT_PER_THREAD, HLSL_MATRIX_LAYOUT, /*transpose*/false> mat = { InputMatrix[0], 0, STRIDE };
 
   if (USE_BIAS) {
-    VectorRef<ACCUM_INTERPRETATION_ENUM> biasVec = { InputBias, 0 };
-    accum = MulAdd<ACCUM_DATA_TYPE>(mat, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input), biasVec);
+    output = MulAdd<ACCUM_DATA_TYPE>(mat, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input), biasVec);
   } else {
-    accum = Mul<ACCUM_DATA_TYPE>(mat, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input));
+    output = Mul<ACCUM_DATA_TYPE>(mat, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input));
+  }
+)";
+    } else if (Config.NumLayers == 2) {
+      ShaderSource += R"(
+  vector<ACCUM_DATA_TYPE, INPUT_PER_THREAD> accum;
+
+  MatrixRef<MATRIX_DATA_TYPE_ENUM, INPUT_PER_THREAD, INPUT_PER_THREAD, HLSL_MATRIX_LAYOUT, /*transpose*/false> mat0 = { InputMatrix[0], 0, STRIDE };
+  if (USE_BIAS) {
+    accum = MulAdd<ACCUM_DATA_TYPE>(mat0, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input), biasVec);
+    //accum = Mul<ACCUM_DATA_TYPE>(mat0, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input));
+  } else {
+    accum = Mul<ACCUM_DATA_TYPE>(mat0, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input));
   }
 
-  vector<float, OUTPUT_PER_THREAD> result = (vector<float, OUTPUT_PER_THREAD>)accum;
+  // Dummy activation function; all of our intermediates are positive (currently).
+  accum = max(accum, 0);
+
+  MatrixRef<MATRIX_DATA_TYPE_ENUM, OUTPUT_PER_THREAD, INPUT_PER_THREAD, HLSL_MATRIX_LAYOUT, /*transpose*/false> mat1 = { InputMatrix[1], 0, STRIDE };
+  if (USE_BIAS) {
+    output = MulAdd<ACCUM_DATA_TYPE>(mat1, MakeInterpretedVector<ACCUM_INTERPRETATION_ENUM>(accum), biasVec);
+  } else {
+    output = Mul<ACCUM_DATA_TYPE>(mat1, MakeInterpretedVector<ACCUM_INTERPRETATION_ENUM>(accum));
+  }
+)";
+    }
+
+    ShaderSource += R"(
+  vector<float, OUTPUT_PER_THREAD> result = (vector<float, OUTPUT_PER_THREAD>)output;
 
   // Ensure 4-byte alignment for vector store
   uint outputOffset = OUTPUT_PER_THREAD * threadIdx * sizeof(float);
   OutputBuffer.Store<vector<float, OUTPUT_PER_THREAD> >(outputOffset, result);
 }
-    )";
+)";
+
+#if 0
+    printf("%s\n", ShaderSource.c_str());
+#endif
 
     auto CreateDefineFromInt = [](const wchar_t *Name, int Value) {
       std::wstringstream Stream;
@@ -12462,7 +12520,7 @@ void main(uint threadIdx : SV_GroupThreadID)
     const std::wstring InputInterpretationEnum =
         CoopVecHelpers::GetHlslInterpretationForDataType(
             MulProps.InputInterpretation);
-    const std::wstring AccumInterpretationEnum =
+    const std::wstring BiasInterpretationEnum =
         CoopVecHelpers::GetHlslInterpretationForDataType(
             MulProps.BiasInterpretation);
 
@@ -12487,10 +12545,15 @@ void main(uint threadIdx : SV_GroupThreadID)
     auto MatrixDataTypeEnumDefine =
         CreateDefineFromString(L"MATRIX_DATA_TYPE_ENUM", MatrixDataTypeEnum);
     auto UseBiasDefine = CreateDefineFromInt(L"USE_BIAS", Config.Bias ? 1 : 0);
+    // Treat the accumulator interpretation the same as the input interpretation
+    // for the purposes of MakeInterpretedVector.
     auto AccumInterpretationEnumDefine = CreateDefineFromString(
-        L"ACCUM_INTERPRETATION_ENUM", AccumInterpretationEnum);
+        L"ACCUM_INTERPRETATION_ENUM", InputInterpretationEnum);
     auto InputVectorStrideDefine = CreateDefineFromInt(
         L"INPUT_VECTOR_STRIDE", (int)InputVector.getStride());
+    auto NumLayersDefine = CreateDefineFromInt(L"NUM_LAYERS", Config.NumLayers);
+    auto BiasInterpretationEnumDefine = CreateDefineFromString(
+        L"BIAS_INTERPRETATION_ENUM", BiasInterpretationEnum);
 
     LPCWSTR Options[] = {
         L"-enable-16bit-types",
@@ -12507,7 +12570,17 @@ void main(uint threadIdx : SV_GroupThreadID)
         UseBiasDefine.c_str(),
         AccumInterpretationEnumDefine.c_str(),
         InputVectorStrideDefine.c_str(),
+        NumLayersDefine.c_str(),
+        BiasInterpretationEnumDefine.c_str(),
     };
+
+#if 0
+    // Print options for debugging
+    WEX::Logging::Log::Comment(L"Shader compilation options:");
+    for (UINT i = 0; i < _countof(Options); i++) {
+      WEX::Logging::Log::Comment(Options[i]);
+    }
+#endif
 
     CComPtr<LinAlgHeaderIncludeHandler> IncludeHandler =
         new LinAlgHeaderIncludeHandler(m_support);
@@ -12531,14 +12604,17 @@ void main(uint threadIdx : SV_GroupThreadID)
       0, D3D12_COMMAND_LIST_TYPE_DIRECT, CommandAllocator, ComputePipelineState,
       IID_PPV_ARGS(&CommandList)));
 
-  // Setup input matrix as all-ones in sint8 format. This will later be
-  // converted to the appropriate data type by the matrix conversion API.
-  CComPtr<ID3D12Resource> InputMatrixSRVResource, InputMatrixSRVUploadResource;
-
-  CreateTestResources(D3DDevice, CommandList, InputMatrix.data(),
-                      InputMatrix.size(),
-                      CD3DX12_RESOURCE_DESC::Buffer(InputMatrix.size()),
-                      &InputMatrixSRVResource, &InputMatrixSRVUploadResource);
+  std::vector<CComPtr<ID3D12Resource>> InputMatrixSRVResources(
+      Config.NumLayers);
+  std::vector<CComPtr<ID3D12Resource>> InputMatrixSRVUploadResources(
+      Config.NumLayers);
+  for (int I = 0; I < Config.NumLayers; ++I) {
+    CreateTestResources(
+        D3DDevice, CommandList, InputMatrices[I].getBuffer(),
+        InputMatrices[I].getTotalBytes(),
+        CD3DX12_RESOURCE_DESC::Buffer(InputMatrices[I].getTotalBytes()),
+        &InputMatrixSRVResources[I], &InputMatrixSRVUploadResources[I]);
+  }
 
   // Create input vector of an appropriate type. All integer types start as
   // SINT8 for now.
@@ -12568,82 +12644,25 @@ void main(uint threadIdx : SV_GroupThreadID)
                (UINT)(InputBias.getTotalBytes() / sizeof(int32_t)),
                InputBiasSRVResource);
 
-  CComPtr<ID3D12Resource> ConvertedMatrixResource;
-  {
-    // Create source matrix info
-    D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO ConvertInfo = {};
-    ConvertInfo.SrcInfo.SrcDataType =
-        CoopVecHelpers::GetMatrixSrcDataType(MulProps.MatrixInterpretation);
-    ConvertInfo.SrcInfo.SrcLayout =
-        D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR;
-
-    // Create destination matrix info
-    ConvertInfo.DestInfo.DestSize = 0; // Will be populated by driver
-    int SrcEltSize = 0;
-    int DestEltSize = 0;
-    switch (MulProps.MatrixInterpretation) {
-    case D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8:
-    case D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8_T4_PACKED:
-      ConvertInfo.DestInfo.DestDataType = D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8;
-      SrcEltSize = 1;
-      DestEltSize = 1;
-      break;
-    case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16:
-      ConvertInfo.DestInfo.DestDataType = D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16;
-      SrcEltSize = 4;  // FP32
-      DestEltSize = 2; // FP16
-      break;
-    case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3:
-      ConvertInfo.DestInfo.DestDataType =
-          D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3;
-      SrcEltSize = 4;  // FP32
-      DestEltSize = 1; // FP8
-      break;
-    case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E5M2:
-      ConvertInfo.DestInfo.DestDataType =
-          D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E5M2;
-      SrcEltSize = 4;  // FP32
-      DestEltSize = 1; // FP8
-      break;
-    }
-    ConvertInfo.SrcInfo.SrcStride = Config.InputPerThread * SrcEltSize;
-    ConvertInfo.SrcInfo.SrcSize =
-        Config.InputPerThread * Config.OutputPerThread * SrcEltSize;
-
-    ConvertInfo.DestInfo.DestLayout = Config.MatrixLayout;
-    ConvertInfo.DestInfo.DestStride = 0;
-    ConvertInfo.DestInfo.NumRows = Config.OutputPerThread;
-    ConvertInfo.DestInfo.NumColumns = Config.InputPerThread;
-
-    if (Config.MatrixLayout == D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR) {
-      ConvertInfo.DestInfo.DestStride = Config.InputPerThread * DestEltSize;
-    } else if (Config.MatrixLayout ==
-               D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR) {
-      ConvertInfo.DestInfo.DestStride = Config.OutputPerThread * DestEltSize;
-    }
-
-    // Get destination size using preview interface
-    {
-      CComPtr<ID3D12DevicePreview> PreviewDevice;
-      VERIFY_SUCCEEDED(D3DDevice->QueryInterface(__uuidof(ID3D12DevicePreview),
-                                                 (void **)&PreviewDevice));
-
-      // Query required destination size
-      PreviewDevice->GetLinearAlgebraMatrixConversionDestinationInfo(
-          &ConvertInfo.DestInfo);
-    }
+  // Create converted matrix resource and SRV for each input matrix
+  std::vector<CComPtr<ID3D12Resource>> ConvertedMatrixResources(
+      Config.NumLayers);
+  for (int I = 0; I < Config.NumLayers; ++I) {
+    auto ConvertInfo = InputMatrices[I].getConversionInfo(
+        D3DDevice, MulProps.MatrixInterpretation, Config.MatrixLayout);
 
     int SRVSize = (ConvertInfo.DestInfo.DestSize + 15) / 16 * 16;
 
     // Create resource to hold matrix copy
     CreateTestResources(D3DDevice, CommandList, nullptr, SRVSize,
                         CD3DX12_RESOURCE_DESC::Buffer(SRVSize),
-                        &ConvertedMatrixResource, nullptr);
+                        &ConvertedMatrixResources[I], nullptr);
 
     // Set up data descriptors
     ConvertInfo.DataDesc.DestVA =
-        ConvertedMatrixResource->GetGPUVirtualAddress();
-    ConvertInfo.DataDesc.SrcVA = InputMatrixSRVResource->GetGPUVirtualAddress();
+        ConvertedMatrixResources[I]->GetGPUVirtualAddress();
+    ConvertInfo.DataDesc.SrcVA =
+        InputMatrixSRVResources[I]->GetGPUVirtualAddress();
 
     // Get command list interface and perform conversion
     CComPtr<ID3D12GraphicsCommandList11> CommandList11;
@@ -12651,8 +12670,9 @@ void main(uint threadIdx : SV_GroupThreadID)
         __uuidof(ID3D12GraphicsCommandList11), (void **)&CommandList11));
     CommandList11->ConvertLinearAlgebraMatrix(&ConvertInfo, 1);
 
+    // This increments BaseHandle
     CreateRawSRV(D3DDevice, BaseHandle, SRVSize / sizeof(int32_t),
-                 ConvertedMatrixResource);
+                 ConvertedMatrixResources[I]);
   }
 
   CComPtr<ID3D12Resource> UavResource;
@@ -12697,14 +12717,18 @@ void main(uint threadIdx : SV_GroupThreadID)
 
     float *ResultBuffer = (float *)MappedData.data();
     bool Equal = true;
-    for (int i = 0; i < OutputBufferSize / sizeof(float); i++) {
-      if (isnan(ResultBuffer[i]) || isnan(ExpectedOutputBuffer[i]) ||
-          fabs(ResultBuffer[i] - ExpectedOutputBuffer[i]) > 0.00001) {
-        LogErrorFmt(L"Result mismatch at index %d", i);
-        LogErrorFmt(L"ResultBuffer[%d]: %f, ExpectedOutputBuffer[%d]: %f", i,
-                    ResultBuffer[i], i, ExpectedOutputBuffer[i]);
-        Equal = false;
-        break;
+
+    for (int i = 0; i < Config.NumThreads; ++i) {
+      for (int j = 0; j < Config.OutputPerThread; ++j) {
+        float Result = ResultBuffer[i * Config.OutputPerThread + j];
+        float Expected = ExpectedOutput.getVector<float>(i)[j];
+        if (isnan(Result) || isnan(Expected) ||
+            fabs(Result - Expected) > 0.00001) {
+          LogErrorFmt(L"Result mismatch at index %d",
+                      i * Config.OutputPerThread + j);
+          LogErrorFmt(L"Result: %f, Expected: %f", Result, Expected);
+          Equal = false;
+        }
       }
     }
     VERIFY_IS_TRUE(Equal);

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -12450,7 +12450,6 @@ void main(uint threadIdx : SV_GroupThreadID)
   MatrixRef<MATRIX_DATA_TYPE_ENUM, INPUT_PER_THREAD, INPUT_PER_THREAD, HLSL_MATRIX_LAYOUT, /*transpose*/false> mat0 = { InputMatrix[0], 0, STRIDE };
   if (USE_BIAS) {
     accum = MulAdd<ACCUM_DATA_TYPE>(mat0, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input), biasVec);
-    //accum = Mul<ACCUM_DATA_TYPE>(mat0, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input));
   } else {
     accum = Mul<ACCUM_DATA_TYPE>(mat0, MakeInterpretedVector<INPUT_INTERPRETATION_ENUM>(input));
   }

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -12476,10 +12476,6 @@ void main(uint threadIdx : SV_GroupThreadID)
 }
 )";
 
-#if 0
-    printf("%s\n", ShaderSource.c_str());
-#endif
-
     auto CreateDefineFromInt = [](const wchar_t *Name, int Value) {
       std::wstringstream Stream;
       Stream << L"-D" << Name << L"=" << Value;
@@ -12573,14 +12569,6 @@ void main(uint threadIdx : SV_GroupThreadID)
         NumLayersDefine.c_str(),
         BiasInterpretationEnumDefine.c_str(),
     };
-
-#if 0
-    // Print options for debugging
-    WEX::Logging::Log::Comment(L"Shader compilation options:");
-    for (UINT i = 0; i < _countof(Options); i++) {
-      WEX::Logging::Log::Comment(Options[i]);
-    }
-#endif
 
     CComPtr<LinAlgHeaderIncludeHandler> IncludeHandler =
         new LinAlgHeaderIncludeHandler(m_support);


### PR DESCRIPTION
This change adds support for NumLevels=2 to verify functional correctness of multi-layer applications of CoopVec. This includes some cleanup work to make it easier to abstract out vectors and matrices in the test code.