### PR TITLE
[NFC] Address compiler warnings: C4146 - Another round of use two's complement instead of negation

### DIFF
--- a/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1117,7 +1117,11 @@ AliasResult BasicAliasAnalysis::aliasGEP(
       // stripped a gep with negative index ('gep <ptr>, -1, ...).
       if (V1Size != MemoryLocation::UnknownSize &&
           V2Size != MemoryLocation::UnknownSize) {
-        if (-(uint64_t)GEP1BaseOffset < V1Size)
+        // GEP1BaseOffset is negative in this else block and because we're
+        // assigning to an unsigned variable, we can make use of
+        // -I == (~I + 1) to compute the absolute value of GEP1BaseOffset.
+        const uint64_t GEP1BaseOffsetAbs = (~GEP1BaseOffset + 1ULL);
+        if (GEP1BaseOffsetAbs < V1Size)
           return PartialAlias;
         return NoAlias;
       }

--- a/lib/Analysis/ConstantFolding.cpp
+++ b/lib/Analysis/ConstantFolding.cpp
@@ -187,7 +187,7 @@ static Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
         // Shift it to the right place, depending on endianness.
         Src = ConstantExpr::getShl(Src,
                                    ConstantInt::get(Src->getType(), ShiftAmt));
-        ShiftAmt += isLittleEndian ? SrcBitSize : -SrcBitSize;
+        ShiftAmt += isLittleEndian ? SrcBitSize : (~SrcBitSize + 1U);
 
         // Mix it in.
         Elt = ConstantExpr::getOr(Elt, Src);
@@ -213,7 +213,7 @@ static Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
       // endianness.
       Constant *Elt = ConstantExpr::getLShr(Src,
                                   ConstantInt::get(Src->getType(), ShiftAmt));
-      ShiftAmt += isLittleEndian ? DstBitSize : -DstBitSize;
+      ShiftAmt += isLittleEndian ? DstBitSize : (~DstBitSize + 1U);
 
       // Truncate the element to an integer with the same pointer size and
       // convert the element back to a pointer using a inttoptr.

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -4109,7 +4109,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
         // Shift it to the right place, depending on endianness.
         Src = ConstantExpr::getShl(Src,
                                    ConstantInt::get(Src->getType(), ShiftAmt));
-        ShiftAmt += isLittleEndian ? SrcBitSize : -SrcBitSize;
+        ShiftAmt += isLittleEndian ? SrcBitSize : (~SrcBitSize + 1U);
 
         // Mix it in.
         Elt = ConstantExpr::getOr(Elt, Src);
@@ -4144,9 +4144,9 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
     for (unsigned j = 0; j != Ratio; ++j) {
       // Shift the piece of the value into the right place, depending on
       // endianness.
-      Constant *Elt = ConstantExpr::getLShr(Src,
-                                  ConstantInt::get(Src->getType(), ShiftAmt));
-      ShiftAmt += isLittleEndian ? DstBitSize : -DstBitSize;
+      Constant *Elt = ConstantExpr::getLShr(
+          Src, ConstantInt::get(Src->getType(), ShiftAmt));
+      ShiftAmt += isLittleEndian ? DstBitSize : (~DstBitSize + 1U);
 
       // Truncate the element to an integer with the same pointer size and
       // convert the element back to a pointer using a inttoptr.


### PR DESCRIPTION
Addresses https://github.com/microsoft/DirectXShaderCompiler/issues/7565

A few more instances where we can take advantage of -N being equivalent to (~N + 1)