### PR TITLE
Fix typo of register -> registers crashes DXC with segfault 

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1026,7 +1026,7 @@ def warn_hlsl_semantic_identifier_collision : Warning <
   "'%0' interpreted as semantic; previous definition(s) ignored">,
   InGroup< HLSLSemanticIdentifierCollision >;
 def err_hlsl_expected_hlsl_attribute : Error <
-  "Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute '%0' was used instead.">;
+  "Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?">;
 def err_hlsl_enum : Error<
   "enum is unsupported in HLSL before 2017">;
 def warn_hlsl_new_feature : Warning <

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -637,8 +637,7 @@ bool Parser::MaybeParseHLSLAttributes(std::vector<hlsl::UnusualAnnotation *> &ta
       // both registr() and packofset() would cause a crash without this fix.
 
       if (Tok.is(tok::l_paren)) {
-        Diag(Tok.getLocation(), diag::err_hlsl_expected_hlsl_attribute)
-            << semanticName;
+        Diag(Tok.getLocation(), diag::err_hlsl_expected_hlsl_attribute);
         ConsumeParen();
         SkipUntil(tok::r_paren, StopAtSemi); // skip through )
         return true;

--- a/tools/clang/test/SemaHLSL/hlsl-attribute-mistype-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl-attribute-mistype-errors.hlsl
@@ -1,29 +1,29 @@
 // RUN: %dxc -T lib_6_3 -verify %s
 
-// expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'registers' was used instead.}}
+// expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
 RWStructuredBuffer<float4> uav1 : registers(u3);
 
-// expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'registers' was used instead.}}
+// expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
 RWStructuredBuffer<float4> uav2 : registers(outer_space);
 
-// expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'UNDEFINED_MACRO1' was used instead.}}
+// expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
 RWStructuredBuffer<float4> uav3 : UNDEFINED_MACRO1(u3);
 
-// expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'UNDEFINED_MACRO' was used instead.}}
+// expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
 RWStructuredBuffer<float4> uav4 : UNDEFINED_MACRO(something, more, complex);
 
 cbuffer buf {
 
-  // expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'packoffsets' was used instead.}}
+  // expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
   float4 v0 : packoffsets(c0);
 
-  // expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'packoffsets' was used instead.}}
+  // expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
   float4 v1 : packoffsets(invalid_syntax);
 
-  // expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'UNDEFINED_MACRO2' was used instead.}}
+  // expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
   float v2 : UNDEFINED_MACRO2(c0.w);
 
-  // expected-error@+1 {{Syntax indicated an hlsl attribute (: packoffset() or : register()), but unexpected attribute 'UNDEFINED_MACRO' was used instead.}}
+  // expected-error@+1 {{Unexpected '(' in semantic annotation. Did you mean 'packoffset()' or 'register()'?}}
   float v3 : UNDEFINED_MACRO(something, more, complex);
 };
 


### PR DESCRIPTION
Fix crash when parsing mistyped HLSL semantics (e.g. `registers()`).
Add diagnostic for unexpected '(' in semantic annotation and skip safely.
Add tests for common misspellings/macros that previously caused a segfault.
Fixes #6599