### PR TITLE
IsSpecialFloat 16 bit implementation for isinf, isnan, and isfinite

### DIFF
--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -644,7 +644,7 @@ public:
     IRBuilder<> Builder(CI);
     Value *Val = CI->getOperand(1);
     DXASSERT(Val->getType()->isHalfTy(),
-	     "Only emulates Half overload of IsInf");
+             "Only emulates Half overload of IsInf");
     Type *IType = Type::getInt16Ty(M.getContext());
     Constant *PosInf = ConstantInt::get(IType, 0x7c00);
     Constant *NegInf = ConstantInt::get(IType, 0xfc00);
@@ -661,7 +661,7 @@ public:
     IRBuilder<> Builder(CI);
     Value *Val = CI->getOperand(1);
     DXASSERT(Val->getType()->isHalfTy(),
-	     "Only emulates Half overload of IsNaN");
+             "Only emulates Half overload of IsNaN");
     Type *IType = Type::getInt16Ty(M.getContext());
 
     Constant *ExpBitMask = ConstantInt::get(IType, 0x7c00);
@@ -682,7 +682,7 @@ public:
     IRBuilder<> Builder(CI);
     Value *Val = CI->getOperand(1);
     DXASSERT(Val->getType()->isHalfTy(),
-	     "Only emulates Half overload of IsFinite");
+             "Only emulates Half overload of IsFinite");
     Type *IType = Type::getInt16Ty(M.getContext());
 
     Constant *ExpBitMask = ConstantInt::get(IType, 0x7c00);

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -692,27 +692,27 @@ public:
     for (auto FnIt : hlslOP->GetOpFuncList(DXIL::OpCode::IsInf)) {
       Function *F = FnIt.second;
       if (!F)
-	continue;
+        continue;
       if (!F->getFunctionType()->getParamType(1)->isHalfTy())
-	continue;
-      
+        continue;
+
       for (auto UserIt = F->user_begin(); UserIt != F->user_end();) {
         CallInst *CI = cast<CallInst>(*(UserIt++));
 
-	uint64_t OpKind = cast<ConstantInt>(CI->getOperand(0))->getZExtValue();
-	switch (OpKind) {
-	case (uint64_t)DXIL::OpCode::IsInf:
-	  convertIsInf(M, CI);
-	  continue;
-	case (uint64_t)DXIL::OpCode::IsNaN:
-	  convertIsNaN(M, CI);
-	  continue;
-	case (uint64_t)DXIL::OpCode::IsFinite:
-	  convertIsFinite(M, CI);
-	  continue;
-	default:
-	  continue;
-	}
+        uint64_t OpKind = cast<ConstantInt>(CI->getOperand(0))->getZExtValue();
+        switch (OpKind) {
+        case (uint64_t)DXIL::OpCode::IsInf:
+          convertIsInf(M, CI);
+          continue;
+        case (uint64_t)DXIL::OpCode::IsNaN:
+          convertIsNaN(M, CI);
+          continue;
+        case (uint64_t)DXIL::OpCode::IsFinite:
+          convertIsFinite(M, CI);
+          continue;
+        default:
+          continue;
+        }
       }
     }
   }

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -644,12 +644,12 @@ public:
     IRBuilder<> Builder(CI);
     Value *Val = CI->getOperand(1);
     Type *IType = Type::getInt16Ty(M.getContext());
-    Constant *Inf1 = ConstantInt::get(IType, 0x7c00);
-    Constant *Inf2 = ConstantInt::get(IType, 0xfc00);
+    Constant *PosInf = ConstantInt::get(IType, 0x7c00);
+    Constant *NegInf = ConstantInt::get(IType, 0xfc00);
 
     Value *IVal = Builder.CreateBitCast(Val, IType);
-    Value *B1 = Builder.CreateICmpEQ(IVal, Inf1);
-    Value *B2 = Builder.CreateICmpEQ(IVal, Inf2);
+    Value *B1 = Builder.CreateICmpEQ(IVal, PosInf);
+    Value *B2 = Builder.CreateICmpEQ(IVal, NegInf);
     Value *B3 = Builder.CreateOr(B1, B2);
     CI->replaceAllUsesWith(B3);
     CI->eraseFromParent();

--- a/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.8.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.8.hlsl
@@ -1,5 +1,10 @@
 // RUN: %dxc -T lib_6_8 -enable-16bit-types %s | FileCheck %s
 
+// 31744 = 0x7c00, which corresponds to positive infinity
+// it is also used as a mask to get the exp bits of a half
+// -1024 = 0xfc00, which corresponds to negative infinity
+// 1023 = 0x3ff, and is used to mask the significand of a half
+
 // CHECK-LABEL: test_isinf
 // CHECK: [[V1:%.*]] = bitcast half {{.*}} to i16
 // CHECK: [[V2:%.*]] = icmp eq i16 [[V1]], 31744
@@ -12,7 +17,7 @@ export bool test_isinf(half h) {
 
 // CHECK-LABEL: test_isnan
 // CHECK: [[V1:%.*]] = bitcast half {{.*}} to i16
-// CHECK: [[V2:%.*]] = and i16 [[V1]], 31744
+// CHECK: [[V2:%.*]] = and i16 [[V1]], 31744 ; 
 // CHECK: [[V3:%.*]] = icmp eq i16 [[V2]], 31744
 // CHECK: [[V4:%.*]] = and i16 [[V1]], 1023
 // CHECK: [[V5:%.*]] = icmp ne i16 [[V4]], 0

--- a/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.8.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.8.hlsl
@@ -1,0 +1,32 @@
+// RUN: %dxc -T lib_6_8 -enable-16bit-types %s | FileCheck %s
+
+// CHECK-LABEL: test_isinf
+// CHECK: [[V1:%.*]] = bitcast half {{.*}} to i16
+// CHECK: [[V2:%.*]] = icmp eq i16 [[V1]], 31744
+// CHECK: [[V3:%.*]] = icmp eq i16 [[V1]], -1024
+// CHECK: [[V4:%.*]] = or i1 [[V2]], [[V3]]
+// CHECK: ret i1 [[V4]]
+export bool test_isinf(half h) {
+  return isinf(h);
+}
+
+// CHECK-LABEL: test_isnan
+// CHECK: [[V1:%.*]] = bitcast half {{.*}} to i16
+// CHECK: [[V2:%.*]] = and i16 [[V1]], 31744
+// CHECK: [[V3:%.*]] = icmp eq i16 [[V2]], 31744
+// CHECK: [[V4:%.*]] = and i16 [[V1]], 1023
+// CHECK: [[V5:%.*]] = icmp ne i16 [[V4]], 0
+// CHECK: [[V6:%.*]] = and i1 [[V3]], [[V5]]
+// CHECK: ret i1 [[V6]]
+export bool test_isnan(half h) {
+  return isnan(h);
+}
+
+// CHECK-LABEL: test_isfinite
+// CHECK: [[V1:%.*]] = bitcast half {{.*}} to i16
+// CHECK: [[V2:%.*]] = and i16 [[V1]], 31744
+// CHECK: [[V3:%.*]] = icmp ne i16 [[V2]], 31744
+// CHECK: ret i1 [[V3]]
+export bool test_isfinite(half h) {
+  return isfinite(h);
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.8.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.8.hlsl
@@ -17,7 +17,7 @@ export bool test_isinf(half h) {
 
 // CHECK-LABEL: test_isnan
 // CHECK: [[V1:%.*]] = bitcast half {{.*}} to i16
-// CHECK: [[V2:%.*]] = and i16 [[V1]], 31744 ; 
+// CHECK: [[V2:%.*]] = and i16 [[V1]], 31744 
 // CHECK: [[V3:%.*]] = icmp eq i16 [[V2]], 31744
 // CHECK: [[V4:%.*]] = and i16 [[V1]], 1023
 // CHECK: [[V5:%.*]] = icmp ne i16 [[V4]], 0

--- a/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.9.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/intrinsics/IsSpecialFloat6.9.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T lib_6_9 -enable-16bit-types -DFUNC=isnan %s | FileCheck %s
+// RUN: %dxc -T lib_6_9 -enable-16bit-types -DFUNC=isinf %s | FileCheck %s
+// RUN: %dxc -T lib_6_9 -enable-16bit-types -DFUNC=isfinite %s | FileCheck %s
+
+// CHECK-LABEL: test_func
+// CHECK:  call i1 @dx.op.isSpecialFloat.f16(i32 [[OP:[0-9]*]], half
+export bool test_func(half h) {
+  return FUNC(h);
+}
+
+// CHECK-LABEL: test_func2
+// CHECK:  call <2 x i1> @dx.op.isSpecialFloat.v2f16(i32 [[OP:[0-9]*]], <2 x half>
+export bool2 test_func2(half2 h) {
+  return FUNC(h);
+}
+
+// CHECK-LABEL: test_func3
+// CHECK:  call <3 x i1> @dx.op.isSpecialFloat.v3f16(i32 [[OP:[0-9]*]], <3 x half>
+export bool3 test_func3(half3 h) {
+  return FUNC(h);
+}
+
+// CHECK-LABEL: test_func4
+// CHECK:  call <4 x i1> @dx.op.isSpecialFloat.v4f16(i32 [[OP:[0-9]*]], <4 x half>
+export bool4 test_func4(half4 h) {
+  return FUNC(h);
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-trivial-isspecial-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-trivial-isspecial-intrinsics.hlsl
@@ -34,9 +34,7 @@ void main() {
 
   // CHECK-NOT: extractelement
   // CHECK-NOT: insertelement
-  // NOTE: This behavior will change with #7588
-  // CHECK: [[tmp:%.*]] = fpext <[[NUM]] x half> [[hvec]] to <[[NUM]] x float>
-  // CHECK: call <[[NUM]] x i1> @dx.op.isSpecialFloat.[[FTY]](i32 [[OP]], <[[NUM]] x float> [[tmp]])
+  // CHECK: call <[[NUM]] x i1> @dx.op.isSpecialFloat.[[HTY]](i32 [[OP]], <[[NUM]] x half> [[hvec]])
   vector<bool, NUM> hRes = FUNC(hVec);
 
   // CHECK-NOT: extractelement

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.isfinite.16bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.isfinite.16bit.hlsl
@@ -1,0 +1,96 @@
+// RUN: %dxc -T ps_6_2 -enable-16bit-types -E main -fcgl  %s -spirv | FileCheck %s
+
+RWStructuredBuffer<half> buffer;
+RWStructuredBuffer<half2x3> buffer_mat;
+RWByteAddressBuffer byte_buffer;
+
+// Since OpIsFinite needs the Kernel capability, translation is done using OpIsNan and OpIsInf.
+// isFinite = !(isNan || isInf)
+
+void main() {
+  half    a;
+  half4   b;
+  half2x3 c;
+
+// CHECK:               [[a:%[0-9]+]] = OpLoad %half %a
+// CHECK-NEXT:    [[a_isNan:%[0-9]+]] = OpIsNan %bool [[a]]
+// CHECK-NEXT:    [[a_isInf:%[0-9]+]] = OpIsInf %bool [[a]]
+// CHECK-NEXT: [[a_NanOrInf:%[0-9]+]] = OpLogicalOr %bool [[a_isNan]] [[a_isInf]]
+// CHECK-NEXT:            {{%[0-9]+}} = OpLogicalNot %bool [[a_NanOrInf]]
+  bool    isf_a = isfinite(a);
+
+// CHECK:                [[b:%[0-9]+]] = OpLoad %v4half %b
+// CHECK-NEXT:     [[b_isNan:%[0-9]+]] = OpIsNan %v4bool [[b]]
+// CHECK-NEXT:     [[b_isInf:%[0-9]+]] = OpIsInf %v4bool [[b]]
+// CHECK-NEXT:  [[b_NanOrInf:%[0-9]+]] = OpLogicalOr %v4bool [[b_isNan]] [[b_isInf]]
+// CHECK-NEXT:             {{%[0-9]+}} = OpLogicalNot %v4bool [[b_NanOrInf]]
+  bool4   isf_b = isfinite(b);
+
+  // TODO: We can not translate the following since boolean matrices are currently not supported.
+  // bool2x3 isf_c = isfinite(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_half %buffer %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %half [[ptr]]
+// CHECK:      [[nan:%[0-9]+]] = OpIsNan %bool [[tmp]]
+// CHECK:      [[inf:%[0-9]+]] = OpIsInf %bool [[tmp]]
+// CHECK:       [[or:%[0-9]+]] = OpLogicalOr %bool [[nan]] [[inf]]
+// CHECK:      [[res:%[0-9]+]] = OpLogicalNot %bool [[or]]
+// CHECK:                        OpStore %res [[res]]
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %res
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %half [[res]] %half_0x1p_0 %half_0x0p_0
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_half %buffer %int_0 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  bool res = isfinite(buffer[0]);
+  buffer[0] = (half)res;
+
+// CHECK:        [[c:%[0-9]+]] = OpLoad %mat2v3half %c
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3half [[c]] 0
+// CHECK: [[isnan_r0:%[0-9]+]] = OpIsNan %v3bool [[r0]]
+// CHECK: [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:    [[or_r0:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r0]] [[isinf_r0]]
+// CHECK:   [[not_r0:%[0-9]+]] = OpLogicalNot %v3bool [[or_r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3half [[c]] 1
+// CHECK: [[isnan_r1:%[0-9]+]] = OpIsNan %v3bool [[r1]]
+// CHECK: [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:    [[or_r1:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r1]] [[isinf_r1]]
+// CHECK:   [[not_r1:%[0-9]+]] = OpLogicalNot %v3bool [[or_r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[not_r0]] [[not_r1]]
+// CHECK:                        OpStore %isfinite_c [[tmp]]
+  bool2x3 isfinite_c = isfinite(c);
+
+// CHECK:         [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_mat2v3half %buffer_mat %int_0 %uint_0
+// CHECK:         [[tmp:%[0-9]+]] = OpLoad %mat2v3half [[ptr]]
+// CHECK:          [[r0:%[0-9]+]] = OpCompositeExtract %v3half [[tmp]] 0
+// CHECK:    [[isnan_r0:%[0-9]+]] = OpIsNan %v3bool [[r0]]
+// CHECK:    [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:       [[or_r0:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r0]] [[isinf_r0]]
+// CHECK: [[isfinite_r0:%[0-9]+]] = OpLogicalNot %v3bool [[or_r0]]
+// CHECK:          [[r1:%[0-9]+]] = OpCompositeExtract %v3half [[tmp]] 1
+// CHECK:    [[isnan_r1:%[0-9]+]] = OpIsNan %v3bool [[r1]]
+// CHECK:    [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:       [[or_r1:%[0-9]+]] = OpLogicalOr %v3bool [[isnan_r1]] [[isinf_r1]]
+// CHECK: [[isfinite_r1:%[0-9]+]] = OpLogicalNot %v3bool [[or_r1]]
+// CHECK:         [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isfinite_r0]] [[isfinite_r1]]
+// CHECK:                           OpStore %isfinite_d [[tmp]]
+  bool2x3 isfinite_d = isfinite(buffer_mat[0]);
+
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmpL:%[0-9]+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[tmpS:%[0-9]+]] = OpShiftRightLogical %uint [[tmpL]] %101
+// CHECK:      [[tmp:%[0-9]+]] = OpUConvert %ushort [[tmpS]]
+// CHECK:      [[val:%[0-9]+]] = OpBitcast %half [[tmp]]
+// CHECK:      [[nan:%[0-9]+]] = OpIsNan %bool [[val]]
+// CHECK:      [[inf:%[0-9]+]] = OpIsInf %bool [[val]]
+// CHECK:       [[or:%[0-9]+]] = OpLogicalOr %bool [[nan]] [[inf]]
+// CHECK:      [[res:%[0-9]+]] = OpLogicalNot %bool [[or]]
+// CHECK:                        OpStore %isfinite_e [[res]]
+  bool isfinite_e = isfinite(byte_buffer.Load<half>(0));
+
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %isfinite_e
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %uint [[res]] %uint_1 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  byte_buffer.Store(0, isfinite_e);
+}

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.isinf.16bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.isinf.16bit.hlsl
@@ -1,0 +1,69 @@
+// RUN: %dxc -T ps_6_2 -enable-16bit-types -E main -fcgl  %s -spirv | FileCheck %s
+
+RWStructuredBuffer<half> buffer;
+RWStructuredBuffer<half2x3> buffer_mat;
+RWByteAddressBuffer byte_buffer;
+
+void main() {
+  half    a;
+  half4   b;
+  half2x3 c;
+
+// CHECK:      [[a:%[0-9]+]] = OpLoad %half %a
+// CHECK-NEXT:   {{%[0-9]+}} = OpIsInf %bool [[a]]
+  bool  isinf_a = isinf(a);
+
+// CHECK:      [[b:%[0-9]+]] = OpLoad %v4half %b
+// CHECK-NEXT:   {{%[0-9]+}} = OpIsInf %v4bool [[b]]
+  bool4 isinf_b = isinf(b);
+
+  // TODO: We can not translate the following since boolean matrices are currently not supported.
+  // bool2x3 isinf_c = isinf(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_half %buffer %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %half [[ptr]]
+// CHECK:      [[res:%[0-9]+]] = OpIsInf %bool [[tmp]]
+// CHECK:                        OpStore %res [[res]]
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %res
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %half [[res]] %half_0x1p_0 %half_0x0p_0
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_half %buffer %int_0 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  bool res = isinf(buffer[0]);
+  buffer[0] = (half)res;
+
+// CHECK:        [[c:%[0-9]+]] = OpLoad %mat2v3half %c
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3half [[c]] 0
+// CHECK: [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3half [[c]] 1
+// CHECK: [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isinf_r0]] [[isinf_r1]]
+// CHECK:                        OpStore %isinf_c [[tmp]]
+  bool2x3 isinf_c = isinf(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_mat2v3half %buffer_mat %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %mat2v3half [[ptr]]
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3half [[tmp]] 0
+// CHECK: [[isinf_r0:%[0-9]+]] = OpIsInf %v3bool [[r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3half [[tmp]] 1
+// CHECK: [[isinf_r1:%[0-9]+]] = OpIsInf %v3bool [[r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isinf_r0]] [[isinf_r1]]
+// CHECK:                        OpStore %isinf_d [[tmp]]
+  bool2x3 isinf_d = isinf(buffer_mat[0]);
+
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmpL:%[0-9]+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[tmpS:%[0-9]+]] = OpShiftRightLogical %uint [[tmpL]] %80
+// CHECK:      [[tmp:%[0-9]+]] = OpUConvert %ushort [[tmpS]]
+// CHECK:      [[val:%[0-9]+]] = OpBitcast %half [[tmp]]
+// CHECK:      [[res:%[0-9]+]] = OpIsInf %bool [[val]]
+// CHECK:                        OpStore %isinf_e [[res]]
+  bool isinf_e = isinf(byte_buffer.Load<half>(0));
+
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %isinf_e
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %uint [[res]] %uint_1 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  byte_buffer.Store(0, isinf_e);
+}

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.isnan.16bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.isnan.16bit.hlsl
@@ -1,0 +1,69 @@
+// RUN: %dxc -T ps_6_2 -enable-16bit-types -E main -fcgl  %s -spirv | FileCheck %s
+
+RWStructuredBuffer<half> buffer;
+RWStructuredBuffer<half2x3> buffer_mat;
+RWByteAddressBuffer byte_buffer;
+
+void main() {
+  half    a;
+  half4   b;
+  half2x3 c;
+
+// CHECK:      [[a:%[0-9]+]] = OpLoad %half %a
+// CHECK-NEXT:   {{%[0-9]+}} = OpIsNan %bool [[a]]
+  bool  isnan_a = isnan(a);
+
+// CHECK:      [[b:%[0-9]+]] = OpLoad %v4half %b
+// CHECK-NEXT:   {{%[0-9]+}} = OpIsNan %v4bool [[b]]
+  bool4 isnan_b = isnan(b);
+
+  // TODO: We can not translate the following since boolean matrices are currently not supported.
+  // bool2x3 isnan_c = isnan(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_half %buffer %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %half [[ptr]]
+// CHECK:      [[res:%[0-9]+]] = OpIsNan %bool [[tmp]]
+// CHECK:                        OpStore %res [[res]]
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %res
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %half [[res]] %half_0x1p_0 %half_0x0p_0
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_half %buffer %int_0 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  bool res = isnan(buffer[0]);
+  buffer[0] = (half)res;
+
+// CHECK:        [[c:%[0-9]+]] = OpLoad %mat2v3half %c
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3half [[c]] 0
+// CHECK: [[isnan_r0:%[0-9]+]] = OpIsNan %v3bool [[r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3half [[c]] 1
+// CHECK: [[isnan_r1:%[0-9]+]] = OpIsNan %v3bool [[r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isnan_r0]] [[isnan_r1]]
+// CHECK:                        OpStore %isnan_c [[tmp]]
+  bool2x3 isnan_c = isnan(c);
+
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_mat2v3half %buffer_mat %int_0 %uint_0
+// CHECK:      [[tmp:%[0-9]+]] = OpLoad %mat2v3half [[ptr]]
+// CHECK:       [[r0:%[0-9]+]] = OpCompositeExtract %v3half [[tmp]] 0
+// CHECK: [[isnan_r0:%[0-9]+]] = OpIsNan %v3bool [[r0]]
+// CHECK:       [[r1:%[0-9]+]] = OpCompositeExtract %v3half [[tmp]] 1
+// CHECK: [[isnan_r1:%[0-9]+]] = OpIsNan %v3bool [[r1]]
+// CHECK:      [[tmp:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[isnan_r0]] [[isnan_r1]]
+// CHECK:                        OpStore %isnan_d [[tmp]]
+  bool2x3 isnan_d = isnan(buffer_mat[0]);
+
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmpL:%[0-9]+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[tmpS:%[0-9]+]] = OpShiftRightLogical %uint [[tmpL]] %80
+// CHECK:      [[tmp:%[0-9]+]] = OpUConvert %ushort [[tmpS]]
+// CHECK:      [[val:%[0-9]+]] = OpBitcast %half [[tmp]]
+// CHECK:      [[res:%[0-9]+]] = OpIsNan %bool [[val]]
+// CHECK:                        OpStore %isnan_e [[res]]
+  bool isnan_e = isnan(byte_buffer.Load<half>(0));
+
+// CHECK:      [[res:%[0-9]+]] = OpLoad %bool %isnan_e
+// CHECK:     [[addr:%[0-9]+]] = OpShiftRightLogical %uint %uint_0 %uint_2
+// CHECK:      [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %byte_buffer %uint_0 [[addr]]
+// CHECK:      [[tmp:%[0-9]+]] = OpSelect %uint [[res]] %uint_1 %uint_0
+// CHECK:                        OpStore [[ptr]] [[tmp]]
+  byte_buffer.Store(0, isnan_e);
+}

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -183,9 +183,9 @@ void [[]] InterlockedXor(ref int32_only result, in uint value, out any_int32 ori
 void [[]] InterlockedCompareStore(ref int32_only result, in uint compare, in uint value);
 void [[]] InterlockedExchange(ref int32_only result, in uint value, out any_int32 original);
 void [[]] InterlockedCompareExchange(ref int32_only result, in uint compare, in uint value, out any_int32 original);
-$match<1, 0> bool<> [[rn]] isfinite(in float<> x);
-$match<1, 0> bool<> [[rn]] isinf(in float<> x);
-$match<1, 0> bool<> [[rn]] isnan(in float<> x);
+$match<1, 0> bool<> [[rn]] isfinite(in float_like<> x);
+$match<1, 0> bool<> [[rn]] isinf(in float_like<> x);
+$match<1, 0> bool<> [[rn]] isnan(in float_like<> x);
 $type1 [[rn]] ldexp(in float_like<> x, in $type1 exp);
 $match<0, 1> float_like [[rn]] length(in float_like<c> x);
 $type1 [[rn]] lerp(in float_like<> a, in $type1 b, in $type1 s);


### PR DESCRIPTION
Add 16 bit overloads for isinf, isnan, and isfinite
For SM6.8 and below; emulate these operations using IR by bitcasting the half to an i16 and performing comparisons to constants
For SM6.9 and later; the 16 bit isSpecialFloat DXIL Op Class is used.

Add tests showing for SM6.8 the emulation in DXIL for isinf, isnan, and isfinite
Add tests showing for SM6.9 the 16 bit version of isSpecialFloat is used
Add tests for SPIRV showing the 16 bit OpIsInf and OpIsNan are used

isinf: Closes #7650, Closes #7645, Closes #7653
isnan: Closes #7651, Closes #7646, Closes #7654
isfinite: Closes #7652, Closes #7647, Closes #7655
Closes #7496