### PR TITLE
[SEMA] Don't emit an error for sizeof an enum.

### DIFF
--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -95,6 +95,8 @@ bool IsHLSLNumericOrAggregateOfNumericType(clang::QualType type) {
   } else if (type->isArrayType()) {
     return IsHLSLNumericOrAggregateOfNumericType(
         QualType(type->getArrayElementTypeNoTypeQual(), 0));
+  } else if (type->isEnumeralType()) {
+    return true;
   }
 
   // Chars can only appear as part of strings, which we don't consider numeric.

--- a/tools/clang/test/CodeGenSPIRV/enum_sizeof.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/enum_sizeof.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -T cs_6_0 -E main  -fcgl %s -spirv | FileCheck %s
+
+enum E1 : uint64_t
+{
+    v1 = 0,
+};
+
+enum E2 : uint32_t
+{
+    v2 = 0,
+};
+
+struct S {
+  E1 e1;
+  E2 e2;
+};
+
+RWBuffer<int> b;
+
+[numthreads(128, 1, 1)]
+void main()
+{
+// CHECK: OpImageWrite {{%.*}} %uint_0 %int_8 None
+    b[0] = sizeof(E1);
+
+// CHECK: OpImageWrite {{%.*}} %uint_1 %int_4 None
+    b[1] = sizeof(E2);
+
+// CHECK: OpImageWrite {{%.*}} %uint_2 %int_16 None
+    b[2] = sizeof(S);
+}

--- a/tools/clang/test/SemaHLSL/enum_sizeof.hlsl
+++ b/tools/clang/test/SemaHLSL/enum_sizeof.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -T cs_6_9 -E main %s -ast-dump-implicit | FileCheck %s --check-prefix AST
+
+enum E1 : uint64_t
+{
+    v1 = 0,
+};
+
+enum E2 : uint32_t
+{
+    v2 = 0,
+};
+
+struct S {
+  E1 e1;
+  E2 e2;
+};
+
+RWBuffer<int> b;
+
+[numthreads(128, 1, 1)]
+void main()
+{
+// AST: UnaryExprOrTypeTraitExpr {{.*}} 'unsigned long' sizeof 'E1'
+    b[0] = sizeof(E1);
+
+// AST: UnaryExprOrTypeTraitExpr {{.*}} 'unsigned long' sizeof 'E2'
+    b[1] = sizeof(E2);
+
+// AST: UnaryExprOrTypeTraitExpr {{.*}} 'unsigned long' sizeof 'S'
+    b[2] = sizeof(S);
+}


### PR DESCRIPTION
Fixes #7416
