### PR TITLE
Eliminates layout mismatch when vk::BufferPointer::Get() result returned from called function.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11016,6 +11016,7 @@ SpirvInstruction *SpirvEmitter::processIntrinsicGetBufferContents(
   if (bufferPointer->isRValue()) {
     bufferPointer->setRValue(false);
     bufferPointer->setStorageClass(spv::StorageClass::PhysicalStorageBuffer);
+    bufferPointer->setLayoutRule(spirvOptions.sBufferLayoutRule);
     return bufferPointer;
   }
 

--- a/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.rvalue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.rvalue.hlsl
@@ -1,4 +1,5 @@
-// RUN: %dxc -spirv -HV 202x -Od -T cs_6_9 %s | FileCheck %s
+// RUN: %dxc -spirv -HV 202x -Od -T cs_6_9 %s | FileCheck %s --check-prefix=CHECK --check-prefix=NOFUN
+// RUN: %dxc -spirv -HV 202x -Od -T cs_6_9 -DFUN %s | FileCheck %s --check-prefix=CHECK --check-prefix=FUN
 
 // Issue #7302: implicit object argument of Get() evaluates to rvalue
 
@@ -20,16 +21,45 @@ struct Content
 // CHECK: [[V2UINT:%[_0-9A-Za-z]*]] = OpTypeVector [[UINT]] 2
 // CHECK: [[VECTOR:%[_0-9A-Za-z]*]] = OpConstantComposite [[V2UINT]] [[UDEADBEEF]] [[U0]]
 // CHECK: [[CONTENT:%[_0-9A-Za-z]*]] = OpTypeStruct [[INT]]
-// CHECK: [[PPCONTENT:%[_0-9A-Za-z]*]] = OpTypePointer PhysicalStorageBuffer [[CONTENT]]
-// CHECK: [[PPINT:%[_0-9A-Za-z]*]] = OpTypePointer PhysicalStorageBuffer [[INT]]
+// FUN: [[PFCONTENT:%[_0-9A-Za-z]*]] = OpTypePointer Function [[CONTENT]]
+// FUN: [[PFINT:%[_0-9A-Za-z]*]] = OpTypePointer Function [[INT]]
+// FUN: [[CONTENT0:%[_0-9A-Za-z]*]] = OpTypeStruct [[INT]]
+// FUN: [[PPCONTENT:%[_0-9A-Za-z]*]] = OpTypePointer PhysicalStorageBuffer [[CONTENT0]]
+// NOFUN: [[PPCONTENT:%[_0-9A-Za-z]*]] = OpTypePointer PhysicalStorageBuffer [[CONTENT]]
+// NOFUN: [[PPINT:%[_0-9A-Za-z]*]] = OpTypePointer PhysicalStorageBuffer [[INT]]
+
+Content f() {
+  return bitcast<vk::BufferPointer<Content> >(uint32_t2(0xdeadbeefu,0x0u)).Get();
+}
 
 [numthreads(1, 1, 1)]
 void main()
 {
+#ifdef FUN
+  Content c = f();
+  c.a = 1;
+#else
   bitcast<vk::BufferPointer<Content> >(uint32_t2(0xdeadbeefu,0x0u)).Get().a = 1;
+#endif
 }
 
-// CHECK: [[BITCAST:%[0-9]*]] = OpBitcast [[PPCONTENT]] [[VECTOR]]
-// CHECK: [[PTR:%[0-9]*]] = OpAccessChain [[PPINT]] [[BITCAST]] [[IO]]
-// CHECK: OpStore [[PTR]] [[I1]] Aligned 4
+// NOFUN: [[BITCAST:%[0-9]*]] = OpBitcast [[PPCONTENT]] [[VECTOR]]
+// NOFUN: [[PTR:%[0-9]*]] = OpAccessChain [[PPINT]] [[BITCAST]] [[IO]]
+// NOFUN: OpStore [[PTR]] [[I1]] Aligned 4
+
+// FUN: [[VAR:%[_0-9A-Za-z]*]] = OpVariable [[PFCONTENT]] Function
+// FUN: [[CALL:%[0-9]*]] = OpFunctionCall [[CONTENT]] [[F:%[_0-9A-Za-z]*]]
+// FUN: OpStore [[VAR]] [[CALL]]
+// FUN: [[PTR:%[0-9]*]] = OpAccessChain [[PFINT]] [[VAR]] [[IO]]
+// FUN: OpStore [[PTR]] [[I1]]
+
+// FUN: [[F]] = OpFunction [[CONTENT]]
+// FUN: [[VAR:%[_0-9A-Za-z]*]] = OpVariable [[PFCONTENT]] Function
+// FUN: [[BITCAST:%[0-9]*]] = OpBitcast [[PPCONTENT]] [[VECTOR]]
+// FUN: [[CVAL0:%[0-9]*]] = OpLoad [[CONTENT0]] [[BITCAST]] Aligned 4
+// FUN: [[IVAL:%[0-9]*]] = OpCompositeExtract [[INT]] [[CVAL0]] 0
+// FUN: [[CVAL1:%[0-9]*]] = OpCompositeConstruct [[CONTENT]] [[IVAL]]
+// FUN: OpStore [[VAR]] [[CVAL1]]
+// FUN: [[RET:%[0-9]*]] = OpLoad [[CONTENT]] [[VAR]]
+// FUN: OpReturnValue [[RET]]
 


### PR DESCRIPTION
Fixes #7460.