### PR TITLE
[SPIRV] Add warning for initialized globals

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2021,6 +2021,11 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
   // variables) belongs to the Function storage class.
   if (isExternalVar(decl)) {
     var = declIdMapper.createExternVar(decl);
+
+    if (decl->hasInit()) {
+      emitWarning("Initializer of external global will be ignored",
+                  decl->getLocation());
+    }
   } else {
     // We already know the variable is not externally visible here. If it does
     // not have local storage, it should be file scope variable.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2021,7 +2021,6 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
   // variables) belongs to the Function storage class.
   if (isExternalVar(decl)) {
     var = declIdMapper.createExternVar(decl);
-
     if (decl->hasInit()) {
       emitWarning("Initializer of external global will be ignored",
                   decl->getLocation());

--- a/tools/clang/test/CodeGenSPIRV/groupshared.init.warning.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/groupshared.init.warning.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T cs_6_0 -E main -spirv %s 2>&1 | FileCheck %s
+
+groupshared uint testing = 0;
+
+[numthreads(64, 1, 1)]
+void main(uint local_thread_id_flat : SV_GroupIndex) {
+    
+    InterlockedAdd(testing, 1);
+    GroupMemoryBarrierWithGroupSync();
+    
+    if (local_thread_id_flat == 0) {
+        if (testing > 64) {
+            printf("testing is %u wtf", testing);
+        }
+    }
+}
+
+// CHECK: warning: Initializer of external global will be ignored
+// CHECK-NEXT: groupshared uint testing = 0;


### PR DESCRIPTION
To be consistent with DXIL, we will start emitting a warning for
extenally visible variables that have an initializer. Until now, there
were silently ignored.

Fixes #3950
