### PR TITLE
Make DXC use new `DxcDllExtValidationLoader` to load external validator before validation.

### DIFF
--- a/include/dxc/Support/dxcapi.extval.h
+++ b/include/dxc/Support/dxcapi.extval.h
@@ -1,4 +1,6 @@
 #include "dxc/Support/dxcapi.use.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include <cassert>
 #include <string>
 
@@ -22,7 +24,7 @@ public:
   HRESULT CreateInstance2Impl(IMalloc *pMalloc, REFCLSID clsid, REFIID riid,
                               IUnknown **pResult) override;
 
-  HRESULT Initialize();
+  HRESULT Initialize(llvm::raw_string_ostream &log);
 
   bool IsEnabled() const override { return DxCompilerSupport.IsEnabled(); }
 };

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -10,13 +10,12 @@
 
 #include "dxc/Support/WinIncludes.h"
 
-#include "dxc/Support/dxcapi.use.h"
-
 #include "dxc/DXIL/DxilShaderModel.h"
 #include "dxc/DxilContainer/DxilContainer.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/HLSLOptions.h"
 #include "dxc/Support/Unicode.h"
+#include "dxc/Support/dxcapi.use.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"

--- a/lib/DxcSupport/dxcapi.extval.cpp
+++ b/lib/DxcSupport/dxcapi.extval.cpp
@@ -25,12 +25,13 @@ HRESULT DxcDllExtValidationLoader::CreateInstance2Impl(IMalloc *pMalloc,
   return DxCompilerSupport.CreateInstance2(pMalloc, clsid, riid, pResult);
 }
 
-HRESULT DxcDllExtValidationLoader::Initialize() {
+HRESULT DxcDllExtValidationLoader::Initialize(llvm::raw_string_ostream &log) {
   // Load dxcompiler.dll
   HRESULT Result =
       DxCompilerSupport.InitializeForDll(kDxCompilerLib, "DxcCreateInstance");
   // if dxcompiler.dll fails to load, return the failed HRESULT
   if (DXC_FAILED(Result)) {
+    log << "dxcompiler.dll failed to load";
     return Result;
   }
 
@@ -45,9 +46,11 @@ HRESULT DxcDllExtValidationLoader::Initialize() {
 
   // Check if path is absolute and exists
   if (!DllPath.is_absolute() || !std::filesystem::exists(DllPath)) {
+    log << "dxil.dll path " << DxilDllPath << " could not be found";
     return E_INVALIDARG;
   }
 
+  log << "Loading external dxil.dll from " << DxilDllPath;
   return DxilExtValSupport.InitializeForDll(DxilDllPath.c_str(),
                                             "DxcCreateInstance");
 }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4247,7 +4247,9 @@ TEST_F(ValidationTest, UnitTestExtValidationSupport) {
   SetEnvVarW(L"DXC_DXIL_DLL_PATH", L"");
 
   // empty initialization should succeed
-  VERIFY_SUCCEEDED(ExtSupportEmpty.Initialize());
+  std::string dllErrorString;
+  llvm::raw_string_ostream dllLogStream(dllErrorString);
+  VERIFY_SUCCEEDED(ExtSupportEmpty.Initialize(dllLogStream));
 
   VERIFY_IS_FALSE(ExtSupportEmpty.DxilDllFailedToLoad());
   std::string EmptyPath = ExtSupportBogus.GetDxilDllPath();
@@ -4257,7 +4259,7 @@ TEST_F(ValidationTest, UnitTestExtValidationSupport) {
   SetEnvVarW(L"DXC_DXIL_DLL_PATH", L"bogus");
 
   if (!ExtSupportBogus.IsEnabled()) {
-    VERIFY_FAILED(ExtSupportBogus.Initialize());
+    VERIFY_FAILED(ExtSupportBogus.Initialize(dllLogStream));
   }
 
   // validate that m_dllExtSupport2 was able to capture the environment


### PR DESCRIPTION
This PR focuses on allowing dxc to use the existing infrastructure to use a `DxcDllExtValidationLoader` object, and load an external dxil.dll with it, via the environment variable.
Some more thought will be needed on testing.