### PR TITLE
[SPIR-V] Fix r-value being used in mul intrinsic

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -80,6 +80,9 @@ public:
   void doDecl(const Decl *decl);
   void doStmt(const Stmt *stmt, llvm::ArrayRef<const Attr *> attrs = {});
   SpirvInstruction *doExpr(const Expr *expr, SourceRange rangeOverride = {});
+  SpirvInstruction *doExprEnsuringRValue(const Expr *expr,
+                                         SourceLocation location,
+                                         SourceRange range);
 
   /// Processes the given expression and emits SPIR-V instructions. If the
   /// result is a GLValue, does an additional load.


### PR DESCRIPTION
When dealing with the Load method on buffers, the operator call can emit a pointer instead of an actual load, and the user is then responsible on loading the value if required.
The `mul` instrinsic code was not handling this, hence caused the pointer to be passed as-is in SPIR-V.

Fixes #7246