### PR TITLE
[SPIRV] Preserve NaN, Inf, and signed zeros w/ -Gis

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -862,6 +862,18 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
                                 SourceLocation());
   }
 
+  // For Vulkan 1.2 and later, add SignedZeroInfNanPreserve when -Gis is
+  // provided to preserve NaN/Inf and signed zeros.
+  if (spirvOptions.IEEEStrict &&
+      featureManager.getSpirvVersion(featureManager.getTargetEnv()) >=
+          VersionTuple(1, 2)) {
+    spvBuilder.addExecutionMode(entryFunction,
+                                spv::ExecutionMode::SignedZeroInfNanPreserve,
+                                {32}, SourceLocation());
+    spvBuilder.requireCapability(spv::Capability::SignedZeroInfNanPreserve,
+                                 SourceLocation());
+  }
+
   llvm::StringRef denormMode = spirvOptions.floatDenormalMode;
   if (!denormMode.empty()) {
     if (denormMode.equals_lower("preserve")) {

--- a/tools/clang/test/CodeGenSPIRV/SignedZeroInfNanPreserve.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/SignedZeroInfNanPreserve.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T cs_6_0 -spirv -Gis %s| FileCheck %s --check-prefixes=CHECK,OLD
+// RUN: %dxc -T cs_6_0 -spirv -Gis -fspv-target-env=vulkan1.2 %s| FileCheck %s --check-prefixes=CHECK,NEW
+
+// OLD-NOT: OpCapability SignedZeroInfNanPreserve
+// NEW: OpCapability SignedZeroInfNanPreserve
+// CHECK: OpEntryPoint
+// OLD-NOT: OpExecutionMode %main SignedZeroInfNanPreserve 32
+// NEW: OpExecutionMode %main SignedZeroInfNanPreserve 32
+
+[numthreads(8,1,1)]
+void main() {}


### PR DESCRIPTION
The `-Gis` flag opts into "strict" IEEE math rules, which include preserving NaN, Inf and signed/unsigned zeros. This change adds the SPIRV SignedZeroInfNanPreserve capability and execution mode when `-Gis` is passed to DXC.