### PR TITLE
[SPIRV] Fix DebugSource for files which are not found

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -136,6 +136,8 @@ uint32_t getHeaderVersion(spv_target_env env) {
 std::string
 ReadSourceCode(llvm::StringRef filePath,
                const clang::spirv::SpirvCodeGenOptions &spvOptions) {
+
+  std::string localFilePath(filePath.begin(), filePath.end());
   try {
     dxc::DxcDllSupport dllSupport;
     IFT(dllSupport.Initialize());
@@ -154,7 +156,10 @@ ReadSourceCode(llvm::StringRef filePath,
   } catch (...) {
     // An exception has occurred while reading the file
     // return the original source (which may have been supplied directly)
-    if (!spvOptions.origSource.empty()) {
+    // only for the main input file
+    if ((!strcmp(localFilePath.c_str(), "hlsl.hlsl") &&
+         spvOptions.inputFile.empty()) ||
+        !strcmp(localFilePath.c_str(), spvOptions.inputFile.c_str())) {
       return spvOptions.origSource.c_str();
     }
     return "";

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -41,4 +41,26 @@ float4 PSMain(float4 color : COLOR) : SV_TARGET { return color; }
           "OpSource HLSL 600 %4 \"// RUN: %dxc -T ps_6_0 -E PSMain -Zi"));
 }
 
+// This test demonstrates that in-memory source is transmitted
+// to OpDebugSource only once when there are multiple files referenced
+TEST_F(LibTest, InlinedCodeWithDebugMultipleFilesTest) {
+  const std::string command(
+      R"(// RUN: %dxc -T vs_6_0 -E main -fspv-debug=vulkan-with-source)");
+  const std::string code = command + R"(
+#line 1 "otherfile.hlsl"
+struct VertexOutput {
+  [[vk::location(0)]] float3 Color : COLOR0;
+};
+
+float4 main(VertexOutput v) : SV_Position
+{
+  return float4(v.Color, 1.0);
+}
+)";
+  std::string spirv = compileCodeAndGetSpirvAsm(code);
+  EXPECT_THAT(spirv, ContainsRegex("%50 = OpString \"// RUN: %dxc -T vs_6_0 -E "
+                                   "main -fspv-debug=vulkan-with-source"));
+  EXPECT_THAT(spirv, ContainsRegex("DebugSource %23\n"));
+  EXPECT_THAT(spirv, ContainsRegex("DebugSource %5 %50\n"));
+}
 } // namespace


### PR DESCRIPTION
https://github.com/microsoft/DirectXShaderCompiler/issues/4218 and https://github.com/microsoft/DirectXShaderCompiler/pull/4362 identified and partially fixed problems with DebugSource generation.  https://github.com/microsoft/DirectXShaderCompiler/pull/6085 recognized that exe and API users were having different outputs in DebugSource, and attempted to fix that.  However, as the conversation in https://github.com/microsoft/DirectXShaderCompiler/issues/7569 shows, the solution was not entirely correct.  This PR causes dxc to connect the input source string, whether by exe or API, to one and only one DebugSource, like other compilers.  Files which are not found produce a DebugSource without the second operand.
This PR fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7569 