### PR TITLE
NFC: Add LSAN leak suppression to ASAN pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,13 +56,13 @@ stages:
 
     strategy:
       matrix:
-        Linux_Clang_Release:
+        Linux_Clang_RelWithDebInfo:
           image: ${{ variables.linux }}
-          configuration: Release
+          configuration: RelWithDebInfo
           CC: clang-18
           CXX: clang++-18
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER='Address;Undefined' -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
-          CHECK_ALL_ENV: ASAN_OPTIONS=alloc_dealloc_mismatch=0
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER='Address;Undefined' -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld-18
+          CHECK_ALL_ENV: ASAN_OPTIONS=alloc_dealloc_mismatch=0 LSAN_OPTIONS=suppressions=$BUILD_SOURCESDIRECTORY/utils/asan/x86_64-pc-linux-gnu.lsan.supp:print_suppressions=0 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 LSAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18
           OS: Linux
         Linux_Clang_Debug:
           image: ${{ variables.linux }}
@@ -107,6 +107,8 @@ stages:
         versionSpec: '3.x'
 
     - bash: |
+        sudo apt-get update
+        sudo apt-get upgrade libc6 libc6-dbg
         sudo apt-get install ninja-build
         wget https://apt.llvm.org/llvm.sh
         chmod u+x llvm.sh

--- a/utils/asan/x86_64-pc-linux-gnu.lsan.supp
+++ b/utils/asan/x86_64-pc-linux-gnu.lsan.supp
@@ -1,0 +1,1 @@
+leak:^call_init$


### PR DESCRIPTION
Address-sanitizer reports a leak coming from the dynamic shared library loading code, though dlopen() is paired with dlclose(). This leak doesn't manifest on main yet because dxc adds dxcompiler directly to target_link_libraries (which it shouldn't have to), and dxil is loaded within that library. A PR to remove dxil loading from dxcompiler exposes the leak when dxc loads dxil dynamically.

This change adds a suppressions file for LSAN to suppress the leak in the loader code that happens under call_init. This also changes the Linux_Clang_Release build to RelWithDebInfo so symbols are present.