### PR TITLE
Remove `hlsl` namespace from SemaHLSL

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -945,6 +945,18 @@ def HLSLCXXOverload : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+// This attribute means something subtly different from the HLSLIntrinsic
+// attribute. Prior to this being introduced a subset of the HLSL intrinsics
+// were placed in the `hlsl` namespace, but not in a way that actually qualified
+// their name lookup. The presence of the namespace as the declcontext was then
+// sused in CGExpr to determine how to emit the call. This attribute replaces
+// the namespace in that context.
+def HLSLBuiltinCall : InheritableAttr {
+  let Spellings = [];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [Undocumented];
+}
+
 def HLSLVector : InheritableAttr {
   let Spellings = []; // No spellings!
   let Subjects = SubjectList<[CXXRecord]>;

--- a/tools/clang/lib/CodeGen/CGExpr.cpp
+++ b/tools/clang/lib/CodeGen/CGExpr.cpp
@@ -3646,14 +3646,8 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
     if (unsigned builtinID = FD->getBuiltinID())
       return EmitBuiltinExpr(FD, builtinID, E, ReturnValue);
     // HLSL Change Starts
-    if (getLangOpts().HLSL) {
-      if (const NamespaceDecl *ns = dyn_cast<NamespaceDecl>(FD->getParent())) {
-        if (ns->getName() == "hlsl") {
-          // do hlsl intrinsic generation
-          return EmitHLSLBuiltinCallExpr(FD, E, ReturnValue);
-        }
-      }
-    }
+    if (getLangOpts().HLSL && FD->hasAttr<HLSLBuiltinCallAttr>())
+      return EmitHLSLBuiltinCallExpr(FD, E, ReturnValue);
     // HLSL Change End
   }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5318,7 +5318,7 @@ public:
   bool Initialize(ASTContext &context) {
     m_context = &context;
 
-    // The HLSL namespace is disabled here pending a decision on whether or
+    // The HLSL namespace is disabled here pending a decision on
     // https://github.com/microsoft/hlsl-specs/issues/484.
     if (false && context.getLangOpts().HLSLVersion >= hlsl::LangStd::v202x) {
       m_hlslNSDecl =

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic.hlsl
@@ -90,49 +90,57 @@ void main( uint GI : SV_GroupIndex, uint3 DTid : SV_DispatchThreadID )
 }
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit InterlockedAdd 'void (unsigned long long &, unsigned long long)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedAdd 'void (int &, unsigned int)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit InterlockedAdd 'void (unsigned long long &, unsigned long long, long long &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedAdd 'void (int &, unsigned int, int &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'int &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'int &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit InterlockedCompareStore 'void (unsigned long long &, unsigned long long, unsigned long long)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedCompareStore 'void (int &, unsigned int, unsigned int)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned int'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned int'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit InterlockedCompareExchange 'void (unsigned long long &, unsigned long long, unsigned long long, long long &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedCompareExchange 'void (int &, unsigned int, unsigned int, int &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned int'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'int &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'unsigned int'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'int &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_float.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_float.hlsl
@@ -127,44 +127,51 @@ void CSMain( uint3 gtid : SV_GroupThreadID, uint ix : SV_GroupIndex)
 
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit InterlockedExchange 'void (unsigned long long &, long long, long long &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'unsigned long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedExchange 'void (float &, float, float &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'float &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'float'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'float &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'float &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'float'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'float &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedExchange 'void (int &, unsigned int, int &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'int &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'int &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned int'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'int &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedExchange 'void (long long &, unsigned long long, unsigned long long &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'unsigned long long &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'unsigned long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'unsigned long long &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedExchange 'void (long long &, long long, long long &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'long long &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'long long'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'long long &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'long long'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'long long &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
 // AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedCompareStoreFloatBitwise 'void (float &, float, float)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'float &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'float'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'float'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'float &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'float'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'float'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit
 
-// AST-NEXT: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedCompareExchangeFloatBitwise 'void (float &, float, float, float &)' extern
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'float &'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'float'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'float'
-// AST-NEXT: |-ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'float &&__restrict'
-// AST-NEXT: `-HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST: FunctionDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} implicit used InterlockedCompareExchangeFloatBitwise 'void (float &, float, float, float &)' extern
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} result 'float &'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} compare 'float'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} value 'float'
+// AST-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} original 'float &&__restrict'
+// AST-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}} Implicit "op" ""
+// AST-NEXT: HLSLBuiltinCallAttr {{0x[0-9a-fA-F]+}} {{[<>a-z ]+}}> Implicit

--- a/tools/clang/test/SemaHLSL/hlsl/linalg/unavailable-pre-sm69.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/linalg/unavailable-pre-sm69.hlsl
@@ -23,7 +23,7 @@ void cs_main()
     const bool matrix_is_transposed = false; 
     const uint matrix_stride = 64;
 
-    //expected-error@+1{{intrinsic hlsl::__builtin_MatVecMul potentially used by ''cs_main'' requires shader model 6.9 or greater}}
+    //expected-error@+1{{intrinsic __builtin_MatVecMul potentially used by ''cs_main'' requires shader model 6.9 or greater}}
     __builtin_MatVecMul(output_vector, is_output_unsigned, input_vector, 
       is_input_unsigned, input_interpretation, matrix_buffer, matrix_offset,
       matrix_interpretation, matrix_dimM, matrix_dimK, matrix_layout,
@@ -32,7 +32,7 @@ void cs_main()
     const uint bias_offset = 0;
     const uint bias_interpretation = 9; /*F32*/
 
-    //expected-error@+1{{intrinsic hlsl::__builtin_MatVecMulAdd potentially used by ''cs_main'' requires shader model 6.9 or greater}}
+    //expected-error@+1{{intrinsic __builtin_MatVecMulAdd potentially used by ''cs_main'' requires shader model 6.9 or greater}}
     __builtin_MatVecMulAdd(output_vector, is_output_unsigned, input_vector,
       is_input_unsigned, input_interpretation, matrix_buffer, matrix_offset,
       matrix_interpretation, matrix_dimM, matrix_dimK, matrix_layout,
@@ -46,14 +46,14 @@ void cs_main()
     const uint opa_matrix_layout = 3; /*OuterProductOptimal*/
     const uint opa_matrix_stride = 0;
 
-    //expected-error@+1{{intrinsic hlsl::__builtin_OuterProductAccumulate potentially used by ''cs_main'' requires shader model 6.9 or greater}}
+    //expected-error@+1{{intrinsic __builtin_OuterProductAccumulate potentially used by ''cs_main'' requires shader model 6.9 or greater}}
     __builtin_OuterProductAccumulate(input_vector1, input_vector2,
       rw_matrix_buffer, opa_matrix_offset, opa_matrix_interpretation,
       opa_matrix_layout, opa_matrix_stride);
 
     const uint va_matrix_offset = 0;
 
-    //expected-error@+1{{intrinsic hlsl::__builtin_VectorAccumulate potentially used by ''cs_main'' requires shader model 6.9 or greater}}
+    //expected-error@+1{{intrinsic __builtin_VectorAccumulate potentially used by ''cs_main'' requires shader model 6.9 or greater}}
     __builtin_VectorAccumulate(input_vector1, rw_matrix_buffer,
       va_matrix_offset);
 }

--- a/tools/clang/test/SemaHLSL/using-namespace-dx-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/using-namespace-dx-errors.hlsl
@@ -28,11 +28,11 @@ struct[raypayload] RayPayload {
 
   {
     int sortKey = 1;
-    MaybeReorderThread(sortKey, 1); // expected-error{{use of undeclared identifier 'MaybeReorderThread'; did you mean 'MaybeReorderThread'?}}
+    MaybeReorderThread(sortKey, 1); // expected-error{{use of undeclared identifier 'MaybeReorderThread'}}
   }
 
   int sortKey = 1;
-  MaybeReorderThread(sortKey, 1); // expected-error{{use of undeclared identifier 'MaybeReorderThread'; did you mean 'MaybeReorderThread'?}}
+  MaybeReorderThread(sortKey, 1); // expected-error{{use of undeclared identifier 'MaybeReorderThread'}}
 
   HitObject hit = // expected-error{{unknown type name 'HitObject'}}
         HitObject::TraceRay(Scene, RAY_FLAG_NONE, ~0, 0, 1, 0,

--- a/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
+++ b/tools/clang/test/SemaHLSL/using-namespace-dx.hlsl
@@ -40,14 +40,15 @@ void MyStuff::MaybeReorderThread(int2 V) {
 
 // Find the DeclRefExpr for the call to MaybeReorderThread:
 
-// CHECK: FunctionDecl [[MyDeclAddr:0x[0-9a-fA-F]+]] parent {{.*}} used MaybeReorderThread 'void (int2)'
-// CHECK: DeclRefExpr {{.*}} 'void (unsigned int, unsigned int)' lvalue Function [[DeclAddr:0x[0-9a-fA-F]+]] 'MaybeReorderThread' 'void (unsigned int, unsigned int)'
-
-// CHECK: FunctionDecl [[DeclAddr]] <<invalid sloc>> <invalid sloc> implicit used MaybeReorderThread 'void (unsigned int, unsigned int)' extern
+// CHECK: NamespaceDecl {{.*}} implicit dx
+// CHECK: FunctionDecl [[DeclAddr:0x[0-9a-fA-F]+]] <<invalid sloc>> <invalid sloc> implicit used MaybeReorderThread 'void (unsigned int, unsigned int)' extern
 // CHECK-NEXT: ParmVarDecl {{.*}} CoherenceHint 'unsigned int'
 // CHECK-NEXT: ParmVarDecl {{.*}} NumCoherenceHintBitsFromLSB 'unsigned int'
 // CHECK-NEXT: HLSLIntrinsicAttr {{.*}} Implicit "op" "" 359
 // CHECK-NEXT: AvailabilityAttr {{.*}} Implicit  6.9 0 0 ""
+
+// CHECK: FunctionDecl [[MyDeclAddr:0x[0-9a-fA-F]+]] parent {{.*}} used MaybeReorderThread 'void (int2)'
+// CHECK: DeclRefExpr {{.*}} 'void (unsigned int, unsigned int)' lvalue Function [[DeclAddr]] 'MaybeReorderThread' 'void (unsigned int, unsigned int)'
 
 // CHECK-LABEL: MyRaygenShader
 

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -1191,23 +1191,23 @@ TEST_F(ExtensionTest, IntrinsicWhenAvailableThenUsed) {
   // - second argument is float, ie it got scalarized
   VERIFY_IS_TRUE(disassembly.npos !=
                  disassembly.find("call void "
-                                  "@\"test.\\01?test_proc@hlsl@@YAXV?$vector@M$"
+                                  "@\"test.\\01?test_proc@@YAXV?$vector@M$"
                                   "01@@@Z.r\"(i32 2, float"));
   VERIFY_IS_TRUE(disassembly.npos !=
                  disassembly.find("call float "
-                                  "@\"test.\\01?test_fn@hlsl@@YA?AV?$vector@M$"
-                                  "01@@V2@@Z.r\"(i32 1, float"));
+                                  "@\"test.\\01?test_fn@@YA?AV?$vector@M$"
+                                  "01@@V1@@Z.r\"(i32 1, float"));
   VERIFY_IS_TRUE(disassembly.npos !=
                  disassembly.find("call i32 "
-                                  "@\"test.\\01?test_fn@hlsl@@YA?AV?$vector@H$"
-                                  "01@@V2@@Z.r\"(i32 1, i32"));
+                                  "@\"test.\\01?test_fn@@YA?AV?$vector@H$"
+                                  "01@@V1@@Z.r\"(i32 1, i32"));
 
   // - attributes are added to the declaration (the # at the end of the decl)
   //   TODO: would be nice to check for the actual attribute (e.g. readonly)
   VERIFY_IS_TRUE(disassembly.npos !=
                  disassembly.find("declare float "
-                                  "@\"test.\\01?test_fn@hlsl@@YA?AV?$vector@M$"
-                                  "01@@V2@@Z.r\"(i32, float) #"));
+                                  "@\"test.\\01?test_fn@@YA?AV?$vector@M$"
+                                  "01@@V1@@Z.r\"(i32, float) #"));
 }
 
 TEST_F(ExtensionTest, CustomIntrinsicName) {
@@ -1629,8 +1629,8 @@ TEST_F(ExtensionTest, WaveIntrinsic) {
                  disassembly.find("%2 = icmp eq i32 %1, 0"));
   VERIFY_IS_TRUE(disassembly.npos !=
                  disassembly.find("call float "
-                                  "@\"test.\\01?wave_proc@hlsl@@YA?AV?$vector@"
-                                  "M$01@@V2@@Z.r\"(i32 16, float"));
+                                  "@\"test.\\01?wave_proc@@YA?AV?$vector@"
+                                  "M$01@@V1@@Z.r\"(i32 16, float"));
   VERIFY_IS_TRUE(disassembly.npos != disassembly.find("br i1 %2"));
 }
 


### PR DESCRIPTION
HLSL intrinsics were previously being added to the translation unit decl but assigned a namespace decl context which was then used only in codegen to determine if special handling was needed for the namespace. This causes an odd array of behaviors including strange mangling and confusing diagnostics.

This PR removes the HLSL namespace and properly adds intrinsics to namespaces when appropriate for the `vk` and `dx` namespaces. This should allow qualified and unqualified name lookup to behave as expected, correct odd mangling, and improve the confusing diagnostics.

The PR introduces a new HLSLBuiltinCallAttr to replace the use of the hlsl namespace. This attribute denotes when a function declaration should be emitted in codegen as an HLSL builtin. It is subtly different from HLSLIntrinsicAttr which is attached to all intrinsic functions and allows the AST to track the HL OpCode.