### PR TITLE
[NFC] Address compiler warnings: C4146 - Use two's complement instead of negation 

### DIFF
--- a/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1118,7 +1118,7 @@ AliasResult BasicAliasAnalysis::aliasGEP(
       if (V1Size != MemoryLocation::UnknownSize &&
           V2Size != MemoryLocation::UnknownSize) {
         // GEP1BaseOffset is negative in this else block and because we're
-        // assigning to a an unsigned variable, we can make use of
+        // assigning to an unsigned variable, we can make use of
         // -I == (~I + 1) to compute the absolute value of GEP1BaseOffset.
         const uint64_t GEP1BaseOffsetAbs = (~GEP1BaseOffset + 1ULL);
         if (GEP1BaseOffsetAbs < V1Size)


### PR DESCRIPTION
Replaces uses of the unary - operator on signed integers with the equivalent (sort of, see the details below) expression '~N + 1', assigning the result to an unsigned type. This avoids undefined behavior in edge cases and ensures correctness when certain conditions are met.

Details:
This transformation is valid when:

The signed value N is guaranteed to be negative.
The result is stored in an unsigned type that can represent the full range of the signed type (e.g., uint64_t for int64_t).
The system uses two's complement representation (as is standard on modern platforms).
While -N is undefined for the minimum representable value (e.g., INT64_MIN), the expression ~N + 1 remains well-defined and yields the correct bit pattern. Assigning this result to an appropriately sized unsigned type preserves the intended two's complement interpretation without triggering undefined behavior.

Addresses #7561.   