### PR TITLE
 Fix the uninitlaized ExpandTokPastingArg option

### DIFF
--- a/tools/clang/include/clang/Lex/PreprocessorOptions.h
+++ b/tools/clang/include/clang/Lex/PreprocessorOptions.h
@@ -149,6 +149,7 @@ public:
 public:
   PreprocessorOptions() : UsePredefines(true), DetailedRecord(false),
                           IgnoreLineDirectives(false), // HLSL Change - ignore line directives.
+                          ExpandTokPastingArg(false), // HLSL Change - allow pre-expand
                           DisablePCHValidation(false),
                           AllowPCHWithCompilerErrors(false),
                           DumpDeserializedPCHDecls(false),


### PR DESCRIPTION
When I call the `ParseTranslationUnit` and `GetDiagnostic` interfaces of dxcisense to obtain diagnostic information, the `ExpandTokPastingArg`  is not properly initialized during the pipeline. This results in undefined behavior due to reading the uninitialized value, making token-pasting indeterminate.
<img width="800" height="200" alt="63ED63EABDCEF510958A852759D74881" src="https://github.com/user-attachments/assets/f7e3c790-6f48-45d7-b459-2686d17a8c7f" />

