### PR TITLE
Merge Long Vector Trigonometric Op Exec Tests

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
+++ b/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
@@ -596,4 +596,98 @@
         <Parameter Name="DataType">float64</Parameter>
       </Row>
     </Table>
+    <Table Id="TrigonometricOpTable">
+      <ParameterTypes>
+        <!-- InputValueSetName1 is optional. If no value is provided use the
+        default value set for the data type. This string is meant to be a key
+        value for the the array of std::pairs defined in LongVectorTestData.h
+        for the applicable DataType-->
+        <ParameterType Name="InputValueSetName1">String</ParameterType>
+        <!-- InputArgsName is optional and is also a key to the array of
+        std::pairs defined in LongVectorTestData.h for the applicable DataType.
+        Used for args like min and max in clamp-->
+        <ParameterType Name="DataType">String</ParameterType>
+        <ParameterType Name="OpTypeEnum">String</ParameterType>
+      </ParameterTypes>
+      <!-- LongVectorUnaryOpTable_Trigonometric DataType: float16 -->
+      <Row Name="Acos_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Acos</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+        <Parameter Name="InputValueSetName1">TrigonometricInputValueSet_RangeOne</Parameter>
+      </Row>
+      <Row Name="Asin_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Asin</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+        <Parameter Name="InputValueSetName1">TrigonometricInputValueSet_RangeHalfPi</Parameter>
+      </Row>
+      <Row Name="Atan_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Atan</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+        <Parameter Name="InputValueSetName1">TrigonometricInputValueSet_RangeHalfPi</Parameter>
+      </Row>
+      <Row Name="Cos_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Cos</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Cosh_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Cosh</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Sin_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Sin</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Sinh_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Sinh</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Tan_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Tan</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Tanh_float16">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Tanh</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <!-- LongVectorUnaryOpTable_Trigonometric DataType: float32 -->
+      <Row Name="Acos_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Acos</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+        <Parameter Name="InputValueSetName1">TrigonometricInputValueSet_RangeOne</Parameter>
+      </Row>
+      <Row Name="Asin_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Asin</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+        <Parameter Name="InputValueSetName1">TrigonometricInputValueSet_RangeHalfPi</Parameter>
+      </Row>
+      <Row Name="Atan_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Atan</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+        <Parameter Name="InputValueSetName1">TrigonometricInputValueSet_RangeHalfPi</Parameter>
+      </Row>
+      <Row Name="Cos_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Cos</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Cosh_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Cosh</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Sin_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Sin</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Sinh_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Sinh</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Tan_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Tan</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Tanh_float32">
+        <Parameter Name="OpTypeEnum">TrigonometricOpType_Tanh</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+    </Table>
 </Data>

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -16,6 +16,13 @@ LongVector::getUnaryOpType(const std::wstring &OpTypeString) {
       std::size(unaryOpTypeStringToEnumMap));
 }
 
+LongVector::TrigonometricOpType
+LongVector::getTrigonometricOpType(const std::wstring &OpTypeString) {
+  return getLongVectorOpType<LongVector::TrigonometricOpType>(
+      trigonometricOpTypeStringToEnumMap, OpTypeString,
+      std::size(trigonometricOpTypeStringToEnumMap));
+}
+
 // These are helper arrays to be used with the TableParameterHandler that parses
 // the LongVectorOpTable.xml file for us.
 static TableParameter BinaryOpParameters[] = {
@@ -87,6 +94,20 @@ TEST_F(LongVector::OpTest, binaryOpTest) {
   std::wstring OpTypeString(Handler.GetTableParamByName(L"OpTypeEnum")->m_str);
 
   auto OpType = LongVector::getBinaryOpType(OpTypeString);
+  dispatchTestByDataType(OpType, DataType, Handler);
+}
+
+TEST_F(LongVector::OpTest, trigonometricOpTest) {
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+  const int TableSize = sizeof(UnaryOpParameters) / sizeof(TableParameter);
+  TableParameterHandler Handler(UnaryOpParameters, TableSize);
+
+  std::wstring DataType(Handler.GetTableParamByName(L"DataType")->m_str);
+  std::wstring OpTypeString(Handler.GetTableParamByName(L"OpTypeEnum")->m_str);
+
+  auto OpType = LongVector::getTrigonometricOpType(OpTypeString);
   dispatchTestByDataType(OpType, DataType, Handler);
 }
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -35,6 +35,11 @@ public:
                        L"Table:LongVectorOpTable.xml#BinaryOpTable")
   END_TEST_METHOD()
 
+  BEGIN_TEST_METHOD(trigonometricOpTest)
+  TEST_METHOD_PROPERTY(L"DataSource",
+                       L"Table:LongVectorOpTable.xml#TrigonometricOpTable")
+  END_TEST_METHOD()
+
   BEGIN_TEST_METHOD(unaryOpTest)
   TEST_METHOD_PROPERTY(L"DataSource",
                        L"Table:LongVectorOpTable.xml#UnaryOpTable")
@@ -150,6 +155,39 @@ static_assert(_countof(unaryOpTypeStringToEnumMap) ==
 
 UnaryOpType getUnaryOpType(const std::wstring &OpTypeString);
 
+enum TrigonometricOpType {
+  TrigonometricOpType_Acos,
+  TrigonometricOpType_Asin,
+  TrigonometricOpType_Atan,
+  TrigonometricOpType_Cos,
+  TrigonometricOpType_Cosh,
+  TrigonometricOpType_Sin,
+  TrigonometricOpType_Sinh,
+  TrigonometricOpType_Tan,
+  TrigonometricOpType_Tanh,
+  TrigonometricOpType_EnumValueCount
+};
+
+static const LongVectorOpTypeStringToEnumValue
+    trigonometricOpTypeStringToEnumMap[] = {
+        {L"TrigonometricOpType_Acos", TrigonometricOpType_Acos},
+        {L"TrigonometricOpType_Asin", TrigonometricOpType_Asin},
+        {L"TrigonometricOpType_Atan", TrigonometricOpType_Atan},
+        {L"TrigonometricOpType_Cos", TrigonometricOpType_Cos},
+        {L"TrigonometricOpType_Cosh", TrigonometricOpType_Cosh},
+        {L"TrigonometricOpType_Sin", TrigonometricOpType_Sin},
+        {L"TrigonometricOpType_Sinh", TrigonometricOpType_Sinh},
+        {L"TrigonometricOpType_Tan", TrigonometricOpType_Tan},
+        {L"TrigonometricOpType_Tanh", TrigonometricOpType_Tanh},
+};
+
+static_assert(_countof(trigonometricOpTypeStringToEnumMap) ==
+                  TrigonometricOpType_EnumValueCount,
+              "trigonometricOpTypeStringToEnumMap size mismatch. Did you add "
+              "a new enum value?");
+
+TrigonometricOpType getTrigonometricOpType(const std::wstring &OpTypeString);
+
 template <typename DataTypeT>
 std::vector<DataTypeT> getInputValueSetByKey(const std::wstring &Key,
                                              bool LogKey = true) {
@@ -214,6 +252,7 @@ public:
 
   TestConfig(UnaryOpType OpType);
   TestConfig(BinaryOpType OpType);
+  TestConfig(TrigonometricOpType OpType);
 
   bool isBinaryOp() const {
     return BasicOpType == LongVector::BasicOpType_Binary ||
@@ -238,8 +277,14 @@ public:
   DataTypeT computeExpectedValue(const DataTypeT &A, const DataTypeT &B,
                                  BinaryOpType OpType) const;
   DataTypeT computeExpectedValue(const DataTypeT &A, const DataTypeT &B) const;
+  DataTypeT computeExpectedValue(const DataTypeT &A,
+                                 TrigonometricOpType OpType) const;
   DataTypeT computeExpectedValue(const DataTypeT &A, UnaryOpType OpType) const;
   DataTypeT computeExpectedValue(const DataTypeT &A) const;
+
+  void setInputArgsArrayName(const std::wstring &InputArgsArrayName) {
+    this->InputArgsArrayName = InputArgsArrayName;
+  }
 
   void setInputValueSet1(const std::wstring &InputValueSetName) {
     this->InputValueSetName1 = InputValueSetName;
@@ -256,6 +301,8 @@ public:
   std::vector<DataTypeT> getInputValueSet2() const {
     return getInputValueSet(2);
   }
+
+  std::vector<DataTypeT> getInputArgsArray() const;
 
   float getTolerance() const { return Tolerance; }
   LongVector::ValidationType getValidationType() const {
@@ -278,6 +325,8 @@ private:
   LongVector::TestConfigTraits<LongVectorOpTypeT> OpTypeTraits;
   std::wstring InputValueSetName1 = L"DefaultInputValueSet1";
   std::wstring InputValueSetName2 = L"DefaultInputValueSet2";
+  // No default args array
+  std::wstring InputArgsArrayName = L"";
 }; // class LongVector::TestConfig
 
 }; // namespace LongVector


### PR DESCRIPTION
Resolves #7629

Merge the long vector trig op exec tests from staging-sm6.9.
Verified locally against WARP:
`F:\hlsl.bin\TAEF\x64\te.exe "F:\hlsl.bin\Debug\bin\ExecHLSLTests.dll" /name:LongVector::OpTest::trig*    /p:D3D12SDKVersion=1 /p:"ExperimentalShaders=*"`