### PR TITLE
[spirv] Corrects output node index parameter.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11256,17 +11256,9 @@ SpirvInstruction *SpirvEmitter::processIntrinsicGetNodeOutputRecords(
 
   const auto *declRefExpr = dyn_cast<DeclRefExpr>(baseExpr->IgnoreImpCasts());
   const auto *paramDecl = dyn_cast<ParmVarDecl>(declRefExpr->getDecl());
-  const auto *nodeID = paramDecl->getAttr<HLSLNodeIdAttr>();
-  StringRef nodeName = paramDecl->getName();
-  unsigned nodeIndex = 0;
-  if (nodeID) {
-    nodeName = nodeID->getName();
-    nodeIndex = nodeID->getArrayIndex();
-  }
-
   if (!shaderIndex) {
-    shaderIndex = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
-                                            llvm::APInt(32, nodeIndex));
+    shaderIndex =
+        spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
   }
 
   LowerTypeVisitor lowerTypeVisitor(astContext, spvContext, spirvOptions,

--- a/tools/clang/test/CodeGenSPIRV/node.renamed.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/node.renamed.hlsl
@@ -12,7 +12,8 @@ struct RECORD {
 [NodeIsProgramEntry]
 void node017_renamed_node([NodeID("output_node_name", 2)] NodeOutput<RECORD> r)
 {
-  r.GetThreadNodeOutputRecords(1);
+  ThreadNodeOutputRecords<RECORD> records = r.GetThreadNodeOutputRecords(1);
+  records.OutputComplete();
 }
 
 // CHECK: OpEntryPoint GLCompute %{{[^ ]*}} "node017_renamed_node"
@@ -20,4 +21,8 @@ void node017_renamed_node([NodeID("output_node_name", 2)] NodeOutput<RECORD> r)
 // CHECK-DAG: OpDecorateId [[TYPE]] PayloadNodeBaseIndexAMDX [[U2:%[0-9A-Za-z_]*]]
 // CHECK: [[UINT:%[^ ]*]] = OpTypeInt 32 0
 // CHECK-DAG: [[STR]] = OpConstantStringAMDX "output_node_name"
+// CHECK-DAG: [[U0:%[_0-9A-Za-z]*]] = OpConstant [[UINT]] 0
+// CHECK-DAG: [[U1:%[_0-9A-Za-z]*]] = OpConstant [[UINT]] 1
 // CHECK-DAG: [[U2]] = OpConstant [[UINT]] 2
+// CHECK-DAG: [[U4:%[_0-9A-Za-z]*]] = OpConstant [[UINT]] 4
+// CHECK: OpAllocateNodePayloadsAMDX %{{[^ ]*}} [[U4]] [[U1]] [[U0]]


### PR DESCRIPTION
The node index parameter of `OpAllocateNodePayloadsAMDX` was being set to the value of the NodeId index argument (which is captured in the `PayloadNodeBaseIndexAMDX` decoration).  Instead, it should be set to the node's index in the node array, if any, or zero for a single node.