### PR TITLE
Fix PAQ memory leak by never pushing redundant stages to backing vector

### DIFF
--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -397,9 +397,19 @@ bool Parser::MaybeParseHLSLAttributes(std::vector<hlsl::UnusualAnnotation *> &ta
           stage = hlsl::DXIL::PayloadAccessShaderStage::Miss;
         } else if (shaderStage == "anyhit") {
           stage = hlsl::DXIL::PayloadAccessShaderStage::Anyhit;
-        } 
+        }
 
-        mod.ShaderStages.push_back(stage);
+        // mod.ShaderStages can only take four elements before it starts to
+        // migrate. Make sure not to add redundant stages.
+        bool IsDuplicate = false;
+        for (auto s : mod.ShaderStages)
+          if (s == stage) {
+            IsDuplicate = true;
+            break;
+          }
+        if (!IsDuplicate)
+          mod.ShaderStages.push_back(stage);
+
         ConsumeToken(); // consume shader type
 
         if (Tok.is(tok::comma)) // check if we have a list of shader types

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/redundant_clause.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/redundant_clause.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T lib_6_9 %s
+
+// COM: No FileCheck required: Error raised by ASAN-enabled DXC builds where underlying bug #7104 is not fixed.
+// COM: This checks that the backing memory of the shader stages vector does not migrate when more than four (it's preallocated size) shader stages are added.
+
+struct [raypayload] Payload
+{
+    int a      : read(anyhit,caller,miss,closesthit,closesthit) : write(anyhit,caller,miss,closesthit,caller);
+};
+
+struct Attribs
+{
+    float2 barys;
+};
+
+[shader("closesthit")]
+void ClosestHitInOut( inout Payload payload, in Attribs attribs )
+{
+  if (payload.a == 1)
+    payload.a = 2;
+}


### PR DESCRIPTION
The backing memory of the `ShaderStages` vector starts to migrate when more than four stages are pushed. ASAN detects and errs on that condition (details in bug).

Closes #7104