### PR TITLE
[SM 6.9] Fix OuterProductAccumulate FP32 Accumulator case in ExecTest.

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13501,6 +13501,11 @@ float4 ps_main() : SV_Target {
       SrcEltSize = 4;  // FP32
       DestEltSize = 2; // FP16
       break;
+    case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32:
+      DestInfo.DestDataType = D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32;
+      SrcEltSize = 4; // FP32
+      DestEltSize = 4; // FP32
+      break;
     case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3:
       DestInfo.DestDataType = D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3;
       SrcEltSize = 4;  // FP32

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13503,7 +13503,7 @@ float4 ps_main() : SV_Target {
       break;
     case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32:
       DestInfo.DestDataType = D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32;
-      SrcEltSize = 4; // FP32
+      SrcEltSize = 4;  // FP32
       DestEltSize = 4; // FP32
       break;
     case D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT_E4M3:


### PR DESCRIPTION
The switch that sets SrcEltSize and DestEltSize is missing an FP32 case.
This results in the matrix buffer not being initialized with all 1.0s and causes tests to fail due to expected result being off by -1.0.

Verified correctness with NVIDIA internal driver build.