### PR TITLE
Fix Typo in PTRBITCAST

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3174,7 +3174,7 @@ INSTR.OPCONST                                         DXIL intrinsic requires an
 INSTR.OPCONSTRANGE                                    Constant values must be in-range for operation.
 INSTR.OPERANDRANGE                                    DXIL intrinsic operand must be within defined range
 INSTR.PARAMMULTIPLE                                   Parameter must be a valid multiple
-INSTR.PTRBITCAST                                      Pointer type bitcast must be have same size.
+INSTR.PTRBITCAST                                      Pointer type bitcast must have same size.
 INSTR.RESOURCECLASSFORLOAD                            load can only run on UAV/SRV resource.
 INSTR.RESOURCECLASSFORSAMPLERGATHER                   sample, lod and gather should be on srv resource.
 INSTR.RESOURCECLASSFORUAVSTORE                        store should be on uav resource.

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1724,7 +1724,7 @@ TEST_F(ValidationTest, PtrBitCast) {
       "%\\1 = getelementptr [4 x i32], [4 x i32]* %\\2, i32 0, i32 0\n"
       "  %X = bitcast i32* %\\1 to double*    \n"
       "  store i32 %\\3, i32* %\\1, align 4",
-      "Pointer type bitcast must be have same size",
+      "Pointer type bitcast must have same size",
       /*bRegex*/ true);
 }
 

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8068,7 +8068,7 @@ class db_dxil(object):
             "Call to DXIL intrinsic '%0' does not match an allowed overload signature.",
         )
         self.add_valrule(
-            "Instr.PtrBitCast", "Pointer type bitcast must be have same size."
+            "Instr.PtrBitCast", "Pointer type bitcast must have same size."
         )
         self.add_valrule(
             "Instr.MinPrecisonBitCast", "Bitcast on minprecison types is not allowed."


### PR DESCRIPTION
update the 
1. docs
2. tests  
3. hctdb.py 

So that `InstrPtrBitCast` in `DxilValidation.inc` & `DxilValidationImpl.inc` have the new error message