### PR TITLE
[SPIRV] Cast derivative opts to 32-bits.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -789,6 +789,21 @@ private:
   SpirvInstruction *processIntrinsicFirstbit(const CallExpr *,
                                              GLSLstd450 glslOpcode);
 
+  SpirvInstruction *
+  processMatrixDerivativeIntrinsic(hlsl::IntrinsicOp hlslOpcode,
+                                   const Expr *arg, SourceLocation loc,
+                                   SourceRange range);
+
+  SpirvInstruction *processDerivativeIntrinsic(hlsl::IntrinsicOp hlslOpcode,
+                                               const Expr *arg,
+                                               SourceLocation loc,
+                                               SourceRange range);
+
+  SpirvInstruction *processDerivativeIntrinsic(hlsl::IntrinsicOp hlslOpcode,
+                                               SpirvInstruction *arg,
+                                               SourceLocation loc,
+                                               SourceRange range);
+
 private:
   /// Returns the <result-id> for constant value 0 of the given type.
   SpirvConstant *getValueZero(QualType type);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.ddx.double.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.ddx.double.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T ps_6_2 -E main -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+// CHECK: :14:22: warning: conversion from larger type 'double' to smaller type 'float', possible loss of data [-Wconversion]
+// CHECK: :20:22: warning: conversion from larger type 'double2' to smaller type 'vector<float, 2>', possible loss of data [-Wconversion]
+
+void main() {
+  double    a;
+  double2   b;
+
+// CHECK:      [[a:%[0-9]+]] = OpLoad %double %a
+// CHECK-NEXT: [[c:%[0-9]+]] = OpFConvert %float [[a]]
+// CHECK-NEXT:   [[r:%[0-9]+]] = OpDPdx %float [[c]]
+// CHECK-NEXT:  OpFConvert %double [[r]]
+  double    da = ddx(a);
+
+// CHECK:      [[b:%[0-9]+]] = OpLoad %v2double %b
+// CHECK-NEXT: [[c:%[0-9]+]] = OpFConvert %v2float [[b]]
+// CHECK-NEXT: [[r:%[0-9]+]] = OpDPdx %v2float [[c]]
+// CHECK-NEXT:  OpFConvert %v2double [[r]]
+  double2   db = ddx(b);
+}

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.ddx.half.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.ddx.half.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T ps_6_2 -E main -enable-16bit-types -fcgl  %s -spirv | FileCheck %s
+
+void main() {
+
+  half    a;
+  half2   b;
+
+// CHECK:      [[a:%[0-9]+]] = OpLoad %half %a
+// CHECK-NEXT: [[c:%[0-9]+]] = OpFConvert %float [[a]]
+// CHECK-NEXT:   [[r:%[0-9]+]] = OpDPdx %float [[c]]
+// CHECK-NEXT:  OpFConvert %half [[r]]
+  half    da = ddx(a);
+
+// CHECK:      [[b:%[0-9]+]] = OpLoad %v2half %b
+// CHECK-NEXT: [[c:%[0-9]+]] = OpFConvert %v2float [[b]]
+// CHECK-NEXT: [[r:%[0-9]+]] = OpDPdx %v2float [[c]]
+// CHECK-NEXT:  OpFConvert %v2half [[r]]
+  half2   db = ddx(b);
+}


### PR DESCRIPTION
The SPIR-V operations require 32-bit floats. Smaller float type can be
cast to 32-bits to perform the operation. The FE already emits a warning
for 64-bits.

Fixes #7431
