### PR TITLE
Minor fix for signedness of asuint bitcast

### DIFF
--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -3784,6 +3784,9 @@ static bool HandleIntrinsicCall(SourceLocation CallLoc, unsigned opcode,
     assert(Args.size() == 1 && "else call should be invalid");
     if (ArgValues[0].isInt()) {
       Result = ArgValues[0];
+      // The result of bitwise cast to uint will be unsigned.
+      const bool isUnsignedTrue = true;
+      Result.getInt().setIsSigned(!isUnsignedTrue);
     }
     else if (ArgValues[0].isFloat()) {
       const bool isUnsignedTrue = true;


### PR DESCRIPTION
The Result of a bitcast via 'asuint' should be unsigned. 

Code that will (incorrectly) generate an assert.
```
RWByteAddressBuffer v : register(u0);
void foo() {
  int v_1 = int(0);
  v.InterlockedAdd(int(16u), asint((asuint(int(0)) - asuint(int(123)))), v_1);
  int x = v_1;
}
```
Failing code (6199) '/dxc/tools/clang/lib/AST/ExprConstant.cpp'

```
  assert(SI.isSigned() == E->getType()->isSignedIntegerOrEnumerationType() &&
           "Invalid evaluation result.");
```
