### PR TITLE
[SPIR-V] Add payload to OpEmitMeshTasksEXT

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13012,7 +13012,7 @@ void SpirvEmitter::processDispatchMesh(const CallExpr *callExpr) {
           : spv::StorageClass::Output;
   auto *payloadArg = doExpr(args[3]);
   bool isValid = false;
-  const VarDecl *param = nullptr;
+  SpirvInstruction *param = nullptr;
   if (const auto *implCastExpr = dyn_cast<CastExpr>(args[3])) {
     if (const auto *arg = dyn_cast<DeclRefExpr>(implCastExpr->getSubExpr())) {
       if (const auto *paramDecl = dyn_cast<VarDecl>(arg->getDecl())) {
@@ -13020,7 +13020,8 @@ void SpirvEmitter::processDispatchMesh(const CallExpr *callExpr) {
           isValid = declIdMapper.createPayloadStageVars(
               sigPoint, sc, paramDecl, /*asInput=*/false, paramDecl->getType(),
               "out.var", &payloadArg);
-          param = paramDecl;
+          param =
+              declIdMapper.getDeclEvalInfo(paramDecl, paramDecl->getLocation());
         }
       }
     }
@@ -13037,7 +13038,7 @@ void SpirvEmitter::processDispatchMesh(const CallExpr *callExpr) {
 
   if (featureManager.isExtensionEnabled(Extension::EXT_mesh_shader)) {
     // for EXT_mesh_shader, create opEmitMeshTasksEXT.
-    spvBuilder.createEmitMeshTasksEXT(threadX, threadY, threadZ, loc, nullptr,
+    spvBuilder.createEmitMeshTasksEXT(threadX, threadY, threadZ, loc, param,
                                       range);
   } else {
     // for NV_mesh_shader, set TaskCountNV = threadX * threadY * threadZ.

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.amplification.payload.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.amplification.payload.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -E main -T as_6_8 -spirv %s -E main -fspv-target-env=vulkan1.1spirv1.4 | FileCheck %s
+
+struct S {
+  uint a;
+};
+
+groupshared S s;
+// CHECK: %s = OpVariable {{.*}} TaskPayloadWorkgroupEXT
+
+[numthreads(1, 1, 1)]
+void main()
+{
+// CHECK: OpEmitMeshTasksEXT %uint_1 %uint_1 %uint_1 %s
+	DispatchMesh(1, 1, 1, s);
+}


### PR DESCRIPTION
This commit fixes the missing payload parameter for the OpEmitMeshTasksEXT instruction.
Errors such as the passed variable storage class or type are already tested.

Fixes #7082

Co-Authored-by: baldurk <baldurk@baldurk.org>