### PR TITLE
[SPIRV] Treat vk::Spirv*Type as opaque when reconstructing

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -7081,14 +7081,17 @@ SpirvInstruction *SpirvEmitter::reconstructValue(SpirvInstruction *srcVal,
 
   // Structs
   if (const auto *recordType = valType->getAs<RecordType>()) {
-    assert(recordType->isStructureType());
-
     if (isTypeInVkNamespace(recordType) &&
-        recordType->getDecl()->getName().equals("BufferPointer")) {
-      // Uniquely among structs, vk::BufferPointer<T> lowers to a pointer type.
+            (recordType->getDecl()->getName().equals("BufferPointer") ||
+             recordType->getDecl()->getName().equals("SpirvType")) ||
+        recordType->getDecl()->getName().equals("SpirvOpaqueType")) {
+      // vk::BufferPointer<T> lowers to a pointer type. No need to reconstruct
+      // the value. The vk::Spirv*Type should be treated an opaque type. All we
+      // can do is leave it the same.
       return srcVal;
     }
 
+    assert(recordType->isStructureType());
     LowerTypeVisitor lowerTypeVisitor(astContext, spvContext, spirvOptions,
                                       spvBuilder);
     const StructType *spirvStructType =

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -7082,9 +7082,9 @@ SpirvInstruction *SpirvEmitter::reconstructValue(SpirvInstruction *srcVal,
   // Structs
   if (const auto *recordType = valType->getAs<RecordType>()) {
     if (isTypeInVkNamespace(recordType) &&
-            (recordType->getDecl()->getName().equals("BufferPointer") ||
-             recordType->getDecl()->getName().equals("SpirvType")) ||
-        recordType->getDecl()->getName().equals("SpirvOpaqueType")) {
+        (recordType->getDecl()->getName().equals("BufferPointer") ||
+         recordType->getDecl()->getName().equals("SpirvType") ||
+         recordType->getDecl()->getName().equals("SpirvOpaqueType"))) {
       // vk::BufferPointer<T> lowers to a pointer type. No need to reconstruct
       // the value. The vk::Spirv*Type should be treated an opaque type. All we
       // can do is leave it the same.

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.hlsl
@@ -12,7 +12,16 @@ struct BufferData {
   float3 v;
 };
 
+using MyInt = vk::SpirvType<
+    /*spv::OpTypeInt*/21,
+    1,1, // size and alignment
+    vk::Literal<vk::integral_constant<uint,16> >, // bits
+    vk::Literal<vk::integral_constant<uint,1> > // signed
+>;
+
 uint64_t Address;
+
+[[vk::ext_capability(/* Int16 */ 22)]]
 float4 main() : SV_Target0 {
   // CHECK:      [[addr:%[0-9]+]] = OpLoad %ulong
   // CHECK-NEXT: [[buf:%[0-9]+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
@@ -49,6 +58,11 @@ float4 main() : SV_Target0 {
   // CHECK: [[buf:%[0-9]+]] = OpBitcast %_ptr_PhysicalStorageBuffer_BufferData_0 %ulong_0
   // CHECK-NEXT: [[load:%[0-9]+]] = OpLoad %BufferData_0 [[buf]] Aligned 4
   d = vk::RawBufferLoad<BufferData>(0);
+
+  // CHECK: [[buf:%[0-9]+]] = OpBitcast %_ptr_PhysicalStorageBuffer_spirvIntrinsicType %ulong_0
+  // CHECK-NEXT: [[load:%[0-9]+]] = OpLoad %spirvIntrinsicType [[buf]] Aligned 4
+  // CHECK-NEXT: OpStore %mi [[load]]
+  MyInt mi = vk::RawBufferLoad<MyInt>(0);
 
   return float4(w.x, x, y, z);
 }


### PR DESCRIPTION
It is possible to have two struct types in spir-v that are the same
except for the decorations. Sometimes we have to reconstruct the value
from one type to another.

In the case of a vk::SpirvType, we do not know anything about the type,
so this should not happen. When trying to reconstuct the value, we
should simply return the original value.

Fixes #6963
