### PR TITLE
Exection Tests: Long Vector UnaryMathOps and some minor cleanup

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
+++ b/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
@@ -779,4 +779,200 @@
         <Parameter Name="InputValueSetName1">SplitDoubleInputValueSet</Parameter>
       </Row>
     </Table>
+      <Table Id="UnaryMathOpTable">
+      <ParameterTypes>
+        <!-- InputValueSetName1 is optional. If no value is provided use the
+        default value set for the data type. This string is meant to be a key
+        value for the the array of std::pairs defined in LongVectorTestData.h
+        for the applicable DataType-->
+        <ParameterType Name="InputValueSetName1">String</ParameterType>
+        <ParameterType Name="DataType">String</ParameterType>
+        <ParameterType Name="OpTypeEnum">String</ParameterType>
+      </ParameterTypes>
+      <!--UnaryMathOpTable int16-->
+      <Row Name="Abs_int16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="Sign_int16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <!--UnaryMathOpTable int32-->
+      <Row Name="Abs_int32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="Sign_int32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <!--UnaryMathOpTable int64-->
+      <Row Name="Abs_int64">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="Sign_int64">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <!--UnaryMathOpTable uint16-->
+      <Row Name="Abs_uint16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="Sign_uint16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <!--UnaryMathOpTable uint32-->
+      <Row Name="Abs_uint32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="Sign_uint32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <!--UnaryMathOpTable uint64-->
+      <Row Name="Abs_uint64">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="Sign_uint64">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <!--UnaryMathOpTable float16-->
+      <Row Name="Abs_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Ceil_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Ceil</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Exp_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Exp</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Floor_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Floor</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Frac_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Frac</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Log_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Log</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Rcp_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Rcp</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Round_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Round</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Rsqrt_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Rsqrt</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Sign_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Sqrt_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sqrt</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Trunc_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Trunc</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Exp2_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Exp2</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Log10_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Log10</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="Log2_float16">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Log2</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <!--UnaryMathOpTable float32-->
+      <Row Name="Abs_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Ceil_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Ceil</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Exp_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Exp</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Floor_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Floor</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Frac_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Frac</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Log_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Log</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Rcp_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Rcp</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Round_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Round</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Rsqrt_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Rsqrt</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Sign_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Sqrt_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sqrt</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Trunc_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Trunc</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Exp2_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Exp2</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Log10_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Log10</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Log2_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Log2</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <!--UnaryMathOpTable float64-->
+      <Row Name="Abs_float64">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Abs</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="Sign_float64">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Sign</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+    </Table>
 </Data>

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+namespace LongVector {
+
 // A helper struct because C++ bools are 1 byte and HLSL bools are 4 bytes.
 // Take int32_t as a constuctor argument and convert it to bool when needed.
 // Comparisons cast to a bool because we only care if the bool representation is
@@ -192,11 +194,11 @@ struct HLSLHalf_t {
   DirectX::PackedVector::HALF Val = 0;
 };
 
-template <typename T> struct LongVectorTestData {
+template <typename T> struct TestData {
   static const std::map<std::wstring, std::vector<T>> Data;
 };
 
-template <> struct LongVectorTestData<HLSLBool_t> {
+template <> struct TestData<HLSLBool_t> {
   inline static const std::map<std::wstring, std::vector<HLSLBool_t>> Data = {
       {L"DefaultInputValueSet1",
        {false, true, false, false, false, false, true, true, true, true}},
@@ -205,49 +207,49 @@ template <> struct LongVectorTestData<HLSLBool_t> {
   };
 };
 
-template <> struct LongVectorTestData<int16_t> {
+template <> struct TestData<int16_t> {
   inline static const std::map<std::wstring, std::vector<int16_t>> Data = {
       {L"DefaultInputValueSet1", {-6, 1, 7, 3, 8, 4, -3, 8, 8, -2}},
       {L"DefaultInputValueSet2", {5, -6, -3, -2, 9, 3, 1, -3, -7, 2}},
   };
 };
 
-template <> struct LongVectorTestData<int32_t> {
+template <> struct TestData<int32_t> {
   inline static const std::map<std::wstring, std::vector<int32_t>> Data = {
       {L"DefaultInputValueSet1", {-6, 1, 7, 3, 8, 4, -3, 8, 8, -2}},
       {L"DefaultInputValueSet2", {5, -6, -3, -2, 9, 3, 1, -3, -7, 2}},
   };
 };
 
-template <> struct LongVectorTestData<int64_t> {
+template <> struct TestData<int64_t> {
   inline static const std::map<std::wstring, std::vector<int64_t>> Data = {
       {L"DefaultInputValueSet1", {-6, 11, 7, 3, 8, 4, -3, 8, 8, -2}},
       {L"DefaultInputValueSet2", {5, -1337, -3, -2, 9, 3, 1, -3, 501, 2}},
   };
 };
 
-template <> struct LongVectorTestData<uint16_t> {
+template <> struct TestData<uint16_t> {
   inline static const std::map<std::wstring, std::vector<uint16_t>> Data = {
       {L"DefaultInputValueSet1", {1, 699, 3, 1023, 5, 6, 0, 8, 9, 10}},
       {L"DefaultInputValueSet2", {2, 111, 3, 4, 5, 9, 21, 8, 9, 10}},
   };
 };
 
-template <> struct LongVectorTestData<uint32_t> {
+template <> struct TestData<uint32_t> {
   inline static const std::map<std::wstring, std::vector<uint32_t>> Data = {
       {L"DefaultInputValueSet1", {1, 2, 3, 4, 5, 0, 7, 8, 9, 10}},
       {L"DefaultInputValueSet2", {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
   };
 };
 
-template <> struct LongVectorTestData<uint64_t> {
+template <> struct TestData<uint64_t> {
   inline static const std::map<std::wstring, std::vector<uint64_t>> Data = {
       {L"DefaultInputValueSet1", {1, 2, 3, 4, 5, 0, 7, 1000, 9, 10}},
       {L"DefaultInputValueSet2", {1, 2, 1337, 4, 5, 6, 7, 8, 9, 10}},
   };
 };
 
-template <> struct LongVectorTestData<HLSLHalf_t> {
+template <> struct TestData<HLSLHalf_t> {
   inline static const std::map<std::wstring, std::vector<HLSLHalf_t>> Data = {
       {L"DefaultInputValueSet1",
        {-1.0, -1.0, 1.0, -0.01, 1.0, -0.01, 1.0, -0.01, 1.0, -0.01}},
@@ -264,7 +266,7 @@ template <> struct LongVectorTestData<HLSLHalf_t> {
   };
 };
 
-template <> struct LongVectorTestData<float> {
+template <> struct TestData<float> {
   inline static const std::map<std::wstring, std::vector<float>> Data = {
       {L"DefaultInputValueSet1",
        {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
@@ -280,7 +282,7 @@ template <> struct LongVectorTestData<float> {
   };
 };
 
-template <> struct LongVectorTestData<double> {
+template <> struct TestData<double> {
   inline static const std::map<std::wstring, std::vector<double>> Data = {
       {L"DefaultInputValueSet1",
        {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0}},
@@ -299,3 +301,5 @@ template <> struct LongVectorTestData<double> {
 };
 
 #endif // LONGVECTORTESTDATA_H
+
+}; // namespace LongVector

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -45,14 +45,6 @@ using VariantVector =
                  std::vector<uint16_t>, std::vector<uint32_t>,
                  std::vector<uint64_t>>;
 
-// A helper struct to clear a VariantVector using std::visit.
-// Example usage: std::visit(ClearVariantVector{}, MyVariantVector);
-struct ClearVariantVector {
-  template <typename T> void operator()(std::vector<T> &vec) const {
-    vec.clear();
-  }
-};
-
 template <typename DataTypeT>
 void fillShaderBufferFromLongVectorData(std::vector<BYTE> &ShaderBuffer,
                                         const std::vector<DataTypeT> &TestData);
@@ -90,17 +82,16 @@ template <typename DataTypeT> std::string getHLSLTypeString();
 // expansion. May be empty. See getCompilerOptionsString() in LongVector.cpp and
 // 'LongVectorOp' entry ShaderOpArith.xml. Expands to things like '+', '-',
 // '*', etc.
-template <typename LongVectorOpTypeT> struct OpTypeMetaData {
+template <typename OpTypeT> struct OpTypeMetaData {
   std::wstring OpTypeString;
-  LongVectorOpTypeT OpType;
+  OpTypeT OpType;
   std::optional<std::string> Intrinsic = std::nullopt;
   std::optional<std::string> Operator = std::nullopt;
 };
 
 template <typename T, size_t Length>
-const OpTypeMetaData<T> &
-getLongVectorOpType(const OpTypeMetaData<T> (&Values)[Length],
-                    const std::wstring &OpTypeString);
+const OpTypeMetaData<T> &getOpType(const OpTypeMetaData<T> (&Values)[Length],
+                                   const std::wstring &OpTypeString);
 
 enum ValidationType {
   ValidationType_Epsilon,
@@ -159,7 +150,9 @@ static_assert(_countof(binaryOpTypeStringToOpMetaData) ==
               "add a new enum value?");
 
 const OpTypeMetaData<BinaryOpType> &
-getBinaryOpType(const std::wstring &OpTypeString);
+getBinaryOpType(const std::wstring &OpTypeString) {
+  return getOpType<BinaryOpType>(binaryOpTypeStringToOpMetaData, OpTypeString);
+}
 
 enum UnaryOpType { UnaryOpType_Initialize, UnaryOpType_EnumValueCount };
 
@@ -173,7 +166,9 @@ static_assert(_countof(unaryOpTypeStringToOpMetaData) ==
               "a new enum value?");
 
 const OpTypeMetaData<UnaryOpType> &
-getUnaryOpType(const std::wstring &OpTypeString);
+getUnaryOpType(const std::wstring &OpTypeString) {
+  return getOpType<UnaryOpType>(unaryOpTypeStringToOpMetaData, OpTypeString);
+}
 
 enum AsTypeOpType {
   AsTypeOpType_AsFloat,
@@ -205,7 +200,9 @@ static_assert(_countof(asTypeOpTypeStringToOpMetaData) ==
               "a new enum value?");
 
 const OpTypeMetaData<AsTypeOpType> &
-getAsTypeOpType(const std::wstring &OpTypeString);
+getAsTypeOpType(const std::wstring &OpTypeString) {
+  return getOpType<AsTypeOpType>(asTypeOpTypeStringToOpMetaData, OpTypeString);
+}
 
 enum TrigonometricOpType {
   TrigonometricOpType_Acos,
@@ -240,7 +237,59 @@ static_assert(
     "a new enum value?");
 
 const OpTypeMetaData<TrigonometricOpType> &
-getTrigonometricOpType(const std::wstring &OpTypeString);
+getTrigonometricOpType(const std::wstring &OpTypeString) {
+  return getOpType<TrigonometricOpType>(trigonometricOpTypeStringToOpMetaData,
+                                        OpTypeString);
+}
+
+enum UnaryMathOpType {
+  UnaryMathOpType_Abs,
+  UnaryMathOpType_Sign,
+  UnaryMathOpType_Ceil,
+  UnaryMathOpType_Floor,
+  UnaryMathOpType_Trunc,
+  UnaryMathOpType_Round,
+  UnaryMathOpType_Frac,
+  UnaryMathOpType_Sqrt,
+  UnaryMathOpType_Rsqrt,
+  UnaryMathOpType_Exp,
+  UnaryMathOpType_Exp2,
+  UnaryMathOpType_Log,
+  UnaryMathOpType_Log2,
+  UnaryMathOpType_Log10,
+  UnaryMathOpType_Rcp,
+  UnaryMathOpType_EnumValueCount
+};
+
+static const OpTypeMetaData<UnaryMathOpType>
+    unaryMathOpTypeStringToOpMetaData[] = {
+        {L"UnaryMathOpType_Abs", UnaryMathOpType_Abs, "abs"},
+        {L"UnaryMathOpType_Sign", UnaryMathOpType_Sign, "sign"},
+        {L"UnaryMathOpType_Ceil", UnaryMathOpType_Ceil, "ceil"},
+        {L"UnaryMathOpType_Floor", UnaryMathOpType_Floor, "floor"},
+        {L"UnaryMathOpType_Trunc", UnaryMathOpType_Trunc, "trunc"},
+        {L"UnaryMathOpType_Round", UnaryMathOpType_Round, "round"},
+        {L"UnaryMathOpType_Frac", UnaryMathOpType_Frac, "frac"},
+        {L"UnaryMathOpType_Sqrt", UnaryMathOpType_Sqrt, "sqrt"},
+        {L"UnaryMathOpType_Rsqrt", UnaryMathOpType_Rsqrt, "rsqrt"},
+        {L"UnaryMathOpType_Exp", UnaryMathOpType_Exp, "exp"},
+        {L"UnaryMathOpType_Exp2", UnaryMathOpType_Exp2, "exp2"},
+        {L"UnaryMathOpType_Log", UnaryMathOpType_Log, "log"},
+        {L"UnaryMathOpType_Log2", UnaryMathOpType_Log2, "log2"},
+        {L"UnaryMathOpType_Log10", UnaryMathOpType_Log10, "log10"},
+        {L"UnaryMathOpType_Rcp", UnaryMathOpType_Rcp, "rcp"},
+};
+
+static_assert(_countof(unaryMathOpTypeStringToOpMetaData) ==
+                  UnaryMathOpType_EnumValueCount,
+              "unaryMathOpTypeStringToOpMetaData size mismatch. Did you add "
+              "a new enum value?");
+
+const OpTypeMetaData<UnaryMathOpType> &
+getUnaryMathOpType(const std::wstring &OpTypeString) {
+  return getOpType<UnaryMathOpType>(unaryMathOpTypeStringToOpMetaData,
+                                    OpTypeString);
+}
 
 template <typename DataTypeT>
 std::vector<DataTypeT> getInputValueSetByKey(const std::wstring &Key,
@@ -248,7 +297,7 @@ std::vector<DataTypeT> getInputValueSetByKey(const std::wstring &Key,
   if (LogKey)
     WEX::Logging::Log::Comment(
         WEX::Common::String().Format(L"Using Value Set Key: %s", Key.c_str()));
-  return std::vector<DataTypeT>(LongVectorTestData<DataTypeT>::Data.at(Key));
+  return std::vector<DataTypeT>(TestData<DataTypeT>::Data.at(Key));
 }
 
 // The TAEF test class.
@@ -280,8 +329,13 @@ public:
                        L"Table:LongVectorOpTable.xml#AsTypeOpTable")
   END_TEST_METHOD()
 
-  template <typename LongVectorOpTypeT>
-  void dispatchTestByDataType(const OpTypeMetaData<LongVectorOpTypeT> &OpTypeMD,
+  BEGIN_TEST_METHOD(unaryMathOpTest)
+  TEST_METHOD_PROPERTY(L"DataSource",
+                       L"Table:LongVectorOpTable.xml#UnaryMathOpTable")
+  END_TEST_METHOD()
+
+  template <typename OpTypeT>
+  void dispatchTestByDataType(const OpTypeMetaData<OpTypeT> &OpTypeMD,
                               std::wstring DataType,
                               TableParameterHandler &Handler);
 
@@ -290,10 +344,14 @@ public:
   dispatchTestByDataType(const OpTypeMetaData<TrigonometricOpType> &OpTypeMD,
                          std::wstring DataType, TableParameterHandler &Handler);
 
-  template <typename DataTypeT, typename LongVectorOpTypeT>
-  void
-  dispatchTestByVectorLength(const OpTypeMetaData<LongVectorOpTypeT> &OpTypeMD,
-                             TableParameterHandler &Handler);
+  template <>
+  void dispatchTestByDataType(const OpTypeMetaData<UnaryMathOpType> &OpTypeMD,
+                              std::wstring DataType,
+                              TableParameterHandler &Handler);
+
+  template <typename DataTypeT, typename OpTypeT>
+  void dispatchTestByVectorLength(const OpTypeMetaData<OpTypeT> &OpTypeMD,
+                                  TableParameterHandler &Handler);
 
   template <typename DataTypeT>
   void testBaseMethod(std::unique_ptr<TestConfig<DataTypeT>> &TestConfig);
@@ -342,8 +400,10 @@ public:
   bool isScalarOp() const { return BasicOpType == BasicOpType_ScalarBinary; }
 
   // Helpers to get the hlsl type as a string for a given C++ type.
-  std::string getHLSLInputTypeString() const;
-  virtual std::string getHLSLOutputTypeString() const;
+  std::string getHLSLInputTypeString() const {
+    return getHLSLTypeString<DataTypeT>();
+  }
+  std::string getHLSLOutputTypeString() const;
 
   virtual void
   computeExpectedValues(const std::vector<DataTypeT> &InputVector1);
@@ -362,10 +422,6 @@ public:
   }
 
   void setLengthToTest(size_t LengthToTest) {
-    // Make sure we clear the expected vector when setting a new length.
-    // The TestConfig may be getting reused.
-    std::visit(ClearVariantVector{}, ExpectedVector);
-
     this->LengthToTest = LengthToTest;
   }
 
@@ -386,11 +442,16 @@ public:
 
   std::string getCompilerOptionsString() const;
 
-  virtual bool
-  verifyOutput(const std::shared_ptr<st::ShaderOpTestResult> &TestResult);
+  bool verifyOutput(const std::shared_ptr<st::ShaderOpTestResult> &TestResult);
 
 private:
   std::vector<DataTypeT> getInputValueSet(size_t ValueSetIndex) const;
+
+  // Templated version to be used when the output data type does not match the
+  // input data type.
+  template <typename OutputDataTypeT>
+  bool verifyOutput(const std::shared_ptr<st::ShaderOpTestResult> &TestResult,
+                    const std::vector<OutputDataTypeT> &ExpectedVector);
 
   // The input value sets are used to fill the shader buffer.
   std::wstring InputValueSetName1 = L"DefaultInputValueSet1";
@@ -401,15 +462,10 @@ private:
 protected:
   // Prevent instances of TestConfig from being created directly. Want to force
   // a derived class to be used for creation.
-  template <typename LongVectorOpTypeT>
-  TestConfig(const OpTypeMetaData<LongVectorOpTypeT> &OpTypeMd)
+  template <typename OpTypeT>
+  TestConfig(const OpTypeMetaData<OpTypeT> &OpTypeMd)
       : OpTypeName(OpTypeMd.OpTypeString), Intrinsic(OpTypeMd.Intrinsic),
         Operator(OpTypeMd.Operator) {}
-
-  // Templated version to be used when the output data type does not match the
-  // input data type.
-  template <typename OutputDataTypeT>
-  bool verifyOutput(const std::shared_ptr<st::ShaderOpTestResult> &TestResult);
 
   // The appropriate computeExpectedValue should be implemented in derived
   // classes. Impelemented as virtual here to prevent requiring all derived
@@ -457,9 +513,6 @@ public:
   void
   computeExpectedValues(const std::vector<DataTypeT> &InputVector1,
                         const std::vector<DataTypeT> &InputVector2) override;
-  std::string getHLSLOutputTypeString() const override;
-  bool verifyOutput(
-      const std::shared_ptr<st::ShaderOpTestResult> &TestResult) override;
 
 private:
   template <typename DataTypeInT>
@@ -634,6 +687,32 @@ private:
 };
 
 template <typename DataTypeT>
+class TestConfigUnaryMath : public TestConfig<DataTypeT> {
+public:
+  TestConfigUnaryMath(const OpTypeMetaData<UnaryMathOpType> &OpTypeMd);
+  DataTypeT computeExpectedValue(const DataTypeT &A) const override;
+  void
+  computeExpectedValues(const std::vector<DataTypeT> &InputVector1) override;
+
+private:
+  UnaryMathOpType OpType = UnaryMathOpType_EnumValueCount;
+
+  template <typename DataTypeT> int32_t sign(const DataTypeT &A) const {
+    // Return 1 for positive, -1 for negative, 0 for zero.
+    // Wrap comparison operands in DataTypeInT constructor to make sure
+    // we are comparing the same type.
+    return A > DataTypeT(0) ? 1 : A < DataTypeT(0) ? -1 : 0;
+  }
+
+  template <typename DataTypeT> DataTypeT abs(const DataTypeT &A) const {
+    if constexpr (std::is_unsigned<DataTypeT>::value)
+      return DataTypeT(A);
+    else
+      return (std::abs)(A);
+  }
+};
+
+template <typename DataTypeT>
 std::unique_ptr<TestConfig<DataTypeT>>
 makeTestConfig(const OpTypeMetaData<UnaryOpType> &OpTypeMetaData) {
   return std::make_unique<TestConfigUnary<DataTypeT>>(OpTypeMetaData);
@@ -655,6 +734,12 @@ template <typename DataTypeT>
 std::unique_ptr<TestConfig<DataTypeT>>
 makeTestConfig(const OpTypeMetaData<AsTypeOpType> &OpTypeMetaData) {
   return std::make_unique<TestConfigAsType<DataTypeT>>(OpTypeMetaData);
+}
+
+template <typename DataTypeT>
+std::unique_ptr<TestConfig<DataTypeT>>
+makeTestConfig(const OpTypeMetaData<UnaryMathOpType> &OpTypeMetaData) {
+  return std::make_unique<TestConfigUnaryMath<DataTypeT>>(OpTypeMetaData);
 }
 
 }; // namespace LongVector


### PR DESCRIPTION
This PR implements tests cases for unary math ops with long vectors. It also includes a few other minor updates:
- Fix a couple format characters in printed strings.
- Some naming updates. Get rid of 'LongVector' where it's not needed.
- Update logic around accessing the VariantVector type to now use std::visit with lambdas.

Resolves ##7614

