### PR TITLE
Add/Update HLK tests for IsSpecialFloat Ops

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -5758,16 +5758,6 @@ static TableParameter UnaryHalfOpParameters[] = {
     {L"Validation.Tolerance", TableParameter::DOUBLE, true},
     {L"Warp.Version", TableParameter::UINT, false}};
 
-static TableParameter IsSpecialFloatHalfOpParameters[] = {
-    {L"ShaderOp.Target", TableParameter::STRING, true},
-    {L"ShaderOp.Text", TableParameter::STRING, true},
-    {L"ShaderOp.Arguments", TableParameter::STRING, true},
-    {L"Validation.Input1", TableParameter::HALF_TABLE, true},
-    {L"Validation.Expected1", TableParameter::HALF_TABLE, true},
-    {L"Validation.Type", TableParameter::STRING, true},
-    {L"Validation.Tolerance", TableParameter::DOUBLE, true},
-    {L"Warp.Version", TableParameter::UINT, false}};
-
 static TableParameter BinaryHalfOpParameters[] = {
     {L"ShaderOp.Target", TableParameter::STRING, true},
     {L"ShaderOp.Text", TableParameter::STRING, true},
@@ -6511,8 +6501,8 @@ TEST_F(ExecutionTest, IsSpecialFloatHalfOpTest) {
 
   // Read data from the table
   int tableSize =
-      sizeof(IsSpecialFloatHalfOpParameters) / sizeof(TableParameter);
-  TableParameterHandler handler(IsSpecialFloatHalfOpParameters, tableSize);
+      sizeof(UnaryHalfOpParameters) / sizeof(TableParameter);
+  TableParameterHandler handler(UnaryHalfOpParameters, tableSize);
 
   CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);
   CW2A Text(handler.GetTableParamByName(L"ShaderOp.Text")->m_str);

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -6500,8 +6500,7 @@ TEST_F(ExecutionTest, IsSpecialFloatHalfOpTest) {
   }
 
   // Read data from the table
-  int tableSize =
-      sizeof(UnaryHalfOpParameters) / sizeof(TableParameter);
+  int tableSize = sizeof(UnaryHalfOpParameters) / sizeof(TableParameter);
   TableParameterHandler handler(UnaryHalfOpParameters, tableSize);
 
   CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -338,8 +338,8 @@ public:
                        L"Table:ShaderOpArithTable.xml#UnaryHalfOpTable")
   END_TEST_METHOD()
   BEGIN_TEST_METHOD(IsSpecialFloatHalfOpTest)
-  TEST_METHOD_PROPERTY(L"DataSource",
-                       L"Table:ShaderOpArithTable.xml#IsSpecialFloatHalfOpTable")
+  TEST_METHOD_PROPERTY(
+      L"DataSource", L"Table:ShaderOpArithTable.xml#IsSpecialFloatHalfOpTable")
   END_TEST_METHOD()
   BEGIN_TEST_METHOD(BinaryHalfOpTest)
   TEST_METHOD_PROPERTY(L"DataSource",
@@ -6510,7 +6510,8 @@ TEST_F(ExecutionTest, IsSpecialFloatHalfOpTest) {
   }
 
   // Read data from the table
-  int tableSize = sizeof(IsSpecialFloatHalfOpParameters) / sizeof(TableParameter);
+  int tableSize =
+      sizeof(IsSpecialFloatHalfOpParameters) / sizeof(TableParameter);
   TableParameterHandler handler(IsSpecialFloatHalfOpParameters, tableSize);
 
   CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -337,6 +337,10 @@ public:
   TEST_METHOD_PROPERTY(L"DataSource",
                        L"Table:ShaderOpArithTable.xml#UnaryHalfOpTable")
   END_TEST_METHOD()
+  BEGIN_TEST_METHOD(IsSpecialFloatHalfOpTest)
+  TEST_METHOD_PROPERTY(L"DataSource",
+                       L"Table:ShaderOpArithTable.xml#IsSpecialFloatHalfOpTable")
+  END_TEST_METHOD()
   BEGIN_TEST_METHOD(BinaryHalfOpTest)
   TEST_METHOD_PROPERTY(L"DataSource",
                        L"Table:ShaderOpArithTable.xml#BinaryHalfOpTable")
@@ -452,7 +456,6 @@ public:
 
   TEST_METHOD(GraphicsRawBufferLdStI16);
   TEST_METHOD(GraphicsRawBufferLdStHalf);
-  TEST_METHOD(IsNormalTest);
 
   BEGIN_TEST_METHOD(PackUnpackTest)
   TEST_METHOD_PROPERTY(L"DataSource",
@@ -5755,6 +5758,16 @@ static TableParameter UnaryHalfOpParameters[] = {
     {L"Validation.Tolerance", TableParameter::DOUBLE, true},
     {L"Warp.Version", TableParameter::UINT, false}};
 
+static TableParameter IsSpecialFloatHalfOpParameters[] = {
+    {L"ShaderOp.Target", TableParameter::STRING, true},
+    {L"ShaderOp.Text", TableParameter::STRING, true},
+    {L"ShaderOp.Arguments", TableParameter::STRING, true},
+    {L"Validation.Input1", TableParameter::HALF_TABLE, true},
+    {L"Validation.Expected1", TableParameter::HALF_TABLE, true},
+    {L"Validation.Type", TableParameter::STRING, true},
+    {L"Validation.Tolerance", TableParameter::DOUBLE, true},
+    {L"Warp.Version", TableParameter::UINT, false}};
+
 static TableParameter BinaryHalfOpParameters[] = {
     {L"ShaderOp.Target", TableParameter::STRING, true},
     {L"ShaderOp.Text", TableParameter::STRING, true},
@@ -6424,6 +6437,81 @@ TEST_F(ExecutionTest, UnaryHalfOpTest) {
   // Read data from the table
   int tableSize = sizeof(UnaryHalfOpParameters) / sizeof(TableParameter);
   TableParameterHandler handler(UnaryHalfOpParameters, tableSize);
+
+  CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);
+  CW2A Text(handler.GetTableParamByName(L"ShaderOp.Text")->m_str);
+  CW2A Arguments(handler.GetTableParamByName(L"ShaderOp.Arguments")->m_str);
+
+  std::vector<uint16_t> *Validation_Input =
+      &(handler.GetTableParamByName(L"Validation.Input1")->m_halfTable);
+  std::vector<uint16_t> *Validation_Expected =
+      &(handler.GetTableParamByName(L"Validation.Expected1")->m_halfTable);
+
+  LPCWSTR Validation_Type =
+      handler.GetTableParamByName(L"Validation.Type")->m_str;
+  double Validation_Tolerance =
+      handler.GetTableParamByName(L"Validation.Tolerance")->m_double;
+
+  size_t count = Validation_Input->size();
+
+  std::shared_ptr<st::ShaderOpTestResult> test = st::RunShaderOpTest(
+      pDevice, m_support, pStream, "UnaryFPOp",
+      // this callback is called when the test
+      // is creating the resource to run the test
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
+        VERIFY_IS_TRUE(0 == _stricmp(Name, "SUnaryFPOp"));
+        size_t size = sizeof(SUnaryHalfOp) * count;
+        Data.resize(size);
+        SUnaryHalfOp *pPrimitives = (SUnaryHalfOp *)Data.data();
+        for (size_t i = 0; i < count; ++i) {
+          SUnaryHalfOp *p = &pPrimitives[i];
+          p->input = (*Validation_Input)[i % Validation_Input->size()];
+        }
+        // use shader from data table
+        pShaderOp->Shaders.at(0).Target = Target.m_psz;
+        pShaderOp->Shaders.at(0).Text = Text.m_psz;
+        pShaderOp->Shaders.at(0).Arguments = Arguments.m_psz;
+      });
+
+  MappedData data;
+  test->Test->GetReadBackData("SUnaryFPOp", &data);
+
+  SUnaryHalfOp *pPrimitives = (SUnaryHalfOp *)data.data();
+  WEX::TestExecution::DisableVerifyExceptions dve;
+  for (unsigned i = 0; i < count; ++i) {
+    SUnaryHalfOp *p = &pPrimitives[i];
+    uint16_t expected = (*Validation_Expected)[i % Validation_Input->size()];
+    LogCommentFmt(L"element #%u, input = %6.8f(0x%04x), output = "
+                  L"%6.8f(0x%04x), expected = %6.8f(0x%04x)",
+                  i, ConvertFloat16ToFloat32(p->input), p->input,
+                  ConvertFloat16ToFloat32(p->output), p->output,
+                  ConvertFloat16ToFloat32(expected), expected);
+    VerifyOutputWithExpectedValueHalf(p->output, expected, Validation_Type,
+                                      Validation_Tolerance);
+  }
+}
+
+TEST_F(ExecutionTest, IsSpecialFloatHalfOpTest) {
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+  CComPtr<IStream> pStream;
+  readHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream, m_support);
+
+  CComPtr<ID3D12Device> pDevice;
+  if (!createDevice(&pDevice, D3D_SHADER_MODEL::D3D_SHADER_MODEL_6_9)) {
+    return;
+  }
+
+  if (!DoesDeviceSupportNative16bitOps(pDevice)) {
+    WEX::Logging::Log::Comment(
+        L"Device does not support native 16-bit operations.");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+
+  // Read data from the table
+  int tableSize = sizeof(IsSpecialFloatHalfOpParameters) / sizeof(TableParameter);
+  TableParameterHandler handler(IsSpecialFloatHalfOpParameters, tableSize);
 
   CW2A Target(handler.GetTableParamByName(L"ShaderOp.Target")->m_str);
   CW2A Text(handler.GetTableParamByName(L"ShaderOp.Text")->m_str);
@@ -12552,91 +12640,6 @@ struct FloatInputUintOutput {
   float input;
   unsigned int output;
 };
-
-TEST_F(ExecutionTest, IsNormalTest) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-
-  CComPtr<ID3D12Device> pDevice;
-  VERIFY_IS_TRUE(createDevice(&pDevice, D3D_SHADER_MODEL_6_0,
-                              false /* skipUnsupported */));
-
-  // The input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN,
-  // Nan, and then 4 normal float numbers. Only the last 4 floats are normal, so
-  // we expect the first 8 results to be 0, and the last 4 to be 1, as defined
-  // by IsNormal.
-  std::vector<float> Validation_Input_Vec = {
-      -0.0,   0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY,
-      -(NAN), NAN, 530.99f,        -530.99f,    -122.900f,   .122900f};
-  std::vector<float> *Validation_Input = &Validation_Input_Vec;
-
-  std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u,
-                                                       0u, 0u, 1u, 1u, 1u, 1u};
-  std::vector<unsigned int> *Validation_Expected = &Validation_Expected_Vec;
-
-  CComPtr<IStream> pStream;
-  readHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream, m_support);
-
-  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
-      std::make_shared<st::ShaderOpSet>();
-  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
-  st::ShaderOp *pShaderOp = ShaderOpSet->GetShaderOp("IsNormal");
-
-  D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
-  LogCommentFmt(L"\r\nVerifying isNormal in shader "
-                L"model 6.%1u",
-                ((UINT)sm & 0x0f));
-
-  size_t count = Validation_Input->size();
-
-  auto ShaderInitFn = MakeShaderReplacementCallback(
-      {L"isSpecialFloat.hlsl", L"-Emain", L"-Tcs_6_0"},
-      // Replace the above with what's below when IsSpecialFloat supports
-      // doubles
-      //{ "@dx.op.isSpecialFloat.f32(i32 8,",  "@dx.op.isSpecialFloat.f64(i32
-      // 8," }, { "@dx.op.isSpecialFloat.f32(i32 11,",
-      //"@dx.op.isSpecialFloat.f64(i32 11," },
-      {"@dx.op.isSpecialFloat.f32(i32 8,"},
-      {"@dx.op.isSpecialFloat.f32(i32 11,"}, m_support);
-
-  auto ResourceInitFn = [&](LPCSTR Name, std::vector<BYTE> &Data,
-                            st::ShaderOp *pShaderOp) {
-    UNREFERENCED_PARAMETER(pShaderOp);
-    VERIFY_IS_TRUE(0 == _stricmp(Name, "g_TestData"));
-    size_t size = sizeof(FloatInputUintOutput) * count;
-    Data.resize(size);
-    FloatInputUintOutput *pPrimitives = (FloatInputUintOutput *)Data.data();
-    for (size_t i = 0; i < count; ++i) {
-      FloatInputUintOutput *p = &pPrimitives[i];
-      float inputFloat = (*Validation_Input)[i % Validation_Input->size()];
-      p->input = inputFloat;
-    }
-  };
-
-  // Test Compute shader
-  {
-    pShaderOp->CS = pShaderOp->GetString("CS60");
-    std::shared_ptr<st::ShaderOpTestResult> test =
-        st::RunShaderOpTestAfterParse(pDevice, m_support, "IsNormal",
-                                      ResourceInitFn, ShaderInitFn,
-                                      ShaderOpSet);
-
-    MappedData data;
-    test->Test->GetReadBackData("g_TestData", &data);
-
-    FloatInputUintOutput *pPrimitives = (FloatInputUintOutput *)data.data();
-    WEX::TestExecution::DisableVerifyExceptions dve;
-    for (unsigned i = 0; i < count; ++i) {
-      FloatInputUintOutput *p = &pPrimitives[i];
-      unsigned int val =
-          (*Validation_Expected)[i % Validation_Expected->size()];
-      LogCommentFmt(
-          L"element #%u, input = %6.8f, output = %6.8f, expected = %d", i,
-          p->input, p->output, val);
-      VERIFY_ARE_EQUAL(p->output, val);
-    }
-  }
-}
 
 #ifndef _HLK_CONF
 static void WriteReadBackDump(st::ShaderOp *pShaderOp, st::ShaderOpTest *pTest,

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3717,39 +3717,6 @@ void MSMain(uint GID : SV_GroupIndex,
     </Shader>
   </ShaderOp>
 
-  <ShaderOp Name="IsNormal" CS="CS60">
-    <Resource Name="g_TestData" Dimension="BUFFER" Width="96" InitialResourceState="COPY_DEST" Init="ByName" Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true" TransitionTo="UNORDERED_ACCESS" />
-
-    <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
-      <Descriptor Name="g_TestData" NumElements="12" Kind="UAV" StructureByteStride="8"/>
-    </DescriptorHeap>
-    
-    <RootValues>
-      <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
-    </RootValues>
-    
-    <Shader Name="CS60" Target="cs_6_0" EntryPoint="main" Text="@MAIN" Callback="True"/> 
-    <Shader Name="MAIN" Target="cs_6_0" EntryPoint="main">
-      <![CDATA[
-      struct TestPoint{
-        float input;
-        uint output;
-      };
-    
-      // Result buffers
-      RWStructuredBuffer <TestPoint> g_TestData     : register(u0);
-   
-      [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=1))")]
-      [NumThreads(12, 1, 1)]
-      void main(uint ix : SV_GroupIndex)
-      {
-        g_TestData[ix].output = isnan(g_TestData[ix].input);
-      }
-    
-    ]]>
-    </Shader>
-  </ShaderOp>
-
   <ShaderOp Name="LongVectorOp" CS="CS">
     <RootSignature>RootFlags(0), UAV(u0), UAV(u1), UAV(u2),
     UAV(u3)</RootSignature>

--- a/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
@@ -1348,7 +1348,7 @@
                     l.output = 0;
                 g_buf[GI] = l;
             };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_2</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
             <Parameter Name="Validation.Input1">
                 <Value>NaN</Value>
                 <Value>-Inf</Value>
@@ -1370,6 +1370,48 @@
                 <Value>1</Value>
                 <Value>0</Value>
                 <Value>0</Value>
+            </Parameter>
+            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
+        </Row>
+	<Row Name="IsNormalHalf">
+            <Parameter Name="Validation.Type">Epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
+                float16_t input;
+                float16_t output;
+            };
+            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isnormal(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            };</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected1">
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>1</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
         </Row>
@@ -1534,7 +1576,7 @@
                     l.output = 0;
                 g_buf[GI] = l;
             };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_2</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
             <Parameter Name="Validation.Input1">
                 <Value>NaN</Value>
                 <Value>-Inf</Value>
@@ -1620,7 +1662,7 @@
                     l.output = 0;
                 g_buf[GI] = l;
             };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_2</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
             <Parameter Name="Validation.Input1">
                 <Value>NaN</Value>
                 <Value>-Inf</Value>

--- a/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
@@ -1308,7 +1308,7 @@
             </Parameter>
         </Row>
     </Table>
-    <Table Id="UnaryHalfOpTable">
+    <Table Id="IsSpecialFloatHalfOpTable">
         <ParameterTypes>
             <ParameterType Name="ShaderOp.Target">String</ParameterType>
             <ParameterType Name="ShaderOp.Arguments">String</ParameterType>
@@ -1319,60 +1319,7 @@
             <ParameterType Array="true" Name="Validation.Expected1">String</ParameterType>
             <ParameterType Name="Warp.Version">unsigned int</ParameterType>
         </ParameterTypes>
-        <Row Name="Round_neHalf">
-            <Parameter Name="Validation.Type">Epsilon</Parameter>
-            <Parameter Name="Validation.Tolerance">0</Parameter>
-            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
-                float16_t input;
-                float16_t output;
-            };
-            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
-            [numthreads(8,8,1)]
-            void main(uint GI : SV_GroupIndex) {
-                SUnaryFPOp l = g_buf[GI];
-                l.output = round(l.input);
-                g_buf[GI] = l;
-            };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_2</Parameter>
-            <Parameter Name="Validation.Input1">
-                <Value>NaN</Value>
-                <Value>-Inf</Value>
-                <Value>-denorm</Value>
-                <Value>-0</Value>
-                <Value>0</Value>
-                <Value>denorm</Value>
-                <Value>Inf</Value>
-                <Value>10.0</Value>
-                <Value>10.4</Value>
-                <Value>10.5</Value>
-                <Value>10.6</Value>
-                <Value>11.5</Value>
-                <Value>-10.0</Value>
-                <Value>-10.4</Value>
-                <Value>-10.5</Value>
-                <Value>-10.6</Value>
-            </Parameter>
-            <Parameter Name="Validation.Expected1">
-                <Value>NaN</Value>
-                <Value>-Inf</Value>
-                <Value>-0</Value>
-                <Value>-0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>Inf</Value>
-                <Value>10.0</Value>
-                <Value>10.0</Value>
-                <Value>10.0</Value>
-                <Value>11.0</Value>
-                <Value>12.0</Value>
-                <Value>-10.0</Value>
-                <Value>-10.0</Value>
-                <Value>-10.0</Value>
-                <Value>-11.0</Value>
-            </Parameter>
-            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
-        </Row>
-        <Row Name="IsInfHalf">
+    <Row Name="IsInfHalf">
             <Parameter Name="Validation.Type">Epsilon</Parameter>
             <Parameter Name="Validation.Tolerance">0</Parameter>
             <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
@@ -1453,6 +1400,156 @@
                 <Value>0</Value>
                 <Value>1</Value>
                 <Value>1</Value>
+            </Parameter>
+            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
+        </Row>
+        <Row Name="IsFiniteHalf">
+            <Parameter Name="Validation.Type">Epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
+                float16_t input;
+                float16_t output;
+            };
+            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isfinite(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            };</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected1">
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+            </Parameter>
+            <Parameter Name="Warp.Version">16202</Parameter>
+            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
+        </Row>
+        <Row Name="IsNaNHalf">
+            <Parameter Name="Validation.Type">Epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
+                float16_t input;
+                float16_t output;
+            };
+            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isnan(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            };</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected1">
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
+        </Row>
+    </Table>
+    <Table Id="UnaryHalfOpTable">
+        <ParameterTypes>
+            <ParameterType Name="ShaderOp.Target">String</ParameterType>
+            <ParameterType Name="ShaderOp.Arguments">String</ParameterType>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.Type">String</ParameterType>
+            <ParameterType Name="Validation.Tolerance">double</ParameterType>
+            <ParameterType Array="true" Name="Validation.Input1">String</ParameterType>
+            <ParameterType Array="true" Name="Validation.Expected1">String</ParameterType>
+            <ParameterType Name="Warp.Version">unsigned int</ParameterType>
+        </ParameterTypes>
+        <Row Name="Round_neHalf">
+            <Parameter Name="Validation.Type">Epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
+                float16_t input;
+                float16_t output;
+            };
+            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = round(l.input);
+                g_buf[GI] = l;
+            };</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_2</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>10.0</Value>
+                <Value>10.4</Value>
+                <Value>10.5</Value>
+                <Value>10.6</Value>
+                <Value>11.5</Value>
+                <Value>-10.0</Value>
+                <Value>-10.4</Value>
+                <Value>-10.5</Value>
+                <Value>-10.6</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-0</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>Inf</Value>
+                <Value>10.0</Value>
+                <Value>10.0</Value>
+                <Value>10.0</Value>
+                <Value>11.0</Value>
+                <Value>12.0</Value>
+                <Value>-10.0</Value>
+                <Value>-10.0</Value>
+                <Value>-10.0</Value>
+                <Value>-11.0</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
         </Row>
@@ -1600,49 +1697,6 @@
             <Parameter Name="Warp.Version">16202</Parameter>
             <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
         </Row>
-        <Row Name="IsFiniteHalf">
-            <Parameter Name="Validation.Type">Epsilon</Parameter>
-            <Parameter Name="Validation.Tolerance">0</Parameter>
-            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
-                float16_t input;
-                float16_t output;
-            };
-            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
-            [numthreads(8,8,1)]
-            void main(uint GI : SV_GroupIndex) {
-                SUnaryFPOp l = g_buf[GI];
-                if (isfinite(l.input))
-                    l.output = 1;
-                else
-                    l.output = 0;
-                g_buf[GI] = l;
-            };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
-            <Parameter Name="Validation.Input1">
-                <Value>NaN</Value>
-                <Value>-Inf</Value>
-                <Value>-denorm</Value>
-                <Value>-0</Value>
-                <Value>0</Value>
-                <Value>denorm</Value>
-                <Value>Inf</Value>
-                <Value>1.0</Value>
-                <Value>-1.0</Value>
-            </Parameter>
-            <Parameter Name="Validation.Expected1">
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>1</Value>
-                <Value>1</Value>
-                <Value>1</Value>
-                <Value>1</Value>
-                <Value>0</Value>
-                <Value>1</Value>
-                <Value>1</Value>
-            </Parameter>
-            <Parameter Name="Warp.Version">16202</Parameter>
-            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
-        </Row>
         <Row Name="AcosHalf">
             <Parameter Name="Validation.Type">Epsilon</Parameter>
             <Parameter Name="Validation.Tolerance">0.0010</Parameter>
@@ -1683,48 +1737,6 @@
                 <Value>3.1415926</Value>
                 <Value>NaN</Value>
                 <Value>NaN</Value>
-            </Parameter>
-            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
-        </Row>
-        <Row Name="IsNaNHalf">
-            <Parameter Name="Validation.Type">Epsilon</Parameter>
-            <Parameter Name="Validation.Tolerance">0</Parameter>
-            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
-                float16_t input;
-                float16_t output;
-            };
-            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
-            [numthreads(8,8,1)]
-            void main(uint GI : SV_GroupIndex) {
-                SUnaryFPOp l = g_buf[GI];
-                if (isnan(l.input))
-                    l.output = 1;
-                else
-                    l.output = 0;
-                g_buf[GI] = l;
-            };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
-            <Parameter Name="Validation.Input1">
-                <Value>NaN</Value>
-                <Value>-Inf</Value>
-                <Value>-denorm</Value>
-                <Value>-0</Value>
-                <Value>0</Value>
-                <Value>denorm</Value>
-                <Value>Inf</Value>
-                <Value>1.0</Value>
-                <Value>-1.0</Value>
-            </Parameter>
-            <Parameter Name="Validation.Expected1">
-                <Value>1</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
         </Row>

--- a/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
@@ -320,6 +320,47 @@
                 <Value>0</Value>
             </Parameter>
         </Row>
+	<Row Name="IsNormal">
+            <Parameter Name="Validation.Type">Epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isnormal(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            };</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected1">
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+            </Parameter>
+        </Row>
         <Row Name="Exp">
             <Parameter Name="Validation.Type">Relative</Parameter>
             <Parameter Name="Validation.Tolerance">21</Parameter>


### PR DESCRIPTION
- update HLK test for 16 bit isinf to specify SM6.9 Closes #7600 
- update HLK test for 16 bit isnan to specify SM6.9 Closes #7601 
- update HLK test for 16 bit isfinite to specify SM6.9 Closes #7602 
- add 16 bit HLK test for isnormal which specifies SM6.9 Closes #7644
- Move 32 bit HLK test for isnormal to use isnormal instead of isnan Closes #7664 
