### PR TITLE
Exection Tests: Long Vector Binary Math Ops

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
+++ b/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <Data>
-    <Table Id="BinaryOpTable">
+    <Table Id="BinaryMathOpTable">
         <ParameterTypes>
           <!-- InputValueSetName1 is optional. If no value is provided use the
           default value set for the data type. This string is meant to be a
@@ -12,526 +12,526 @@
           <ParameterType Name="DataType">String</ParameterType>
           <ParameterType Name="OpTypeEnum">String</ParameterType>
         </ParameterTypes>
-        <!-- LongVectorBinaryOpTypeTable DataType: bool -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: bool -->
         <Row Name="ScalarAdd_bool">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">bool</Parameter>
         </Row>
         <Row Name="Add_bool">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">bool</Parameter>
         </Row>
         <Row Name="ScalarSubtract_bool">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">bool</Parameter>
         </Row>
         <Row Name="Subtract_bool">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">bool</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: int16 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: int16 -->
         <Row Name="ScalarAdd_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Add_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="ScalarSubtract_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Subtract_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="ScalarMultiply_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Multiply_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="ScalarDivide_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Divide_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="ScalarModulus_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Modulus_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="ScalarMin_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Min_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="ScalarMax_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
         <Row Name="Max_int16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">int16</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: int32 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: int32 -->
         <Row Name="ScalarAdd_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Add_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="ScalarSubtract_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Subtract_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="ScalarMultiply_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Multiply_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="ScalarDivide_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Divide_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="ScalarModulus_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Modulus_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="ScalarMin_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Min_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="ScalarMax_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
         <Row Name="Max_int32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">int32</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: int64 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: int64 -->
         <Row Name="ScalarAdd_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Add_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="ScalarSubtract_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Subtract_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="ScalarMultiply_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Multiply_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="ScalarDivide_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Divide_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="ScalarModulus_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Modulus_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="ScalarMin_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Min_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="ScalarMax_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
         <Row Name="Max_int64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">int64</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: uint16 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: uint16 -->
         <Row Name="ScalarAdd_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Add_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="ScalarSubtract_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Subtract_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="ScalarMultiply_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Multiply_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="ScalarDivide_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Divide_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="ScalarModulus_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Modulus_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="ScalarMin_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Min_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="ScalarMax_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
         <Row Name="Max_uint16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">uint16</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: uint32 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: uint32 -->
         <Row Name="ScalarAdd_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Add_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="ScalarSubtract_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Subtract_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="ScalarMultiply_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Multiply_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="ScalarDivide_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Divide_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="ScalarModulus_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Modulus_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="ScalarMin_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Min_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="ScalarMax_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
         <Row Name="Max_uint32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">uint32</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: uint64 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: uint64 -->
         <Row Name="ScalarAdd_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Add_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="ScalarSubtract_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Subtract_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="ScalarMultiply_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Multiply_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="ScalarDivide_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Divide_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="ScalarModulus_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Modulus_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="ScalarMin_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Min_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="ScalarMax_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
         <Row Name="Max_uint64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">uint64</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: float16 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: float16 -->
         <Row Name="ScalarAdd_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Add_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="ScalarSubtract_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Subtract_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="ScalarMultiply_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Multiply_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="ScalarDivide_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Divide_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="ScalarModulus_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Modulus_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="ScalarMin_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Min_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="ScalarMax_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
         <Row Name="Max_float16">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: float32 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: float32 -->
         <Row Name="ScalarAdd_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Add_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="ScalarSubtract_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Subtract_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="ScalarMultiply_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Multiply_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="ScalarDivide_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Divide_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="ScalarModulus_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarModulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Modulus</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Modulus_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Modulus</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Modulus</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="ScalarMin_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Min_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="ScalarMax_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
         <Row Name="Max_float32">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">float32</Parameter>
         </Row>
-        <!-- LongVectorBinaryOpTypeTable DataType: float64 -->
+        <!-- LongVectorBinaryMathOpTypeTable DataType: float64 -->
         <Row Name="ScalarAdd_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarAdd</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Add</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="Add_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Add</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="ScalarSubtract_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarSubtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Subtract</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="Subtract_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Subtract</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Subtract</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="ScalarMultiply_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMultiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Multiply</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="Multiply_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Multiply</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Multiply</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="ScalarDivide_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarDivide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Divide</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="Divide_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Divide</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Divide</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="ScalarMin_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMin</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Min</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="Min_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Min</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Min</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="ScalarMax_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_ScalarMax</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Scalar_Max</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
         <Row Name="Max_float64">
-          <Parameter Name="OpTypeEnum">BinaryOpType_Max</Parameter>
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">float64</Parameter>
         </Row>
     </Table>

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -73,6 +73,12 @@ template <typename DataTypeT> constexpr bool isFloatingPointType() {
          std::is_same_v<DataTypeT, HLSLHalf_t>;
 }
 
+template <typename DataTypeT> constexpr bool is16BitType() {
+  return std::is_same_v<DataTypeT, int16_t> ||
+         std::is_same_v<DataTypeT, uint16_t> ||
+         std::is_same_v<DataTypeT, HLSLHalf_t>;
+}
+
 template <typename DataTypeT> std::string getHLSLTypeString();
 
 // Helpful metadata struct so we can define some common properties for a test in
@@ -83,7 +89,7 @@ template <typename DataTypeT> std::string getHLSLTypeString();
 //
 // OpTypeString : This is populated by the TableParamaterHandler parsing the
 // LongVectorOpTable.xml file. It's used to find the enum value in one of the
-// arrays below. Such as binaryOpTypeStringToOpMetaData.
+// arrays below. Such as binaryMathOpTypeStringToOpMetaData.
 //
 // OpType : Populated via the lookup with OpTypeString.
 //
@@ -117,55 +123,6 @@ enum BasicOpType {
   BasicOpType_ScalarBinary,
   BasicOpType_EnumValueCount
 };
-
-enum BinaryOpType {
-  BinaryOpType_ScalarAdd,
-  BinaryOpType_ScalarMultiply,
-  BinaryOpType_ScalarSubtract,
-  BinaryOpType_ScalarDivide,
-  BinaryOpType_ScalarModulus,
-  BinaryOpType_Multiply,
-  BinaryOpType_Add,
-  BinaryOpType_Subtract,
-  BinaryOpType_Divide,
-  BinaryOpType_Modulus,
-  BinaryOpType_Min,
-  BinaryOpType_Max,
-  BinaryOpType_ScalarMin,
-  BinaryOpType_ScalarMax,
-  BinaryOpType_EnumValueCount
-};
-
-static const OpTypeMetaData<BinaryOpType> binaryOpTypeStringToOpMetaData[] = {
-    {L"BinaryOpType_ScalarAdd", BinaryOpType_ScalarAdd, std::nullopt, "+"},
-    {L"BinaryOpType_ScalarMultiply", BinaryOpType_ScalarMultiply, std::nullopt,
-     "*"},
-    {L"BinaryOpType_ScalarSubtract", BinaryOpType_ScalarSubtract, std::nullopt,
-     "-"},
-    {L"BinaryOpType_ScalarDivide", BinaryOpType_ScalarDivide, std::nullopt,
-     "/"},
-    {L"BinaryOpType_ScalarModulus", BinaryOpType_ScalarModulus, std::nullopt,
-     "%"},
-    {L"BinaryOpType_Add", BinaryOpType_Add, std::nullopt, "+"},
-    {L"BinaryOpType_Multiply", BinaryOpType_Multiply, std::nullopt, "*"},
-    {L"BinaryOpType_Subtract", BinaryOpType_Subtract, std::nullopt, "-"},
-    {L"BinaryOpType_Divide", BinaryOpType_Divide, std::nullopt, "/"},
-    {L"BinaryOpType_Modulus", BinaryOpType_Modulus, std::nullopt, "%"},
-    {L"BinaryOpType_Min", BinaryOpType_Min, "min", ","},
-    {L"BinaryOpType_Max", BinaryOpType_Max, "max", ","},
-    {L"BinaryOpType_ScalarMin", BinaryOpType_ScalarMin, "min", ","},
-    {L"BinaryOpType_ScalarMax", BinaryOpType_ScalarMax, "max", ","},
-};
-
-static_assert(_countof(binaryOpTypeStringToOpMetaData) ==
-                  BinaryOpType_EnumValueCount,
-              "binaryOpTypeStringToOpMetaData size mismatch. Did you "
-              "add a new enum value?");
-
-const OpTypeMetaData<BinaryOpType> &
-getBinaryOpType(const std::wstring &OpTypeString) {
-  return getOpType<BinaryOpType>(binaryOpTypeStringToOpMetaData, OpTypeString);
-}
 
 enum UnaryOpType { UnaryOpType_Initialize, UnaryOpType_EnumValueCount };
 
@@ -304,6 +261,64 @@ getUnaryMathOpType(const std::wstring &OpTypeString) {
                                     OpTypeString);
 }
 
+enum BinaryMathOpType {
+  BinaryMathOpType_Scalar_Add,
+  BinaryMathOpType_Scalar_Multiply,
+  BinaryMathOpType_Scalar_Subtract,
+  BinaryMathOpType_Scalar_Divide,
+  BinaryMathOpType_Scalar_Modulus,
+  BinaryMathOpType_Multiply,
+  BinaryMathOpType_Add,
+  BinaryMathOpType_Subtract,
+  BinaryMathOpType_Divide,
+  BinaryMathOpType_Modulus,
+  BinaryMathOpType_Min,
+  BinaryMathOpType_Max,
+  BinaryMathOpType_Scalar_Min,
+  BinaryMathOpType_Scalar_Max,
+  BinaryMathOpType_EnumValueCount
+};
+
+static const OpTypeMetaData<BinaryMathOpType>
+    binaryMathOpTypeStringToOpMetaData[] = {
+        {L"BinaryMathOpType_Scalar_Add", BinaryMathOpType_Scalar_Add,
+         std::nullopt, "+"},
+        {L"BinaryMathOpType_Scalar_Multiply", BinaryMathOpType_Scalar_Multiply,
+         std::nullopt, "*"},
+        {L"BinaryMathOpType_Scalar_Subtract", BinaryMathOpType_Scalar_Subtract,
+         std::nullopt, "-"},
+        {L"BinaryMathOpType_Scalar_Divide", BinaryMathOpType_Scalar_Divide,
+         std::nullopt, "/"},
+        {L"BinaryMathOpType_Scalar_Modulus", BinaryMathOpType_Scalar_Modulus,
+         std::nullopt, "%"},
+        {L"BinaryMathOpType_Add", BinaryMathOpType_Add, std::nullopt, "+"},
+        {L"BinaryMathOpType_Multiply", BinaryMathOpType_Multiply, std::nullopt,
+         "*"},
+        {L"BinaryMathOpType_Subtract", BinaryMathOpType_Subtract, std::nullopt,
+         "-"},
+        {L"BinaryMathOpType_Divide", BinaryMathOpType_Divide, std::nullopt,
+         "/"},
+        {L"BinaryMathOpType_Modulus", BinaryMathOpType_Modulus, std::nullopt,
+         "%"},
+        {L"BinaryMathOpType_Min", BinaryMathOpType_Min, "min", ","},
+        {L"BinaryMathOpType_Max", BinaryMathOpType_Max, "max", ","},
+        {L"BinaryMathOpType_Scalar_Min", BinaryMathOpType_Scalar_Min, "min",
+         ","},
+        {L"BinaryMathOpType_Scalar_Max", BinaryMathOpType_Scalar_Max, "max",
+         ","},
+};
+
+static_assert(_countof(binaryMathOpTypeStringToOpMetaData) ==
+                  BinaryMathOpType_EnumValueCount,
+              "binaryMathOpTypeStringToOpMetaData size mismatch. Did you "
+              "add a new enum value?");
+
+const OpTypeMetaData<BinaryMathOpType> &
+getBinaryMathOpType(const std::wstring &OpTypeString) {
+  return getOpType<BinaryMathOpType>(binaryMathOpTypeStringToOpMetaData,
+                                     OpTypeString);
+}
+
 template <typename DataTypeT>
 std::vector<DataTypeT> getInputValueSetByKey(const std::wstring &Key,
                                              bool LogKey = true) {
@@ -322,9 +337,9 @@ public:
 
   TEST_CLASS_SETUP(classSetup);
 
-  BEGIN_TEST_METHOD(binaryOpTest)
+  BEGIN_TEST_METHOD(binaryMathOpTest)
   TEST_METHOD_PROPERTY(L"DataSource",
-                       L"Table:LongVectorOpTable.xml#BinaryOpTable")
+                       L"Table:LongVectorOpTable.xml#BinaryMathOpTable")
   END_TEST_METHOD()
 
   BEGIN_TEST_METHOD(trigonometricOpTest)
@@ -674,14 +689,14 @@ private:
 };
 
 template <typename DataTypeT>
-class TestConfigBinary : public TestConfig<DataTypeT> {
+class TestConfigBinaryMath : public TestConfig<DataTypeT> {
 public:
-  TestConfigBinary(const OpTypeMetaData<BinaryOpType> &OpTypeMd);
+  TestConfigBinaryMath(const OpTypeMetaData<BinaryMathOpType> &OpTypeMd);
   DataTypeT computeExpectedValue(const DataTypeT &A,
                                  const DataTypeT &B) const override;
 
 private:
-  BinaryOpType OpType = BinaryOpType_EnumValueCount;
+  BinaryMathOpType OpType = BinaryMathOpType_EnumValueCount;
 
   // Helpers so we do the right thing for float types. HLSLHalf_t is handled in
   // an operator overload.
@@ -733,12 +748,6 @@ makeTestConfig(const OpTypeMetaData<UnaryOpType> &OpTypeMetaData) {
 
 template <typename DataTypeT>
 std::unique_ptr<TestConfig<DataTypeT>>
-makeTestConfig(const OpTypeMetaData<BinaryOpType> &OpTypeMetaData) {
-  return std::make_unique<TestConfigBinary<DataTypeT>>(OpTypeMetaData);
-}
-
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
 makeTestConfig(const OpTypeMetaData<TrigonometricOpType> &OpTypeMetaData) {
   return std::make_unique<TestConfigTrigonometric<DataTypeT>>(OpTypeMetaData);
 }
@@ -753,6 +762,12 @@ template <typename DataTypeT>
 std::unique_ptr<TestConfig<DataTypeT>>
 makeTestConfig(const OpTypeMetaData<UnaryMathOpType> &OpTypeMetaData) {
   return std::make_unique<TestConfigUnaryMath<DataTypeT>>(OpTypeMetaData);
+}
+
+template <typename DataTypeT>
+std::unique_ptr<TestConfig<DataTypeT>>
+makeTestConfig(const OpTypeMetaData<BinaryMathOpType> &OpTypeMetaData) {
+  return std::make_unique<TestConfigBinaryMath<DataTypeT>>(OpTypeMetaData);
 }
 
 }; // namespace LongVector


### PR DESCRIPTION
This PR is mostly NFC, aside from some cleanup in the getCompilerOptionsString logic. All of the binary math ops test cases are simply renamed from earlier work. The binary math ops issue included two additional intrinsics: pow and step. However, upon closer inspection, I realized we already have coverage or will have coverage later for the relevant DXIL ops and LLVM instructions. Therefore, no new test cases needed to be added.

Resolves #7615 