### PR TITLE
[SPIRV] Handle member travrersal with template type

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1601,7 +1601,10 @@ void forEachSpirvField(
   uint32_t lastConvertedIndex = 0;
   size_t astFieldIndex = 0;
   for (const auto &base : cxxDecl->bases()) {
-    const auto &type = base.getType();
+    auto type = base.getType();
+    if (auto *templatedType = dyn_cast<SubstTemplateTypeParmType>(type))
+      type = templatedType->getReplacementType();
+
     const auto &spirvField = spirvType->getFields()[astFieldIndex];
     if (!operation(spirvField.fieldIndex, type, spirvField)) {
       return;
@@ -1620,7 +1623,10 @@ void forEachSpirvField(
       continue;
     }
 
-    const auto &type = field->getType();
+    auto type = field->getType();
+    if (auto *templatedType = dyn_cast<SubstTemplateTypeParmType>(type))
+      type = templatedType->getReplacementType();
+
     if (!operation(currentFieldIndex, type, spirvField)) {
       return;
     }

--- a/tools/clang/test/CodeGenSPIRV/cast.flat.template.memeber.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat.template.memeber.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T cs_6_8 -E main %s -spirv | FileCheck %s
+
+struct T
+{
+    float3 direction;
+};
+
+template<class TT>
+struct S
+{
+    TT L;
+};
+
+RWStructuredBuffer< S<T> > o;
+
+// CHECK: [[f120:%.+]] = OpConstant %float 120
+// CHECK: [[v120:%.+]] = OpConstantComposite %v3float [[f120]] [[f120]] [[f120]]
+// CHECK: [[T:%.+]] = OpConstantComposite %T [[v120]]
+// CHECK: [[S:%.+]] = OpConstantComposite %S [[T]]
+
+[numthreads(32, 32, 1)]
+void main(uint32_t threadID : SV_DispatchThreadID)
+{
+    uint32_t infinity = 0x78;
+    S<T> s = (S<T>)infinity;
+
+// CHECK: OpStore {{%.*}} [[S]]
+    o[0] = s;
+}


### PR DESCRIPTION
The SPIR-V backend does not handle SubstTemplateTypeParmType types when
traversing getting the SPIR-V fields. In these cases, we will always
want the replacement type. So we modify forEachSpirvField to do that in
all cases.

Fixes #7178
