### PR TITLE
[SPIRV] Create only 1 DebugCompilationUnit per spirv module

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -161,6 +161,10 @@ public:
     return debugInstructions;
   }
 
+  // Access the one DebugCompilationUnit per module
+  SpirvDebugCompilationUnit *getDebugCompilationUnit();
+  void setDebugCompilationUnit(SpirvDebugCompilationUnit *unit);
+
   // Adds the given OpModuleProcessed to the module.
   void addModuleProcessed(SpirvModuleProcessed *);
 
@@ -220,6 +224,10 @@ private:
 
   // Keep all rich DebugInfo instructions.
   llvm::SmallVector<SpirvDebugInstruction *, 32> debugInstructions;
+
+  // There is one debugCompilationUnit per module
+  SpirvDebugCompilationUnit *debugCompilationUnit;
+
   // Whether current module is in pervertex interpolation mode.
   bool perVertexInterp;
 };

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -62,7 +62,7 @@ SpirvDebugTypeComposite *DebugTypeVisitor::createDebugTypeComposite(
     } else {
       auto *dbgSrc = spvBuilder.createDebugSource(file);
       setDefaultDebugInfo(dbgSrc);
-      auto dbgCompUnit = spvBuilder.createDebugCompilationUnit(dbgSrc);
+      auto dbgCompUnit = spvBuilder.getModule()->getDebugCompilationUnit();
       setDefaultDebugInfo(dbgCompUnit);
       debugInfo =
           &debugInfoMap.insert({file, RichDebugInfo(dbgSrc, dbgCompUnit)})

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1214,6 +1214,7 @@ SpirvBuilder::createDebugCompilationUnit(SpirvDebugSource *source) {
   auto *inst = new (context) SpirvDebugCompilationUnit(
       /*version*/ 1, /*DWARF version*/ 4, source);
   mod->addDebugInfo(inst);
+  mod->setDebugCompilationUnit(inst);
   return inst;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1065,9 +1065,10 @@ SpirvEmitter::getOrCreateRichDebugInfoImpl(llvm::StringRef file) {
   // returns {{string key, RichDebugInfo}, true /*Success*/}.
   // debugInfo.insert().first->second is a RichDebugInfo.
   return &debugInfo
-              .insert({file, RichDebugInfo(
-                                 dbgSrc, spvBuilder.createDebugCompilationUnit(
-                                             dbgSrc))})
+              .insert({file,
+                       RichDebugInfo(
+                           dbgSrc,
+                           spvBuilder.getModule()->getDebugCompilationUnit())})
               .first->second;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -376,5 +376,16 @@ void SpirvModule::addModuleProcessed(SpirvModuleProcessed *p) {
   moduleProcesses.push_back(p);
 }
 
+SpirvDebugCompilationUnit *SpirvModule::getDebugCompilationUnit() {
+  SpirvDebugCompilationUnit *unit = debugCompilationUnit;
+  assert(unit && "null DebugCompilationUnit");
+  return unit;
+}
+
+void SpirvModule::setDebugCompilationUnit(SpirvDebugCompilationUnit *unit) {
+  assert(unit);
+  debugCompilationUnit = unit;
+}
+
 } // end namespace spirv
 } // end namespace clang

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
@@ -6,15 +6,16 @@
 // CHECK: spirv.debug.opline.include-file-1.hlsli
 // CHECK: spirv.debug.opline.include-file-2.hlsli
 // CHECK: spirv.debug.opline.include-file-3.hlsli
+// CHECK: [[main_code:%[0-9]+]] = OpString "// RUN: %dxc -T ps_6_0 -E main -fspv-debug=rich-with-source -fcgl  %s -spirv | FileCheck %s
 // CHECK: [[file3_code:%[0-9]+]] = OpString "int b;
 // CHECK: [[file2_code:%[0-9]+]] = OpString "static int a;
 // CHECK: [[file1_code:%[0-9]+]] = OpString "int function1() {
-// CHECK: [[main_code:%[0-9]+]] = OpString "// RUN: %dxc -T ps_6_0 -E main -fspv-debug=rich-with-source -fcgl  %s -spirv | FileCheck %s
 
+
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[debugSet]] DebugSource {{%[0-9]+}} [[main_code]]
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[debugSet]] DebugSource {{%[0-9]+}} [[file3_code]]
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[debugSet]] DebugSource {{%[0-9]+}} [[file2_code]]
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[debugSet]] DebugSource {{%[0-9]+}} [[file1_code]]
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[debugSet]] DebugSource {{%[0-9]+}} [[main_code]]
 
 #include "spirv.debug.opline.include-file-1.hlsli"
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.parent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.parent.hlsl
@@ -29,19 +29,18 @@ int callFunction3() {
   CALL_FUNCTION_3;
 }
 
+
+// CHECK: [[main:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
+// CHECK: [[c3:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[main]] HLSL
+// CHECK-NOT: DebugCompilationUnit
 // CHECK: [[s3:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
-// CHECK: [[c3:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[s3]] HLSL
 // CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugFunction [[f3]] {{%[0-9]+}} [[s3]] 3 1 [[c3]]
 
 // CHECK: [[s2:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
-// CHECK: [[c2:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[s2]] HLSL
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugFunction [[f2]] {{%[0-9]+}} [[s2]] 2 1 [[c2]]
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugFunction [[f2]] {{%[0-9]+}} [[s2]] 2 1 [[c3]]
 
 // CHECK: [[s1:%[0-9]+]] = OpExtInst %void [[set]] DebugSource
-// CHECK: [[c1:%[0-9]+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[s1]] HLSL
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugFunction [[f1]] {{%[0-9]+}} [[s1]] 1 1 [[c1]]
-
-// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugSource
+// CHECK: {{%[0-9]+}} = OpExtInst %void [[set]] DebugFunction [[f1]] {{%[0-9]+}} [[s1]] 1 1 [[c3]]
 
 void main() {
   callFunction1();

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.include.hlsl
@@ -12,10 +12,10 @@
 // CHECK:           OpString
 // CHECK:           [[file1:%[0-9]+]] = OpString
 // CHECK-SAME:      spirv.debug.opline.include-file-1.hlsli
+// CHECK:      [[src0:%[0-9]+]] = OpExtInst %void %1 DebugSource [[main]]
 // CHECK:      [[src3:%[0-9]+]] = OpExtInst %void %1 DebugSource [[file3]]
 // CHECK:      [[src2:%[0-9]+]] = OpExtInst %void %1 DebugSource [[file2]]
 // CHECK:      [[src1:%[0-9]+]] = OpExtInst %void %1 DebugSource [[file1]]
-// CHECK:      [[src0:%[0-9]+]] = OpExtInst %void %1 DebugSource [[main]]
 
 // DebugLine cannot preceed OpFunction
 // CHECK:      %src_main = OpFunction %void None

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -58,9 +58,9 @@ float4 main(VertexOutput v) : SV_Position
 }
 )";
   std::string spirv = compileCodeAndGetSpirvAsm(code);
-  EXPECT_THAT(spirv, ContainsRegex("%50 = OpString \"// RUN: %dxc -T vs_6_0 -E "
+  EXPECT_THAT(spirv, ContainsRegex("%23 = OpString \"// RUN: %dxc -T vs_6_0 -E "
                                    "main -fspv-debug=vulkan-with-source"));
-  EXPECT_THAT(spirv, ContainsRegex("DebugSource %23\n"));
-  EXPECT_THAT(spirv, ContainsRegex("DebugSource %5 %50\n"));
+  EXPECT_THAT(spirv, ContainsRegex("DebugSource %5 %23\n"));
+  EXPECT_THAT(spirv, ContainsRegex("DebugSource %28\n"));
 }
 } // namespace


### PR DESCRIPTION
Currently, dxc emits multiple DebugCompilationUnits for one spirv module.  This is incorrect, as acknowledged in [this comment:](https://github.com/microsoft/DirectXShaderCompiler/issues/7569#issuecomment-3019493146).  This PR corrects the problem.