### PR TITLE
[NFC] Address compiler warnings: C4146 - Trivial std::numeric_limits<T> cases

### DIFF
--- a/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
@@ -34,7 +34,7 @@ private:
   struct Range {
     explicit Range(uint64_t LowPC = std::numeric_limits<uint64_t>::max(),
                    uint64_t HighPC = std::numeric_limits<uint64_t>::max(),
-                   uint32_t CUOffset = -std::numeric_limits<uint32_t>::max())
+                   uint32_t CUOffset = std::numeric_limits<uint32_t>::max())
         : LowPC(LowPC), Length(HighPC - LowPC), CUOffset(CUOffset) {}
 
     void setHighPC(uint64_t HighPC) {

--- a/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
@@ -32,12 +32,13 @@ private:
   void construct();
 
   struct Range {
-    explicit Range(uint64_t LowPC = -1ULL, uint64_t HighPC = -1ULL,
-                   uint32_t CUOffset = -1U)
-      : LowPC(LowPC), Length(HighPC - LowPC), CUOffset(CUOffset) {}
+    explicit Range(uint64_t LowPC = std::numeric_limits<uint64_t>::max(),
+                   uint64_t HighPC = std::numeric_limits<uint64_t>::max(),
+                   uint32_t CUOffset = -std::numeric_limits<uint32_t>::max())
+        : LowPC(LowPC), Length(HighPC - LowPC), CUOffset(CUOffset) {}
 
     void setHighPC(uint64_t HighPC) {
-      if (HighPC == -1ULL || HighPC <= LowPC)
+      if (HighPC == std::numeric_limits<uint64_t>::max() || HighPC <= LowPC)
         Length = 0;
       else
         Length = HighPC - LowPC;
@@ -45,7 +46,7 @@ private:
     uint64_t HighPC() const {
       if (Length)
         return LowPC + Length;
-      return -1ULL;
+      return std::numeric_limits<uint64_t>::max();
     }
 
     bool containsAddress(uint64_t Address) const {

--- a/include/llvm/Support/BlockFrequency.h
+++ b/include/llvm/Support/BlockFrequency.h
@@ -15,6 +15,7 @@
 #define LLVM_SUPPORT_BLOCKFREQUENCY_H
 
 #include "llvm/Support/DataTypes.h"
+#include <limits>
 
 namespace llvm {
 

--- a/include/llvm/Support/BlockFrequency.h
+++ b/include/llvm/Support/BlockFrequency.h
@@ -29,7 +29,9 @@ public:
   BlockFrequency(uint64_t Freq = 0) : Frequency(Freq) { }
 
   /// \brief Returns the maximum possible frequency, the saturation value.
-  static uint64_t getMaxFrequency() { return -1ULL; }
+  static uint64_t getMaxFrequency() {
+    return std::numeric_limits<uint64_t>::max();
+  }
 
   /// \brief Returns the frequency as a fixpoint number scaled by the entry
   /// frequency.

--- a/include/llvm/Support/LEB128.h
+++ b/include/llvm/Support/LEB128.h
@@ -67,7 +67,7 @@ inline unsigned encodeULEB128(uint64_t Value, uint8_t *p,
   } while (Value != 0);
 
   // Pad with 0x80 and emit a null byte at the end.
-  if (Padding != 0) {
+
     for (; Padding != 1; --Padding)
       *p++ = '\x80';
     *p++ = '\x00';
@@ -103,7 +103,7 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr) {
   } while (Byte >= 128);
   // Sign extend negative numbers.
   if (Byte & 0x40)
-    Value |= (-1ULL) << Shift;
+    Value |= ~0ULL << Shift;
   if (n)
     *n = (unsigned)(p - orig_p);
   return Value;

--- a/include/llvm/Support/LEB128.h
+++ b/include/llvm/Support/LEB128.h
@@ -67,7 +67,7 @@ inline unsigned encodeULEB128(uint64_t Value, uint8_t *p,
   } while (Value != 0);
 
   // Pad with 0x80 and emit a null byte at the end.
-
+  if (Padding != 0) {
     for (; Padding != 1; --Padding)
       *p++ = '\x80';
     *p++ = '\x00';

--- a/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1179,7 +1179,7 @@ bool MemoryDepChecker::areDepsSafe(DepCandidates &AccessSets,
                                    MemAccessInfoSet &CheckDeps,
                                    const ValueToValueMap &Strides) {
 
-  MaxSafeDepDistBytes = -1U;
+  MaxSafeDepDistBytes = std::numeric_limits<unsigned>::max();
   while (!CheckDeps.empty()) {
     MemAccessInfo CurAccess = *CheckDeps.begin();
 

--- a/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1937,7 +1937,8 @@ Instruction *InstCombiner::visitAllocSite(Instruction &MI) {
       } else if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(I)) {
         if (II->getIntrinsicID() == Intrinsic::objectsize) {
           ConstantInt *CI = cast<ConstantInt>(II->getArgOperand(1));
-          uint64_t DontKnow = CI->isZero() ? -1ULL : 0;
+          uint64_t DontKnow =
+              CI->isZero() ? std::numeric_limits<uint64_t>::max() : 0;
           ReplaceInstUsesWith(*I, ConstantInt::get(I->getType(), DontKnow));
         }
       }

--- a/lib/Transforms/Scalar/LoadCombine.cpp
+++ b/lib/Transforms/Scalar/LoadCombine.cpp
@@ -131,10 +131,10 @@ bool LoadCombine::aggregateLoads(SmallVectorImpl<LoadPOPPair> &Loads) {
   LoadInst *BaseLoad = nullptr;
   SmallVector<LoadPOPPair, 8> AggregateLoads;
   bool Combined = false;
-  uint64_t PrevOffset = -1ull;
+  uint64_t PrevOffset = std::numeric_limits<uint64_t>::max();
   uint64_t PrevSize = 0;
   for (auto &L : Loads) {
-    if (PrevOffset == -1ull) {
+    if (PrevOffset == std::numeric_limits<uint64_t>::max()) {
       BaseLoad = L.Load;
       PrevOffset = L.POP.Offset;
       PrevSize = L.Load->getModule()->getDataLayout().getTypeStoreSize(

--- a/tools/clang/include/clang/AST/Expr.h
+++ b/tools/clang/include/clang/AST/Expr.h
@@ -4510,7 +4510,9 @@ public:
   Expr *getControllingExpr() { return cast<Expr>(SubExprs[CONTROLLING]); }
 
   /// Whether this generic selection is result-dependent.
-  bool isResultDependent() const { return ResultIndex == std::numeric_limits<unsigned>::max(); }
+  bool isResultDependent() const {
+    return ResultIndex == std::numeric_limits<unsigned>::max();
+  }
 
   /// The zero-based index of the result expression's generic association in
   /// the generic selection's association list.  Defined only if the

--- a/tools/clang/include/clang/AST/Expr.h
+++ b/tools/clang/include/clang/AST/Expr.h
@@ -4510,7 +4510,7 @@ public:
   Expr *getControllingExpr() { return cast<Expr>(SubExprs[CONTROLLING]); }
 
   /// Whether this generic selection is result-dependent.
-  bool isResultDependent() const { return ResultIndex == -1U; }
+  bool isResultDependent() const { return ResultIndex == std::numeric_limits<unsigned>::max(); }
 
   /// The zero-based index of the result expression's generic association in
   /// the generic selection's association list.  Defined only if the

--- a/tools/clang/lib/AST/Expr.cpp
+++ b/tools/clang/lib/AST/Expr.cpp
@@ -3883,25 +3883,21 @@ GenericSelectionExpr::GenericSelectionExpr(const ASTContext &Context,
   std::copy(AssocExprs.begin(), AssocExprs.end(), SubExprs+END_EXPR);
 }
 
-GenericSelectionExpr::GenericSelectionExpr(const ASTContext &Context,
-                               SourceLocation GenericLoc, Expr *ControllingExpr,
-                               ArrayRef<TypeSourceInfo*> AssocTypes,
-                               ArrayRef<Expr*> AssocExprs,
-                               SourceLocation DefaultLoc,
-                               SourceLocation RParenLoc,
-                               bool ContainsUnexpandedParameterPack)
-  : Expr(GenericSelectionExprClass,
-         Context.DependentTy,
-         VK_RValue,
-         OK_Ordinary,
-         /*isTypeDependent=*/true,
-         /*isValueDependent=*/true,
-         /*isInstantiationDependent=*/true,
-         ContainsUnexpandedParameterPack),
-    AssocTypes(new (Context) TypeSourceInfo*[AssocTypes.size()]),
-    SubExprs(new (Context) Stmt*[END_EXPR+AssocExprs.size()]),
-    NumAssocs(AssocExprs.size()), ResultIndex(-1U), GenericLoc(GenericLoc),
-    DefaultLoc(DefaultLoc), RParenLoc(RParenLoc) {
+GenericSelectionExpr::GenericSelectionExpr(
+    const ASTContext &Context, SourceLocation GenericLoc, Expr *ControllingExpr,
+    ArrayRef<TypeSourceInfo *> AssocTypes, ArrayRef<Expr *> AssocExprs,
+    SourceLocation DefaultLoc, SourceLocation RParenLoc,
+    bool ContainsUnexpandedParameterPack)
+    : Expr(GenericSelectionExprClass, Context.DependentTy, VK_RValue,
+           OK_Ordinary,
+           /*isTypeDependent=*/true,
+           /*isValueDependent=*/true,
+           /*isInstantiationDependent=*/true, ContainsUnexpandedParameterPack),
+      AssocTypes(new(Context) TypeSourceInfo *[AssocTypes.size()]),
+      SubExprs(new(Context) Stmt *[END_EXPR + AssocExprs.size()]),
+      NumAssocs(AssocExprs.size()),
+      ResultIndex(std::numeric_limits<unsigned>::max()), GenericLoc(GenericLoc),
+      DefaultLoc(DefaultLoc), RParenLoc(RParenLoc) {
   SubExprs[CONTROLLING] = ControllingExpr;
   assert(AssocTypes.size() == AssocExprs.size());
   std::copy(AssocTypes.begin(), AssocTypes.end(), this->AssocTypes);

--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2560,7 +2560,7 @@ void ScalarExprEmitter::EmitUndefinedBehaviorIntegerDivAndRemCheck(
     llvm::Value *IntMin =
       Builder.getInt(llvm::APInt::getSignedMinValue(Ty->getBitWidth()));
     llvm::Value *NegOne =
-        llvm::ConstantInt::get(Ty, std::numeric_limits<uint64_t>::min());
+        llvm::ConstantInt::get(Ty, std::numeric_limits<uint64_t>::max());
 
     llvm::Value *LHSCmp = Builder.CreateICmpNE(Ops.LHS, IntMin);
     llvm::Value *RHSCmp = Builder.CreateICmpNE(Ops.RHS, NegOne);

--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2560,7 +2560,7 @@ void ScalarExprEmitter::EmitUndefinedBehaviorIntegerDivAndRemCheck(
     llvm::Value *IntMin =
       Builder.getInt(llvm::APInt::getSignedMinValue(Ty->getBitWidth()));
     llvm::Value *NegOne =
-        llvm::ConstantInt::get(Ty, std::numeric_limits<int64_t>::min());
+        llvm::ConstantInt::get(Ty, std::numeric_limits<uint64_t>::min());
 
     llvm::Value *LHSCmp = Builder.CreateICmpNE(Ops.LHS, IntMin);
     llvm::Value *RHSCmp = Builder.CreateICmpNE(Ops.RHS, NegOne);

--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2559,7 +2559,8 @@ void ScalarExprEmitter::EmitUndefinedBehaviorIntegerDivAndRemCheck(
 
     llvm::Value *IntMin =
       Builder.getInt(llvm::APInt::getSignedMinValue(Ty->getBitWidth()));
-    llvm::Value *NegOne = llvm::ConstantInt::get(Ty, -1ULL);
+    llvm::Value *NegOne =
+        llvm::ConstantInt::get(Ty, std::numeric_limits<int64_t>::min());
 
     llvm::Value *LHSCmp = Builder.CreateICmpNE(Ops.LHS, IntMin);
     llvm::Value *RHSCmp = Builder.CreateICmpNE(Ops.RHS, NegOne);

--- a/tools/clang/lib/Lex/Lexer.cpp
+++ b/tools/clang/lib/Lex/Lexer.cpp
@@ -2737,7 +2737,7 @@ uint32_t Lexer::tryReadUCN(const char *&StartPtr, const char *SlashLoc,
     char C = getCharAndSize(CurPtr, CharSize);
 
     unsigned Value = llvm::hexDigitValue(C);
-    if (Value == -1U) {
+    if (Value == std::numeric_limits<unsigned>::max()) {
       if (Result && !isLexingRawMode()) {
         if (i == 0) {
           Diag(BufferPtr, diag::warn_ucn_escape_no_digits)

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -1466,7 +1466,7 @@ Sema::CreateGenericSelectionExpr(SourceLocation KeyLoc,
         ContainsUnexpandedParameterPack);
 
   SmallVector<unsigned, 1> CompatIndices;
-  unsigned DefaultIndex = -1U;
+  unsigned DefaultIndex = std::numeric_limits<unsigned>::max();
   for (unsigned i = 0; i < NumAssocs; ++i) {
     if (!Types[i])
       DefaultIndex = i;
@@ -1498,7 +1498,8 @@ Sema::CreateGenericSelectionExpr(SourceLocation KeyLoc,
   // C11 6.5.1.1p2 "If a generic selection has no default generic association,
   // its controlling expression shall have type compatible with exactly one of
   // the types named in its generic association list."
-  if (DefaultIndex == -1U && CompatIndices.size() == 0) {
+  if (DefaultIndex == std::numeric_limits<unsigned>::max() &&
+      CompatIndices.size() == 0) {
     // We strip parens here because the controlling expression is typically
     // parenthesized in macro definitions.
     ControllingExpr = ControllingExpr->IgnoreParens();

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -462,7 +462,7 @@ distributeObjCPointerTypeAttrFromDeclarator(TypeProcessingState &state,
 
   // objc_gc goes on the innermost pointer to something that's not a
   // pointer.
-  unsigned innermost = -1U;
+  unsigned innermost = std::numeric_limits<unsigned>::max();
   bool considerDeclSpec = true;
   for (unsigned i = 0, e = declarator.getNumTypeObjects(); i != e; ++i) {
     DeclaratorChunk &chunk = declarator.getTypeObject(i);
@@ -501,7 +501,7 @@ distributeObjCPointerTypeAttrFromDeclarator(TypeProcessingState &state,
 
   // Otherwise, if we found an appropriate chunk, splice the attribute
   // into it.
-  if (innermost != -1U) {
+  if (innermost != std::numeric_limits<unsigned>::max()) {
     moveAttrFromListToList(attr, declarator.getAttrListRef(),
                        declarator.getTypeObject(innermost).getAttrListRef());
     return;

--- a/utils/TableGen/FixedLenDecoderEmitter.cpp
+++ b/utils/TableGen/FixedLenDecoderEmitter.cpp
@@ -547,10 +547,11 @@ void Filter::recurse() {
 
     // Delegates to an inferior filter chooser for further processing on this
     // group of instructions whose segment values are variable.
-    FilterChooserMap.insert(
-        std::make_pair(-1U, llvm::make_unique<FilterChooser>(
-                                Owner->AllInstructions, VariableInstructions,
-                                Owner->Operands, BitValueArray, *Owner)));
+    FilterChooserMap.insert(std::make_pair(
+        std::numeric_limits<unsigned>::max(),
+        llvm::make_unique<FilterChooser>(Owner->AllInstructions,
+                                         VariableInstructions, Owner->Operands,
+                                         BitValueArray, *Owner)));
   }
 
   // No need to recurse for a singleton filtered instruction.


### PR DESCRIPTION
Addresses #7558. There is also one trivial change to use the ~ operator included in LEB128.h. My notes on the files were wrong and suggested that it should use std::numeric_limits<T> but looking at it again using ~0ULL made more sense.