### PR TITLE
[SPIRV] Add the derivative group execution mode only on shader types that allow it.

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/amplification_shader_derivative.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/amplification_shader_derivative.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T as_6_5 -E main -fspv-target-env=vulkan1.3 %s -spirv | FileCheck %s --check-prefix=VK13
+// RUN: %dxc -T as_6_5 -E main -fspv-target-env=vulkan1.1 -Vd %s -spirv | FileCheck %s --check-prefix=VK11
+
+// VK13-DAG: OpCapability ComputeDerivativeGroupLinearKHR
+// VK13-DAG: OpCapability DerivativeControl
+// VK13-DAG: OpCapability MeshShadingEXT
+// VK13-DAG: OpExtension "SPV_EXT_mesh_shader"
+// VK13-DAG: OpExtension "SPV_KHR_compute_shader_derivatives"
+// VK13: OpEntryPoint TaskEXT %main "main"
+// VK13: OpExecutionMode %main DerivativeGroupLinearKHR
+
+// VK11-DAG: OpExtension "SPV_NV_mesh_shader"
+// VK11: OpEntryPoint TaskNV %main "main"
+// VK11-NOT: OpExecutionMode %main DerivativeGroup
+
+struct AmplificationPayload
+{
+    float4 value;
+};
+
+groupshared AmplificationPayload payload;
+
+[numthreads(4, 1, 1)]
+void main(in uint tid : SV_GroupThreadID, in uint gtid : SV_GroupID)
+{
+    payload.value = ddx_coarse(float4(tid, 0, 0, 0));
+    DispatchMesh(1,1,1, payload);
+}

--- a/tools/clang/test/CodeGenSPIRV/mesh_shader_derivative.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/mesh_shader_derivative.hlsl
@@ -1,0 +1,34 @@
+// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.3 %s -spirv | FileCheck %s --check-prefix=VK13
+// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1 -Vd %s -spirv | FileCheck %s --check-prefix=VK11
+
+// VK13-DAG: OpCapability ComputeDerivativeGroupLinearKHR
+// VK13-DAG: OpCapability DerivativeControl
+// vk13-DAG: OpCapability MeshShadingEXT
+// VK13-DAG: OpExtension "SPV_EXT_mesh_shader"
+// VK13-DAG: OpExtension "SPV_KHR_compute_shader_derivatives"
+// VK13: OpEntryPoint MeshEXT %main "main"
+// VK13: OpExecutionMode %main DerivativeGroupLinearKHR
+
+// VK11-DAG: OpExtension "SPV_NV_mesh_shader"
+// VK11: OpEntryPoint MeshNV %main "main"
+// VK11-NOT: OpExecutionMode %main DerivativeGroup
+
+struct VSOut
+{
+    float4 pos : SV_Position;
+};
+
+[numthreads(4, 1, 1)]
+[outputtopology("triangle")]
+void main(in uint tid : SV_GroupThreadID, out vertices VSOut verts[3], out indices uint3 tris[1])
+{
+    SetMeshOutputCounts(3, 1);
+
+    float4 val = ddx_coarse(float4(tid, 0, 0, 0));
+
+    verts[0].pos = val;
+    verts[1].pos = val + float4(0,1,0,0);
+    verts[2].pos = val + float4(1,0,0,0);
+
+    tris[0] = uint3(0,1,2);
+}

--- a/tools/clang/test/CodeGenSPIRV/vertex_shader_derivative_in_branch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vertex_shader_derivative_in_branch.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.3 %s -spirv | FileCheck %s
+
+// CHECK-NOT: OpCapability DerivativeControl
+// CHECK-NOT: OpExtension "SPV_KHR_compute_shader_derivatives"
+
+struct VSOut
+{
+    float4 pos : SV_Position;
+};
+
+VSOut main(float4 pos : POSITION)
+{
+    VSOut output;
+    output.pos = pos;
+    if (false)
+    {
+        output.pos += ddx(pos);
+    }
+    return output;
+}

--- a/tools/clang/test/CodeGenSPIRV/vertex_shader_derivative_in_branch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vertex_shader_derivative_in_branch.hlsl
@@ -1,7 +1,10 @@
-// RUN: %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.3 %s -spirv | FileCheck %s
-
+// RUN: %dxc -T vs_6_0 -E main -DCOND=false -fspv-target-env=vulkan1.3 %s -spirv | FileCheck %s
 // CHECK-NOT: OpCapability DerivativeControl
 // CHECK-NOT: OpExtension "SPV_KHR_compute_shader_derivatives"
+
+// RUN: not %dxc -T vs_6_0 -E main -DCOND=true -fspv-target-env=vulkan1.3 %s -spirv 2>&1 | FileCheck %s -check-prefix=ERROR
+// ERROR: generated SPIR-V is invalid:
+// ERROR-NEXT: Derivative instructions require Fragment, GLCompute, MeshEXT or TaskEXT execution model: DPdx
 
 struct VSOut
 {
@@ -12,7 +15,7 @@ VSOut main(float4 pos : POSITION)
 {
     VSOut output;
     output.pos = pos;
-    if (false)
+    if (COND)
     {
         output.pos += ddx(pos);
     }


### PR DESCRIPTION
DXC allows user to use decrivative instruction in shader models that do
not allow it, but they must be dead code that will be removed. However,
when we see a derivative instruction in the SPIR-V backend that is not
in a pixel shader we assume it need the DerivativeGroup execution mode,
and we fail when we try to add it to a vertex shader.

To allow out implementation to match DXIL, we will not assume we can add
the execution mode. We will only add it for shader that we know can use
is, and skip the other.

If the derivative instruction is not removed during optimizations, there
will be a validation error.

While fixing this, we observed another bug that is fixed at the same
time since they are closely related. The TaskNV and TaskEXT shader types
do not have the same id, and the SPV_KHR_compute_shader_derivatives does
not work with the NV mesh shader extension. That was fixed up.

Fixes #7478
