### PR TITLE
Fix intrinsic lookup with namespaces

### DIFF
--- a/tools/clang/include/clang/Sema/ExternalSemaSource.h
+++ b/tools/clang/include/clang/Sema/ExternalSemaSource.h
@@ -213,6 +213,7 @@ public:
   virtual bool AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
     ArrayRef<Expr *> Args,
     OverloadCandidateSet &CandidateSet,
+    Scope *S,
     bool PartialOverloading)
   {
     return false;

--- a/tools/clang/include/clang/Sema/ExternalSemaSource.h
+++ b/tools/clang/include/clang/Sema/ExternalSemaSource.h
@@ -211,11 +211,9 @@ public:
   // add call candidates to the given expression. It returns 'true'
   // if standard overload search should be suppressed; false otherwise.
   virtual bool AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
-    ArrayRef<Expr *> Args,
-    OverloadCandidateSet &CandidateSet,
-    Scope *S,
-    bool PartialOverloading)
-  {
+                                           ArrayRef<Expr *> Args,
+                                           OverloadCandidateSet &CandidateSet,
+                                           Scope *S, bool PartialOverloading) {
     return false;
   }
 

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -2495,6 +2495,10 @@ public:
                                             DeclAccessPair FoundDecl,
                                             FunctionDecl *Fn);
 
+  // HLSL Change Begin
+  void CollectNamespaceContexts(Scope *,
+                                SmallVectorImpl<const DeclContext *> &);
+  // HLSL Change End
   void AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
                                    ArrayRef<Expr *> Args,
                                    OverloadCandidateSet &CandidateSet,

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -2498,6 +2498,7 @@ public:
   void AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
                                    ArrayRef<Expr *> Args,
                                    OverloadCandidateSet &CandidateSet,
+                                   Scope *S, // HLSL Change
                                    bool PartialOverloading = false);
 
   // An enum used to represent the different possible results of building a

--- a/tools/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/tools/clang/lib/Sema/SemaCodeComplete.cpp
@@ -4020,7 +4020,7 @@ void Sema::CodeCompleteCall(Scope *S, Expr *Fn, ArrayRef<Expr *> Args) {
 
   Expr *NakedFn = Fn->IgnoreParenCasts();
   if (auto ULE = dyn_cast<UnresolvedLookupExpr>(NakedFn))
-    AddOverloadedCallCandidates(ULE, Args, CandidateSet, S,   // HLSL Change 
+    AddOverloadedCallCandidates(ULE, Args, CandidateSet, S, // HLSL Change
                                 /*PartialOverloading=*/true);
   else if (auto UME = dyn_cast<UnresolvedMemberExpr>(NakedFn)) {
     TemplateArgumentListInfo TemplateArgsBuffer, *TemplateArgs = nullptr;

--- a/tools/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/tools/clang/lib/Sema/SemaCodeComplete.cpp
@@ -4020,7 +4020,7 @@ void Sema::CodeCompleteCall(Scope *S, Expr *Fn, ArrayRef<Expr *> Args) {
 
   Expr *NakedFn = Fn->IgnoreParenCasts();
   if (auto ULE = dyn_cast<UnresolvedLookupExpr>(NakedFn))
-    AddOverloadedCallCandidates(ULE, Args, CandidateSet,
+    AddOverloadedCallCandidates(ULE, Args, CandidateSet, S,   // HLSL Change 
                                 /*PartialOverloading=*/true);
   else if (auto UME = dyn_cast<UnresolvedMemberExpr>(NakedFn)) {
     TemplateArgumentListInfo TemplateArgsBuffer, *TemplateArgs = nullptr;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2990,13 +2990,6 @@ static TypedefDecl *CreateGlobalTypedef(ASTContext *context, const char *ident,
   return decl;
 }
 
-// Helper function copied from SemaLookup.cpp
-static bool isNamespaceOrTranslationUnitScope(Scope *S) {
-  if (DeclContext *Ctx = S->getEntity())
-    return Ctx->isFileContext();
-  return false;
-}
-
 class HLSLExternalSource : public ExternalSemaSource {
 private:
   // Inner types.

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -373,7 +373,7 @@ enum ArBasicKind {
 
 #define IS_BPROP_STREAM(_Props) (((_Props)&BPROP_STREAM) != 0)
 
-#define IS_BPROP_PATCH(_Props) (((_Props)&BPROP_PATCH) != 0)
+#define IS_BPROP_PATCH(_Props) (((_Props) & BPROP_PATCH) != 0)
 
 #define IS_BPROP_SAMPLER(_Props) (((_Props)&BPROP_SAMPLER) != 0)
 
@@ -5366,18 +5366,22 @@ public:
         SearchTables;
 
     if (isDxNamespace)
-      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_DxIntrinsics), m_dxNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl *>(
+          IntrisnicArray(g_DxIntrinsics), m_dxNSDecl));
 #ifdef ENABLE_SPIRV_CODEGEN
     else if (isVkNamespace)
-      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_VkIntrinsics), m_vkNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl *>(
+          IntrisnicArray(g_VkIntrinsics), m_vkNSDecl));
 #endif
     else if (isGlobalNamespace)
-      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_Intrinsics), m_hlslNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl *>(
+          IntrisnicArray(g_Intrinsics), m_hlslNSDecl));
     else if (!isQualified) {
       // If the name isn't qualified, we need to search all scopes that are
       // accessible without qualification. This starts with the global scope and
       // extends into any scopes that are referred to by using declarations.
-      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_Intrinsics), m_hlslNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl *>(
+          IntrisnicArray(g_Intrinsics), m_hlslNSDecl));
 
       // If we have a scope chain, walk it to get using declarations.
       if (S) {
@@ -5405,16 +5409,20 @@ public:
         bool DXFound = false;
         bool VKFound = false;
         for (const auto &UD : UDirs) {
-          if (static_cast<DeclContext *>(m_dxNSDecl) == UD.getNominatedNamespace())
+          if (static_cast<DeclContext *>(m_dxNSDecl) ==
+              UD.getNominatedNamespace())
             DXFound = true;
-          else if (static_cast<DeclContext *>(m_vkNSDecl) == UD.getNominatedNamespace())
+          else if (static_cast<DeclContext *>(m_vkNSDecl) ==
+                   UD.getNominatedNamespace())
             VKFound = true;
         }
         if (DXFound)
-          SearchTables.push_back(std::make_pair(IntrisnicArray(g_DxIntrinsics), m_dxNSDecl));
+          SearchTables.push_back(
+              std::make_pair(IntrisnicArray(g_DxIntrinsics), m_dxNSDecl));
 #ifdef ENABLE_SPIRV_CODEGEN
         if (VKFound)
-          SearchTables.push_back(std::make_pair(IntrisnicArray(g_VkIntrinsics), m_vkNSDecl));
+          SearchTables.push_back(
+              std::make_pair(IntrisnicArray(g_VkIntrinsics), m_vkNSDecl));
 #endif
       }
     }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5469,8 +5469,8 @@ public:
           DXASSERT(tableName,
                    "otherwise IDxcIntrinsicTable::GetTableName() failed");
           intrinsicFuncDecl =
-              AddHLSLIntrinsicFunction(*m_context, T.NS, tableName,
-                                       lowering, pIntrinsic, &functionArgTypes);
+              AddHLSLIntrinsicFunction(*m_context, T.NS, tableName, lowering,
+                                       pIntrinsic, &functionArgTypes);
           insertResult.first->setFunctionDecl(intrinsicFuncDecl);
         } else {
           intrinsicFuncDecl = (*insertResult.first).getFunctionDecl();

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5361,28 +5361,23 @@ public:
 
     StringRef nameIdentifier = idInfo->getName();
     using IntrisnicArray = llvm::ArrayRef<const HLSL_INTRINSIC>;
-    IntrisnicArray GlobalIntrinsics(g_Intrinsics);
-    IntrisnicArray DXIntrinsics(g_DxIntrinsics);
-#ifdef ENABLE_SPIRV_CODEGEN
-    IntrisnicArray VKIntrinsics = IntrisnicArray(g_VkIntrinsics);
-#endif // ENABLE_SPIRV_CODEGEN
 
     llvm::SmallVector<std::pair<IntrisnicArray, NamespaceDecl *>, 3>
         SearchTables;
 
     if (isDxNamespace)
-      SearchTables.push_back(std::make_pair(DXIntrinsics, m_dxNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_DxIntrinsics), m_dxNSDecl));
 #ifdef ENABLE_SPIRV_CODEGEN
     else if (isVkNamespace)
-      SearchTables.push_back(std::make_pair(VKIntrinsics, m_vkNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_VkIntrinsics), m_vkNSDecl));
 #endif
     else if (isGlobalNamespace)
-      SearchTables.push_back(std::make_pair(GlobalIntrinsics, m_hlslNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_Intrinsics), m_hlslNSDecl));
     else if (!isQualified) {
       // If the name isn't qualified, we need to search all scopes that are
       // accessible without qualification. This starts with the global scope and
       // extends into any scopes that are referred to by using declarations.
-      SearchTables.push_back(std::make_pair(GlobalIntrinsics, m_hlslNSDecl));
+      SearchTables.push_back(std::pair<IntrisnicArray, NamespaceDecl*>(IntrisnicArray(g_Intrinsics), m_hlslNSDecl));
 
       // If we have a scope chain, walk it to get using declarations.
       if (S) {
@@ -5416,9 +5411,11 @@ public:
             VKFound = true;
         }
         if (DXFound)
-          SearchTables.push_back(std::make_pair(DXIntrinsics, m_dxNSDecl));
+          SearchTables.push_back(std::make_pair(IntrisnicArray(g_DxIntrinsics), m_dxNSDecl));
+#ifdef ENABLE_SPIRV_CODEGEN
         if (VKFound)
-          SearchTables.push_back(std::make_pair(VKIntrinsics, m_vkNSDecl));
+          SearchTables.push_back(std::make_pair(IntrisnicArray(g_VkIntrinsics), m_vkNSDecl));
+#endif
       }
     }
 

--- a/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/tools/clang/lib/Sema/SemaLookup.cpp
@@ -4810,7 +4810,7 @@ void Sema::diagnoseTypo(const TypoCorrection &Correction,
 
   NamedDecl *ChosenDecl =
       Correction.isKeyword() ? nullptr : Correction.getCorrectionDecl();
-   // HLSL Change begin: don't put notes on invalid source locations.
+  // HLSL Change begin: don't put notes on invalid source locations.
   if (PrevNote.getDiagID() && ChosenDecl &&
       !ChosenDecl->getLocation().isInvalid())
     Diag(ChosenDecl->getLocation(), PrevNote)

--- a/tools/clang/lib/Sema/SemaLookup.cpp
+++ b/tools/clang/lib/Sema/SemaLookup.cpp
@@ -55,6 +55,7 @@
 using namespace clang;
 using namespace sema;
 
+// HLSL Note: This set of utilities copied to SemaHLSL.cpp.
 namespace {
   class UnqualUsingEntry {
     const DeclContext *Nominated;
@@ -4809,9 +4810,12 @@ void Sema::diagnoseTypo(const TypoCorrection &Correction,
 
   NamedDecl *ChosenDecl =
       Correction.isKeyword() ? nullptr : Correction.getCorrectionDecl();
-  if (PrevNote.getDiagID() && ChosenDecl)
+   // HLSL Change begin: don't put notes on invalid source locations.
+  if (PrevNote.getDiagID() && ChosenDecl &&
+      !ChosenDecl->getLocation().isInvalid())
     Diag(ChosenDecl->getLocation(), PrevNote)
       << CorrectedQuotedStr << (ErrorRecovery ? FixItHint() : FixTypo);
+  // HLSL Change end
 }
 
 TypoExpr *Sema::createDelayedTypo(std::unique_ptr<TypoCorrectionConsumer> TCC,

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -10627,6 +10627,7 @@ static void AddOverloadedCallCandidate(Sema &S,
 void Sema::AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
                                        ArrayRef<Expr *> Args,
                                        OverloadCandidateSet &CandidateSet,
+                                       Scope *S, // HLSL Change
                                        bool PartialOverloading) {
 
 #ifndef NDEBUG
@@ -10660,7 +10661,7 @@ void Sema::AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
 
   // HLSL Change - allow ExternalSource the ability to add the overloads for a call.
   if (ExternalSource &&
-    ExternalSource->AddOverloadedCallCandidates(ULE, Args, CandidateSet, PartialOverloading)) {
+    ExternalSource->AddOverloadedCallCandidates(ULE, Args, CandidateSet, S, PartialOverloading)) {
     return;
   }
 
@@ -10970,7 +10971,7 @@ bool Sema::buildOverloadedCallSet(Scope *S, Expr *Fn,
 
   // Add the functions denoted by the callee to the set of candidate
   // functions, including those from argument-dependent lookup.
-  AddOverloadedCallCandidates(ULE, Args, *CandidateSet);
+  AddOverloadedCallCandidates(ULE, Args, *CandidateSet, S); // HLSL Change
 
   if (getLangOpts().MSVCCompat &&
       CurContext->isDependentContext() && !isSFINAEContext() &&

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -10660,8 +10660,8 @@ void Sema::AddOverloadedCallCandidates(UnresolvedLookupExpr *ULE,
 #endif
 
   // HLSL Change - allow ExternalSource the ability to add the overloads for a call.
-  if (ExternalSource &&
-    ExternalSource->AddOverloadedCallCandidates(ULE, Args, CandidateSet, S, PartialOverloading)) {
+  if (ExternalSource && ExternalSource->AddOverloadedCallCandidates(
+                            ULE, Args, CandidateSet, S, PartialOverloading)) {
     return;
   }
 

--- a/tools/clang/test/SemaHLSL/effects-syntax.hlsl
+++ b/tools/clang/test/SemaHLSL/effects-syntax.hlsl
@@ -108,12 +108,10 @@ static const PixelShader ps1 { state=foo; };                /* expected-warning 
 /*verify-ast
   No matching AST found for line!
 */
-// expected-note@? {{'PixelShader' declared here}}
 PixelShadeR ps < int foo=1;>  = ps1;   // Case insensitive! /* expected-error {{unknown type name 'PixelShadeR'; did you mean 'PixelShader'?}} expected-warning {{effect object ignored - effect syntax is deprecated}} expected-warning {{possible effect annotation ignored - effect syntax is deprecated}} fxc-pass {{}} */
 /*verify-ast
   No matching AST found for line!
 */
-// expected-note@? {{'VertexShader' declared here}}
 VertexShadeR vs;        // Case insensitive!                /* expected-error {{unknown type name 'VertexShadeR'; did you mean 'VertexShader'?}} expected-warning {{effect object ignored - effect syntax is deprecated}} fxc-pass {{}} */
 
 // Case sensitive

--- a/tools/clang/test/SemaHLSL/raytracings.hlsl
+++ b/tools/clang/test/SemaHLSL/raytracings.hlsl
@@ -12,14 +12,14 @@ void run() {
     RAY_FLAG_CULL_OPAQUE                     +
     RAY_FLAG_CULL_NON_OPAQUE;
 
-  rayFlags += RAY_FLAG_INVALID;                             /* expected-note@? {{'RAY_FLAG_NONE' declared here}} expected-error {{use of undeclared identifier 'RAY_FLAG_INVALID'; did you mean 'RAY_FLAG_NONE'?}} */
+  rayFlags += RAY_FLAG_INVALID;                             /* expected-error {{use of undeclared identifier 'RAY_FLAG_INVALID'; did you mean 'RAY_FLAG_NONE'?}} */
 
   int intFlag = RAY_FLAG_CULL_OPAQUE;
 
   int hitKindFlag =
     HIT_KIND_TRIANGLE_FRONT_FACE + HIT_KIND_TRIANGLE_BACK_FACE;
 
-  hitKindFlag += HIT_KIND_INVALID;                          /* expected-note@? {{'HIT_KIND_NONE' declared here}} expected-error {{use of undeclared identifier 'HIT_KIND_INVALID'; did you mean 'HIT_KIND_NONE'?}} */
+  hitKindFlag += HIT_KIND_INVALID;                          /* expected-error {{use of undeclared identifier 'HIT_KIND_INVALID'; did you mean 'HIT_KIND_NONE'?}} */
 
 
   BuiltInTriangleIntersectionAttributes attr;

--- a/tools/clang/test/SemaHLSL/using-namespace-dx-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/using-namespace-dx-errors.hlsl
@@ -1,0 +1,42 @@
+// RUN: %dxc -T lib_6_9 %s -verify
+
+RaytracingAccelerationStructure Scene : register(t0, space0);
+
+struct[raypayload] RayPayload {
+  float4 color : write(caller) : read(closesthit);
+};
+
+[shader("raygeneration")] void MyRaygenShader() {
+  // Set the ray's extents.
+  RayDesc ray;
+  ray.Origin = float3(0, 0, 1);
+  ray.Direction = float3(1, 0, 0);
+  ray.TMin = 0.001;
+  ray.TMax = 10000.0;
+
+  RayPayload payload = {float4(0, 0, 0, 0)};
+
+  {
+    using namespace dx;
+    HitObject hit =
+        HitObject::TraceRay(Scene, RAY_FLAG_NONE, ~0, 0, 1, 0,
+                            ray, payload);
+
+    int sortKey = 1;
+    MaybeReorderThread(sortKey, 1);
+  }
+
+  {
+    int sortKey = 1;
+    MaybeReorderThread(sortKey, 1); // expected-error{{use of undeclared identifier 'MaybeReorderThread'; did you mean 'MaybeReorderThread'?}}
+  }
+
+  int sortKey = 1;
+  MaybeReorderThread(sortKey, 1); // expected-error{{use of undeclared identifier 'MaybeReorderThread'; did you mean 'MaybeReorderThread'?}}
+
+  HitObject hit = // expected-error{{unknown type name 'HitObject'}}
+        HitObject::TraceRay(Scene, RAY_FLAG_NONE, ~0, 0, 1, 0,
+                            ray, payload);
+
+  HitObject::Invoke(hit, payload); // expected-error{{use of undeclared identifier 'HitObject'}}
+}

--- a/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
+++ b/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
@@ -6,6 +6,15 @@ struct[raypayload] RayPayload {
   float4 color : write(caller) : read(closesthit);
 };
 
+namespace MyStuff {
+  using namespace dx;
+  void MaybeReorderThread(int2 V);
+}
+
+void MyStuff::MaybeReorderThread(int2 V) {
+  MaybeReorderThread(V.x, V.y);
+}
+
 [shader("raygeneration")] void MyRaygenShader() {
   // Set the ray's extents.
   RayDesc ray;
@@ -25,6 +34,8 @@ struct[raypayload] RayPayload {
   MaybeReorderThread(sortKey, 1);
 
   HitObject::Invoke(hit, payload);
+
+  MyStuff::MaybeReorderThread(int2(sortKey, 1));
 }
 
 // Find the DeclRefExpr for the call to MaybeReorderThread:

--- a/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
+++ b/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -T lib_6_9 -ast-dump-implicit %s | FileCheck %s
+
+RaytracingAccelerationStructure Scene : register(t0, space0);
+
+struct[raypayload] RayPayload {
+  float4 color : write(caller) : read(closesthit);
+};
+
+[shader("raygeneration")] void MyRaygenShader() {
+  // Set the ray's extents.
+  RayDesc ray;
+  ray.Origin = float3(0, 0, 1);
+  ray.Direction = float3(1, 0, 0);
+  ray.TMin = 0.001;
+  ray.TMax = 10000.0;
+
+  RayPayload payload = {float4(0, 0, 0, 0)};
+  
+  using namespace dx;
+  HitObject hit =
+      HitObject::TraceRay(Scene, RAY_FLAG_NONE, ~0, 0, 1, 0,
+                          ray, payload);
+
+  int sortKey = 1;
+  MaybeReorderThread(sortKey, 1);
+
+  HitObject::Invoke(hit, payload);
+}
+
+// Find the DeclRefExpr for the call to MaybeReorderThread:
+
+// CHECK: DeclRefExpr {{.*}} 'void (unsigned int, unsigned int)' lvalue Function [[DeclAddr:0x[0-9a-fA-F]+]] 'MaybeReorderThread' 'void (unsigned int, unsigned int)'
+// CHECK: FunctionDecl [[DeclAddr]] <<invalid sloc>> <invalid sloc> implicit used MaybeReorderThread 'void (unsigned int, unsigned int)' extern
+// CHECK-NEXT: ParmVarDecl {{.*}} CoherenceHint 'unsigned int'
+// CHECK-NEXT: ParmVarDecl {{.*}} NumCoherenceHintBitsFromLSB 'unsigned int'
+// CHECK-NEXT: HLSLIntrinsicAttr {{.*}} Implicit "op" "" 359
+// CHECK-NEXT: AvailabilityAttr {{.*}} Implicit  6.9 0 0 ""

--- a/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
+++ b/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
@@ -40,9 +40,17 @@ void MyStuff::MaybeReorderThread(int2 V) {
 
 // Find the DeclRefExpr for the call to MaybeReorderThread:
 
+// CHECK: FunctionDecl [[MyDeclAddr:0x[0-9a-fA-F]+]] parent {{.*}} used MaybeReorderThread 'void (int2)'
 // CHECK: DeclRefExpr {{.*}} 'void (unsigned int, unsigned int)' lvalue Function [[DeclAddr:0x[0-9a-fA-F]+]] 'MaybeReorderThread' 'void (unsigned int, unsigned int)'
+
 // CHECK: FunctionDecl [[DeclAddr]] <<invalid sloc>> <invalid sloc> implicit used MaybeReorderThread 'void (unsigned int, unsigned int)' extern
 // CHECK-NEXT: ParmVarDecl {{.*}} CoherenceHint 'unsigned int'
 // CHECK-NEXT: ParmVarDecl {{.*}} NumCoherenceHintBitsFromLSB 'unsigned int'
 // CHECK-NEXT: HLSLIntrinsicAttr {{.*}} Implicit "op" "" 359
 // CHECK-NEXT: AvailabilityAttr {{.*}} Implicit  6.9 0 0 ""
+
+// CHECK-LABEL: MyRaygenShader
+
+// CHECK: DeclRefExpr {{.*}} 'void (unsigned int, unsigned int)' lvalue Function [[DeclAddr:0x[0-9a-fA-F]+]] 'MaybeReorderThread' 'void (unsigned int, unsigned int)'
+// CHECK: DeclRefExpr {{.*}} 'void (int2)' lvalue Function [[MyDeclAddr:0x[0-9a-fA-F]+]] 'MaybeReorderThread' 'void (int2)'
+


### PR DESCRIPTION
This change fixes issues with intrinsic lookup caused by not correctly respecting the using declaration(s) that impact unqualified lookups.

This probably isn't a perfect solution because I'm sure there's some nuance of unqualified lookups in C++ that I'm not handling, but this does respect scoped using directives and allows us to get things working.

Additionally this change disables emitting some "declared here" notes when the source location referred to is invalid.

Fixes #7495