### PR TITLE
Make a deep copy of the returned value from setlocale

### DIFF
--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -916,7 +916,7 @@ unsigned int SysStringLen(const BSTR bstrString);
 // RAII style mechanism for setting/unsetting a locale for the specified Windows
 // codepage
 class ScopedLocale {
-  const char *m_prevLocale;
+  std::string m_prevLocale;
 
 public:
   explicit ScopedLocale(uint32_t codePage)
@@ -926,9 +926,7 @@ public:
     setlocale(LC_ALL, "en_US.UTF-8");
   }
   ~ScopedLocale() {
-    if (m_prevLocale != nullptr) {
-      setlocale(LC_ALL, m_prevLocale);
-    }
+    setlocale(LC_ALL, m_prevLocale.c_str());
   }
 };
 
@@ -937,12 +935,12 @@ public:
 template <int t_nBufferLength = 128> class CW2AEX {
 public:
   CW2AEX(LPCWSTR psz) {
-    ScopedLocale locale(CP_UTF8);
-
     if (!psz) {
       m_psz = NULL;
       return;
     }
+
+    ScopedLocale locale(CP_UTF8);
 
     int len = (wcslen(psz) + 1) * 4;
     m_psz = new char[len];
@@ -962,12 +960,12 @@ typedef CW2AEX<> CW2A;
 template <int t_nBufferLength = 128> class CA2WEX {
 public:
   CA2WEX(LPCSTR psz) {
-    ScopedLocale locale(CP_UTF8);
-
     if (!psz) {
       m_psz = NULL;
       return;
     }
+
+    ScopedLocale locale(CP_UTF8);
 
     int len = strlen(psz) + 1;
     m_psz = new wchar_t[len];

--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -52,8 +52,7 @@ int MultiByteToWideChar(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  const char *prevLocale = setlocale(LC_ALL, nullptr);
-  setlocale(LC_ALL, "en_US.UTF-8");
+  ScopedLocale locale(CP_UTF8);
   if (lpMultiByteStr[cbMultiByte - 1] != '\0') {
     char *srcStr = (char *)malloc((cbMultiByte + 1) * sizeof(char));
     strncpy(srcStr, lpMultiByteStr, cbMultiByte);
@@ -63,9 +62,6 @@ int MultiByteToWideChar(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
   } else {
     rv = mbstowcs(lpWideCharStr, lpMultiByteStr, cchWideChar);
   }
-
-  if (prevLocale)
-    setlocale(LC_ALL, prevLocale);
 
   if (rv == (size_t)cbMultiByte)
     return rv;
@@ -108,8 +104,7 @@ int WideCharToMultiByte(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  const char *prevLocale = setlocale(LC_ALL, nullptr);
-  setlocale(LC_ALL, "en_US.UTF-8");
+  ScopedLocale locale(CP_UTF8);
   if (lpWideCharStr[cchWideChar - 1] != L'\0') {
     wchar_t *srcStr = (wchar_t *)malloc((cchWideChar + 1) * sizeof(wchar_t));
     wcsncpy(srcStr, lpWideCharStr, cchWideChar);
@@ -119,9 +114,6 @@ int WideCharToMultiByte(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
   } else {
     rv = wcstombs(lpMultiByteStr, lpWideCharStr, cbMultiByte);
   }
-
-  if (prevLocale)
-    setlocale(LC_ALL, prevLocale);
 
   if (rv == (size_t)cchWideChar)
     return rv;


### PR DESCRIPTION
When I tested this library on Linux Manjaro 6.6.85 with enabled ASAN I faced with the issue `heep-use-after-free`.

As I understood it's necessary to make a deep copy of the returned value from `setlocale`, because during the next call of this function, the returned memory can be freed.
Also https://en.cppreference.com/w/cpp/locale/setlocale recommends making a deep copy.
When I looked at the `setlocale` implementation in glibc 2.41 (it's a version from my system) I see that there is a chance of such behaviour (a returned memory can be freed):
https://github.com/bminor/glibc/blob/release/2.41/master/locale/setlocale.c#L395
I made such a fix and now everything is OK.

My compiler is clang 19.1.7.