### PR TITLE
Update CMake variable so that dxcapi.use.cpp is detected regardless of root dir

### DIFF
--- a/tools/clang/tools/dxopt/CMakeLists.txt
+++ b/tools/clang/tools/dxopt/CMakeLists.txt
@@ -8,7 +8,7 @@ set( LLVM_LINK_COMPONENTS
   Support    # just for assert and raw streams
   )
 
-set(DXCSUPPORT_DIR "${CMAKE_SOURCE_DIR}/lib/DxcSupport")
+set(DXCSUPPORT_DIR "${LLVM_SOURCE_DIR}/lib/DxcSupport")
 
 add_clang_executable(dxopt
   dxopt.cpp


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7708