### PR TITLE
[Bug] Execution Tests: Long Vector tests aren't parsing scalar flags for AsType op tests

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -343,7 +343,7 @@ TEST_F(OpTest, asTypeOpTest) {
   std::wstring OpTypeString(Handler.GetTableParamByName(L"OpTypeEnum")->m_str);
 
   auto OpTypeMD = getAsTypeOpType(OpTypeString);
-    std::wstring ScalarInputFlags(
+  std::wstring ScalarInputFlags(
       Handler.GetTableParamByName(L"ScalarInputFlags")->m_str);
   if (!ScalarInputFlags.empty())
     VERIFY_IS_TRUE(

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -343,6 +343,13 @@ TEST_F(OpTest, asTypeOpTest) {
   std::wstring OpTypeString(Handler.GetTableParamByName(L"OpTypeEnum")->m_str);
 
   auto OpTypeMD = getAsTypeOpType(OpTypeString);
+    std::wstring ScalarInputFlags(
+      Handler.GetTableParamByName(L"ScalarInputFlags")->m_str);
+  if (!ScalarInputFlags.empty())
+    VERIFY_IS_TRUE(
+        IsHexString(ScalarInputFlags.c_str(), &OpTypeMD.ScalarInputFlags),
+        L"ScalarInputFlags must be a hex string if provided.");
+
   dispatchTestByDataType(OpTypeMD, DataTypeIn, Handler);
 }
 


### PR DESCRIPTION
This PR fixes a bug where the AsTypeOp tests were not parsing the scalar input flags from the taef metadata.