### PR TITLE
[SPIRV] Handle partial template class specialization

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1021,6 +1021,17 @@ void SpirvEmitter::doDecl(const Decl *decl) {
       // functions inside namespaces.
       if (!isa<FunctionDecl>(subDecl))
         doDecl(subDecl);
+  } else if (const auto *classTemplateDecl =
+                 dyn_cast<ClassTemplateDecl>(decl)) {
+    doClassTemplateDecl(classTemplateDecl);
+  } else if (const auto *classTemplateDecl =
+                 dyn_cast<ClassTemplatePartialSpecializationDecl>(decl)) {
+    // Do nothing. We cannot generate any code with a partial specialization,
+    // and when there is a specialization of this decl it will be a
+    // specialization of the orginal ClassTemplateDecl that this specializes.
+    // The code for the full specialization will be handlded when processing the
+    // ClassTemplateDecl. Note that this is also a RecordDecl, so we must check
+    // for it before RecordDecl.
   } else if (const auto *funcDecl = dyn_cast<FunctionDecl>(decl)) {
     doFunctionDecl(funcDecl);
   } else if (const auto *bufferDecl = dyn_cast<HLSLBufferDecl>(decl)) {
@@ -1029,9 +1040,6 @@ void SpirvEmitter::doDecl(const Decl *decl) {
     doRecordDecl(recordDecl);
   } else if (const auto *enumDecl = dyn_cast<EnumDecl>(decl)) {
     doEnumDecl(enumDecl);
-  } else if (const auto *classTemplateDecl =
-                 dyn_cast<ClassTemplateDecl>(decl)) {
-    doClassTemplateDecl(classTemplateDecl);
   } else if (isa<TypedefNameDecl>(decl)) {
     declIdMapper.recordsSpirvTypeAlias(decl);
   } else if (isa<FunctionTemplateDecl>(decl)) {

--- a/tools/clang/test/CodeGenSPIRV/template.class.partial.specialization.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/template.class.partial.specialization.hlsl
@@ -1,0 +1,55 @@
+// RUN: %dxc -HV 2021 -T cs_6_7 -E main -fcgl  %s -spirv | FileCheck %s
+
+template<typename MatT>
+struct matrix_traits;
+
+template<typename T, int32_t N, int32_t M>
+struct matrix_traits<matrix<T,N,M> >
+{
+    static const uint32_t RowCount = N;
+    static const uint32_t ColumnCount = M;
+};
+
+template<typename MatT>
+uint32_t elementCount()
+{
+    return matrix_traits<MatT>::RowCount * matrix_traits<MatT>::ColumnCount;
+}
+
+RWBuffer<int> o;
+
+// Initialize the static members at the start of wrapper
+// CHECK: %main = OpFunction %void None 
+// CHECK: OpStore %RowCount %uint_4
+// CHECK: OpStore %ColumnCount %uint_4
+// CHECK: OpStore %RowCount_0 %uint_3
+// CHECK: OpStore %ColumnCount_0 %uint_2
+// CHECK: OpFunctionEnd
+
+
+
+// CHECK: %src_main = OpFunction %void None
+[numthreads(64,1,1)]
+void main()
+{
+// CHECK: OpFunctionCall %uint %elementCount
+    o[0] = elementCount<float32_t4x4>();
+// CHECK: OpFunctionCall %uint %elementCount_0
+    o[1] = elementCount<float32_t3x2>();
+}
+
+// CHECK: %elementCount = OpFunction %uint None
+// CHECK-NEXT: OpLabel
+// CHECK-NEXT: [[rc:%[0-9]+]] = OpLoad %uint %RowCount
+// CHECK-NEXT: [[cc:%[0-9]+]] = OpLoad %uint %ColumnCount
+// CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %uint [[rc]] [[cc]]
+// CHECK-NEXT: OpReturnValue [[mul]]
+// CHECK-NEXT: OpFunctionEnd
+
+// CHECK: %elementCount_0 = OpFunction %uint None
+// CHECK-NEXT: %bb_entry_1 = OpLabel
+// CHECK-NEXT: [[rc:%[0-9]+]] = OpLoad %uint %RowCount_0
+// CHECK-NEXT: [[cc:%[0-9]+]] = OpLoad %uint %ColumnCount_0
+// CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %uint [[rc]] [[cc]]
+// CHECK-NEXT: OpReturnValue [[mul]]
+// CHECK-NEXT: OpFunctionEnd


### PR DESCRIPTION
The SpirvEmitter does not handle
ClassTemplatePartialSpecializationDecl. Since it extends RecordDecl, DXC
attempts to generate code for the partial specialization, but fails
because that is not possible.

We need to avoid trying to generate code for the partial specialization
and wait for a full specialization.

Fixes #7007
