### PR TITLE
[SPIR-V] Explicitly state which layout rules require scalar block layout

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -1011,16 +1011,19 @@ right now:
    They are the default.
 2. DirectX memory layout rules for uniform buffers and storage buffers:
    they allow packing data on the application side that can be shared with
-   DirectX. They can be enabled by ``-fvk-use-dx-layout``. NOTE: This requires
-   ``VK_EXT_scalar_block_layout`` to be enabled on the application side.
+   DirectX. They can be enabled by ``-fvk-use-dx-layout``.
+   
+   NOTE: This requires ``VK_EXT_scalar_block_layout`` to be enabled on the
+   application side.
 3. Strict OpenGL ``std140`` for uniform buffers and strict OpenGL ``std430``
    for storage buffers: they allow packing data on the application side that
    can be shared with OpenGL. They can be enabled by ``-fvk-use-gl-layout``.
 4. Scalar layout rules introduced via `VK_EXT_scalar_block_layout`, which
    basically aligns all aggregrate types according to their elements'
-   natural alignment. They can be enabled by ``-fvk-use-scalar-layout``. NOTE:
-   This requires ``VK_EXT_scalar_block_layout`` to be enabled on the application
-   side.
+   natural alignment. They can be enabled by ``-fvk-use-scalar-layout``.
+   
+   NOTE: This requires ``VK_EXT_scalar_block_layout`` to be enabled on the
+   application side.
 
 In the above, "vector-relaxed OpenGL ``std140``/``std430``" rules mean OpenGL
 ``std140``/``std430`` rules with the following modification for vector type

--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -1011,18 +1011,16 @@ right now:
    They are the default.
 2. DirectX memory layout rules for uniform buffers and storage buffers:
    they allow packing data on the application side that can be shared with
-   DirectX. They can be enabled by ``-fvk-use-dx-layout``.
+   DirectX. They can be enabled by ``-fvk-use-dx-layout``. NOTE: This requires
+   ``VK_EXT_scalar_block_layout`` to be enabled on the application side.
 3. Strict OpenGL ``std140`` for uniform buffers and strict OpenGL ``std430``
    for storage buffers: they allow packing data on the application side that
    can be shared with OpenGL. They can be enabled by ``-fvk-use-gl-layout``.
 4. Scalar layout rules introduced via `VK_EXT_scalar_block_layout`, which
    basically aligns all aggregrate types according to their elements'
-   natural alignment. They can be enabled by ``-fvk-use-scalar-layout``.
-
-To use scalar layout, the application side need to request
-``VK_EXT_scalar_block_layout``. This is also true for using DirectX memory
-layout since there is no dedicated DirectX layout extension for Vulkan
-(at least for now). So we must request something more permissive.
+   natural alignment. They can be enabled by ``-fvk-use-scalar-layout``. NOTE:
+   This requires ``VK_EXT_scalar_block_layout`` to be enabled on the application
+   side.
 
 In the above, "vector-relaxed OpenGL ``std140``/``std430``" rules mean OpenGL
 ``std140``/``std430`` rules with the following modification for vector type
@@ -1032,7 +1030,7 @@ alignment:
 2. If the above causes an `improper straddle <https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-resources-layout>`_,
    the alignment will be set to 16 bytes.
 
-As an exmaple, for the following HLSL definition:
+As an example, for the following HLSL definition:
 
 .. code:: hlsl
 


### PR DESCRIPTION
I was trying to debug a Vulkan Storage Buffer-related memory alignment issue in my application where I was using SPIR-V generated via `dxc` with `-fvk-use-dx-layout`. In `SPIR-V.rst`, I happened to miss the paragraph that follows the list of layout rules (removed in this proposal). That paragraph starts with "To use scalar layout", which given my use of DirectX layout, I did not think was relevant to me. However, the next sentence of that paragraph sneakily and indirectly mentions that `VK_EXT_scalar_block_layout` is required for the DirectX memory layout as well.

I have proposed explicitly stating the extension requirement when the relevant layout rules are listed.