### PR TITLE
Merge HLSLHalf_t and HLSLBool_t

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
+++ b/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
@@ -12,6 +12,23 @@
           <ParameterType Name="DataType">String</ParameterType>
           <ParameterType Name="OpTypeEnum">String</ParameterType>
         </ParameterTypes>
+        <!-- LongVectorBinaryOpTypeTable DataType: bool -->
+        <Row Name="ScalarAdd_bool">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <Row Name="Add_bool">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_bool">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
+        <Row Name="Subtract_bool">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">bool</Parameter>
+        </Row>
         <!-- LongVectorBinaryOpTypeTable DataType: int16 -->
         <Row Name="ScalarAdd_int16">
           <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
@@ -354,6 +371,63 @@
           <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
+        <!-- LongVectorBinaryOpTypeTable DataType: float16 -->
+        <Row Name="ScalarAdd_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Add_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarSubtract_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Subtract_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarMultiply_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Multiply_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarDivide_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Divide_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarModulus_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Modulus_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarMin_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Min_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarMax_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="Max_float16">
+          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
         <!-- LongVectorBinaryOpTypeTable DataType: float32 -->
         <Row Name="ScalarAdd_float32">
           <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
@@ -471,6 +545,11 @@
         <ParameterType Name="DataType">String</ParameterType>
         <ParameterType Name="OpTypeEnum">String</ParameterType>
       </ParameterTypes>
+      <!-- LongVectorUnaryOpTypeTable DataType: bool -->
+      <Row Name="Initialize_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: int16 -->
       <Row Name="Initialize_int16">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
@@ -500,6 +579,11 @@
       <Row Name="Initialize_uint64">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
         <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTypeTable DataType: float16 -->
+      <Row Name="Initialize_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
       </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: float32 -->
       <Row Name="Initialize_float32">

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -7,8 +7,202 @@
 #include <string>
 #include <vector>
 
+// A helper struct because C++ bools are 1 byte and HLSL bools are 4 bytes.
+// Take int32_t as a constuctor argument and convert it to bool when needed.
+// Comparisons cast to a bool because we only care if the bool representation is
+// true or false.
+struct HLSLBool_t {
+  HLSLBool_t() : Val(0) {}
+  HLSLBool_t(int32_t Val) : Val(Val) {}
+  HLSLBool_t(bool Val) : Val(Val) {}
+  HLSLBool_t(const HLSLBool_t &Other) : Val(Other.Val) {}
+
+  bool operator==(const HLSLBool_t &Other) const {
+    return static_cast<bool>(Val) == static_cast<bool>(Other.Val);
+  }
+
+  bool operator!=(const HLSLBool_t &Other) const {
+    return static_cast<bool>(Val) != static_cast<bool>(Other.Val);
+  }
+
+  bool operator<(const HLSLBool_t &Other) const { return Val < Other.Val; }
+
+  bool operator>(const HLSLBool_t &Other) const { return Val > Other.Val; }
+
+  bool operator<=(const HLSLBool_t &Other) const { return Val <= Other.Val; }
+
+  bool operator>=(const HLSLBool_t &Other) const { return Val >= Other.Val; }
+
+  HLSLBool_t operator*(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val * Other.Val);
+  }
+
+  HLSLBool_t operator+(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val + Other.Val);
+  }
+
+  HLSLBool_t operator-(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val - Other.Val);
+  }
+
+  HLSLBool_t operator/(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val / Other.Val);
+  }
+
+  HLSLBool_t operator%(const HLSLBool_t &Other) const {
+    return HLSLBool_t(Val % Other.Val);
+  }
+
+  // So we can construct std::wstrings using std::wostream
+  friend std::wostream &operator<<(std::wostream &Os, const HLSLBool_t &Obj) {
+    Os << static_cast<bool>(Obj.Val);
+    return Os;
+  }
+
+  // So we can construct std::strings using std::ostream
+  friend std::ostream &operator<<(std::ostream &Os, const HLSLBool_t &Obj) {
+    Os << static_cast<bool>(Obj.Val);
+    return Os;
+  }
+
+  int32_t Val = 0;
+};
+
+//  No native float16 type in C++ until C++23 . So we use uint16_t to represent
+//  it. Simple little wrapping struct to help handle the right behavior.
+struct HLSLHalf_t {
+  HLSLHalf_t() : Val(0) {}
+  HLSLHalf_t(DirectX::PackedVector::HALF Val) : Val(Val) {}
+  HLSLHalf_t(const HLSLHalf_t &Other) : Val(Other.Val) {}
+  HLSLHalf_t(const float F) {
+    Val = DirectX::PackedVector::XMConvertFloatToHalf(F);
+  }
+  HLSLHalf_t(const double D) {
+    float F = 0.0f;
+    // We wrap '::max' in () to prevent it from being expanded as a
+    // macro by the Windows SDK.
+    if (D >= (std::numeric_limits<double>::max)())
+      F = (std::numeric_limits<float>::max)();
+    else if (D <= std::numeric_limits<double>::lowest())
+      F = std::numeric_limits<float>::lowest();
+    else
+      F = static_cast<float>(D);
+
+    Val = DirectX::PackedVector::XMConvertFloatToHalf(F);
+  }
+  HLSLHalf_t(const int I) {
+    VERIFY_IS_TRUE(I == 0, L"HLSLHalf_t constructor with int override only "
+                           L"meant for cases when initializing to 0.");
+    const float F = static_cast<float>(I);
+    Val = DirectX::PackedVector::XMConvertFloatToHalf(F);
+  }
+
+  // Implicit conversion to float for use with things like std::acos, std::tan,
+  // etc
+  operator float() const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val);
+  }
+
+  bool operator==(const HLSLHalf_t &Other) const {
+    // Convert to floats to properly handle the '0 == -0' case which must
+    // compare to true but have different uint16_t values.
+    // That is, 0 == -0 is true. We store Val as a uint16_t.
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    const float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return A == B;
+  }
+
+  bool operator<(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) <
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+  }
+
+  bool operator>(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) >
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+  }
+
+  // Used by tolerance checks in the tests.
+  bool operator>(float F) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    return A > F;
+  }
+
+  bool operator<(float F) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    return A < F;
+  }
+
+  bool operator<=(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) <=
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+  }
+
+  bool operator>=(const HLSLHalf_t &Other) const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val) >=
+           DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+  }
+
+  bool operator!=(const HLSLHalf_t &Other) const { return Val != Other.Val; }
+
+  HLSLHalf_t operator*(const HLSLHalf_t &Other) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    const float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A * B));
+  }
+
+  HLSLHalf_t operator+(const HLSLHalf_t &Other) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    const float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A + B));
+  }
+
+  HLSLHalf_t operator-(const HLSLHalf_t &Other) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    const float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A - B));
+  }
+
+  HLSLHalf_t operator/(const HLSLHalf_t &Other) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    const float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(A / B));
+  }
+
+  HLSLHalf_t operator%(const HLSLHalf_t &Other) const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    const float B = DirectX::PackedVector::XMConvertHalfToFloat(Other.Val);
+    const float C = std::fmod(A, B);
+    return HLSLHalf_t(DirectX::PackedVector::XMConvertFloatToHalf(C));
+  }
+
+  // So we can construct std::wstrings using std::wostream
+  friend std::wostream &operator<<(std::wostream &Os, const HLSLHalf_t &Obj) {
+    Os << DirectX::PackedVector::XMConvertHalfToFloat(Obj.Val);
+    return Os;
+  }
+
+  // So we can construct std::wstrings using std::wostream
+  friend std::ostream &operator<<(std::ostream &Os, const HLSLHalf_t &Obj) {
+    Os << DirectX::PackedVector::XMConvertHalfToFloat(Obj.Val);
+    return Os;
+  }
+
+  // HALF is an alias to uint16_t
+  DirectX::PackedVector::HALF Val = 0;
+};
+
 template <typename T> struct LongVectorTestData {
   static const std::map<std::wstring, std::vector<T>> Data;
+};
+
+template <> struct LongVectorTestData<HLSLBool_t> {
+  inline static const std::map<std::wstring, std::vector<HLSLBool_t>> Data = {
+      {L"DefaultInputValueSet1",
+       {false, true, false, false, false, false, true, true, true, true}},
+      {L"DefaultInputValueSet2",
+       {true, false, false, false, false, true, true, true, false, false}},
+  };
 };
 
 template <> struct LongVectorTestData<int16_t> {
@@ -53,12 +247,36 @@ template <> struct LongVectorTestData<uint64_t> {
   };
 };
 
+template <> struct LongVectorTestData<HLSLHalf_t> {
+  inline static const std::map<std::wstring, std::vector<HLSLHalf_t>> Data = {
+      {L"DefaultInputValueSet1",
+       {-1.0, -1.0, 1.0, -0.01, 1.0, -0.01, 1.0, -0.01, 1.0, -0.01}},
+      {L"DefaultInputValueSet2",
+       {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
+      {L"DefaultClampArgs", {-1.0, 1.0}}, // Min, Max values for clamp
+      // Range [ -pi/2, pi/2]
+      {L"TrigonometricInputValueSet_RangeHalfPi",
+       {-1.073, 0.044, -1.047, 0.313, 1.447, -0.865, 1.364, -0.715, -0.800,
+        0.541}},
+      {L"TrigonometricInputValueSet_RangeOne",
+       {0.331, 0.727, -0.957, 0.677, -0.025, 0.495, 0.855, -0.673, -0.678,
+        -0.905}},
+  };
+};
+
 template <> struct LongVectorTestData<float> {
   inline static const std::map<std::wstring, std::vector<float>> Data = {
       {L"DefaultInputValueSet1",
        {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
       {L"DefaultInputValueSet2",
        {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
+      // Range [ -pi/2, pi/2]
+      {L"TrigonometricInputValueSet_RangeHalfPi",
+       {0.315f, -0.316f, 1.409f, -0.09f, -1.569f, 1.302f, -0.326f, 0.781f,
+        -1.235f, 0.623f}},
+      {L"TrigonometricInputValueSet_RangeOne",
+       {0.727f, 0.331f, -0.957f, 0.677f, -0.025f, 0.495f, 0.855f, -0.673f,
+        -0.678f, -0.905f}},
   };
 };
 
@@ -68,7 +286,13 @@ template <> struct LongVectorTestData<double> {
        {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
       {L"DefaultInputValueSet2",
        {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
-  };
+      // Range [ -pi/2, pi/2]
+      {L"TrigonometricInputValueSet_RangeHalfPi",
+       {0.807, 0.605, 1.317, 0.188, 1.566, -1.507, 0.67, -1.553, 0.194,
+        -0.883}},
+      {L"TrigonometricInputValueSet_RangeOne",
+       {0.331, 0.277, -0.957, 0.677, -0.025, 0.495, 0.855, -0.673, -0.678,
+        -0.905}}};
 };
 
 #endif // LONGVECTORTESTDATA_H

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -110,7 +110,9 @@ void LongVector::OpTest::dispatchTestByDataType(
     TableParameterHandler &Handler) {
   using namespace WEX::Common;
 
-  if (DataType == L"int16")
+  if (DataType == L"bool")
+    dispatchTestByVectorSize<HLSLBool_t>(OpType, Handler);
+  else if (DataType == L"int16")
     dispatchTestByVectorSize<int16_t>(OpType, Handler);
   else if (DataType == L"int32")
     dispatchTestByVectorSize<int32_t>(OpType, Handler);
@@ -122,6 +124,8 @@ void LongVector::OpTest::dispatchTestByDataType(
     dispatchTestByVectorSize<uint32_t>(OpType, Handler);
   else if (DataType == L"uint64")
     dispatchTestByVectorSize<uint64_t>(OpType, Handler);
+  else if (DataType == L"float16")
+    dispatchTestByVectorSize<HLSLHalf_t>(OpType, Handler);
   else if (DataType == L"float32")
     dispatchTestByVectorSize<float>(OpType, Handler);
   else if (DataType == L"float64")

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -68,7 +68,9 @@ void fillLongVectorDataFromShaderBuffer(MappedData &ShaderBuffer,
                                         size_t NumElements);
 
 template <typename DataTypeT> constexpr bool isFloatingPointType() {
-  return std::is_same_v<DataTypeT, float> || std::is_same_v<DataTypeT, double>;
+  return std::is_same_v<DataTypeT, float> ||
+         std::is_same_v<DataTypeT, double> ||
+         std::is_same_v<DataTypeT, HLSLHalf_t>;
 }
 
 struct LongVectorOpTypeStringToEnumValue {
@@ -135,7 +137,10 @@ static_assert(_countof(binaryOpTypeStringToEnumMap) ==
 
 BinaryOpType getBinaryOpType(const std::wstring &OpTypeString);
 
-enum UnaryOpType { UnaryOpType_Initialize, UnaryOpType_EnumValueCount };
+enum UnaryOpType {
+  UnaryOpType_Initialize,
+  UnaryOpType_EnumValueCount
+};
 
 static const LongVectorOpTypeStringToEnumValue unaryOpTypeStringToEnumMap[] = {
     {L"UnaryOpType_Initialize", UnaryOpType_Initialize},
@@ -169,6 +174,9 @@ template <typename LongVectorOpTypeT> struct TestConfigTraits {
 
 template <typename DataTypeT>
 bool doValuesMatch(DataTypeT A, DataTypeT B, float Tolerance, ValidationType);
+bool doValuesMatch(HLSLBool_t A, HLSLBool_t B, float, ValidationType);
+bool doValuesMatch(HLSLHalf_t A, HLSLHalf_t B, float Tolerance,
+                   ValidationType ValidationType);
 bool doValuesMatch(float A, float B, float Tolerance,
                    ValidationType ValidationType);
 bool doValuesMatch(double A, double B, float Tolerance,


### PR DESCRIPTION
This PR merges some more long vector exec test code from staging-sm6.9 into main. Specifically, we bring over the helper classes that define data types for half and bool. Halfs are only available in newer c++ versions so a simple class was needed to implement the proper logic using existing DX helpers that were added for this same reason. The bool class is used as the size of a bool in c++ differs from that in HLSL.

Also brings in some tests cases using these data types. Test cases were verified locally by running against WARP.

Addresses #7546
