### PR TITLE
Execution Tests: Fix bug parsing bools in TableParameterHandler

### DIFF
--- a/tools/clang/unittests/HLSLExec/TableParameterHandler.cpp
+++ b/tools/clang/unittests/HLSLExec/TableParameterHandler.cpp
@@ -129,7 +129,7 @@ HRESULT TableParameterHandler::ParseTableRow() {
       if (FAILED(WEX::TestExecution::TestData::TryGetValue(table[i].m_name,
                                                            table[i].m_int32)) &&
           table[i].m_required) {
-        // TryGetValue does not suppport reading from int16
+        // TryGetValue does not suppport reading from int8
         hlsl_test::LogErrorFmt(L"Failed to get %s", table[i].m_name);
         return E_FAIL;
       }
@@ -179,8 +179,8 @@ HRESULT TableParameterHandler::ParseTableRow() {
       break;
     case TableParameter::BOOL:
       if (FAILED(WEX::TestExecution::TestData::TryGetValue(table[i].m_name,
-                                                           table[i].m_str)) &&
-          table[i].m_bool) {
+                                                           table[i].m_bool)) &&
+          table[i].m_required) {
         hlsl_test::LogErrorFmt(L"Failed to get %s", table[i].m_name);
         return E_FAIL;
       }


### PR DESCRIPTION
This PR fixes a bug in the Exec tests utility TableParamaterHandler which parses TAEF metadata which has either been populated via an xml file or TAEF macros. There was a bug when parsing a TableParameter::BOOL a string was being passed to TryGetValue instead of a bool.

The first argument to TryGetValue is the name of the parameter and the second is a reference to the variable to store the value. 

How tested: I'm adding a test that's using the handler to retrieve a bool value. I confirmed that it's working now.