### PR TITLE
Fix generation of f16 special float ops

### DIFF
--- a/tools/clang/test/CodeGenDXIL/Ops/SpecialFloat.hlsl
+++ b/tools/clang/test/CodeGenDXIL/Ops/SpecialFloat.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T lib_6_3 -enable-16bit-types %s | FileCheck %s
+
+// CHECK-LABEL: test_isinf
+// CHECK:  call i1 @dx.op.isSpecialFloat.f16(i32 9, half
+export bool test_isinf(half h) {
+  return isinf(h);
+}
+
+// CHECK-LABEL: test_isnan
+// CHECK:  call i1 @dx.op.isSpecialFloat.f16(i32 8, half
+
+export bool test_isnan(half h) {
+  return isnan(h);
+}
+
+// CHECK-LABEL: test_isfinite
+// CHECK:  call i1 @dx.op.isSpecialFloat.f16(i32 10, half
+
+export bool test_isfinite(half h) {
+  return isfinite(h);
+}

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -183,9 +183,9 @@ void [[]] InterlockedXor(ref int32_only result, in uint value, out any_int32 ori
 void [[]] InterlockedCompareStore(ref int32_only result, in uint compare, in uint value);
 void [[]] InterlockedExchange(ref int32_only result, in uint value, out any_int32 original);
 void [[]] InterlockedCompareExchange(ref int32_only result, in uint compare, in uint value, out any_int32 original);
-$match<1, 0> bool<> [[rn]] isfinite(in float<> x);
-$match<1, 0> bool<> [[rn]] isinf(in float<> x);
-$match<1, 0> bool<> [[rn]] isnan(in float<> x);
+$match<1, 0> bool<> [[rn]] isfinite(in float_like<> x);
+$match<1, 0> bool<> [[rn]] isinf(in float_like<> x);
+$match<1, 0> bool<> [[rn]] isnan(in float_like<> x);
 $type1 [[rn]] ldexp(in float_like<> x, in $type1 exp);
 $match<0, 1> float_like [[rn]] length(in float_like<c> x);
 $type1 [[rn]] lerp(in float_like<> a, in $type1 b, in $type1 s);


### PR DESCRIPTION
Due to a bug in the special float builtin function declarations DXC never generated fp16 variants of isnan, isinf, and isfinite. This corrects the issue by making the functions take float_like arguments instead of float arguments.

Fixes #7496