### PR TITLE
Execution Tests: Long Vector tests add Special Math Ops

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
+++ b/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
@@ -625,6 +625,15 @@
           <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">float16</Parameter>
         </Row>
+        <Row Name="Ldexp_float16">
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Ldexp</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+        </Row>
+        <Row Name="ScalarLdexp_float16">
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Ldexp</Parameter>
+          <Parameter Name="DataType">float16</Parameter>
+          <Parameter Name="ScalarInputFlags">0x2</Parameter>
+        </Row>
         <!-- LongVectorBinaryMathOpTypeTable DataType: float32 -->
         <Row Name="ScalarAdd_float32">
           <Parameter Name="OpTypeEnum">BinaryMathOpType_Add</Parameter>
@@ -688,6 +697,15 @@
         <Row Name="Max_float32">
           <Parameter Name="OpTypeEnum">BinaryMathOpType_Max</Parameter>
           <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="Ldexp_float32">
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Ldexp</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+        </Row>
+        <Row Name="ScalarLdexp_float32">
+          <Parameter Name="OpTypeEnum">BinaryMathOpType_Ldexp</Parameter>
+          <Parameter Name="DataType">float32</Parameter>
+          <Parameter Name="ScalarInputFlags">0x2</Parameter>
         </Row>
         <!-- LongVectorBinaryMathOpTypeTable DataType: float64 -->
         <Row Name="ScalarAdd_float64">
@@ -1179,6 +1197,10 @@
       </Row>
       <Row Name="Log2_float32">
         <Parameter Name="OpTypeEnum">UnaryMathOpType_Log2</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="Frexp_float32">
+        <Parameter Name="OpTypeEnum">UnaryMathOpType_Frexp</Parameter>
         <Parameter Name="DataType">float32</Parameter>
       </Row>
       <!--UnaryMathOpTable float64-->

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -962,7 +962,7 @@ void AsTypeOpTestConfig<T>::computeExpectedValues(const TestInputs<T> &Inputs) {
 
 template <typename T>
 void AsTypeOpTestConfig<T>::computeExpectedValues_SplitDouble(
-    const std::vector<T> &InputVector1) {
+    const std::vector<T> &InputVector) {
 
   DXASSERT_NOMSG(OpType == AsTypeOpType_AsUint_SplitDouble);
 
@@ -974,11 +974,13 @@ void AsTypeOpTestConfig<T>::computeExpectedValues_SplitDouble(
   ExpectedVector = std::vector<uint32_t>{};
   auto *TypedExpectedValues =
       std::get_if<std::vector<uint32_t>>(&ExpectedVector);
-  TypedExpectedValues->resize(InputVector1.size() * 2);
+  TypedExpectedValues->resize(InputVector.size() * 2);
+
   uint32_t LowBits, HighBits;
-  const size_t InputSize = InputVector1.size();
+  const size_t InputSize = InputVector.size();
+
   for (size_t Index = 0; Index < InputSize; ++Index) {
-    splitDouble(InputVector1[Index], LowBits, HighBits);
+    splitDouble(InputVector[Index], LowBits, HighBits);
     (*TypedExpectedValues)[Index] = LowBits;
     (*TypedExpectedValues)[Index + InputSize] = HighBits;
   }
@@ -1088,15 +1090,63 @@ UnaryMathOpTestConfig<T>::UnaryMathOpTestConfig(
     ValidationType = ValidationType_Ulp;
   }
 
-  if (OpType == UnaryMathOpType_Sign) {
+  switch (OpType) {
+  case (UnaryMathOpType_Sign) : {
     // Sign has overridden special logic.
     auto ComputeFunc = [this](const T &A) { return this->sign(A); };
     InitUnaryOpValueComputer<int32_t>(ComputeFunc);
-  } else {
+    break;
+  }
+  case (UnaryMathOpType_Frexp) :
+    // Don't initialize a ValueComputer, Frexp has special logic for handling
+    // its output
+    SpecialDefines = " -DFUNC_FREXP=1";
+    break;
+  default : {
     auto ComputeFunc = [this](const T &A) {
       return this->computeExpectedValue(A);
     };
     InitUnaryOpValueComputer<T>(ComputeFunc);
+  }
+}
+}
+
+template <typename T>
+void UnaryMathOpTestConfig<T>::computeExpectedValues(const TestInputs<T> &Inputs) {
+
+  // Base case
+  if (ExpectedValueComputer) {
+    ExpectedVector = ExpectedValueComputer->computeExpectedValues(Inputs);
+    return;
+  }
+
+  computeExpectedValues_Frexp(Inputs.InputVector1);
+}
+
+// Frexp has a return value as well as an output paramater. So we handle it
+// with special logic. Frexp is only supported for fp32 values.
+template <typename T>
+void UnaryMathOpTestConfig<T>::computeExpectedValues_Frexp(const std::vector<T> &InputVector) {
+
+  DXASSERT_NOMSG(OpType == UnaryMathOpType_Frexp);
+
+  ExpectedVector = std::vector<float>{};
+  auto *TypedExpectedValues = std::get_if<std::vector<float>>(&ExpectedVector);
+
+  // Expected values size is doubled. In the first half we store the Mantissas
+  // and in the second half we store the Exponents. This way we can leverage the
+  // existing logic which verify expected values in a single vector. We just
+  // need to make sure that we organize the output in the same way in the shader
+  // and when we read it back.
+  const size_t InputSize = InputVector.size();
+  TypedExpectedValues->resize(InputSize * 2);
+  float Exp = 0;
+  float Man = 0;
+
+  for (size_t Index = 0; Index < InputSize; ++Index) {
+    Man = frexp(InputVector[Index], &Exp);
+    (*TypedExpectedValues)[Index] = Man;
+    (*TypedExpectedValues)[Index + InputSize] = Exp;
   }
 }
 
@@ -1206,6 +1256,8 @@ T BinaryMathOpTestConfig<T>::computeExpectedValue(const T &A,
     return (std::min)(A, B);
   case BinaryMathOpType_Max:
     return (std::max)(A, B);
+  case BinaryMathOpType_Ldexp:
+    return ldexp(A, B);
   default:
     LOG_ERROR_FMT_THROW(L"Unknown BinaryMathOpType: %ls", OpTypeName.c_str());
     return T();

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -235,6 +235,7 @@ enum UnaryMathOpType {
   UnaryMathOpType_Log2,
   UnaryMathOpType_Log10,
   UnaryMathOpType_Rcp,
+  UnaryMathOpType_Frexp,
   UnaryMathOpType_EnumValueCount
 };
 
@@ -255,6 +256,7 @@ static const OpTypeMetaData<UnaryMathOpType>
         {L"UnaryMathOpType_Log2", UnaryMathOpType_Log2, "log2"},
         {L"UnaryMathOpType_Log10", UnaryMathOpType_Log10, "log10"},
         {L"UnaryMathOpType_Rcp", UnaryMathOpType_Rcp, "rcp"},
+        {L"UnaryMathOpType_Frexp", UnaryMathOpType_Frexp, "TestFrexp"},
 };
 
 static_assert(_countof(unaryMathOpTypeStringToOpMetaData) ==
@@ -276,6 +278,7 @@ enum BinaryMathOpType {
   BinaryMathOpType_Modulus,
   BinaryMathOpType_Min,
   BinaryMathOpType_Max,
+  BinaryMathOpType_Ldexp,
   BinaryMathOpType_EnumValueCount
 };
 
@@ -292,6 +295,7 @@ static const OpTypeMetaData<BinaryMathOpType>
          "%"},
         {L"BinaryMathOpType_Min", BinaryMathOpType_Min, "min", ","},
         {L"BinaryMathOpType_Max", BinaryMathOpType_Max, "max", ","},
+        {L"BinaryMathOpType_Ldexp", BinaryMathOpType_Ldexp, "ldexp", ","},
 };
 
 static_assert(_countof(binaryMathOpTypeStringToOpMetaData) ==
@@ -670,7 +674,7 @@ public:
   void computeExpectedValues(const TestInputs<T> &Inputs) override;
 
 private:
-  void computeExpectedValues_SplitDouble(const std::vector<T> &InputVector1);
+  void computeExpectedValues_SplitDouble(const std::vector<T> &InputVector);
 
   template <typename T>
   HLSLHalf_t asFloat16([[maybe_unused]] const T &A) const {
@@ -818,9 +822,14 @@ template <typename T> class UnaryMathOpTestConfig : public TestConfig<T> {
 public:
   UnaryMathOpTestConfig(const OpTypeMetaData<UnaryMathOpType> &OpTypeMd);
 
+  // Override the base class method so we can handle frexp as it has
+  // an out parameter.
+  void computeExpectedValues(const TestInputs<T> &Inputs) override;
   T computeExpectedValue(const T &A) const;
 
 private:
+  void computeExpectedValues_Frexp(const std::vector<T> &InputVector);
+
   UnaryMathOpType OpType = UnaryMathOpType_EnumValueCount;
 
   // The majority of HLSL intrinsics return a DataType matching the
@@ -842,6 +851,31 @@ private:
       // lost precision.
       return static_cast<T>((std::abs)(A));
   }
+
+  template <typename T = DataTypeT>
+  typename std::enable_if<!(std::is_same<T, float>::value), float>::type
+  frexp([[maybe_unused]] const T &A, [[maybe_unused]] float *Exponent) const {
+    LOG_ERROR_FMT_THROW(L"Programmer Error: frexp only accepts floats. "
+                        L"Have DataTypeT: %s",
+                        typeid(T).name());
+    return 0.0f;
+  }
+
+  template <typename T = DataTypeT>
+  typename std::enable_if<(std::is_same<T, float>::value), T>::type
+  frexp(const T &A, T *Exponent) const {
+    int IntExp = 0;
+
+    // std::frexp returns a signed mantissa. But the HLSL implmentation returns
+    // an unsigned mantissa.
+    T mantissa = std::abs(std::frexp(A, &IntExp));
+
+    // std::frexp returns the exponent as an int, but HLSL stores it as a float.
+    // However, the HLSL exponents fractional component is always 0. So it can
+    // conversion between float and int is safe.
+    *Exponent = static_cast<T>(IntExp);
+    return mantissa;
+  }
 };
 
 template <typename T> class BinaryMathOpTestConfig : public TestConfig<T> {
@@ -855,7 +889,7 @@ private:
 
   // Helpers so we do the right thing for float types. HLSLHalf_t is handled in
   // an operator overload.
-  template <typename T> T mod(const T &A, const T &B) const { return A % B; }
+  template <typename T = DataTypeT> T mod(const T &A, const T &B) const { return A % B; }
 
   template <> float mod(const float &A, const float &B) const {
     return std::fmod(A, B);
@@ -863,6 +897,25 @@ private:
 
   template <> double mod(const double &A, const double &B) const {
     return std::fmod(A, B);
+  }
+
+  template <typename T = T>
+  typename std::enable_if<!(std::is_same<T, float>::value ||
+                            std::is_same<T, HLSLHalf_t>::value),
+                          T>::type
+  ldexp([[maybe_unused]] const T &A, [[maybe_unused]] const T &Exponent) const {
+    LOG_ERROR_FMT_THROW(L"Programmer Error: ldexp only accepts floatlikes. "
+                        L"Have T: %s",
+                        typeid(T).name());
+    return T();
+  }
+
+  template <typename T = T>
+  typename std::enable_if<(std::is_same<T, float>::value ||
+                           std::is_same<T, HLSLHalf_t>::value),
+                          T>::type
+  ldexp(const T &A, const T &Exponent) const {
+    return A * T(std::pow(2.0f, Exponent));
   }
 };
 

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3827,6 +3827,23 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
+        #ifdef FUNC_FREXP
+        vector<OUT_TYPE, NUM> TestFrexp(vector<TYPE, NUM> Vector)
+        {
+          vector<OUT_TYPE, NUM> Mantissa;
+          vector<OUT_TYPE, NUM> Exponent;
+
+          Mantissa = frexp(Vector, Exponent);
+
+          // Store the exponent outputs in the second half of the output vector.
+          // Exponent values are always floats, so we can use 4 bytes per
+          // element for our offset.
+          g_OutputVector.Store< vector<OUT_TYPE, NUM> >(4 * NUM, Exponent);
+
+          return Mantissa;
+        }
+        #endif
+
         [numthreads(1,1,1)]
         void main(uint GI : SV_GroupIndex) {
 


### PR DESCRIPTION
This PR adds the Ldexp and Frexp tests. 

Resolves #7465 