### PR TITLE
Change type of DiagnosticHandlerTy

### DIFF
--- a/include/dxc/DxilValidation/DxilValidation.h
+++ b/include/dxc/DxilValidation/DxilValidation.h
@@ -81,7 +81,7 @@ public:
   bool HasWarnings() const;
   void Handle(const llvm::DiagnosticInfo &DI);
 
-  static void PrintDiagnosticHandler(const llvm::DiagnosticInfo &DI,
+  static void PrintDiagnosticHandler(const llvm::DiagnosticInfo *DI,
                                      void *Context);
 };
 

--- a/include/llvm/IR/LLVMContext.h
+++ b/include/llvm/IR/LLVMContext.h
@@ -83,7 +83,7 @@ public:
   /// Defines the type of a diagnostic handler.
   /// \see LLVMContext::setDiagnosticHandler.
   /// \see LLVMContext::diagnose.
-  typedef void (*DiagnosticHandlerTy)(const DiagnosticInfo &DI, void *Context);
+  typedef void (*DiagnosticHandlerTy)(const DiagnosticInfo *DI, void *Context);
 
   /// Defines the type of a yield callback.
   /// \see LLVMContext::setYieldCallback.

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -85,9 +85,9 @@ void PrintDiagnosticContext::Handle(const DiagnosticInfo &DI) {
   m_Printer << "\n";
 }
 
-void PrintDiagnosticContext::PrintDiagnosticHandler(const DiagnosticInfo &DI,
+void PrintDiagnosticContext::PrintDiagnosticHandler(const DiagnosticInfo *DI,
                                                     void *Context) {
-  reinterpret_cast<hlsl::PrintDiagnosticContext *>(Context)->Handle(DI);
+  reinterpret_cast<hlsl::PrintDiagnosticContext *>(Context)->Handle(*DI);
 }
 
 struct PSExecutionInfo {

--- a/lib/IR/LLVMContext.cpp
+++ b/lib/IR/LLVMContext.cpp
@@ -227,7 +227,7 @@ void LLVMContext::diagnose(const DiagnosticInfo &DI) {
   // If there is a report handler, use it.
   if (pImpl->DiagnosticHandler) {
     if (!pImpl->RespectDiagnosticFilters || isDiagnosticEnabled(DI))
-      pImpl->DiagnosticHandler(DI, pImpl->DiagnosticContext);
+      pImpl->DiagnosticHandler(&DI, pImpl->DiagnosticContext);
     return;
   }
 

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -238,9 +238,9 @@ namespace clang {
 
     void linkerDiagnosticHandler(const llvm::DiagnosticInfo &DI);
 
-    static void DiagnosticHandler(const llvm::DiagnosticInfo &DI,
+    static void DiagnosticHandler(const llvm::DiagnosticInfo *DI,
                                   void *Context) {
-      ((BackendConsumer *)Context)->DiagnosticHandlerImpl(DI);
+      ((BackendConsumer *)Context)->DiagnosticHandlerImpl(*DI);
     }
 
     void InlineAsmDiagHandler2(const llvm::SMDiagnostic &,

--- a/tools/llvm-dis/llvm-dis.cpp
+++ b/tools/llvm-dis/llvm-dis.cpp
@@ -115,10 +115,10 @@ public:
 
 } // end anon namespace
 
-static void diagnosticHandler(const DiagnosticInfo &DI, void *Context) {
+static void diagnosticHandler(const DiagnosticInfo *DI, void *Context) {
   raw_ostream &OS = errs();
   OS << (char *)Context << ": ";
-  switch (DI.getSeverity()) {
+  switch (DI->getSeverity()) {
   case DS_Error: OS << "error: "; break;
   case DS_Warning: OS << "warning: "; break;
   case DS_Remark: OS << "remark: "; break;
@@ -126,10 +126,10 @@ static void diagnosticHandler(const DiagnosticInfo &DI, void *Context) {
   }
 
   DiagnosticPrinterRawOStream DP(OS);
-  DI.print(DP);
+  DI->print(DP);
   OS << '\n';
 
-  if (DI.getSeverity() == DS_Error)
+  if (DI->getSeverity() == DS_Error)
     exit(1);
 }
 


### PR DESCRIPTION
Newer versions of clang include -Wcast-function-type-mismatch in -Wextra, which triggers a warning when we cast between function pointers that differ between a pointer and a reference in an argument. Resolve this by making the types consistent.

This change is equivalent to llvm/llvm-project#86504 from upstream.