### PR TITLE
[NFC] Execution Tests: Long Vector tests update template parameter names

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -28,12 +28,12 @@ const OpTypeMetaData<T> &getOpType(const OpTypeMetaData<T> (&Values)[Length],
 
 // Helper to fill the test data from the shader buffer based on type. Convenient
 // to be used when copying HLSL*_t types so we can use the underlying type.
-template <typename DataTypeT>
+template <typename T>
 void fillLongVectorDataFromShaderBuffer(const MappedData &ShaderBuffer,
-                                        std::vector<DataTypeT> &TestData,
+                                        std::vector<T> &TestData,
                                         size_t NumElements) {
 
-  if constexpr (std::is_same_v<DataTypeT, HLSLHalf_t>) {
+  if constexpr (std::is_same_v<T, HLSLHalf_t>) {
     auto ShaderBufferPtr =
         static_cast<const DirectX::PackedVector::HALF *>(ShaderBuffer.data());
     for (size_t I = 0; I < NumElements; I++)
@@ -42,7 +42,7 @@ void fillLongVectorDataFromShaderBuffer(const MappedData &ShaderBuffer,
     return;
   }
 
-  if constexpr (std::is_same_v<DataTypeT, HLSLBool_t>) {
+  if constexpr (std::is_same_v<T, HLSLBool_t>) {
     auto ShaderBufferPtr = static_cast<const int32_t *>(ShaderBuffer.data());
     for (size_t I = 0; I < NumElements; I++)
       // HLSLBool_t has a int32_t based constructor.
@@ -50,18 +50,18 @@ void fillLongVectorDataFromShaderBuffer(const MappedData &ShaderBuffer,
     return;
   }
 
-  auto ShaderBufferPtr = static_cast<const DataTypeT *>(ShaderBuffer.data());
+  auto ShaderBufferPtr = static_cast<const T *>(ShaderBuffer.data());
   for (size_t I = 0; I < NumElements; I++)
     TestData.push_back(ShaderBufferPtr[I]);
   return;
 }
 
-template <typename DataTypeT>
-bool doValuesMatch(DataTypeT A, DataTypeT B, float Tolerance, ValidationType) {
+template <typename T>
+bool doValuesMatch(T A, T B, float Tolerance, ValidationType) {
   if (Tolerance == 0.0f)
     return A == B;
 
-  DataTypeT Diff = A > B ? A - B : B - A;
+  T Diff = A > B ? A - B : B - A;
   return Diff <= Tolerance;
 }
 
@@ -117,11 +117,10 @@ bool doValuesMatch(double A, double B, float Tolerance,
   }
 }
 
-template <typename DataTypeT>
-bool doVectorsMatch(const std::vector<DataTypeT> &ActualValues,
-                    const std::vector<DataTypeT> &ExpectedValues,
-                    float Tolerance, ValidationType ValidationType,
-                    bool VerboseLogging) {
+template <typename T>
+bool doVectorsMatch(const std::vector<T> &ActualValues,
+                    const std::vector<T> &ExpectedValues, float Tolerance,
+                    ValidationType ValidationType, bool VerboseLogging) {
 
   DXASSERT(
       ActualValues.size() == ExpectedValues.size(),
@@ -159,12 +158,11 @@ bool doVectorsMatch(const std::vector<DataTypeT> &ActualValues,
 
 // A helper to create and fill the expected vector with computed values.
 // Also helps us factor out the generic fill loop via a passed in ComputeFn.
-template <typename DataTypeT, typename ComputeFnT>
+template <typename T, typename ComputeFnT>
 VariantVector generateExpectedVector(size_t Count, ComputeFnT ComputeFn) {
 
-  VariantVector ExpectedVector = std::vector<DataTypeT>{};
-  auto *TypedExpectedValues =
-      std::get_if<std::vector<DataTypeT>>(&ExpectedVector);
+  VariantVector ExpectedVector = std::vector<T>{};
+  auto *TypedExpectedValues = std::get_if<std::vector<T>>(&ExpectedVector);
 
   // A TestConfig may be reused for a different vector length. So this is a
   // good time to make sure we clear the expected vector.
@@ -176,9 +174,8 @@ VariantVector generateExpectedVector(size_t Count, ComputeFnT ComputeFn) {
   return ExpectedVector;
 }
 
-template <typename DataTypeT>
-void logLongVector(const std::vector<DataTypeT> &Values,
-                   const std::wstring &Name) {
+template <typename T>
+void logLongVector(const std::vector<T> &Values, const std::wstring &Name) {
   WEX::Logging::Log::Comment(
       WEX::Common::String().Format(L"LongVector Name: %s", Name.c_str()));
 
@@ -200,29 +197,29 @@ void logLongVector(const std::vector<DataTypeT> &Values,
   WEX::Logging::Log::Comment(Wss.str().c_str());
 }
 
-template <typename DataTypeT> std::string getHLSLTypeString() {
-  if (std::is_same_v<DataTypeT, HLSLBool_t>)
+template <typename T> std::string getHLSLTypeString() {
+  if (std::is_same_v<T, HLSLBool_t>)
     return "bool";
-  if (std::is_same_v<DataTypeT, HLSLHalf_t>)
+  if (std::is_same_v<T, HLSLHalf_t>)
     return "half";
-  if (std::is_same_v<DataTypeT, float>)
+  if (std::is_same_v<T, float>)
     return "float";
-  if (std::is_same_v<DataTypeT, double>)
+  if (std::is_same_v<T, double>)
     return "double";
-  if (std::is_same_v<DataTypeT, int16_t>)
+  if (std::is_same_v<T, int16_t>)
     return "int16_t";
-  if (std::is_same_v<DataTypeT, int32_t>)
+  if (std::is_same_v<T, int32_t>)
     return "int";
-  if (std::is_same_v<DataTypeT, int64_t>)
+  if (std::is_same_v<T, int64_t>)
     return "int64_t";
-  if (std::is_same_v<DataTypeT, uint16_t>)
+  if (std::is_same_v<T, uint16_t>)
     return "uint16_t";
-  if (std::is_same_v<DataTypeT, uint32_t>)
+  if (std::is_same_v<T, uint32_t>)
     return "uint32_t";
-  if (std::is_same_v<DataTypeT, uint64_t>)
+  if (std::is_same_v<T, uint64_t>)
     return "uint64_t";
 
-  LOG_ERROR_FMT_THROW(L"Unsupported type: %S", typeid(DataTypeT).name());
+  LOG_ERROR_FMT_THROW(L"Unsupported type: %S", typeid(T).name());
   return "UnknownType";
 }
 
@@ -414,8 +411,8 @@ TEST_F(OpTest, ternaryMathOpTest) {
 }
 
 // Generic dispatch that dispatchs all DataTypes recognized in these tests
-template <typename OpTypeT>
-void OpTest::dispatchTestByDataType(const OpTypeMetaData<OpTypeT> &OpTypeMd,
+template <typename T>
+void OpTest::dispatchTestByDataType(const OpTypeMetaData<T> &OpTypeMd,
                                     std::wstring DataType,
                                     TableParameterHandler &Handler) {
   switch (Hash_djb2a(DataType)) {
@@ -520,13 +517,13 @@ void OpTest::dispatchTrigonometricOpTestByDataType(
         DataType.c_str());
 }
 
-template <typename DataTypeT, typename OpTypeT>
-void OpTest::dispatchTestByVectorLength(const OpTypeMetaData<OpTypeT> &OpTypeMd,
+template <typename T, typename T2>
+void OpTest::dispatchTestByVectorLength(const OpTypeMetaData<T2> &OpTypeMd,
                                         TableParameterHandler &Handler) {
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
-  auto TestConfig = makeTestConfig<DataTypeT>(OpTypeMd);
+  auto TestConfig = makeTestConfig<T>(OpTypeMd);
   TestConfig->setVerboseLogging(VerboseLogging);
   auto OperandCount = TestConfig->getNumOperands();
 
@@ -555,13 +552,12 @@ void OpTest::dispatchTestByVectorLength(const OpTypeMetaData<OpTypeT> &OpTypeMd,
     // We could create a new config for each test case with the new length, but
     // that feels wasteful. Instead, we just update the length to test.
     TestConfig->setLengthToTest(SizeToTest);
-    testBaseMethod<DataTypeT>(TestConfig);
+    testBaseMethod<T>(TestConfig);
   }
 }
 
-template <typename DataTypeT>
-void OpTest::testBaseMethod(
-    std::unique_ptr<TestConfig<DataTypeT>> &TestConfig) {
+template <typename T>
+void OpTest::testBaseMethod(std::unique_ptr<TestConfig<T>> &TestConfig) {
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
@@ -578,7 +574,7 @@ void OpTest::testBaseMethod(
 #endif
   }
 
-  TestInputs<DataTypeT> Inputs = TestInputs<DataTypeT>();
+  TestInputs<T> Inputs = TestInputs<T>();
   TestConfig->fillInputs(Inputs);
 
   TestConfig->computeExpectedValues(Inputs);
@@ -661,18 +657,18 @@ void OpTest::testBaseMethod(
 // Helper to fill the shader buffer based on type. Convenient to be used when
 // copying HLSL*_t types so we can copy the underlying type directly instead of
 // the struct.
-template <typename DataTypeT>
-void fillShaderBufferFromLongVectorData(
-    std::vector<BYTE> &ShaderBuffer, const std::vector<DataTypeT> &TestData) {
+template <typename T>
+void fillShaderBufferFromLongVectorData(std::vector<BYTE> &ShaderBuffer,
+                                        const std::vector<T> &TestData) {
 
   // Note: DataSize for HLSLHalf_t and HLSLBool_t may be larger than the
   // underlying type in some cases. Thats fine. Resize just makes sure we have
   // enough space.
   const size_t NumElements = TestData.size();
-  const size_t DataSize = sizeof(DataTypeT) * NumElements;
+  const size_t DataSize = sizeof(T) * NumElements;
   ShaderBuffer.resize(DataSize);
 
-  if constexpr (std::is_same_v<DataTypeT, HLSLHalf_t>) {
+  if constexpr (std::is_same_v<T, HLSLHalf_t>) {
     auto ShaderBufferPtr =
         reinterpret_cast<DirectX::PackedVector::HALF *>(ShaderBuffer.data());
     for (size_t I = 0; I < NumElements; I++)
@@ -680,14 +676,14 @@ void fillShaderBufferFromLongVectorData(
     return;
   }
 
-  if constexpr (std::is_same_v<DataTypeT, HLSLBool_t>) {
+  if constexpr (std::is_same_v<T, HLSLBool_t>) {
     auto ShaderBufferPtr = reinterpret_cast<int32_t *>(ShaderBuffer.data());
     for (size_t I = 0; I < NumElements; I++)
       ShaderBufferPtr[I] = TestData[I].Val;
     return;
   }
 
-  auto ShaderBufferPtr = reinterpret_cast<DataTypeT *>(ShaderBuffer.data());
+  auto ShaderBufferPtr = reinterpret_cast<T *>(ShaderBuffer.data());
   for (size_t I = 0; I < NumElements; I++)
     ShaderBufferPtr[I] = TestData[I];
   return;
@@ -696,12 +692,12 @@ void fillShaderBufferFromLongVectorData(
 // Returns the compiler options string to be used for the shader compilation.
 // Reference ShaderOpArith.xml and the 'LongVectorOp' shader source to see how
 // the defines are used in the shader code.
-template <typename DataTypeT>
-std::string TestConfig<DataTypeT>::getCompilerOptionsString() const {
+template <typename T>
+std::string TestConfig<T>::getCompilerOptionsString() const {
 
   std::stringstream CompilerOptions("");
 
-  if (is16BitType<DataTypeT>())
+  if (is16BitType<T>())
     CompilerOptions << " -enable-16bit-types";
 
   CompilerOptions << " -DTYPE=" << getHLSLInputTypeString();
@@ -729,8 +725,8 @@ std::string TestConfig<DataTypeT>::getCompilerOptionsString() const {
   return CompilerOptions.str();
 }
 
-template <typename DataTypeT>
-std::string TestConfig<DataTypeT>::getBasicOpTypeHexString() const {
+template <typename T>
+std::string TestConfig<T>::getBasicOpTypeHexString() const {
 
   if (BasicOpType == BasicOpType_Unary)
     return "0x1";
@@ -744,8 +740,7 @@ std::string TestConfig<DataTypeT>::getBasicOpTypeHexString() const {
   return "0x0";
 }
 
-template <typename DataTypeT>
-size_t TestConfig<DataTypeT>::getNumOperands() const {
+template <typename T> size_t TestConfig<T>::getNumOperands() const {
   if (BasicOpType == BasicOpType_Unary)
     return 1;
 
@@ -760,25 +755,24 @@ size_t TestConfig<DataTypeT>::getNumOperands() const {
   return 0;
 }
 
-template <typename DataTypeT>
-std::vector<DataTypeT>
-TestConfig<DataTypeT>::getInputValueSet(size_t ValueSetIndex) const {
+template <typename T>
+std::vector<T> TestConfig<T>::getInputValueSet(size_t ValueSetIndex) const {
   if (BasicOpType == BasicOpType_Unary && ValueSetIndex == 0)
-    return getInputValueSetByKey<DataTypeT>(InputValueSetKeys[ValueSetIndex]);
+    return getInputValueSetByKey<T>(InputValueSetKeys[ValueSetIndex]);
 
   if (BasicOpType == BasicOpType_Binary && ValueSetIndex <= 1)
-    return getInputValueSetByKey<DataTypeT>(InputValueSetKeys[ValueSetIndex]);
+    return getInputValueSetByKey<T>(InputValueSetKeys[ValueSetIndex]);
 
   if (BasicOpType == BasicOpType_Ternary && ValueSetIndex <= 2)
-    return getInputValueSetByKey<DataTypeT>(InputValueSetKeys[ValueSetIndex]);
+    return getInputValueSetByKey<T>(InputValueSetKeys[ValueSetIndex]);
 
   LOG_ERROR_FMT_THROW(L"Invalid ValueSetIndex: %d for OpType: %ls",
                       ValueSetIndex, OpTypeName.c_str());
-  return std::vector<DataTypeT>();
+  return std::vector<T>();
 }
 
-template <typename DataTypeT>
-std::string TestConfig<DataTypeT>::getHLSLOutputTypeString() const {
+template <typename T>
+std::string TestConfig<T>::getHLSLOutputTypeString() const {
   // std::visit allows us to dispatch a call to getHLSLTypeString<T>() with the
   // the current underlying element type of ExpectedVector.
   return std::visit(
@@ -789,8 +783,8 @@ std::string TestConfig<DataTypeT>::getHLSLOutputTypeString() const {
       ExpectedVector);
 }
 
-template <typename DataTypeT>
-bool TestConfig<DataTypeT>::verifyOutput(
+template <typename T>
+bool TestConfig<T>::verifyOutput(
     const std::shared_ptr<st::ShaderOpTestResult> &TestResult) {
 
   // std::visit allows us to dispatch a call to the private version of
@@ -798,7 +792,7 @@ bool TestConfig<DataTypeT>::verifyOutput(
   // ExpectedVector. This works because ExpectedVector is a std::variant of
   // vector types, and the lambda receives the active type at runtime. It's
   // important that the TestConfig instance has correctly assigned the expected
-  // output type to ExpectedVector. By default, this is std::vector<DataTypeT>,
+  // output type to ExpectedVector. By default, this is std::vector<T>,
   // but ops like AsTypeOpType must override it. For example,
   // AsTypeOpType_AsFloat16 sets ExpectedVector to std::vector<HLSLHalf_t>.
   return std::visit(
@@ -810,16 +804,18 @@ bool TestConfig<DataTypeT>::verifyOutput(
 }
 
 // Private version of verifyOutput. Called by the public version of verifyOutput
-// which resolves OutputDataTypeT based on the ExpectedVector type.
-template <typename DataTypeT>
-template <typename OutputDataTypeT>
-bool TestConfig<DataTypeT>::verifyOutput(
+// which resolves OutT based on the ExpectedVector type. Most intrinsics will
+// have an OutT that matches the input type being tested (which is T). But some,
+// such as the 'AsType' ops, i.e 'AsUint' have an OutT that doesn't match T.
+template <typename T>  // Primary template from TestConfig
+template <typename OutT> // Secondary template for verifyOutput
+bool TestConfig<T>::verifyOutput(
     const std::shared_ptr<st::ShaderOpTestResult> &TestResult,
-    const std::vector<OutputDataTypeT> &ExpectedVector) {
+    const std::vector<OutT> &ExpectedVector) {
 
   WEX::Logging::Log::Comment(WEX::Common::String().Format(
       L"verifyOutput with OpType: %ls ExpectedVector<%S>", OpTypeName.c_str(),
-      typeid(OutputDataTypeT).name()));
+      typeid(OutT).name()));
 
   DXASSERT(!ExpectedVector.empty(),
            "Programmer Error: ExpectedVector is empty.");
@@ -829,7 +825,7 @@ bool TestConfig<DataTypeT>::verifyOutput(
 
   const size_t OutputVectorSize = ExpectedVector.size();
 
-  std::vector<OutputDataTypeT> ActualValues;
+  std::vector<OutT> ActualValues;
   fillLongVectorDataFromShaderBuffer(ShaderOutData, ActualValues,
                                      OutputVectorSize);
 
@@ -839,12 +835,12 @@ bool TestConfig<DataTypeT>::verifyOutput(
 
 // Generic fillInput. Fill the inputs based on the OpType and the
 // ScalarInputFlags.
-template <typename DataTypeT>
-void TestConfig<DataTypeT>::fillInputs(TestInputs<DataTypeT> &Inputs) const {
+template <typename T>
+void TestConfig<T>::fillInputs(TestInputs<T> &Inputs) const {
 
-  auto fillVecFromValueSet = [this](std::vector<DataTypeT> &Vec,
-                                    size_t ValueSetIndex, size_t Count) {
-    std::vector<DataTypeT> ValueSet = getInputValueSet(ValueSetIndex);
+  auto fillVecFromValueSet = [this](std::vector<T> &Vec, size_t ValueSetIndex,
+                                    size_t Count) {
+    std::vector<T> ValueSet = getInputValueSet(ValueSetIndex);
     for (size_t Index = 0; Index < Count; Index++)
       Vec.push_back(ValueSet[Index % ValueSet.size()]);
   };
@@ -863,7 +859,7 @@ void TestConfig<DataTypeT>::fillInputs(TestInputs<DataTypeT> &Inputs) const {
       (ScalarInputFlags & SCALAR_INPUT_FLAGS_OPERAND_2_IS_SCALAR)
           ? 1
           : LengthToTest;
-  Inputs.InputVector2 = std::vector<DataTypeT>();
+  Inputs.InputVector2 = std::vector<T>();
   fillVecFromValueSet(*Inputs.InputVector2, ValueSetIndex++, Input2Length);
 
   if (BasicOpType == BasicOpType_Binary)
@@ -875,40 +871,40 @@ void TestConfig<DataTypeT>::fillInputs(TestInputs<DataTypeT> &Inputs) const {
       (ScalarInputFlags & SCALAR_INPUT_FLAGS_OPERAND_3_IS_SCALAR)
           ? 1
           : LengthToTest;
-  Inputs.InputVector3 = std::vector<DataTypeT>();
+  Inputs.InputVector3 = std::vector<T>();
   fillVecFromValueSet(*Inputs.InputVector3, ValueSetIndex++, Input3Length);
 }
 
-template <typename DataTypeT>
-AsTypeOpTestConfig<DataTypeT>::AsTypeOpTestConfig(
+template <typename T>
+AsTypeOpTestConfig<T>::AsTypeOpTestConfig(
     const OpTypeMetaData<AsTypeOpType> &OpTypeMd)
-    : TestConfig<DataTypeT>(OpTypeMd), OpType(OpTypeMd.OpType) {
+    : TestConfig<T>(OpTypeMd), OpType(OpTypeMd.OpType) {
 
   BasicOpType = BasicOpType_Unary;
 
   switch (OpType) {
   case AsTypeOpType_AsFloat16: {
-    auto ComputeFunc = [this](const DataTypeT &Val) { return asFloat16(Val); };
+    auto ComputeFunc = [this](const T &Val) { return asFloat16(Val); };
     InitUnaryOpValueComputer<HLSLHalf_t>(ComputeFunc);
     break;
   }
   case AsTypeOpType_AsFloat: {
-    auto ComputeFunc = [this](const DataTypeT &Val) { return asFloat(Val); };
+    auto ComputeFunc = [this](const T &Val) { return asFloat(Val); };
     InitUnaryOpValueComputer<float>(ComputeFunc);
     break;
   }
   case AsTypeOpType_AsInt: {
-    auto ComputeFunc = [this](const DataTypeT &Val) { return asInt(Val); };
+    auto ComputeFunc = [this](const T &Val) { return asInt(Val); };
     InitUnaryOpValueComputer<int32_t>(ComputeFunc);
     break;
   }
   case AsTypeOpType_AsInt16: {
-    auto ComputeFunc = [this](const DataTypeT &Val) { return asInt16(Val); };
+    auto ComputeFunc = [this](const T &Val) { return asInt16(Val); };
     InitUnaryOpValueComputer<int16_t>(ComputeFunc);
     break;
   }
   case AsTypeOpType_AsUint: {
-    auto ComputeFunc = [this](const DataTypeT &Val) { return asUint(Val); };
+    auto ComputeFunc = [this](const T &Val) { return asUint(Val); };
     InitUnaryOpValueComputer<uint32_t>(ComputeFunc);
     break;
   }
@@ -917,13 +913,13 @@ AsTypeOpTestConfig<DataTypeT>::AsTypeOpTestConfig(
     break;
   }
   case AsTypeOpType_AsUint16: {
-    auto ComputeFunc = [this](const DataTypeT &Val) { return asUint16(Val); };
+    auto ComputeFunc = [this](const T &Val) { return asUint16(Val); };
     InitUnaryOpValueComputer<uint16_t>(ComputeFunc);
     break;
   }
   case AsTypeOpType_AsDouble: {
     BasicOpType = BasicOpType_Binary;
-    auto ComputeFunc = [this](const DataTypeT &A, const DataTypeT &B) {
+    auto ComputeFunc = [this](const T &A, const T &B) {
       return asDouble(A, B);
     };
     InitBinaryOpValueComputer<double>(ComputeFunc);
@@ -934,9 +930,8 @@ AsTypeOpTestConfig<DataTypeT>::AsTypeOpTestConfig(
   }
 }
 
-template <typename DataTypeT>
-void TestConfig<DataTypeT>::computeExpectedValues(
-    const TestInputs<DataTypeT> &Inputs) {
+template <typename T>
+void TestConfig<T>::computeExpectedValues(const TestInputs<T> &Inputs) {
 
   // Either a ExpectedValueComputer member should be set or the deriving class
   // should have overridden computeExpectedValues.
@@ -948,9 +943,8 @@ void TestConfig<DataTypeT>::computeExpectedValues(
   ExpectedVector = ExpectedValueComputer->computeExpectedValues(Inputs);
 }
 
-template <typename DataTypeT>
-void AsTypeOpTestConfig<DataTypeT>::computeExpectedValues(
-    const TestInputs<DataTypeT> &Inputs) {
+template <typename T>
+void AsTypeOpTestConfig<T>::computeExpectedValues(const TestInputs<T> &Inputs) {
 
   if (BasicOpType != BasicOpType_Unary && BasicOpType != BasicOpType_Binary)
     LOG_ERROR_FMT_THROW(L"Programmer Error: computeExpectedValue called with "
@@ -965,9 +959,9 @@ void AsTypeOpTestConfig<DataTypeT>::computeExpectedValues(
     computeExpectedValues_SplitDouble(Inputs.InputVector1);
 }
 
-template <typename DataTypeT>
-void AsTypeOpTestConfig<DataTypeT>::computeExpectedValues_SplitDouble(
-    const std::vector<DataTypeT> &InputVector1) {
+template <typename T>
+void AsTypeOpTestConfig<T>::computeExpectedValues_SplitDouble(
+    const std::vector<T> &InputVector1) {
 
   DXASSERT_NOMSG(OpType == AsTypeOpType_AsUint_SplitDouble);
 
@@ -989,13 +983,13 @@ void AsTypeOpTestConfig<DataTypeT>::computeExpectedValues_SplitDouble(
   }
 }
 
-template <typename DataTypeT>
-TrigonometricOpTestConfig<DataTypeT>::TrigonometricOpTestConfig(
+template <typename T>
+TrigonometricOpTestConfig<T>::TrigonometricOpTestConfig(
     const OpTypeMetaData<TrigonometricOpType> &OpTypeMd)
-    : TestConfig<DataTypeT>(OpTypeMd), OpType(OpTypeMd.OpType) {
+    : TestConfig<T>(OpTypeMd), OpType(OpTypeMd.OpType) {
 
   static_assert(
-      isFloatingPointType<DataTypeT>(),
+      isFloatingPointType<T>(),
       "Trigonometric ops are only supported for floating point types.");
 
   BasicOpType = BasicOpType_Unary;
@@ -1006,21 +1000,20 @@ TrigonometricOpTestConfig<DataTypeT>::TrigonometricOpTestConfig(
   // cos is available here:
   // https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#22.10.20
   ValidationType = ValidationType_Epsilon;
-  if (std::is_same_v<DataTypeT, HLSLHalf_t>)
+  if (std::is_same_v<T, HLSLHalf_t>)
     Tolerance = 0.0010f;
-  else if (std::is_same_v<DataTypeT, float>)
+  else if (std::is_same_v<T, float>)
     Tolerance = 0.0008f;
 
-  auto ComputeFunc = [this](const DataTypeT &A) {
+  auto ComputeFunc = [this](const T &A) {
     return this->computeExpectedValue(A);
   };
-  InitUnaryOpValueComputer<DataTypeT>(ComputeFunc);
+  InitUnaryOpValueComputer<T>(ComputeFunc);
 }
 
 // computeExpectedValue Trigonometric
-template <typename DataTypeT>
-DataTypeT TrigonometricOpTestConfig<DataTypeT>::computeExpectedValue(
-    const DataTypeT &A) const {
+template <typename T>
+T TrigonometricOpTestConfig<T>::computeExpectedValue(const T &A) const {
 
   switch (OpType) {
   case TrigonometricOpType_Acos:
@@ -1044,14 +1037,14 @@ DataTypeT TrigonometricOpTestConfig<DataTypeT>::computeExpectedValue(
   default:
     LOG_ERROR_FMT_THROW(L"Unknown TrigonometricOpType: %ls",
                         OpTypeName.c_str());
-    return DataTypeT();
+    return T();
   }
 }
 
-template <typename DataTypeT>
-UnaryOpTestConfig<DataTypeT>::UnaryOpTestConfig(
+template <typename T>
+UnaryOpTestConfig<T>::UnaryOpTestConfig(
     const OpTypeMetaData<UnaryOpType> &OpTypeMd)
-    : TestConfig<DataTypeT>(OpTypeMd), OpType(OpTypeMd.OpType) {
+    : TestConfig<T>(OpTypeMd), OpType(OpTypeMd.OpType) {
 
   BasicOpType = BasicOpType_Unary;
 
@@ -1063,72 +1056,70 @@ UnaryOpTestConfig<DataTypeT>::UnaryOpTestConfig(
     LOG_ERROR_FMT_THROW(L"Unsupported UnaryOpType: %ls", OpTypeName.c_str());
   }
 
-  auto ComputeFunc = [this](const DataTypeT &A) {
+  auto ComputeFunc = [this](const T &A) {
     return this->computeExpectedValue(A);
   };
-  InitUnaryOpValueComputer<DataTypeT>(ComputeFunc);
+  InitUnaryOpValueComputer<T>(ComputeFunc);
 }
 
-template <typename DataTypeT>
-DataTypeT
-UnaryOpTestConfig<DataTypeT>::computeExpectedValue(const DataTypeT &A) const {
+template <typename T>
+T UnaryOpTestConfig<T>::computeExpectedValue(const T &A) const {
   if (OpType != UnaryOpType_Initialize) {
-    LOG_ERROR_FMT_THROW(L"computeExpectedValue(const DataTypeT &A, "
+    LOG_ERROR_FMT_THROW(L"computeExpectedValue(const T &A, "
                         L"UnaryOpType OpType) called on an "
                         L"unrecognized unary op: %ls",
                         OpTypeName.c_str());
-    return DataTypeT();
+    return T();
   }
 
-  return DataTypeT(A);
+  return T(A);
 }
 
-template <typename DataTypeT>
-UnaryMathOpTestConfig<DataTypeT>::UnaryMathOpTestConfig(
+template <typename T>
+UnaryMathOpTestConfig<T>::UnaryMathOpTestConfig(
     const OpTypeMetaData<UnaryMathOpType> &OpTypeMd)
-    : TestConfig<DataTypeT>(OpTypeMd), OpType(OpTypeMd.OpType) {
+    : TestConfig<T>(OpTypeMd), OpType(OpTypeMd.OpType) {
 
   BasicOpType = BasicOpType_Unary;
 
-  if (isFloatingPointType<DataTypeT>()) {
+  if (isFloatingPointType<T>()) {
     Tolerance = 1;
     ValidationType = ValidationType_Ulp;
   }
 
   if (OpType == UnaryMathOpType_Sign) {
     // Sign has overridden special logic.
-    auto ComputeFunc = [this](const DataTypeT &A) { return this->sign(A); };
+    auto ComputeFunc = [this](const T &A) { return this->sign(A); };
     InitUnaryOpValueComputer<int32_t>(ComputeFunc);
   } else {
-    auto ComputeFunc = [this](const DataTypeT &A) {
+    auto ComputeFunc = [this](const T &A) {
       return this->computeExpectedValue(A);
     };
-    InitUnaryOpValueComputer<DataTypeT>(ComputeFunc);
+    InitUnaryOpValueComputer<T>(ComputeFunc);
   }
 }
 
-template <typename DataTypeT>
-DataTypeT UnaryMathOpTestConfig<DataTypeT>::computeExpectedValue(
-    const DataTypeT &A) const {
+template <typename T>
+T UnaryMathOpTestConfig<T>::computeExpectedValue(const T &A) const {
 
-  if constexpr (std::is_integral<DataTypeT>::value) {
+  if constexpr (std::is_integral<T>::value) {
     // Abs and Sign are the only UnaryMathOps thats support integral types.
     // Sign always returns int32 values, so its handled elsewhere.
     DXASSERT_NOMSG(OpType == UnaryMathOpType_Abs);
     return abs(A);
   }
 
-  if constexpr (!isFloatingPointType<DataTypeT>()) {
+  if constexpr (!isFloatingPointType<T>()) {
     LOG_ERROR_FMT_THROW(L"Programmer error: UnaryMathOpType OpType: %ls only "
                         L"supports floating point types",
                         OpTypeName.c_str());
-    return DataTypeT();
+    return T();
   }
 
   // Most of the std math functions here are only defined for floating point
   // types. If we don't use a mechanism to ensure that we're only using floating
   // point types then the compiler will complain about implicit conversions.
-  if constexpr (isFloatingPointType<DataTypeT>()) {
+  if constexpr (isFloatingPointType<T>()) {
     // A bunch of the std match functions here are  wrapped in () to avoid
     // collisions with the macro defitions for various functions in windows.h
     switch (OpType) {
@@ -1147,12 +1138,12 @@ DataTypeT UnaryMathOpTestConfig<DataTypeT>::computeExpectedValue(
       return (std::round)(A);
     case UnaryMathOpType_Frac:
       // std::frac is not a standard C++ function, but we can implement it as
-      return A - DataTypeT((std::floor)(A));
+      return A - T((std::floor)(A));
     case UnaryMathOpType_Sqrt:
       return (std::sqrt)(A);
     case UnaryMathOpType_Rsqrt:
       // std::rsqrt is not a standard C++ function, but we can implement it as
-      return DataTypeT(1.0) / DataTypeT((std::sqrt)(A));
+      return T(1.0) / T((std::sqrt)(A));
     case UnaryMathOpType_Exp:
       return (std::exp)(A);
     case UnaryMathOpType_Exp2:
@@ -1165,37 +1156,37 @@ DataTypeT UnaryMathOpTestConfig<DataTypeT>::computeExpectedValue(
       return (std::log10)(A);
     case UnaryMathOpType_Rcp:
       // std::.rcp is not a standard C++ function, but we can implement it as
-      return DataTypeT(1.0) / A;
+      return T(1.0) / A;
     default:
-      LOG_ERROR_FMT_THROW(L"computeExpectedValue(const DataTypeT &A)"
+      LOG_ERROR_FMT_THROW(L"computeExpectedValue(const T &A)"
                           L"called on an unrecognized unary math op: %ls",
                           OpTypeName.c_str());
-      return DataTypeT();
+      return T();
     }
   }
 }
 
-template <typename DataTypeT>
-BinaryMathOpTestConfig<DataTypeT>::BinaryMathOpTestConfig(
+template <typename T>
+BinaryMathOpTestConfig<T>::BinaryMathOpTestConfig(
     const OpTypeMetaData<BinaryMathOpType> &OpTypeMd)
-    : TestConfig<DataTypeT>(OpTypeMd), OpType(OpTypeMd.OpType) {
+    : TestConfig<T>(OpTypeMd), OpType(OpTypeMd.OpType) {
 
-  if (isFloatingPointType<DataTypeT>()) {
+  if (isFloatingPointType<T>()) {
     Tolerance = 1;
     ValidationType = ValidationType_Ulp;
   }
 
   BasicOpType = BasicOpType_Binary;
 
-  auto ComputeFunc = [this](const DataTypeT &A, const DataTypeT &B) {
+  auto ComputeFunc = [this](const T &A, const T &B) {
     return this->computeExpectedValue(A, B);
   };
-  InitBinaryOpValueComputer<DataTypeT>(ComputeFunc);
+  InitBinaryOpValueComputer<T>(ComputeFunc);
 }
 
-template <typename DataTypeT>
-DataTypeT BinaryMathOpTestConfig<DataTypeT>::computeExpectedValue(
-    const DataTypeT &A, const DataTypeT &B) const {
+template <typename T>
+T BinaryMathOpTestConfig<T>::computeExpectedValue(const T &A,
+                                                  const T &B) const {
 
   switch (OpType) {
   case BinaryMathOpType_Multiply:
@@ -1216,16 +1207,16 @@ DataTypeT BinaryMathOpTestConfig<DataTypeT>::computeExpectedValue(
     return (std::max)(A, B);
   default:
     LOG_ERROR_FMT_THROW(L"Unknown BinaryMathOpType: %ls", OpTypeName.c_str());
-    return DataTypeT();
+    return T();
   }
 }
 
-template <typename DataTypeT>
-TernaryMathOpTestConfig<DataTypeT>::TernaryMathOpTestConfig(
+template <typename T>
+TernaryMathOpTestConfig<T>::TernaryMathOpTestConfig(
     const OpTypeMetaData<TernaryMathOpType> &OpTypeMd)
-    : TestConfig<DataTypeT>(OpTypeMd), OpType(OpTypeMd.OpType) {
+    : TestConfig<T>(OpTypeMd), OpType(OpTypeMd.OpType) {
 
-  if (isFloatingPointType<DataTypeT>()) {
+  if (isFloatingPointType<T>()) {
     Tolerance = 1;
     ValidationType = ValidationType_Ulp;
   }
@@ -1241,11 +1232,10 @@ TernaryMathOpTestConfig<DataTypeT>::TernaryMathOpTestConfig(
     LOG_ERROR_FMT_THROW(L"Invalid TernaryMathOpType: %ls", OpTypeName.c_str());
   }
 
-  auto ComputeFunc = [this](const DataTypeT &A, const DataTypeT &B,
-                            const DataTypeT &C) {
+  auto ComputeFunc = [this](const T &A, const T &B, const T &C) {
     return this->computeExpectedValue(A, B, C);
   };
-  InitTernaryOpValueComputer<DataTypeT>(ComputeFunc);
+  InitTernaryOpValueComputer<T>(ComputeFunc);
 }
 
 }; // namespace LongVector

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -4,9 +4,10 @@
 
 namespace LongVector {
 
-template <typename T, size_t Length>
-const OpTypeMetaData<T> &getOpType(const OpTypeMetaData<T> (&Values)[Length],
-                                   const std::wstring &OpTypeString) {
+template <typename OpT, size_t Length>
+const OpTypeMetaData<OpT> &
+getOpType(const OpTypeMetaData<OpT> (&Values)[Length],
+          const std::wstring &OpTypeString) {
   for (size_t I = 0; I < Length; I++) {
     if (Values[I].OpTypeString == OpTypeString)
       return Values[I];
@@ -411,8 +412,8 @@ TEST_F(OpTest, ternaryMathOpTest) {
 }
 
 // Generic dispatch that dispatchs all DataTypes recognized in these tests
-template <typename T>
-void OpTest::dispatchTestByDataType(const OpTypeMetaData<T> &OpTypeMd,
+template <typename OpT>
+void OpTest::dispatchTestByDataType(const OpTypeMetaData<OpT> &OpTypeMd,
                                     std::wstring DataType,
                                     TableParameterHandler &Handler) {
   switch (Hash_djb2a(DataType)) {
@@ -517,8 +518,8 @@ void OpTest::dispatchTrigonometricOpTestByDataType(
         DataType.c_str());
 }
 
-template <typename T, typename T2>
-void OpTest::dispatchTestByVectorLength(const OpTypeMetaData<T2> &OpTypeMd,
+template <typename T, typename OpT>
+void OpTest::dispatchTestByVectorLength(const OpTypeMetaData<OpT> &OpTypeMd,
                                         TableParameterHandler &Handler) {
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -807,7 +807,7 @@ bool TestConfig<T>::verifyOutput(
 // which resolves OutT based on the ExpectedVector type. Most intrinsics will
 // have an OutT that matches the input type being tested (which is T). But some,
 // such as the 'AsType' ops, i.e 'AsUint' have an OutT that doesn't match T.
-template <typename T>  // Primary template from TestConfig
+template <typename T>    // Primary template from TestConfig
 template <typename OutT> // Secondary template for verifyOutput
 bool TestConfig<T>::verifyOutput(
     const std::shared_ptr<st::ShaderOpTestResult> &TestResult,

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -114,9 +114,10 @@ template <typename T> struct OpTypeMetaData {
   uint16_t ScalarInputFlags = static_cast<uint16_t>(SCALAR_INPUT_FLAGS_NONE);
 };
 
-template <typename T, size_t Length>
-const OpTypeMetaData<T> &getOpType(const OpTypeMetaData<T> (&Values)[Length],
-                                   const std::wstring &OpTypeString);
+template <typename OpT, size_t Length>
+const OpTypeMetaData<OpT> &
+getOpType(const OpTypeMetaData<OpT> (&Values)[Length],
+          const std::wstring &OpTypeString);
 
 enum ValidationType {
   ValidationType_Epsilon,
@@ -378,8 +379,8 @@ public:
                        L"Table:LongVectorOpTable.xml#AsTypeOpTable")
   END_TEST_METHOD()
 
-  template <typename T>
-  void dispatchTestByDataType(const OpTypeMetaData<T> &OpTypeMD,
+  template <typename OpT>
+  void dispatchTestByDataType(const OpTypeMetaData<OpT> &OpTypeMD,
                               std::wstring DataType,
                               TableParameterHandler &Handler);
 
@@ -391,8 +392,8 @@ public:
       const OpTypeMetaData<UnaryMathOpType> &OpTypeMD, std::wstring DataType,
       TableParameterHandler &Handler);
 
-  template <typename T, typename T2>
-  void dispatchTestByVectorLength(const OpTypeMetaData<T2> &OpTypeMD,
+  template <typename T, typename OpT>
+  void dispatchTestByVectorLength(const OpTypeMetaData<OpT> &OpTypeMD,
                                   TableParameterHandler &Handler);
 
   template <typename T>
@@ -597,8 +598,8 @@ private:
 protected:
   // Prevent instances of TestConfig from being created directly. Want to force
   // a derived class to be used for creation.
-  template <typename T>
-  TestConfig(const OpTypeMetaData<T> &OpTypeMd)
+  template <typename OpT>
+  TestConfig(const OpTypeMetaData<OpT> &OpTypeMd)
       : OpTypeName(OpTypeMd.OpTypeString), Intrinsic(OpTypeMd.Intrinsic),
         Operator(OpTypeMd.Operator),
         ScalarInputFlags(OpTypeMd.ScalarInputFlags) {}

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -57,28 +57,26 @@ using VariantVector =
                  std::vector<uint16_t>, std::vector<uint32_t>,
                  std::vector<uint64_t>>;
 
-template <typename DataTypeT>
+template <typename T>
 void fillShaderBufferFromLongVectorData(std::vector<BYTE> &ShaderBuffer,
-                                        const std::vector<DataTypeT> &TestData);
+                                        const std::vector<T> &TestData);
 
-template <typename DataTypeT>
+template <typename T>
 void fillLongVectorDataFromShaderBuffer(const MappedData &ShaderBuffer,
-                                        std::vector<DataTypeT> &TestData,
+                                        std::vector<T> &TestData,
                                         size_t NumElements);
 
-template <typename DataTypeT> constexpr bool isFloatingPointType() {
-  return std::is_same_v<DataTypeT, float> ||
-         std::is_same_v<DataTypeT, double> ||
-         std::is_same_v<DataTypeT, HLSLHalf_t>;
+template <typename T> constexpr bool isFloatingPointType() {
+  return std::is_same_v<T, float> || std::is_same_v<T, double> ||
+         std::is_same_v<T, HLSLHalf_t>;
 }
 
-template <typename DataTypeT> constexpr bool is16BitType() {
-  return std::is_same_v<DataTypeT, int16_t> ||
-         std::is_same_v<DataTypeT, uint16_t> ||
-         std::is_same_v<DataTypeT, HLSLHalf_t>;
+template <typename T> constexpr bool is16BitType() {
+  return std::is_same_v<T, int16_t> || std::is_same_v<T, uint16_t> ||
+         std::is_same_v<T, HLSLHalf_t>;
 }
 
-template <typename DataTypeT> std::string getHLSLTypeString();
+template <typename T> std::string getHLSLTypeString();
 
 enum SCALAR_INPUT_FLAGS : uint16_t {
   // SCALAR_INPUT_FLAGS_OPERAND_1_IS_SCALAR is intentionally omitted. Input 1 is
@@ -108,9 +106,9 @@ enum SCALAR_INPUT_FLAGS : uint16_t {
 // expansion. May be empty. See getCompilerOptionsString() in LongVector.cpp and
 // 'LongVectorOp' entry ShaderOpArith.xml. Expands to things like '+', '-',
 // '*', etc.
-template <typename OpTypeT> struct OpTypeMetaData {
+template <typename T> struct OpTypeMetaData {
   std::wstring OpTypeString;
-  OpTypeT OpType;
+  T OpType;
   std::optional<std::string> Intrinsic = std::nullopt;
   std::optional<std::string> Operator = std::nullopt;
   uint16_t ScalarInputFlags = static_cast<uint16_t>(SCALAR_INPUT_FLAGS_NONE);
@@ -332,17 +330,17 @@ getTernaryMathOpType(const std::wstring &OpTypeString) {
                                       OpTypeString);
 }
 
-template <typename DataTypeT>
-std::vector<DataTypeT> getInputValueSetByKey(const std::wstring &Key,
-                                             bool LogKey = true) {
+template <typename T>
+std::vector<T> getInputValueSetByKey(const std::wstring &Key,
+                                     bool LogKey = true) {
   if (LogKey)
     WEX::Logging::Log::Comment(
         WEX::Common::String().Format(L"Using Value Set Key: %s", Key.c_str()));
-  return std::vector<DataTypeT>(TestData<DataTypeT>::Data.at(Key));
+  return std::vector<T>(TestData<T>::Data.at(Key));
 }
 
 // The TAEF test class.
-template <typename DataTypeT> class TestConfig; // Forward declaration.
+template <typename T> class TestConfig; // Forward declaration.
 class OpTest {
 public:
   BEGIN_TEST_CLASS(OpTest)
@@ -380,8 +378,8 @@ public:
                        L"Table:LongVectorOpTable.xml#AsTypeOpTable")
   END_TEST_METHOD()
 
-  template <typename OpTypeT>
-  void dispatchTestByDataType(const OpTypeMetaData<OpTypeT> &OpTypeMD,
+  template <typename T>
+  void dispatchTestByDataType(const OpTypeMetaData<T> &OpTypeMD,
                               std::wstring DataType,
                               TableParameterHandler &Handler);
 
@@ -393,12 +391,12 @@ public:
       const OpTypeMetaData<UnaryMathOpType> &OpTypeMD, std::wstring DataType,
       TableParameterHandler &Handler);
 
-  template <typename DataTypeT, typename OpTypeT>
-  void dispatchTestByVectorLength(const OpTypeMetaData<OpTypeT> &OpTypeMD,
+  template <typename T, typename T2>
+  void dispatchTestByVectorLength(const OpTypeMetaData<T2> &OpTypeMD,
                                   TableParameterHandler &Handler);
 
-  template <typename DataTypeT>
-  void testBaseMethod(std::unique_ptr<TestConfig<DataTypeT>> &TestConfig);
+  template <typename T>
+  void testBaseMethod(std::unique_ptr<TestConfig<T>> &TestConfig);
 
 private:
   dxc::SpecificDllLoader DxilDllLoader;
@@ -406,8 +404,8 @@ private:
   bool VerboseLogging = false;
 };
 
-template <typename DataTypeT>
-bool doValuesMatch(DataTypeT A, DataTypeT B, float Tolerance, ValidationType);
+template <typename T>
+bool doValuesMatch(T A, T B, float Tolerance, ValidationType);
 bool doValuesMatch(HLSLBool_t A, HLSLBool_t B, float, ValidationType);
 bool doValuesMatch(HLSLHalf_t A, HLSLHalf_t B, float Tolerance,
                    ValidationType ValidationType);
@@ -416,15 +414,13 @@ bool doValuesMatch(float A, float B, float Tolerance,
 bool doValuesMatch(double A, double B, float Tolerance,
                    ValidationType ValidationType);
 
-template <typename DataTypeT>
-bool doVectorsMatch(const std::vector<DataTypeT> &ActualValues,
-                    const std::vector<DataTypeT> &ExpectedValues,
-                    float Tolerance, ValidationType ValidationType,
-                    bool VerboseLogging = false);
+template <typename T>
+bool doVectorsMatch(const std::vector<T> &ActualValues,
+                    const std::vector<T> &ExpectedValues, float Tolerance,
+                    ValidationType ValidationType, bool VerboseLogging = false);
 
-template <typename DataTypeT>
-void logLongVector(const std::vector<DataTypeT> &Values,
-                   const std::wstring &Name);
+template <typename T>
+void logLongVector(const std::vector<T> &Values, const std::wstring &Name);
 
 // The TestInputs struct is used to help simplify calls to
 // TestConfig::computeExpectedValues and to help us re-infer information about
@@ -454,6 +450,9 @@ public:
   virtual VariantVector computeExpectedValues(const TestInputs<T> &Inputs) = 0;
 };
 
+// Default T2 to T1 as most intrinsics have a return type that matches the input
+// type. For intrinsics that don't match that pattern the caller can specify
+// the output type explicitly via an argument for T2.
 template <typename T1, typename T2 = T1>
 class UnaryOpExpectedValueComputer : public ExpectedValueComputerBase<T1> {
 public:
@@ -470,6 +469,9 @@ private:
   const ComputeFuncPtr ComputeFunc;
 };
 
+// Default T2 to T1 as most intrinsics have a return type that matches the input
+// type. For intrinsics that don't match that pattern the caller can specify
+// the output type explicitly via an argument for T2.
 template <typename T1, typename T2 = T1>
 class BinaryOpExpectedValueComputer : public ExpectedValueComputerBase<T1> {
 public:
@@ -498,6 +500,9 @@ private:
   const ComputeFuncPtr ComputeFunc;
 };
 
+// Default T2 to T1 as most intrinsics have a return type that matches the input
+// type. For intrinsics that don't match that pattern the caller can specify
+// the output type explicitly via an argument for T2.
 template <typename T1, typename T2 = T1>
 class TernaryOpExpectedValueComputer : public ExpectedValueComputerBase<T1> {
 
@@ -542,15 +547,15 @@ private:
 // includes some basic setup like setting the BasicOpType as well as logic to
 // compute expected values. See ExpectedValueComputer* use and definitions for
 // more details on computing expected values.
-template <typename DataTypeT> class TestConfig {
+template <typename T> class TestConfig {
 public:
   virtual ~TestConfig() = default;
 
-  void fillInputs(TestInputs<DataTypeT> &Inputs) const;
+  void fillInputs(TestInputs<T> &Inputs) const;
 
   // Derived classes don't need to implement this function if they configure and
   // set a ExpectedValueComputer member.
-  virtual void computeExpectedValues(const TestInputs<DataTypeT> &Inputs);
+  virtual void computeExpectedValues(const TestInputs<T> &Inputs);
 
   void setInputValueSetKey(const std::wstring &InputValueSetName,
                            size_t Index) {
@@ -574,19 +579,15 @@ public:
   std::string getBasicOpTypeHexString() const;
 
 private:
-  std::vector<DataTypeT> getInputValueSet(size_t ValueSetIndex) const;
+  std::vector<T> getInputValueSet(size_t ValueSetIndex) const;
 
   // Helpers to get the hlsl type as a string for a given C++ type.
-  std::string getHLSLInputTypeString() const {
-    return getHLSLTypeString<DataTypeT>();
-  }
+  std::string getHLSLInputTypeString() const { return getHLSLTypeString<T>(); }
   std::string getHLSLOutputTypeString() const;
 
-  // Templated version to be used when the output data type does not match the
-  // input data type.
-  template <typename OutputDataTypeT>
+  template <typename OutT>
   bool verifyOutput(const std::shared_ptr<st::ShaderOpTestResult> &TestResult,
-                    const std::vector<OutputDataTypeT> &ExpectedVector);
+                    const std::vector<OutT> &ExpectedVector);
 
   // The input value sets are used to fill the shader buffer.
   std::array<std::wstring, 3> InputValueSetKeys = {L"DefaultInputValueSet1",
@@ -596,48 +597,48 @@ private:
 protected:
   // Prevent instances of TestConfig from being created directly. Want to force
   // a derived class to be used for creation.
-  template <typename OpTypeT>
-  TestConfig(const OpTypeMetaData<OpTypeT> &OpTypeMd)
+  template <typename T>
+  TestConfig(const OpTypeMetaData<T> &OpTypeMd)
       : OpTypeName(OpTypeMd.OpTypeString), Intrinsic(OpTypeMd.Intrinsic),
         Operator(OpTypeMd.Operator),
         ScalarInputFlags(OpTypeMd.ScalarInputFlags) {}
 
   // Helper to initialize a unary value computer.
-  template <typename DataTypeOutT>
-  void InitUnaryOpValueComputer(
-      std::function<DataTypeOutT(const DataTypeT &)> ComputeFunc) {
+  // OutT defaults to T as most intrinsics have a return type that matches the
+  // input type.
+  template <typename OutT = T>
+  void InitUnaryOpValueComputer(std::function<OutT(const T &)> ComputeFunc) {
     DXASSERT_NOMSG(BasicOpType == BasicOpType_Unary);
     DXASSERT_NOMSG(ExpectedValueComputer == nullptr);
     ExpectedValueComputer =
-        std::make_unique<UnaryOpExpectedValueComputer<DataTypeT, DataTypeOutT>>(
-            ComputeFunc);
+        std::make_unique<UnaryOpExpectedValueComputer<T, OutT>>(ComputeFunc);
   }
 
   // Helper to initialize a binary value computer.
-  template <typename DataTypeOutT>
+  // OutT defaults to T as most intrinsics have a return type that matches the
+  // input type.
+  template <typename OutT = T>
   void InitBinaryOpValueComputer(
-      std::function<DataTypeOutT(const DataTypeT &, const DataTypeT &)>
-          ComputeFunc) {
+      std::function<OutT(const T &, const T &)> ComputeFunc) {
     DXASSERT_NOMSG(BasicOpType == BasicOpType_Binary);
     DXASSERT_NOMSG(ExpectedValueComputer == nullptr);
-    ExpectedValueComputer = std::make_unique<
-        BinaryOpExpectedValueComputer<DataTypeT, DataTypeOutT>>(ComputeFunc);
+    ExpectedValueComputer =
+        std::make_unique<BinaryOpExpectedValueComputer<T, OutT>>(ComputeFunc);
   }
 
   // Helper to initialize a ternary value computer.
-  template <typename DataTypeOutT>
+  // OutT defaults to T as most intrinsics have a return type that matches the
+  // input type.
+  template <typename OutT = T>
   void InitTernaryOpValueComputer(
-      std::function<DataTypeOutT(const DataTypeT &, const DataTypeT &,
-                                 const DataTypeT &)>
-          ComputeFunc) {
+      std::function<OutT(const T &, const T &, const T &)> ComputeFunc) {
     DXASSERT_NOMSG(BasicOpType == BasicOpType_Ternary);
     DXASSERT_NOMSG(ExpectedValueComputer == nullptr);
-    ExpectedValueComputer = std::make_unique<
-        TernaryOpExpectedValueComputer<DataTypeT, DataTypeOutT>>(ComputeFunc);
+    ExpectedValueComputer =
+        std::make_unique<TernaryOpExpectedValueComputer<T, OutT>>(ComputeFunc);
   }
 
-  std::unique_ptr<ExpectedValueComputerBase<DataTypeT>> ExpectedValueComputer =
-      nullptr;
+  std::unique_ptr<ExpectedValueComputerBase<T>> ExpectedValueComputer = nullptr;
 
   // To be used for the value of -DOPERATOR
   std::optional<std::string> Operator;
@@ -648,9 +649,9 @@ protected:
   BasicOpType BasicOpType = BasicOpType_EnumValueCount;
   float Tolerance = 0.0;
   ValidationType ValidationType = ValidationType::ValidationType_Epsilon;
-  // Default the TypedOutputVector to use DataTypeT, Ops that don't have a
+  // Default the TypedOutputVector to use T, Ops that don't have a
   // matching output type will override this.
-  VariantVector ExpectedVector = std::vector<DataTypeT>{};
+  VariantVector ExpectedVector = std::vector<T>{};
   size_t LengthToTest = 0;
 
   // Just used for logging purposes.
@@ -665,23 +666,21 @@ protected:
 // computing expected values to provide runtime errors if an unsupported data
 // type is used for a given intrinsic. See the individual overrides of functions
 // for more details.
-template <typename DataTypeT>
-class AsTypeOpTestConfig : public TestConfig<DataTypeT> {
+template <typename T> class AsTypeOpTestConfig : public TestConfig<T> {
 public:
   AsTypeOpTestConfig(const OpTypeMetaData<AsTypeOpType> &OpTypeMd);
 
   // Override the base class method so we can handle split double as it has two
   // out parameters.
-  void computeExpectedValues(const TestInputs<DataTypeT> &Inputs) override;
+  void computeExpectedValues(const TestInputs<T> &Inputs) override;
 
 private:
-  void
-  computeExpectedValues_SplitDouble(const std::vector<DataTypeT> &InputVector1);
+  void computeExpectedValues_SplitDouble(const std::vector<T> &InputVector1);
 
-  template <typename DataTypeInT>
-  HLSLHalf_t asFloat16([[maybe_unused]] const DataTypeInT &A) const {
-    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsFloat16 DataTypeInT: %s",
-                        typeid(DataTypeInT).name());
+  template <typename T>
+  HLSLHalf_t asFloat16([[maybe_unused]] const T &A) const {
+    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsFloat16 T: %s",
+                        typeid(T).name());
     return HLSLHalf_t();
   }
 
@@ -695,9 +694,9 @@ private:
     return HLSLHalf_t(bit_cast<DirectX::PackedVector::HALF>(A));
   }
 
-  template <typename DataTypeInT> float asFloat(const DataTypeInT &) const {
-    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsFloat DataTypeInT: %S",
-                        typeid(DataTypeInT).name());
+  template <typename T> float asFloat(const T &) const {
+    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsFloat T: %S",
+                        typeid(T).name());
     return 0.0f;
   }
 
@@ -705,12 +704,11 @@ private:
   float asFloat(const int32_t &A) const { return bit_cast<float>(A); }
   float asFloat(const uint32_t &A) const { return bit_cast<float>(A); }
 
-  template <typename DataTypeInT>
-  int32_t asInt([[maybe_unused]] const DataTypeInT &A) const {
+  template <typename T> int32_t asInt([[maybe_unused]] const T &A) const {
     // This path is unexpected outside of an issue when brining up new tests. So
     // throwing an exception is appropriate.
-    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsInt DataTypeInT: %S",
-                        typeid(DataTypeInT).name());
+    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsInt T: %S",
+                        typeid(T).name());
     return 0;
   }
 
@@ -718,12 +716,11 @@ private:
   int32_t asInt(const int32_t &A) const { return A; }
   int32_t asInt(const uint32_t &A) const { return bit_cast<int32_t>(A); }
 
-  template <typename DataTypeInT>
-  int16_t asInt16([[maybe_unused]] const DataTypeInT &A) const {
+  template <typename T> int16_t asInt16([[maybe_unused]] const T &A) const {
     // This path is unexpected outside of an issue when brining up new tests. So
     // throwing an exception is appropriate.
-    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsInt16 DataTypeInT: %S",
-                        typeid(DataTypeInT).name());
+    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsInt16 T: %S",
+                        typeid(T).name());
     return 0;
   }
 
@@ -733,12 +730,11 @@ private:
   int16_t asInt16(const int16_t &A) const { return A; }
   int16_t asInt16(const uint16_t &A) const { return bit_cast<int16_t>(A); }
 
-  template <typename DataTypeInT>
-  uint16_t asUint16([[maybe_unused]] const DataTypeInT &A) const {
+  template <typename T> uint16_t asUint16([[maybe_unused]] const T &A) const {
     // This path is unexpected outside of an issue when brining up new tests. So
     // throwing an exception is appropriate.
-    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsUint16 DataTypeInT: %S",
-                        typeid(DataTypeInT).name());
+    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsUint16 T: %S",
+                        typeid(T).name());
     return 0;
   }
 
@@ -748,12 +744,11 @@ private:
   uint16_t asUint16(const uint16_t &A) const { return A; }
   uint16_t asUint16(const int16_t &A) const { return bit_cast<uint16_t>(A); }
 
-  template <typename DataTypeInT>
-  unsigned int asUint([[maybe_unused]] const DataTypeInT &A) const {
+  template <typename T> unsigned int asUint([[maybe_unused]] const T &A) const {
     // This path is unexpected outside of an issue when brining up new tests. So
     // throwing an exception is appropriate.
-    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsUint DataTypeInT: %S",
-                        typeid(DataTypeInT).name());
+    LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid AsUint T: %S",
+                        typeid(T).name());
     return 0;
   }
 
@@ -763,15 +758,15 @@ private:
   }
   unsigned int asUint(const int &A) const { return bit_cast<unsigned int>(A); }
 
-  template <typename DataTypeInT>
-  void splitDouble([[maybe_unused]] const DataTypeInT &A,
+  template <typename T>
+  void splitDouble([[maybe_unused]] const T &A,
                    [[maybe_unused]] uint32_t &LowBits,
                    [[maybe_unused]] uint32_t &HighBits) const {
     // This path is unexpected outside of an issue when brining up new tests. So
     // throwing an exception is appropriate.
     LOG_ERROR_FMT_THROW(L"Programmer Error: splitDouble only accepts a double "
                         L"as input. Have DataTypeInT: %s",
-                        typeid(DataTypeInT).name());
+                        typeid(T).name());
   }
 
   void splitDouble(const double &A, uint32_t &LowBits,
@@ -782,14 +777,14 @@ private:
     HighBits = static_cast<uint32_t>(Bits >> 32);
   }
 
-  template <typename DataTypeInT>
-  double asDouble([[maybe_unused]] const DataTypeInT &LowBits,
-                  [[maybe_unused]] const DataTypeInT &HighBits) const {
+  template <typename T>
+  double asDouble([[maybe_unused]] const T &LowBits,
+                  [[maybe_unused]] const T &HighBits) const {
     // This path is unexpected outside of an issue when brining up new tests. So
     // throwing an exception is appropriate.
     LOG_ERROR_FMT_THROW(L"Programmer Error: asDouble only accepts two uint32_t "
-                        L"inputs. Have DataTypeInT : %S",
-                        typeid(DataTypeInT).name());
+                        L"inputs. Have T : %S",
+                        typeid(T).name());
     return 0.0;
   }
 
@@ -803,76 +798,69 @@ private:
   AsTypeOpType OpType = AsTypeOpType_EnumValueCount;
 };
 
-template <typename DataTypeT>
-class TrigonometricOpTestConfig : public TestConfig<DataTypeT> {
+template <typename T> class TrigonometricOpTestConfig : public TestConfig<T> {
 public:
   TrigonometricOpTestConfig(
       const OpTypeMetaData<TrigonometricOpType> &OpTypeMd);
 
-  DataTypeT computeExpectedValue(const DataTypeT &A) const;
+  T computeExpectedValue(const T &A) const;
 
 private:
   TrigonometricOpType OpType = TrigonometricOpType_EnumValueCount;
 };
 
-template <typename DataTypeT>
-class UnaryOpTestConfig : public TestConfig<DataTypeT> {
+template <typename T> class UnaryOpTestConfig : public TestConfig<T> {
 public:
   UnaryOpTestConfig(const OpTypeMetaData<UnaryOpType> &OpTypeMd);
 
-  DataTypeT computeExpectedValue(const DataTypeT &A) const;
+  T computeExpectedValue(const T &A) const;
 
 private:
   UnaryOpType OpType = UnaryOpType_EnumValueCount;
 };
 
-template <typename DataTypeT>
-class UnaryMathOpTestConfig : public TestConfig<DataTypeT> {
+template <typename T> class UnaryMathOpTestConfig : public TestConfig<T> {
 public:
   UnaryMathOpTestConfig(const OpTypeMetaData<UnaryMathOpType> &OpTypeMd);
 
-  DataTypeT computeExpectedValue(const DataTypeT &A) const;
+  T computeExpectedValue(const T &A) const;
 
 private:
   UnaryMathOpType OpType = UnaryMathOpType_EnumValueCount;
 
   // The majority of HLSL intrinsics return a DataType matching the
   // input DataType. However, Sign always returns an int32_t.
-  template <typename DataTypeT> int32_t sign(const DataTypeT &A) const {
+  template <typename T> int32_t sign(const T &A) const {
     // Return 1 for positive, -1 for negative, 0 for zero.
     // Wrap comparison operands in DataTypeInT constructor to make sure
     // we are comparing the same type.
-    return A > DataTypeT(0) ? 1 : A < DataTypeT(0) ? -1 : 0;
+    return A > T(0) ? 1 : A < T(0) ? -1 : 0;
   }
 
-  template <typename DataTypeT> DataTypeT abs(const DataTypeT &A) const {
-    if constexpr (std::is_unsigned<DataTypeT>::value)
-      return DataTypeT(A);
+  template <typename T> T abs(const T &A) const {
+    if constexpr (std::is_unsigned<T>::value)
+      return T(A);
     else
-      // Cast to DataTypeT for the int16_t case because std::abs implicitly
+      // Cast to T for the int16_t case because std::abs implicitly
       // converts to and returns an int. Without the cast back to an int the
       // compiler will complain that the implicit conversion back to int16_t has
       // lost precision.
-      return static_cast<DataTypeT>((std::abs)(A));
+      return static_cast<T>((std::abs)(A));
   }
 };
 
-template <typename DataTypeT>
-class BinaryMathOpTestConfig : public TestConfig<DataTypeT> {
+template <typename T> class BinaryMathOpTestConfig : public TestConfig<T> {
 public:
   BinaryMathOpTestConfig(const OpTypeMetaData<BinaryMathOpType> &OpTypeMd);
 
-  DataTypeT computeExpectedValue(const DataTypeT &A, const DataTypeT &B) const;
+  T computeExpectedValue(const T &A, const T &B) const;
 
 private:
   BinaryMathOpType OpType = BinaryMathOpType_EnumValueCount;
 
   // Helpers so we do the right thing for float types. HLSLHalf_t is handled in
   // an operator overload.
-  template <typename DataTypeT>
-  DataTypeT mod(const DataTypeT &A, const DataTypeT &B) const {
-    return A % B;
-  }
+  template <typename T> T mod(const T &A, const T &B) const { return A % B; }
 
   template <> float mod(const float &A, const float &B) const {
     return std::fmod(A, B);
@@ -883,13 +871,11 @@ private:
   }
 };
 
-template <typename DataTypeT>
-class TernaryMathOpTestConfig : public TestConfig<DataTypeT> {
+template <typename T> class TernaryMathOpTestConfig : public TestConfig<T> {
 public:
   TernaryMathOpTestConfig(const OpTypeMetaData<TernaryMathOpType> &OpTypeMd);
 
-  DataTypeT computeExpectedValue(const DataTypeT &A, const DataTypeT &B,
-                                 const DataTypeT &C) const {
+  T computeExpectedValue(const T &A, const T &B, const T &C) const {
     switch (OpType) {
     case TernaryMathOpType_Fma:
       return fma(A, B, C);
@@ -900,18 +886,18 @@ public:
     default:
       LOG_ERROR_FMT_THROW(L"Programmer Error: Invalid TernaryMathOpType: %d",
                           OpType);
-      return DataTypeT();
+      return T();
     }
   }
 
 private:
   TernaryMathOpType OpType = TernaryMathOpType_EnumValueCount;
 
-  template <typename T = DataTypeT>
+  template <typename T = T>
   T fma([[maybe_unused]] const T &A, [[maybe_unused]] const T &B,
         const T &C) const {
     LOG_ERROR_FMT_THROW(L"Programmer Error: fma only accepts doubles. Have "
-                        L"DataTypeT: %s",
+                        L"T: %s",
                         typeid(T).name());
     return T();
   }
@@ -939,7 +925,7 @@ private:
   }
 
   // Smoothstep Fallback: only enabled when T is NOT a floatlike
-  template <typename T = DataTypeT>
+  template <typename T = T>
   typename std::enable_if<!(std::is_same<T, float>::value ||
                             std::is_same<T, HLSLHalf_t>::value ||
                             std::is_same<T, double>::value),
@@ -947,13 +933,13 @@ private:
   smoothStep([[maybe_unused]] const T &Min, [[maybe_unused]] const T &Max,
              [[maybe_unused]] const T &X) const {
     LOG_ERROR_FMT_THROW(L"Programmer Error: smoothStep only accepts "
-                        L"floatlikes. Have DataTypeT: %s",
+                        L"floatlikes. Have T: %s",
                         typeid(T).name());
     return T();
   }
 
   // Smoothstep is only enabled for floatlikes
-  template <typename T = DataTypeT>
+  template <typename T = T>
   typename std::enable_if<std::is_same<T, float>::value ||
                               std::is_same<T, HLSLHalf_t>::value ||
                               std::is_same<T, double>::value,
@@ -972,40 +958,40 @@ private:
   }
 };
 
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
+template <typename T>
+std::unique_ptr<TestConfig<T>>
 makeTestConfig(const OpTypeMetaData<UnaryOpType> &OpTypeMetaData) {
-  return std::make_unique<UnaryOpTestConfig<DataTypeT>>(OpTypeMetaData);
+  return std::make_unique<UnaryOpTestConfig<T>>(OpTypeMetaData);
 }
 
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
+template <typename T>
+std::unique_ptr<TestConfig<T>>
 makeTestConfig(const OpTypeMetaData<TrigonometricOpType> &OpTypeMetaData) {
-  return std::make_unique<TrigonometricOpTestConfig<DataTypeT>>(OpTypeMetaData);
+  return std::make_unique<TrigonometricOpTestConfig<T>>(OpTypeMetaData);
 }
 
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
+template <typename T>
+std::unique_ptr<TestConfig<T>>
 makeTestConfig(const OpTypeMetaData<AsTypeOpType> &OpTypeMetaData) {
-  return std::make_unique<AsTypeOpTestConfig<DataTypeT>>(OpTypeMetaData);
+  return std::make_unique<AsTypeOpTestConfig<T>>(OpTypeMetaData);
 }
 
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
+template <typename T>
+std::unique_ptr<TestConfig<T>>
 makeTestConfig(const OpTypeMetaData<UnaryMathOpType> &OpTypeMetaData) {
-  return std::make_unique<UnaryMathOpTestConfig<DataTypeT>>(OpTypeMetaData);
+  return std::make_unique<UnaryMathOpTestConfig<T>>(OpTypeMetaData);
 }
 
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
+template <typename T>
+std::unique_ptr<TestConfig<T>>
 makeTestConfig(const OpTypeMetaData<BinaryMathOpType> &OpTypeMetaData) {
-  return std::make_unique<BinaryMathOpTestConfig<DataTypeT>>(OpTypeMetaData);
+  return std::make_unique<BinaryMathOpTestConfig<T>>(OpTypeMetaData);
 }
 
-template <typename DataTypeT>
-std::unique_ptr<TestConfig<DataTypeT>>
+template <typename T>
+std::unique_ptr<TestConfig<T>>
 makeTestConfig(const OpTypeMetaData<TernaryMathOpType> &OpTypeMetaData) {
-  return std::make_unique<TernaryMathOpTestConfig<DataTypeT>>(OpTypeMetaData);
+  return std::make_unique<TernaryMathOpTestConfig<T>>(OpTypeMetaData);
 }
 }; // namespace LongVector
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -604,9 +604,7 @@ protected:
         ScalarInputFlags(OpTypeMd.ScalarInputFlags) {}
 
   // Helper to initialize a unary value computer.
-  // OutT defaults to T as most intrinsics have a return type that matches the
-  // input type.
-  template <typename OutT = T>
+  template <typename OutT>
   void InitUnaryOpValueComputer(std::function<OutT(const T &)> ComputeFunc) {
     DXASSERT_NOMSG(BasicOpType == BasicOpType_Unary);
     DXASSERT_NOMSG(ExpectedValueComputer == nullptr);
@@ -615,9 +613,7 @@ protected:
   }
 
   // Helper to initialize a binary value computer.
-  // OutT defaults to T as most intrinsics have a return type that matches the
-  // input type.
-  template <typename OutT = T>
+  template <typename OutT>
   void InitBinaryOpValueComputer(
       std::function<OutT(const T &, const T &)> ComputeFunc) {
     DXASSERT_NOMSG(BasicOpType == BasicOpType_Binary);
@@ -627,9 +623,7 @@ protected:
   }
 
   // Helper to initialize a ternary value computer.
-  // OutT defaults to T as most intrinsics have a return type that matches the
-  // input type.
-  template <typename OutT = T>
+  template <typename OutT>
   void InitTernaryOpValueComputer(
       std::function<OutT(const T &, const T &, const T &)> ComputeFunc) {
     DXASSERT_NOMSG(BasicOpType == BasicOpType_Ternary);
@@ -893,7 +887,7 @@ public:
 private:
   TernaryMathOpType OpType = TernaryMathOpType_EnumValueCount;
 
-  template <typename T = T>
+  template <typename T>
   T fma([[maybe_unused]] const T &A, [[maybe_unused]] const T &B,
         const T &C) const {
     LOG_ERROR_FMT_THROW(L"Programmer Error: fma only accepts doubles. Have "
@@ -925,7 +919,7 @@ private:
   }
 
   // Smoothstep Fallback: only enabled when T is NOT a floatlike
-  template <typename T = T>
+  template <typename T>
   typename std::enable_if<!(std::is_same<T, float>::value ||
                             std::is_same<T, HLSLHalf_t>::value ||
                             std::is_same<T, double>::value),


### PR DESCRIPTION
This PR shortens template argument names to shorter standard names. 'DataTypeT' -> 'T'.

In earlier revisions of these tests there were multiple template arguments being used. The template argument names were made more descriptive but since then the code has been simplified. The longer names have been driving me a little nuts. So this PR shortens them back to standard template argument names again.