### PR TITLE
Fix python literal string errors in TestRunner.py

### DIFF
--- a/utils/lit/lit/TestRunner.py
+++ b/utils/lit/lit/TestRunner.py
@@ -441,7 +441,7 @@ def parseIntegratedTestScript(test, normalize_slashes=False,
     re_cond_end = re.compile('%{')
     re_if = re.compile('(.*?)(?:%if)')
     re_nested_if = re.compile('(.*?)(?:%if|%})')
-    re_else = re.compile('^\s*%else\s*(%{)?')
+    re_else = re.compile(r'^\s*%else\s*(%{)?')
 
 
     # Collect the test lines from the script.
@@ -455,13 +455,13 @@ def parseIntegratedTestScript(test, normalize_slashes=False,
             ln = ln.rstrip()
 
             # Substitute line number expressions
-            ln = re.sub('%\(line\)', str(line_number), ln)
+            ln = re.sub(r'%\(line\)', str(line_number), ln)
             def replace_line_number(match):
                 if match.group(1) == '+':
                     return str(line_number + int(match.group(2)))
                 if match.group(1) == '-':
                     return str(line_number - int(match.group(2)))
-            ln = re.sub('%\(line *([\+-]) *(\d+)\)', replace_line_number, ln)
+            ln = re.sub(r'%\(line *([\+-]) *(\d+)\)', replace_line_number, ln)
 
             # Collapse lines with trailing '\\'.
             if script and script[-1][-1] == '\\':


### PR DESCRIPTION
This fixes some long-standing errors reported from lit/TestRunner.py due to a need to specify `r` for raw strings for a few regular expressions that contain invalid escape sequences otherwise.