### PR TITLE
LongVectors: fix unnecessary copy of the input data

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -654,15 +654,12 @@ DATA_TYPE_NAME(double, L"float64");
 
 #undef DATA_TYPE_NAME
 
-template <typename DATA_TYPE>
-std::vector<DATA_TYPE> buildTestInput(const wchar_t *InputValueSetName,
-                                      size_t SizeToTest) {
-  // TODO: remove the need to build up a RawValueSet, only to use that to build
-  // ValueSet.
-  std::vector<DATA_TYPE> RawValueSet =
-      getInputValueSetByKey<DATA_TYPE>(InputValueSetName);
+template <typename T>
+std::vector<T> buildTestInput(const wchar_t *InputValueSetName,
+                              size_t SizeToTest) {
+  const std::vector<T> &RawValueSet = TestData<T>::Data.at(InputValueSetName);
 
-  std::vector<DATA_TYPE> ValueSet;
+  std::vector<T> ValueSet;
   ValueSet.reserve(SizeToTest);
   for (size_t I = 0; I < SizeToTest; ++I)
     ValueSet.push_back(RawValueSet[I % RawValueSet.size()]);

--- a/tools/clang/unittests/HLSLExec/LongVectors.h
+++ b/tools/clang/unittests/HLSLExec/LongVectors.h
@@ -277,15 +277,6 @@ getTernaryMathOpType(const std::wstring &OpTypeString) {
                                       OpTypeString);
 }
 
-template <typename T>
-std::vector<T> getInputValueSetByKey(const std::wstring &Key,
-                                     bool LogKey = true) {
-  if (LogKey)
-    WEX::Logging::Log::Comment(
-        WEX::Common::String().Format(L"Using Value Set Key: %s", Key.c_str()));
-  return std::vector<T>(TestData<T>::Data.at(Key));
-}
-
 class OpTest {
 public:
   BEGIN_TEST_CLASS(OpTest)


### PR DESCRIPTION
Previously getInputValueSetByKey returned a copy of the input data, which was then copied again into the actual input set, with the size adjusted.

This change just uses a reference to the raw data set, and inlines the operation to get that reference.