### PR TITLE
[SER] GetAttributes(out udt) instead of templated return

### DIFF
--- a/include/dxc/HLSL/HLOperations.h
+++ b/include/dxc/HLSL/HLOperations.h
@@ -462,6 +462,9 @@ const unsigned kHitObjectInvoke_PayloadOpIdx = 2;
 const unsigned kHitObjectFromRayQuery_WithAttrs_AttributeOpIdx = 4;
 const unsigned kHitObjectFromRayQuery_WithAttrs_NumOp = 5;
 
+// HitObject::GetAttributes
+const unsigned kHitObjectGetAttributes_AttributeOpIdx = 2;
+
 // Linear Algebra Operations
 
 // MatVecMul

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -6378,18 +6378,11 @@ Value *TranslateHitObjectGetAttributes(CallInst *CI, IntrinsicOp IOP,
 
   Value *HitObjectPtr = CI->getArgOperand(1);
   Value *HitObject = Builder.CreateLoad(HitObjectPtr);
-
-  Type *AttrTy = cast<PointerType>(CI->getType())->getPointerElementType();
-
-  IRBuilder<> EntryBuilder(
-      dxilutil::FindAllocaInsertionPt(CI->getParent()->getParent()));
-  unsigned AttrAlign = Helper.dataLayout.getABITypeAlignment(AttrTy);
-  AllocaInst *AttrMem = EntryBuilder.CreateAlloca(AttrTy);
-  AttrMem->setAlignment(AttrAlign);
-  Constant *opArg = OP->GetU32Const((unsigned)OpCode);
-  TrivialDxilOperation(OpCode, {opArg, HitObject, AttrMem}, CI->getType(),
-                       Helper.voidTy, OP, Builder);
-  return AttrMem;
+  Value *AttrOutPtr =
+      CI->getArgOperand(HLOperandIndex::kHitObjectGetAttributes_AttributeOpIdx);
+  TrivialDxilOperation(OpCode, {nullptr, HitObject, AttrOutPtr},
+                       AttrOutPtr->getType(), CI, OP);
+  return nullptr;
 }
 
 Value *TranslateHitObjectScalarGetter(CallInst *CI, IntrinsicOp IOP,

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1518,6 +1518,10 @@ static bool isUDTIntrinsicArg(CallInst *CI, unsigned OpIdx) {
     if (OpIdx == HLOperandIndex::kHitObjectInvoke_PayloadOpIdx)
       return true;
     break;
+  case IntrinsicOp::MOP_DxHitObject_GetAttributes:
+    if (OpIdx == HLOperandIndex::kHitObjectGetAttributes_AttributeOpIdx)
+      return true;
+    break;
   default:
     break;
   }

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -8825,7 +8825,6 @@ private:
                         bool AllowOnePastEnd=true, bool IndexNegated=false);
   // HLSL Change Starts - checking array subscript access to vector or matrix member
   void CheckHLSLArrayAccess(const Expr *expr);
-  bool CheckNoInterpolationParams(FunctionDecl *FDecl, CallExpr *TheCall);
   // HLSL Change ends
   void CheckArrayAccess(const Expr *E);
   // Used to grab the relevant information from a FormatAttr and a

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -3806,8 +3806,7 @@ public:
   void DiagnoseHLSLDeclAttr(const Decl *D, const Attr *A);
   void DiagnoseCoherenceMismatch(const Expr *SrcExpr, QualType TargetType,
                                  SourceLocation Loc);
-  void CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
-                             const FunctionProtoType *Proto);
+  void CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall);
   void DiagnoseReachableHLSLCall(CallExpr *CE, const hlsl::ShaderModel *SM,
                                  hlsl::DXIL::ShaderKind EntrySK,
                                  hlsl::DXIL::NodeLaunchType NodeLaunchTy,

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -8826,8 +8826,7 @@ private:
                         bool AllowOnePastEnd=true, bool IndexNegated=false);
   // HLSL Change Starts - checking array subscript access to vector or matrix member
   void CheckHLSLArrayAccess(const Expr *expr);
-  bool CheckHLSLIntrinsicCall(FunctionDecl *FDecl, CallExpr *TheCall);
-  bool CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall);
+  bool CheckNoInterpolationParams(FunctionDecl *FDecl, CallExpr *TheCall);
   // HLSL Change ends
   void CheckArrayAccess(const Expr *E);
   // Used to grab the relevant information from a FormatAttr and a

--- a/tools/clang/lib/Sema/SemaChecking.cpp
+++ b/tools/clang/lib/Sema/SemaChecking.cpp
@@ -1426,7 +1426,7 @@ bool Sema::CheckFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
     CheckMemaccessArguments(TheCall, CMId, FnInfo);
 #endif // HLSL Change Ends
 
-  CheckHLSLFunctionCall(FDecl, TheCall, Proto); // HLSL Change
+  CheckHLSLFunctionCall(FDecl, TheCall); // HLSL Change
 
   return false;
 }

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -5349,8 +5349,6 @@ Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
   if (FDecl) {
     if (CheckFunctionCall(FDecl, TheCall, Proto))
       return ExprError();
-    if (CheckHLSLFunctionCall(FDecl, TheCall))
-      return ExprError();
     if (BuiltinID)
       return CheckBuiltinFunctionCall(FDecl, BuiltinID, TheCall);
   } else if (NDecl) {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12282,8 +12282,7 @@ static bool CheckUDTIntrinsicArg(Sema *S, Expr *Arg) {
 }
 
 // Check HLSL call constraints, not fatal to creating the AST.
-void Sema::CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
-                                 const FunctionProtoType *Proto) {
+void Sema::CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall) {
   if (CheckNoInterpolationParams(FDecl, TheCall))
     return;
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12259,13 +12259,13 @@ static bool isRelatedDeclMarkedNointerpolation(Expr *E) {
   return false;
 }
 
-static bool CheckIntrinsicGetAttributeAtVertex(Sema *S, FunctionDecl *FDecl,
+static bool CheckIntrinsicGetAttributeAtVertex(Sema &S, FunctionDecl *FDecl,
                                                CallExpr *TheCall) {
   assert(TheCall->getNumArgs() > 0);
   auto argument = TheCall->getArg(0)->IgnoreCasts();
 
   if (!isRelatedDeclMarkedNointerpolation(argument)) {
-    S->Diag(argument->getExprLoc(), diag::err_hlsl_parameter_requires_attribute)
+    S.Diag(argument->getExprLoc(), diag::err_hlsl_parameter_requires_attribute)
         << 0 << FDecl->getName() << "nointerpolation";
     return true;
   }
@@ -12274,10 +12274,10 @@ static bool CheckIntrinsicGetAttributeAtVertex(Sema *S, FunctionDecl *FDecl,
 }
 
 // Verify that user-defined intrinsic struct args contain no long vectors
-static bool CheckUDTIntrinsicArg(Sema *S, Expr *Arg) {
+static bool CheckUDTIntrinsicArg(Sema &S, Expr *Arg) {
   const TypeDiagContext DiagContext =
       TypeDiagContext::UserDefinedStructParameter;
-  return DiagnoseTypeElements(*S, Arg->getExprLoc(), Arg->getType(),
+  return DiagnoseTypeElements(S, Arg->getExprLoc(), Arg->getType(),
                               DiagContext, DiagContext);
 }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12277,7 +12277,7 @@ static bool CheckNoInterpolationParams(Sema &S, FunctionDecl *FDecl,
                                        CallExpr *TheCall) {
   // See #hlsl-specs/issues/181. Feature is broken. For SPIR-V we want
   // to limit the scope, and fail gracefully in some cases.
-  if (!getLangOpts().SPIRV)
+  if (!S.getLangOpts().SPIRV)
     return false;
 
   bool error = false;
@@ -12343,16 +12343,16 @@ void Sema::CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall) {
     // to limit the scope, and fail gracefully in some cases.
     if (!getLangOpts().SPIRV)
       return;
-    CheckIntrinsicGetAttributeAtVertex(this, FDecl, TheCall);
+    CheckIntrinsicGetAttributeAtVertex(*this, FDecl, TheCall);
     break;
   case hlsl::IntrinsicOp::IOP_DispatchMesh:
-    CheckUDTIntrinsicArg(this, TheCall->getArg(3)->IgnoreCasts());
+    CheckUDTIntrinsicArg(*this, TheCall->getArg(3)->IgnoreCasts());
     break;
   case hlsl::IntrinsicOp::IOP_CallShader:
-    CheckUDTIntrinsicArg(this, TheCall->getArg(1)->IgnoreCasts());
+    CheckUDTIntrinsicArg(*this, TheCall->getArg(1)->IgnoreCasts());
     break;
   case hlsl::IntrinsicOp::IOP_TraceRay:
-    CheckUDTIntrinsicArg(this, TheCall->getArg(7)->IgnoreCasts());
+    CheckUDTIntrinsicArg(*this, TheCall->getArg(7)->IgnoreCasts());
     break;
   case hlsl::IntrinsicOp::IOP_ReportHit:
     CheckIntersectionAttributeArg(*this, TheCall->getArg(2)->IgnoreCasts());

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12318,9 +12318,6 @@ void Sema::CheckHLSLFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall) {
     // to limit the scope, and fail gracefully in some cases.
     if (!getLangOpts().SPIRV)
       return;
-    // This should never happen for SPIR-V. But on the DXIL side, extension can
-    // be added by inserting new intrinsics, meaning opcodes can collide with
-    // existing ones. See the ExtensionTest.EvalAttributeCollision test.
     CheckIntrinsicGetAttributeAtVertex(this, FDecl, TheCall);
     break;
   case hlsl::IntrinsicOp::IOP_DispatchMesh:

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/HitObject/hitobject_attributes.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/HitObject/hitobject_attributes.hlsl
@@ -20,7 +20,8 @@ CustomAttrs {
 [shader("raygeneration")]
 void main() {
   dx::HitObject hit;
-  CustomAttrs attrs = hit.GetAttributes<CustomAttrs>();
+  CustomAttrs attrs;
+  hit.GetAttributes(attrs);
   float sum = attrs.v.x + attrs.v.y + attrs.v.z + attrs.v.w + attrs.y;
   outbuf.Store(0, sum);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/HitObject/hitobject_attributes_builtin.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/HitObject/hitobject_attributes_builtin.hlsl
@@ -5,7 +5,7 @@
 // as a template argument to GetAttributes.
 
 // For -fcgl, just check the form of the HL call.
-// FCGL: %{{[^ ]+}} = call %struct.BuiltInTriangleIntersectionAttributes* @"dx.hl.op..%struct.BuiltInTriangleIntersectionAttributes* (i32, %dx.types.HitObject*)"(i32 364, %dx.types.HitObject* %{{[^ ]+}})
+// FCGL: call void @"dx.hl.op..void (i32, %dx.types.HitObject*, %struct.BuiltInTriangleIntersectionAttributes*)"(i32 364, %dx.types.HitObject* %{{[^ ]+}}, %struct.BuiltInTriangleIntersectionAttributes* %{{[^ ]+}})
 
 // CHECK: %[[ATTR:[^ ]+]] = alloca %struct.BuiltInTriangleIntersectionAttributes
 // CHECK: call void @dx.op.hitObject_Attributes.struct.BuiltInTriangleIntersectionAttributes(i32 289, %dx.types.HitObject %{{[^ ]+}}, %struct.BuiltInTriangleIntersectionAttributes* nonnull %[[ATTR]])
@@ -34,7 +34,8 @@ void MyRaygenShader()
 
     dx::HitObject hit = dx::HitObject::TraceRay(Scene, RAY_FLAG_NONE, ~0, 0, 1, 0, ray, payload);
 
-    MyAttribs attr = hit.GetAttributes<MyAttribs>();
+    MyAttribs attr;
+    hit.GetAttributes(attr);
     payload.color += float4(attr,0,1);
 
     // Write the raytraced color to the output texture.

--- a/tools/clang/test/DXC/Passes/DxilGen/hitobject_attributes_dxilgen.ll
+++ b/tools/clang/test/DXC/Passes/DxilGen/hitobject_attributes_dxilgen.ll
@@ -30,30 +30,41 @@ target triple = "dxil-ms-dx"
 define void @"\01?main@@YAXXZ"() #0 {
 entry:
   %hit = alloca %dx.types.HitObject, align 4
-  %0 = bitcast %dx.types.HitObject* %hit to i8*, !dbg !21 ; line:22 col:3
-  call void @llvm.lifetime.start(i64 4, i8* %0) #0, !dbg !21 ; line:22 col:3
-  %1 = call %dx.types.HitObject* @"dx.hl.op..%dx.types.HitObject* (i32, %dx.types.HitObject*)"(i32 358, %dx.types.HitObject* %hit), !dbg !25 ; line:22 col:17
-  %2 = call %struct.CustomAttrs* @"dx.hl.op..%struct.CustomAttrs* (i32, %dx.types.HitObject*)"(i32 364, %dx.types.HitObject* %hit), !dbg !26 ; line:23 col:23
-  %3 = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %2, i32 0, i32 0, !dbg !26 ; line:23 col:23
-  %4 = load <4 x float>, <4 x float>* %3, !dbg !26 ; line:23 col:23
-  %5 = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %2, i32 0, i32 1, !dbg !26 ; line:23 col:23
-  %6 = load i32, i32* %5, !dbg !26 ; line:23 col:23
-  %7 = extractelement <4 x float> %4, i32 0, !dbg !27 ; line:24 col:15
-  %8 = extractelement <4 x float> %4, i32 1, !dbg !28 ; line:24 col:27
-  %add = fadd float %7, %8, !dbg !29 ; line:24 col:25
-  %9 = extractelement <4 x float> %4, i32 2, !dbg !30 ; line:24 col:39
-  %add4 = fadd float %add, %9, !dbg !31 ; line:24 col:37
-  %10 = extractelement <4 x float> %4, i32 3, !dbg !32 ; line:24 col:51
-  %add6 = fadd float %add4, %10, !dbg !33 ; line:24 col:49
-  %conv = sitofp i32 %6 to float, !dbg !34 ; line:24 col:63
-  %add7 = fadd float %add6, %conv, !dbg !35 ; line:24 col:61
-  %11 = load %struct.RWByteAddressBuffer, %struct.RWByteAddressBuffer* @"\01?outbuf@@3URWByteAddressBuffer@@A", !dbg !36 ; line:25 col:3
-  %12 = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.RWByteAddressBuffer)"(i32 0, %struct.RWByteAddressBuffer %11), !dbg !36 ; line:25 col:3
-  %13 = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.RWByteAddressBuffer)"(i32 14, %dx.types.Handle %12, %dx.types.ResourceProperties { i32 4107, i32 0 }, %struct.RWByteAddressBuffer zeroinitializer), !dbg !36 ; line:25 col:3
-  call void @"dx.hl.op..void (i32, %dx.types.Handle, i32, float)"(i32 277, %dx.types.Handle %13, i32 0, float %add7), !dbg !36 ; line:25 col:3
-  %14 = bitcast %dx.types.HitObject* %hit to i8*, !dbg !37 ; line:26 col:1
-  call void @llvm.lifetime.end(i64 4, i8* %14) #0, !dbg !37 ; line:26 col:1
-  ret void, !dbg !37 ; line:26 col:1
+  %attrs = alloca %struct.CustomAttrs, align 4
+  %0 = bitcast %dx.types.HitObject* %hit to i8*, !dbg !21 ; line:29 col:3
+  call void @llvm.lifetime.start(i64 4, i8* %0) #0, !dbg !21 ; line:29 col:3
+  %1 = call %dx.types.HitObject* @"dx.hl.op..%dx.types.HitObject* (i32, %dx.types.HitObject*)"(i32 358, %dx.types.HitObject* %hit), !dbg !25 ; line:29 col:17
+  %2 = bitcast %struct.CustomAttrs* %attrs to i8*, !dbg !26 ; line:30 col:3
+  call void @llvm.lifetime.start(i64 20, i8* %2) #0, !dbg !26 ; line:30 col:3
+  call void @"dx.hl.op..void (i32, %dx.types.HitObject*, %struct.CustomAttrs*)"(i32 364, %dx.types.HitObject* %hit, %struct.CustomAttrs* %attrs), !dbg !27 ; line:31 col:3
+  %v = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %attrs, i32 0, i32 0, !dbg !28 ; line:32 col:21
+  %3 = load <4 x float>, <4 x float>* %v, align 4, !dbg !29 ; line:32 col:15
+  %4 = extractelement <4 x float> %3, i32 0, !dbg !29 ; line:32 col:15
+  %v1 = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %attrs, i32 0, i32 0, !dbg !30 ; line:32 col:33
+  %5 = load <4 x float>, <4 x float>* %v1, align 4, !dbg !31 ; line:32 col:27
+  %6 = extractelement <4 x float> %5, i32 1, !dbg !31 ; line:32 col:27
+  %add = fadd float %4, %6, !dbg !32 ; line:32 col:25
+  %v2 = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %attrs, i32 0, i32 0, !dbg !33 ; line:32 col:45
+  %7 = load <4 x float>, <4 x float>* %v2, align 4, !dbg !34 ; line:32 col:39
+  %8 = extractelement <4 x float> %7, i32 2, !dbg !34 ; line:32 col:39
+  %add3 = fadd float %add, %8, !dbg !35 ; line:32 col:37
+  %v4 = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %attrs, i32 0, i32 0, !dbg !36 ; line:32 col:57
+  %9 = load <4 x float>, <4 x float>* %v4, align 4, !dbg !37 ; line:32 col:51
+  %10 = extractelement <4 x float> %9, i32 3, !dbg !37 ; line:32 col:51
+  %add5 = fadd float %add3, %10, !dbg !38 ; line:32 col:49
+  %y = getelementptr inbounds %struct.CustomAttrs, %struct.CustomAttrs* %attrs, i32 0, i32 1, !dbg !39 ; line:32 col:69
+  %11 = load i32, i32* %y, align 4, !dbg !39, !tbaa !40 ; line:32 col:69
+  %conv = sitofp i32 %11 to float, !dbg !44 ; line:32 col:63
+  %add6 = fadd float %add5, %conv, !dbg !45 ; line:32 col:61
+  %12 = load %struct.RWByteAddressBuffer, %struct.RWByteAddressBuffer* @"\01?outbuf@@3URWByteAddressBuffer@@A", !dbg !46 ; line:33 col:3
+  %13 = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.RWByteAddressBuffer)"(i32 0, %struct.RWByteAddressBuffer %12), !dbg !46 ; line:33 col:3
+  %14 = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.RWByteAddressBuffer)"(i32 14, %dx.types.Handle %13, %dx.types.ResourceProperties { i32 4107, i32 0 }, %struct.RWByteAddressBuffer zeroinitializer), !dbg !46 ; line:33 col:3
+  call void @"dx.hl.op..void (i32, %dx.types.Handle, i32, float)"(i32 277, %dx.types.Handle %14, i32 0, float %add6), !dbg !46 ; line:33 col:3
+  %15 = bitcast %struct.CustomAttrs* %attrs to i8*, !dbg !47 ; line:34 col:1
+  call void @llvm.lifetime.end(i64 20, i8* %15) #0, !dbg !47 ; line:34 col:1
+  %16 = bitcast %dx.types.HitObject* %hit to i8*, !dbg !47 ; line:34 col:1
+  call void @llvm.lifetime.end(i64 4, i8* %16) #0, !dbg !47 ; line:34 col:1
+  ret void, !dbg !47 ; line:34 col:1
 }
 
 ; Function Attrs: nounwind
@@ -66,7 +77,7 @@ declare void @llvm.lifetime.end(i64, i8* nocapture) #0
 declare %dx.types.HitObject* @"dx.hl.op..%dx.types.HitObject* (i32, %dx.types.HitObject*)"(i32, %dx.types.HitObject*) #0
 
 ; Function Attrs: nounwind
-declare %struct.CustomAttrs* @"dx.hl.op..%struct.CustomAttrs* (i32, %dx.types.HitObject*)"(i32, %dx.types.HitObject*) #0
+declare void @"dx.hl.op..void (i32, %dx.types.HitObject*, %struct.CustomAttrs*)"(i32, %dx.types.HitObject*, %struct.CustomAttrs*) #0
 
 ; Function Attrs: nounwind
 declare void @"dx.hl.op..void (i32, %dx.types.Handle, i32, float)"(i32, %dx.types.Handle, i32, float) #0
@@ -111,20 +122,30 @@ attributes #1 = { nounwind readnone }
 !18 = !{void ()* @"\01?main@@YAXXZ", i32 7}
 !19 = !{i32 -2147483584}
 !20 = !{i32 -1}
-!21 = !DILocation(line: 22, column: 3, scope: !22)
-!22 = !DISubprogram(name: "main", scope: !23, file: !23, line: 21, type: !24, isLocal: false, isDefinition: true, scopeLine: 21, flags: DIFlagPrototyped, isOptimized: false, function: void ()* @"\01?main@@YAXXZ")
-!23 = !DIFile(filename: "tools/clang/test/CodeGenDXIL/hlsl/objects/HitObject/hitobject_attributes.hlsl", directory: "")
+!21 = !DILocation(line: 29, column: 3, scope: !22)
+!22 = !DISubprogram(name: "main", scope: !23, file: !23, line: 28, type: !24, isLocal: false, isDefinition: true, scopeLine: 28, flags: DIFlagPrototyped, isOptimized: false, function: void ()* @"\01?main@@YAXXZ")
+!23 = !DIFile(filename: "tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes.hlsl", directory: "")
 !24 = !DISubroutineType(types: !13)
-!25 = !DILocation(line: 22, column: 17, scope: !22)
-!26 = !DILocation(line: 23, column: 23, scope: !22)
-!27 = !DILocation(line: 24, column: 15, scope: !22)
-!28 = !DILocation(line: 24, column: 27, scope: !22)
-!29 = !DILocation(line: 24, column: 25, scope: !22)
-!30 = !DILocation(line: 24, column: 39, scope: !22)
-!31 = !DILocation(line: 24, column: 37, scope: !22)
-!32 = !DILocation(line: 24, column: 51, scope: !22)
-!33 = !DILocation(line: 24, column: 49, scope: !22)
-!34 = !DILocation(line: 24, column: 63, scope: !22)
-!35 = !DILocation(line: 24, column: 61, scope: !22)
-!36 = !DILocation(line: 25, column: 3, scope: !22)
-!37 = !DILocation(line: 26, column: 1, scope: !22)
+!25 = !DILocation(line: 29, column: 17, scope: !22)
+!26 = !DILocation(line: 30, column: 3, scope: !22)
+!27 = !DILocation(line: 31, column: 3, scope: !22)
+!28 = !DILocation(line: 32, column: 21, scope: !22)
+!29 = !DILocation(line: 32, column: 15, scope: !22)
+!30 = !DILocation(line: 32, column: 33, scope: !22)
+!31 = !DILocation(line: 32, column: 27, scope: !22)
+!32 = !DILocation(line: 32, column: 25, scope: !22)
+!33 = !DILocation(line: 32, column: 45, scope: !22)
+!34 = !DILocation(line: 32, column: 39, scope: !22)
+!35 = !DILocation(line: 32, column: 37, scope: !22)
+!36 = !DILocation(line: 32, column: 57, scope: !22)
+!37 = !DILocation(line: 32, column: 51, scope: !22)
+!38 = !DILocation(line: 32, column: 49, scope: !22)
+!39 = !DILocation(line: 32, column: 69, scope: !22)
+!40 = !{!41, !41, i64 0}
+!41 = !{!"int", !42, i64 0}
+!42 = !{!"omnipotent char", !43, i64 0}
+!43 = !{!"Simple C/C++ TBAA"}
+!44 = !DILocation(line: 32, column: 63, scope: !22)
+!45 = !DILocation(line: 32, column: 61, scope: !22)
+!46 = !DILocation(line: 33, column: 3, scope: !22)
+!47 = !DILocation(line: 34, column: 1, scope: !22)

--- a/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes.hlsl
@@ -1,15 +1,20 @@
 // RUN: %dxc -T lib_6_9 -E main %s -ast-dump-implicit | FileCheck %s --check-prefix AST
 // RUN: %dxc -T lib_6_9 -E main %s -fcgl | FileCheck %s --check-prefix FCGL
 
+
 // AST: | | |-FunctionTemplateDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> GetAttributes
 // AST-NEXT: | | | |-TemplateTypeParmDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> class TResult
-// AST-NEXT: | | | |-CXXMethodDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> implicit GetAttributes 'TResult () const'
-// AST-NEXT: | | | `-CXXMethodDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> used GetAttributes 'CustomAttrs &()' extern
+// AST-NEXT: | | | |-TemplateTypeParmDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> class TAttributes
+// AST-NEXT: | | | |-CXXMethodDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> implicit GetAttributes 'TResult (TAttributes &) const'
+// AST-NEXT: | | | | `-ParmVarDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> Attributes 'TAttributes &'
+// AST-NEXT: | | | `-CXXMethodDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> used GetAttributes 'void (CustomAttrs &)' extern
+// AST-NEXT: | | |   |-TemplateArgument type 'void'
 // AST-NEXT: | | |   |-TemplateArgument type 'CustomAttrs'
+// AST-NEXT: | | |   |-ParmVarDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> GetAttributes 'CustomAttrs &&__restrict'
 // AST-NEXT: | | |   |-HLSLIntrinsicAttr {{[^ ]+}} <<invalid sloc>> Implicit "op" "" 364
 // AST-NEXT: | | |   `-AvailabilityAttr {{[^ ]+}} <<invalid sloc>> Implicit  6.9 0 0 ""
 
-// FCGL: %{{[^ ]+}} = call %struct.CustomAttrs* @"dx.hl.op..%struct.CustomAttrs* (i32, %dx.types.HitObject*)"(i32 364, %dx.types.HitObject* %{{[^ ]+}})
+// FCGL: call void @"dx.hl.op..void (i32, %dx.types.HitObject*, %struct.CustomAttrs*)"(i32 364, %dx.types.HitObject* %{{[^ ]+}}, %struct.CustomAttrs* %{{[^ ]+}})
 
 RWByteAddressBuffer outbuf;
 
@@ -22,7 +27,8 @@ CustomAttrs {
 [shader("raygeneration")]
 void main() {
   dx::HitObject hit;
-  CustomAttrs attrs = hit.GetAttributes<CustomAttrs>();
+  CustomAttrs attrs;
+  hit.GetAttributes(attrs);
   float sum = attrs.v.x + attrs.v.y + attrs.v.z + attrs.v.w + attrs.y;
   outbuf.Store(0, sum);
 }

--- a/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes_invalid_longvec.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes_invalid_longvec.hlsl
@@ -9,6 +9,7 @@ CustomAttrs {
 [shader("raygeneration")]
 void main() {
   dx::HitObject hit;
-  // expected-error@+1{{vectors of over 4 elements in attributes are not supported}}
-  CustomAttrs attrs = hit.GetAttributes<CustomAttrs>();
+  // expected-error@+2{{vectors of over 4 elements in attributes are not supported}}
+  CustomAttrs attrs;
+  hit.GetAttributes(attrs);
 }

--- a/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes_invalid_udt.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject_attributes_invalid_udt.hlsl
@@ -9,6 +9,8 @@ CustomAttrs {
 [shader("raygeneration")]
 void main() {
   dx::HitObject hit;
-  // expected-error@+1{{attributes type must be a user-defined type composed of only numeric types}}
-  CustomAttrs attrs = hit.GetAttributes<CustomAttrs>();
+  CustomAttrs attrs;
+  hit.GetAttributes(attrs);
+  // expected-error@-1{{vectors of over 4 elements in attributes are not supported}}
+  // expected-error@-2{{attributes type must be a user-defined type composed of only numeric types}}
 }

--- a/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-struct.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-struct.hlsl
@@ -264,7 +264,7 @@ void Intersection() {
   float hitT = RayTCurrent();
   RTTYPE attr = (RTTYPE)0;
   bool bReported = ReportHit(hitT, 0, attr);
-  // expected-error@-1{{object 'dx::HitObject' is not allowed in user-defined struct parameter}}
+  // expected-error@-1{{object 'dx::HitObject' is not allowed in attributes}}
   // expected-note@16{{'dx::HitObject' field declared here}}
 }
 

--- a/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-templated.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-templated.hlsl
@@ -275,7 +275,7 @@ void Intersection() {
   float hitT = RayTCurrent();
   RTTYPE attr = (RTTYPE)0;
   bool bReported = ReportHit(hitT, 0, attr);
-  // expected-error@-1{{object 'dx::HitObject' is not allowed in user-defined struct parameter}}
+  // expected-error@-1{{object 'dx::HitObject' is not allowed in attributes}}
   // expected-note@40{{'dx::HitObject' field declared here}}
 }
 

--- a/tools/clang/test/SemaHLSL/hlsl/types/invalid-longvec-decls.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/types/invalid-longvec-decls.hlsl
@@ -146,7 +146,7 @@ void Miss(inout RTTYPE payload){ // expected-error{{vectors of over 4 elements i
 void Intersection() {
   float hitT = RayTCurrent();
   RTTYPE attr = (RTTYPE)0;
-  bool bReported = ReportHit(hitT, 0, attr); // expected-error{{vectors of over 4 elements in user-defined struct parameter are not supported}}
+  bool bReported = ReportHit(hitT, 0, attr); // expected-error{{vectors of over 4 elements in attributes are not supported}}
 }
 
 [shader("callable")]

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -1131,7 +1131,7 @@ namespace DxHitObjectMethods {
     uint [[rn,class_prefix,min_sm=6.9]] GetPrimitiveIndex();
     uint [[rn,class_prefix,min_sm=6.9]] GetHitKind();
     uint [[rn,class_prefix,min_sm=6.9]] GetShaderTableIndex();
-    $funcT [[class_prefix,min_sm=6.9]] GetAttributes();
+    void [[class_prefix,min_sm=6.9]] GetAttributes(out udt Attributes);
     void [[class_prefix,min_sm=6.9]] SetShaderTableIndex(in uint RecordIndex);
     uint [[ro,class_prefix,min_sm=6.9]] LoadLocalRootTableConstant(in uint RootConstantOffsetInBytes);
 } namespace


### PR DESCRIPTION
```
Old: T    HitObject::GetAttributes<T>()
New: void HitObject::GetAttributes(out udt)
```
- remove HitObject::GetAttributes<T> template code path from DeduceTemplateArgumentsForHLSL
- cleanup intersection attribute diagnostic code path
- adjust GetAttributes calls and expected AST, HLOps in tests (DXIL unaffected)

Closes #7534

This is a breaking change. Merge and release must be coordinated with:
- hlsl-spec change (https://github.com/microsoft/hlsl-specs/issues/495)
- HLK releases (SM6.9 preview tests use old signature)