### PR TITLE
[ExecutionTests] Fix shader source to prevent OOB access for ExecutionTests::AtomicsShared64Test

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -2552,11 +2552,11 @@
 
         void InitSharedMem(uint ix) {
           // Zero-init shared memory, with special cases
-          if (ix < 6)
+          if (ix < 7)
             g_uintShare[ix] = ix == 1 ? 99999999 : ix == 3 ? -1 : 0;
-          if (ix < 3)
+          if (ix < 4)
             g_sintShare[ix] = ix == 1 ? 99999999 : 0;
-          if (ix < 64)
+          if (ix < 65)
             g_xchgShare[ix] = 0;
 
           GroupMemoryBarrierWithGroupSync();


### PR DESCRIPTION
Fixes #5198. 
 
ExecutionTests::AtomicsShared64Test could sporadically fail.
 
g_sint64Share is indexed with ix%3 + 1, which could lead to an out of bounds access.
Increase the size of g_sint64Share to 4 and ensure all values are initialized. 