### PR TITLE
[SPIRV] Get alignemnt from pointee type for vk::BufferPoitner store

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -313,7 +313,7 @@ SpirvStore *SpirvBuilder::createStore(SpirvInstruction *address,
     AlignmentSizeCalculator alignmentCalc(astContext, spirvOptions);
     uint32_t align, size, stride;
     std::tie(align, size) = alignmentCalc.getAlignmentAndSize(
-        address->getAstResultType(), address->getLayoutRule(), llvm::None,
+        source->getAstResultType(), address->getLayoutRule(), llvm::None,
         &stride);
     instruction->setAlignment(align);
   }

--- a/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.read.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.read.hlsl
@@ -36,7 +36,8 @@ struct TestPushConstant_t
 float4 MainPs(void) : SV_Target0
 {
       float4 vTest = g_PushConstants.m_nBufferDeviceAddress.Get().g_vTestFloat4;
-      return vTest;
+      float f = vk::BufferPointer<float,4>(0xdeadbeefull).Get();
+      return vTest+f;
 }
 
 // CHECK: [[FUN]] = OpFunction
@@ -44,5 +45,9 @@ float4 MainPs(void) : SV_Target0
 // CHECK: [[X2:%[_0-9A-Za-z]*]] = OpLoad [[PGLOBALS]] [[X1]]
 // CHECK: [[X3:%[_0-9A-Za-z]*]] = OpAccessChain [[PV4FLOAT2]] [[X2]] [[S1]]
 // CHECK: [[X4:%[_0-9A-Za-z]*]] = OpLoad [[V4FLOAT]] [[X3]] Aligned 16
-// CHECK: OpStore [[OUT]] [[X4]]
+// CHECK: [[TEMP_PTR:%[_0-9A-Za-z]*]] = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_float %ulong_3735928559
+// CHECK: [[LD:%[_0-9A-Za-z]*]] = OpLoad %float [[TEMP_PTR]] Aligned 4
+// CHECK: [[CONSTRUCT:%[_0-9A-Za-z]*]] = OpCompositeConstruct [[V4FLOAT]] [[LD]] [[LD]] [[LD]] [[LD]]
+// CHECK: [[ADD:%[_0-9A-Za-z]*]] = OpFAdd [[V4FLOAT]] [[X4]] [[CONSTRUCT]]
+// CHECK: OpStore [[OUT]] [[ADD]]
 // CHECK: OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.write.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.write.hlsl
@@ -40,6 +40,7 @@ float4 MainPs(void) : SV_Target0
 {
       float4 vTest = float4(1.0,0.0,0.0,0.0);
       g_PushConstants.m_nBufferDeviceAddress.Get().g_vTestFloat4 = vTest;
+      vk::BufferPointer<float,4>(0xdeadbeefull).Get() = 4.5f;
       return vTest;
 }
 
@@ -48,5 +49,7 @@ float4 MainPs(void) : SV_Target0
 // CHECK: [[X2:%[_0-9A-Za-z]*]] = OpLoad [[PGLOBALS]] [[X1]]
 // CHECK: [[X3:%[_0-9A-Za-z]*]] = OpAccessChain [[PV4FLOAT2]] [[X2]] [[S1]]
 // CHECK: OpStore [[X3]] [[CV4FLOAT]] Aligned 16
+// CHECK: [[TEMP_PTR:%[_0-9A-Za-z]*]] = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_float %ulong_3735928559
+// CHECK: OpStore [[TEMP_PTR]] %float_4_5 Aligned 4
 // CHECK: OpStore [[OUT]] [[CV4FLOAT]]
 // CHECK: OpFunctionEnd


### PR DESCRIPTION
A small mistake for stores to vk:BufferPointer when storing directly to
the return value of `get()`. We were getting the alignment of the
pointer itself, which is always 8 instead of the type pointed to.

I tested loads, and it does not have the same problem.

Fixes #7459
