### PR TITLE
[SPIRV] Fix declaration order of values in decorations

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -678,9 +678,20 @@ public:
                bool isPrecise, bool isNointerp, llvm::StringRef name = "",
                llvm::Optional<SpirvInstruction *> init = llvm::None,
                SourceLocation loc = {});
+
+  // Adds a variable to the module.
   SpirvVariable *
   addModuleVar(const SpirvType *valueType, spv::StorageClass storageClass,
                bool isPrecise, bool isNointerp, llvm::StringRef name = "",
+               llvm::Optional<SpirvInstruction *> init = llvm::None,
+               SourceLocation loc = {});
+
+  // Adds a variable to the module. It will be placed in the variable list
+  // before `pos`.
+  SpirvVariable *
+  addModuleVar(const SpirvType *valueType, spv::StorageClass storageClass,
+               bool isPrecise, bool isNointerp, SpirvInstruction *before,
+               llvm::StringRef name = "",
                llvm::Optional<SpirvInstruction *> init = llvm::None,
                SourceLocation loc = {});
 

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -139,6 +139,10 @@ public:
   // Adds a variable to the module.
   void addVariable(SpirvVariable *);
 
+  // Adds a variable to the module immediately before `pos`.
+  // If `pos` is not found, `var` is added at the end of the variable list.
+  void addVariable(SpirvVariable *var, SpirvInstruction *pos);
+
   // Adds a decoration to the module.
   void addDecoration(SpirvDecoration *);
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1861,7 +1861,7 @@ void DeclResultIdMapper::createCounterVar(
   }
 
   SpirvVariable *counterInstr = spvBuilder.addModuleVar(
-      counterType, sc, /*isPrecise*/ false, false, counterName);
+      counterType, sc, /*isPrecise*/ false, false, declInstr, counterName);
 
   if (!isAlias) {
     // Non-alias counter variables should be put in to resourceVars so that

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -2644,80 +2644,15 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
   // NodePayloadArray types
   else if (const auto *npaType = dyn_cast<NodePayloadArrayType>(type)) {
     const uint32_t elemTypeId = emitType(npaType->getElementType());
+
+    // Output the decorations for the type first. This will create other values
+    // that are on the decorations, and they must appear before the type.
+    emitDecorationsForNodePayloadArrayTypes(npaType, id);
+
     initTypeInstruction(spv::Op::OpTypeNodePayloadArrayAMDX);
     curTypeInst.push_back(id);
     curTypeInst.push_back(elemTypeId);
     finalizeTypeInstruction();
-
-    // Emit decorations
-    const ParmVarDecl *nodeDecl = npaType->getNodeDecl();
-    if (hlsl::IsHLSLNodeOutputType(nodeDecl->getType())) {
-      StringRef name = nodeDecl->getName();
-      unsigned index = 0;
-      if (auto nodeID = nodeDecl->getAttr<HLSLNodeIdAttr>()) {
-        name = nodeID->getName();
-        index = nodeID->getArrayIndex();
-      }
-
-      auto *str = new (context) SpirvConstantString(name);
-      uint32_t nodeName = getOrCreateConstantString(str);
-      emitDecoration(id, spv::Decoration::PayloadNodeNameAMDX, {nodeName},
-                     llvm::None, true);
-      if (index) {
-        uint32_t baseIndex = getOrCreateConstantInt(
-            llvm::APInt(32, index), context.getUIntType(32), false);
-        emitDecoration(id, spv::Decoration::PayloadNodeBaseIndexAMDX,
-                       {baseIndex}, llvm::None, true);
-      }
-    }
-
-    uint32_t maxRecords;
-    if (const auto *attr = nodeDecl->getAttr<HLSLMaxRecordsAttr>()) {
-      maxRecords = getOrCreateConstantInt(llvm::APInt(32, attr->getMaxCount()),
-                                          context.getUIntType(32), false);
-    } else {
-      maxRecords = getOrCreateConstantInt(llvm::APInt(32, 1),
-                                          context.getUIntType(32), false);
-    }
-    emitDecoration(id, spv::Decoration::NodeMaxPayloadsAMDX, {maxRecords},
-                   llvm::None, true);
-
-    if (const auto *attr = nodeDecl->getAttr<HLSLMaxRecordsSharedWithAttr>()) {
-      const DeclContext *dc = nodeDecl->getParentFunctionOrMethod();
-      if (const auto *funDecl = dyn_cast_or_null<FunctionDecl>(dc)) {
-        IdentifierInfo *ii = attr->getName();
-        bool alreadyExists = false;
-        for (auto *paramDecl : funDecl->params()) {
-          if (paramDecl->getIdentifier() == ii) {
-            assert(paramDecl != nodeDecl);
-            auto otherType = context.getNodeDeclPayloadType(paramDecl);
-            const uint32_t otherId =
-                getResultIdForType(otherType, &alreadyExists);
-            assert(alreadyExists && "forward references not allowed in "
-                                    "MaxRecordsSharedWith attribute");
-            emitDecoration(id, spv::Decoration::NodeSharesPayloadLimitsWithAMDX,
-                           {otherId}, llvm::None, true);
-            break;
-          }
-        }
-        assert(alreadyExists &&
-               "invalid reference in MaxRecordsSharedWith attribute");
-      }
-    }
-    if (const auto *attr = nodeDecl->getAttr<HLSLAllowSparseNodesAttr>()) {
-      emitDecoration(id, spv::Decoration::PayloadNodeSparseArrayAMDX, {},
-                     llvm::None);
-    }
-    if (const auto *attr = nodeDecl->getAttr<HLSLUnboundedSparseNodesAttr>()) {
-      emitDecoration(id, spv::Decoration::PayloadNodeSparseArrayAMDX, {},
-                     llvm::None);
-    }
-    if (const auto *attr = nodeDecl->getAttr<HLSLNodeArraySizeAttr>()) {
-      uint32_t arraySize = getOrCreateConstantInt(
-          llvm::APInt(32, attr->getCount()), context.getUIntType(32), false);
-      emitDecoration(id, spv::Decoration::PayloadNodeArraySizeAMDX, {arraySize},
-                     llvm::None, true);
-    }
   }
   // Structure types
   else if (const auto *structType = dyn_cast<StructType>(type)) {
@@ -2996,6 +2931,79 @@ void EmitTypeHandler::emitNameForType(llvm::StringRef name,
   nameInstr[0] |= static_cast<uint32_t>(nameInstr.size()) << 16;
   debugVariableBinary->insert(debugVariableBinary->end(), nameInstr.begin(),
                               nameInstr.end());
+}
+
+void EmitTypeHandler::emitDecorationsForNodePayloadArrayTypes(
+    const NodePayloadArrayType *npaType, uint32_t id) {
+  // Emit decorations
+  const ParmVarDecl *nodeDecl = npaType->getNodeDecl();
+  if (hlsl::IsHLSLNodeOutputType(nodeDecl->getType())) {
+    StringRef name = nodeDecl->getName();
+    unsigned index = 0;
+    if (auto nodeID = nodeDecl->getAttr<HLSLNodeIdAttr>()) {
+      name = nodeID->getName();
+      index = nodeID->getArrayIndex();
+    }
+
+    auto *str = new (context) SpirvConstantString(name);
+    uint32_t nodeName = getOrCreateConstantString(str);
+    emitDecoration(id, spv::Decoration::PayloadNodeNameAMDX, {nodeName},
+                   llvm::None, true);
+    if (index) {
+      uint32_t baseIndex = getOrCreateConstantInt(
+          llvm::APInt(32, index), context.getUIntType(32), false);
+      emitDecoration(id, spv::Decoration::PayloadNodeBaseIndexAMDX, {baseIndex},
+                     llvm::None, true);
+    }
+  }
+
+  uint32_t maxRecords;
+  if (const auto *attr = nodeDecl->getAttr<HLSLMaxRecordsAttr>()) {
+    maxRecords = getOrCreateConstantInt(llvm::APInt(32, attr->getMaxCount()),
+                                        context.getUIntType(32), false);
+  } else {
+    maxRecords = getOrCreateConstantInt(llvm::APInt(32, 1),
+                                        context.getUIntType(32), false);
+  }
+  emitDecoration(id, spv::Decoration::NodeMaxPayloadsAMDX, {maxRecords},
+                 llvm::None, true);
+
+  if (const auto *attr = nodeDecl->getAttr<HLSLMaxRecordsSharedWithAttr>()) {
+    const DeclContext *dc = nodeDecl->getParentFunctionOrMethod();
+    if (const auto *funDecl = dyn_cast_or_null<FunctionDecl>(dc)) {
+      IdentifierInfo *ii = attr->getName();
+      bool alreadyExists = false;
+      for (auto *paramDecl : funDecl->params()) {
+        if (paramDecl->getIdentifier() == ii) {
+          assert(paramDecl != nodeDecl);
+          auto otherType = context.getNodeDeclPayloadType(paramDecl);
+          const uint32_t otherId =
+              getResultIdForType(otherType, &alreadyExists);
+          assert(alreadyExists && "forward references not allowed in "
+                                  "MaxRecordsSharedWith attribute");
+          emitDecoration(id, spv::Decoration::NodeSharesPayloadLimitsWithAMDX,
+                         {otherId}, llvm::None, true);
+          break;
+        }
+      }
+      assert(alreadyExists &&
+             "invalid reference in MaxRecordsSharedWith attribute");
+    }
+  }
+  if (const auto *attr = nodeDecl->getAttr<HLSLAllowSparseNodesAttr>()) {
+    emitDecoration(id, spv::Decoration::PayloadNodeSparseArrayAMDX, {},
+                   llvm::None);
+  }
+  if (const auto *attr = nodeDecl->getAttr<HLSLUnboundedSparseNodesAttr>()) {
+    emitDecoration(id, spv::Decoration::PayloadNodeSparseArrayAMDX, {},
+                   llvm::None);
+  }
+  if (const auto *attr = nodeDecl->getAttr<HLSLNodeArraySizeAttr>()) {
+    uint32_t arraySize = getOrCreateConstantInt(
+        llvm::APInt(32, attr->getCount()), context.getUIntType(32), false);
+    emitDecoration(id, spv::Decoration::PayloadNodeArraySizeAMDX, {arraySize},
+                   llvm::None, true);
+  }
 }
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -135,6 +135,10 @@ private:
   void emitNameForType(llvm::StringRef name, uint32_t targetTypeId,
                        llvm::Optional<uint32_t> memberIndex = llvm::None);
 
+  void
+  emitDecorationsForNodePayloadArrayTypes(const NodePayloadArrayType *npaType,
+                                          uint32_t id);
+
   // There is no guarantee that an instruction or a function or a basic block
   // has been assigned result-id. This method returns the result-id for the
   // given object. If a result-id has not been assigned yet, it'll assign

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1675,6 +1675,21 @@ SpirvVariable *SpirvBuilder::addModuleVar(
   return var;
 }
 
+SpirvVariable *SpirvBuilder::addModuleVar(
+    const SpirvType *type, spv::StorageClass storageClass, bool isPrecise,
+    bool isNointerp, SpirvInstruction *pos, llvm::StringRef name,
+    llvm::Optional<SpirvInstruction *> init, SourceLocation loc) {
+  assert(storageClass != spv::StorageClass::Function);
+  // Note: We store the underlying type in the variable, *not* the pointer type.
+  auto *var = new (context)
+      SpirvVariable(type, loc, storageClass, isPrecise, isNointerp,
+                    init.hasValue() ? init.getValue() : nullptr);
+  var->setResultType(type);
+  var->setDebugName(name);
+  mod->addVariable(var, pos);
+  return var;
+}
+
 void SpirvBuilder::decorateLocation(SpirvInstruction *target,
                                     uint32_t location) {
   auto *decor =

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -341,6 +341,12 @@ void SpirvModule::addVariable(SpirvVariable *var) {
   variables.push_back(var);
 }
 
+void SpirvModule::addVariable(SpirvVariable *var, SpirvInstruction *pos) {
+  assert(var && "cannot add null variable to the module");
+  auto location = std::find(variables.begin(), variables.end(), pos);
+  variables.insert(location, var);
+}
+
 void SpirvModule::addDecoration(SpirvDecoration *decor) {
   assert(decor && "cannot add null decoration to the module");
   decorations.insert(decor);

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.counter.nested-struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.counter.nested-struct.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: %counter_var_t_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
 // CHECK: %counter_var_rw = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+// CHECK: %counter_var_t_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
 // CHECK: %counter_var_s_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
   
 RWStructuredBuffer<uint> rw : register(u0); 

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.hlsl
@@ -26,6 +26,7 @@ RWStructuredBuffer<S1>      selectRWSBuffer(RWStructuredBuffer<S1>    paramRWSBu
 AppendStructuredBuffer<S2>  selectASBuffer(AppendStructuredBuffer<S2>  paramASBuffer,  bool selector);
 ConsumeStructuredBuffer<S3> selectCSBuffer(ConsumeStructuredBuffer<S3> paramCSBuffer,  bool selector);
 
+// CHECK: %counter_var_globalRWSBuffer = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<S1>      globalRWSBuffer;
 // CHECK: %counter_var_globalASBuffer = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 AppendStructuredBuffer<S2>  globalASBuffer;
@@ -38,7 +39,6 @@ static RWStructuredBuffer<S1>      staticgRWSBuffer = globalRWSBuffer;
 // CHECK: %counter_var_staticgASBuffer = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
 static AppendStructuredBuffer<S2>  staticgASBuffer  = globalASBuffer;
 // CHECK: %counter_var_staticgCSBuffer = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
-// CHECK: %counter_var_globalRWSBuffer = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 static ConsumeStructuredBuffer<S3> staticgCSBuffer  = globalCSBuffer;
 
 // Counter variables for function returns, function parameters, and local variables have an extra level of pointer.

--- a/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.array.hlsl
@@ -10,8 +10,8 @@ struct T {
 // CHECK: OpDecorate %counter_var_myAppendStructuredBuffer DescriptorSet 0
 // CHECK: OpDecorate %counter_var_myAppendStructuredBuffer Binding 1
 
-// CHECK: %myAppendStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_AppendStructuredBuffer_T_uint_5 Uniform
 // CHECK: %counter_var_myAppendStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %myAppendStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_AppendStructuredBuffer_T_uint_5 Uniform
 AppendStructuredBuffer<T> myAppendStructuredBuffer[5];
 
 void main() {}

--- a/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.hlsl
@@ -2,31 +2,31 @@
 
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
-// CHECK: OpName %type_AppendStructuredBuffer_v4float "type.AppendStructuredBuffer.v4float"
-// CHECK: OpName %buffer1 "buffer1"
+// CHECK-DAG: OpName %type_AppendStructuredBuffer_v4float "type.AppendStructuredBuffer.v4float"
+// CHECK-DAG: OpName %buffer1 "buffer1"
 
-// CHECK: OpName %type_ACSBuffer_counter "type.ACSBuffer.counter"
-// CHECK: OpName %counter_var_buffer1 "counter.var.buffer1"
+// CHECK-DAG: OpName %type_ACSBuffer_counter "type.ACSBuffer.counter"
+// CHECK-DAG: OpName %counter_var_buffer1 "counter.var.buffer1"
 
-// CHECK: OpName %type_AppendStructuredBuffer_S "type.AppendStructuredBuffer.S"
-// CHECK: OpName %buffer2 "buffer2"
+// CHECK-DAG: OpName %type_AppendStructuredBuffer_S "type.AppendStructuredBuffer.S"
+// CHECK-DAG: OpName %buffer2 "buffer2"
 
-// CHECK: OpName %counter_var_buffer2 "counter.var.buffer2"
+// CHECK-DAG: OpName %counter_var_buffer2 "counter.var.buffer2"
 
-// CHECK: OpDecorateId %buffer1 CounterBuffer %counter_var_buffer1
-// CHECK: OpDecorateId %buffer2 CounterBuffer %counter_var_buffer2
-
-// CHECK: %type_AppendStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
-// CHECK: %_ptr_Uniform_type_AppendStructuredBuffer_v4float = OpTypePointer Uniform %type_AppendStructuredBuffer_v4float
+// CHECK-DAG: OpDecorateId %buffer1 CounterBuffer %counter_var_buffer1
+// CHECK-DAG: OpDecorateId %buffer2 CounterBuffer %counter_var_buffer2
 
 // CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
 // CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
 
+// CHECK: %type_AppendStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
+// CHECK: %_ptr_Uniform_type_AppendStructuredBuffer_v4float = OpTypePointer Uniform %type_AppendStructuredBuffer_v4float
+
 // CHECK: %type_AppendStructuredBuffer_S = OpTypeStruct %_runtimearr_S
 // CHECK: %_ptr_Uniform_type_AppendStructuredBuffer_S = OpTypePointer Uniform %type_AppendStructuredBuffer_S
 
-// CHECK: %buffer1 = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_v4float Uniform
 // CHECK: %counter_var_buffer1 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+// CHECK: %buffer1 = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_v4float Uniform
 AppendStructuredBuffer<float4> buffer1;
 
 struct S {
@@ -35,8 +35,8 @@ struct S {
     float2x3 c;
 };
 
-// CHECK: %buffer2 = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_S Uniform
 // CHECK: %counter_var_buffer2 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+// CHECK: %buffer2 = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_S Uniform
 AppendStructuredBuffer<S> buffer2;
 
 float main() : A {

--- a/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.array.hlsl
@@ -10,8 +10,8 @@ struct T {
 // CHECK: OpDecorate %counter_var_myConsumeStructuredBuffer DescriptorSet 0
 // CHECK: OpDecorate %counter_var_myConsumeStructuredBuffer Binding 1
 
-// CHECK: %myConsumeStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ConsumeStructuredBuffer_T_uint_2 Uniform
 // CHECK: %counter_var_myConsumeStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_2 Uniform
+// CHECK: %myConsumeStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ConsumeStructuredBuffer_T_uint_2 Uniform
 ConsumeStructuredBuffer<T> myConsumeStructuredBuffer[2];
 
 void main() {}

--- a/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.hlsl
@@ -2,31 +2,31 @@
 
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
-// CHECK: OpName %type_ConsumeStructuredBuffer_v4float "type.ConsumeStructuredBuffer.v4float"
-// CHECK: OpName %buffer1 "buffer1"
+// CHECK-DAG: OpName %type_ConsumeStructuredBuffer_v4float "type.ConsumeStructuredBuffer.v4float"
+// CHECK-DAG: OpName %buffer1 "buffer1"
 
-// CHECK: OpName %type_ACSBuffer_counter "type.ACSBuffer.counter"
-// CHECK: OpName %counter_var_buffer1 "counter.var.buffer1"
+// CHECK-DAG: OpName %type_ACSBuffer_counter "type.ACSBuffer.counter"
+// CHECK-DAG: OpName %counter_var_buffer1 "counter.var.buffer1"
 
-// CHECK: OpName %type_ConsumeStructuredBuffer_S "type.ConsumeStructuredBuffer.S"
-// CHECK: OpName %buffer2 "buffer2"
+// CHECK-DAG: OpName %type_ConsumeStructuredBuffer_S "type.ConsumeStructuredBuffer.S"
+// CHECK-DAG: OpName %buffer2 "buffer2"
 
-// CHECK: OpName %counter_var_buffer2 "counter.var.buffer2"
+// CHECK-DAG: OpName %counter_var_buffer2 "counter.var.buffer2"
 
 // CHECK: OpDecorateId %buffer1 CounterBuffer %counter_var_buffer1
 // CHECK: OpDecorateId %buffer2 CounterBuffer %counter_var_buffer2
 
-// CHECK: %type_ConsumeStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
-// CHECK: %_ptr_Uniform_type_ConsumeStructuredBuffer_v4float = OpTypePointer Uniform %type_ConsumeStructuredBuffer_v4float
-
 // CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
 // CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
+
+// CHECK: %type_ConsumeStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
+// CHECK: %_ptr_Uniform_type_ConsumeStructuredBuffer_v4float = OpTypePointer Uniform %type_ConsumeStructuredBuffer_v4float
 
 // CHECK: %type_ConsumeStructuredBuffer_S = OpTypeStruct %_runtimearr_S
 // CHECK: %_ptr_Uniform_type_ConsumeStructuredBuffer_S = OpTypePointer Uniform %type_ConsumeStructuredBuffer_S
 
-// CHECK: %buffer1 = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_v4float Uniform
 // CHECK: %counter_var_buffer1 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+// CHECK: %buffer1 = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_v4float Uniform
 ConsumeStructuredBuffer<float4> buffer1;
 
 struct S {
@@ -35,8 +35,8 @@ struct S {
     float2x3 c;
 };
 
-// CHECK: %buffer2 = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_S Uniform
 // CHECK: %counter_var_buffer2 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+// CHECK: %buffer2 = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_S Uniform
 ConsumeStructuredBuffer<S> buffer2;
 
 float main() : A {

--- a/tools/clang/test/CodeGenSPIRV/type.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.enum.hlsl
@@ -12,8 +12,8 @@ enum Number {
 };
 
 //CHECK:      %a = OpVariable %_ptr_Private_int Private
-//CHECK-NEXT: %b = OpVariable %_ptr_Workgroup_int Workgroup
-//CHECK-NEXT: %c = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_ Uniform
+//CHECK: %b = OpVariable %_ptr_Workgroup_int Workgroup
+//CHECK: %c = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_ Uniform
 
 //CHECK:      [[second:%[0-9]+]] = OpLoad %int %Second
 //CHECK-NEXT:                   OpStore %a [[second]]

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.binding.attributes.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.binding.attributes.hlsl
@@ -10,8 +10,8 @@ struct PSInput
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 4
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 4
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 [[vk::binding(3,4), vk::counter_binding(4)]] RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.const.index.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.const.index.hlsl
@@ -10,8 +10,8 @@ struct PSInput
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.flatten.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.flatten.hlsl
@@ -14,8 +14,8 @@ struct PSInput
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 5
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.hlsl
@@ -14,8 +14,8 @@ struct PSInput
 // CHECK:   OpDecorate %type_ACSBuffer_counter BufferBlock
 // CHECK-NOT: OpDecorate %_runtimearr_type_ACSBuffer_counter ArrayStride
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.indirect.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.indirect.hlsl
@@ -10,8 +10,8 @@ struct PSInput
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 void func(RWStructuredBuffer<uint> local) {

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.indirect2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.indirect2.hlsl
@@ -10,8 +10,8 @@ struct PSInput
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
 RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.unbounded.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.unbounded.counter.hlsl
@@ -14,8 +14,8 @@ struct PSInput
 // CHECK:   OpDecorate %type_ACSBuffer_counter BufferBlock
 // CHECK-NOT: OpDecorate %_runtimearr_type_ACSBuffer_counter ArrayStride
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_RWStructuredBuffer_uint Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_ACSBuffer_counter Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_RWStructuredBuffer_uint Uniform
 RWStructuredBuffer<uint> g_rwbuffer[] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.unbounded.array.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.unbounded.array.counter.hlsl
@@ -10,8 +10,8 @@ struct PSInput
 // CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
 
-// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_RWStructuredBuffer_uint Uniform
 // CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_ACSBuffer_counter Uniform
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_RWStructuredBuffer_uint Uniform
 RWStructuredBuffer<uint> g_rwbuffer[] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/vk.1p2.block-decoration.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.1p2.block-decoration.hlsl
@@ -14,8 +14,8 @@
 // CHECK: %_ptr_StorageBuffer_type_RWByteAddressBuffer = OpTypePointer StorageBuffer %type_RWByteAddressBuffer
 // CHECK: %_ptr_StorageBuffer_type_TextureBuffer_S = OpTypePointer StorageBuffer %type_TextureBuffer_S
 // CHECK: %_ptr_StorageBuffer_type_StructuredBuffer_v3uint = OpTypePointer StorageBuffer %type_StructuredBuffer_v3uint
-// CHECK: %rwsb = OpVariable %_ptr_StorageBuffer_type_RWStructuredBuffer_S StorageBuffer
 // CHECK: %counter_var_rwsb = OpVariable %_ptr_StorageBuffer_type_ACSBuffer_counter StorageBuffer
+// CHECK: %rwsb = OpVariable %_ptr_StorageBuffer_type_RWStructuredBuffer_S StorageBuffer
 struct S {
   float4 f[5];
 };

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.asbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.asbuffer.std430.hlsl
@@ -1,38 +1,38 @@
 // RUN: %dxc -T vs_6_0 -E main -fvk-use-gl-layout -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: OpDecorate %_arr_float_uint_2 ArrayStride 4
-// CHECK: OpDecorate %_arr_v3float_uint_2 ArrayStride 16
-// CHECK: OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 32
-// CHECK: OpDecorate %_arr_mat2v3float_uint_2_0 ArrayStride 24
-// CHECK: OpDecorate %_arr_v3int_uint_2 ArrayStride 16
-// CHECK: OpDecorate %_arr__arr_v3int_uint_2_uint_2 ArrayStride 32
+// CHECK-DAG: OpDecorate %_arr_float_uint_2 ArrayStride 4
+// CHECK-DAG: OpDecorate %_arr_v3float_uint_2 ArrayStride 16
+// CHECK-DAG: OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 32
+// CHECK-DAG: OpDecorate %_arr_mat2v3float_uint_2_0 ArrayStride 24
+// CHECK-DAG: OpDecorate %_arr_v3int_uint_2 ArrayStride 16
+// CHECK-DAG: OpDecorate %_arr__arr_v3int_uint_2_uint_2 ArrayStride 32
 
-// CHECK: OpMemberDecorate %S 0 Offset 0
-// CHECK: OpMemberDecorate %S 1 Offset 16
-// CHECK: OpMemberDecorate %S 2 Offset 48
-// CHECK: OpMemberDecorate %S 2 MatrixStride 16
-// CHECK: OpMemberDecorate %S 2 ColMajor
-// CHECK: OpMemberDecorate %S 3 Offset 112
-// CHECK: OpMemberDecorate %S 3 MatrixStride 8
-// CHECK: OpMemberDecorate %S 3 RowMajor
-// CHECK: OpMemberDecorate %S 4 Offset 160
-// CHECK: OpMemberDecorate %S 4 MatrixStride 8
-// CHECK: OpMemberDecorate %S 4 RowMajor
-// CHECK: OpMemberDecorate %S 5 Offset 208
-// CHECK: OpMemberDecorate %S 6 Offset 272
+// CHECK-DAG: OpMemberDecorate %S 0 Offset 0
+// CHECK-DAG: OpMemberDecorate %S 1 Offset 16
+// CHECK-DAG: OpMemberDecorate %S 2 Offset 48
+// CHECK-DAG: OpMemberDecorate %S 2 MatrixStride 16
+// CHECK-DAG: OpMemberDecorate %S 2 ColMajor
+// CHECK-DAG: OpMemberDecorate %S 3 Offset 112
+// CHECK-DAG: OpMemberDecorate %S 3 MatrixStride 8
+// CHECK-DAG: OpMemberDecorate %S 3 RowMajor
+// CHECK-DAG: OpMemberDecorate %S 4 Offset 160
+// CHECK-DAG: OpMemberDecorate %S 4 MatrixStride 8
+// CHECK-DAG: OpMemberDecorate %S 4 RowMajor
+// CHECK-DAG: OpMemberDecorate %S 5 Offset 208
+// CHECK-DAG: OpMemberDecorate %S 6 Offset 272
 
-// CHECK: OpDecorate %_arr_S_uint_2 ArrayStride 288
+// CHECK-DAG: OpDecorate %_arr_S_uint_2 ArrayStride 288
 
-// CHECK: OpMemberDecorate %T 0 Offset 0
-// CHECK: OpMemberDecorate %T 1 Offset 576
+// CHECK-DAG: OpMemberDecorate %T 0 Offset 0
+// CHECK-DAG: OpMemberDecorate %T 1 Offset 576
 
-// CHECK: OpDecorate %_runtimearr_T ArrayStride 592
+// CHECK-DAG: OpDecorate %_runtimearr_T ArrayStride 592
 
-// CHECK: OpMemberDecorate %type_AppendStructuredBuffer_T 0 Offset 0
-// CHECK: OpDecorate %type_AppendStructuredBuffer_T BufferBlock
+// CHECK-DAG: OpMemberDecorate %type_AppendStructuredBuffer_T 0 Offset 0
+// CHECK-DAG: OpDecorate %type_AppendStructuredBuffer_T BufferBlock
 
-// CHECK: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
-// CHECK: OpDecorate %type_ACSBuffer_counter BufferBlock
+// CHECK-DAG: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
+// CHECK-DAG: OpDecorate %type_ACSBuffer_counter BufferBlock
 struct S {
                  float    a[2];
                  float3   b[2];

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.csbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.csbuffer.std430.hlsl
@@ -1,38 +1,38 @@
 // RUN: %dxc -T vs_6_0 -E main -fvk-use-gl-layout -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: OpDecorate %_arr_float_uint_2 ArrayStride 4
-// CHECK: OpDecorate %_arr_v3float_uint_2 ArrayStride 16
-// CHECK: OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 32
-// CHECK: OpDecorate %_arr_mat2v3float_uint_2_0 ArrayStride 24
-// CHECK: OpDecorate %_arr_v3int_uint_2 ArrayStride 16
-// CHECK: OpDecorate %_arr__arr_v3int_uint_2_uint_2 ArrayStride 32
+// CHECK-DAG: OpDecorate %_arr_float_uint_2 ArrayStride 4
+// CHECK-DAG: OpDecorate %_arr_v3float_uint_2 ArrayStride 16
+// CHECK-DAG: OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 32
+// CHECK-DAG: OpDecorate %_arr_mat2v3float_uint_2_0 ArrayStride 24
+// CHECK-DAG: OpDecorate %_arr_v3int_uint_2 ArrayStride 16
+// CHECK-DAG: OpDecorate %_arr__arr_v3int_uint_2_uint_2 ArrayStride 32
 
-// CHECK: OpMemberDecorate %S 0 Offset 0
-// CHECK: OpMemberDecorate %S 1 Offset 16
-// CHECK: OpMemberDecorate %S 2 Offset 48
-// CHECK: OpMemberDecorate %S 2 MatrixStride 16
-// CHECK: OpMemberDecorate %S 2 ColMajor
-// CHECK: OpMemberDecorate %S 3 Offset 112
-// CHECK: OpMemberDecorate %S 3 MatrixStride 8
-// CHECK: OpMemberDecorate %S 3 RowMajor
-// CHECK: OpMemberDecorate %S 4 Offset 160
-// CHECK: OpMemberDecorate %S 4 MatrixStride 8
-// CHECK: OpMemberDecorate %S 4 RowMajor
-// CHECK: OpMemberDecorate %S 5 Offset 208
-// CHECK: OpMemberDecorate %S 6 Offset 272
+// CHECK-DAG: OpMemberDecorate %S 0 Offset 0
+// CHECK-DAG: OpMemberDecorate %S 1 Offset 16
+// CHECK-DAG: OpMemberDecorate %S 2 Offset 48
+// CHECK-DAG: OpMemberDecorate %S 2 MatrixStride 16
+// CHECK-DAG: OpMemberDecorate %S 2 ColMajor
+// CHECK-DAG: OpMemberDecorate %S 3 Offset 112
+// CHECK-DAG: OpMemberDecorate %S 3 MatrixStride 8
+// CHECK-DAG: OpMemberDecorate %S 3 RowMajor
+// CHECK-DAG: OpMemberDecorate %S 4 Offset 160
+// CHECK-DAG: OpMemberDecorate %S 4 MatrixStride 8
+// CHECK-DAG: OpMemberDecorate %S 4 RowMajor
+// CHECK-DAG: OpMemberDecorate %S 5 Offset 208
+// CHECK-DAG: OpMemberDecorate %S 6 Offset 272
 
-// CHECK: OpDecorate %_arr_S_uint_2 ArrayStride 288
+// CHECK-DAG: OpDecorate %_arr_S_uint_2 ArrayStride 288
 
-// CHECK: OpMemberDecorate %T 0 Offset 0
-// CHECK: OpMemberDecorate %T 1 Offset 576
+// CHECK-DAG: OpMemberDecorate %T 0 Offset 0
+// CHECK-DAG: OpMemberDecorate %T 1 Offset 576
 
-// CHECK: OpDecorate %_runtimearr_T ArrayStride 592
+// CHECK-DAG: OpDecorate %_runtimearr_T ArrayStride 592
 
-// CHECK: OpMemberDecorate %type_ConsumeStructuredBuffer_T 0 Offset 0
-// CHECK: OpDecorate %type_ConsumeStructuredBuffer_T BufferBlock
+// CHECK-DAG: OpMemberDecorate %type_ConsumeStructuredBuffer_T 0 Offset 0
+// CHECK-DAG: OpDecorate %type_ConsumeStructuredBuffer_T BufferBlock
 
-// CHECK: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
-// CHECK: OpDecorate %type_ACSBuffer_counter BufferBlock
+// CHECK-DAG: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
+// CHECK-DAG: OpDecorate %type_ACSBuffer_counter BufferBlock
 struct S {
                  float    a[2];
                  float3   b[2];


### PR DESCRIPTION
The value that decorates another value must be declared before the value
it decorates. See https://github.com/KhronosGroup/SPIRV-Tools/pull/6227.
