### PR TITLE
[SPIR-V]: Fix spirv codegen for `uabs` intrinsic when argument is unsigned.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9686,6 +9686,17 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
                                         callExpr->getSourceRange());
     break;
   }
+  case hlsl::IntrinsicOp::IOP_uabs: {
+    if (isUintOrVecMatOfUintType(callExpr->getArg(0)->getType())) {
+      // If unsigned, it's a no-op. Skip generating an `OpExtInst` instruction.
+      // Simply load and store the value.
+      auto *loadInst = doExpr(callExpr->getArg(0));
+      retVal = loadInst;
+      break;
+    }
+    emitError("uabs intrinsic requires unsigned integer input type", srcLoc);
+    return nullptr;
+  }
     INTRINSIC_SPIRV_OP_CASE(countbits, BitCount, false);
     INTRINSIC_SPIRV_OP_CASE(fmod, FRem, true);
     INTRINSIC_SPIRV_OP_CASE(fwidth, Fwidth, true);
@@ -9693,7 +9704,6 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     INTRINSIC_SPIRV_OP_CASE(and, LogicalAnd, false);
     INTRINSIC_SPIRV_OP_CASE(or, LogicalOr, false);
     INTRINSIC_OP_CASE(round, RoundEven, true);
-    INTRINSIC_OP_CASE(uabs, SAbs, true);
     INTRINSIC_OP_CASE_INT_FLOAT(abs, SAbs, FAbs, true);
     INTRINSIC_OP_CASE(acos, Acos, true);
     INTRINSIC_OP_CASE(asin, Asin, true);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.abs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.abs.hlsl
@@ -64,6 +64,18 @@ void main() {
   int3 i;
   iresult3 = abs(i);
 
+// abs on unsigned int is a no-op.
+// CHECK-NEXT: [[j:%[0-9]+]] = OpLoad %uint %j
+// CHECK-NEXT: OpStore %j [[j]]
+  uint j;
+  j = abs(j);
+
+// abs on unsigned int vector is a no-op.
+// CHECK-NEXT: [[k:%[0-9]+]] = OpLoad %v3uint %k
+// CHECK-NEXT: OpStore %k [[k]]
+  uint3 k;
+  k = abs(k);
+
 // TODO: Integer matrices are not supported yet. Therefore we cannot run the following test yet.
 // XXXXX-NEXT: [[h:%[0-9]+]] = OpLoad %mat3v4float %h
 // XXXXX-NEXT: [[h_row0:%[0-9]+]] = OpCompositeExtract %v4float [[h]] 0


### PR DESCRIPTION
Fix the spirv codegen for `abs()` on `uint`, to **not** generate `OpExtInst` instruction but simply load and pass the value. Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7512

# Example 
```
[numthreads(1,1,1)]
void main() {
  uint32_t A = uint32_t(0xffffffff);
  uint32_t B = abs(A);
}
```

## Previously generated SPIR-V
```
 %A = OpVariable %_ptr_Function_uint Function
 %B = OpVariable %_ptr_Function_uint Function
      OpStore %A %uint_4294967295
%13 = OpLoad %uint %A
%14 = OpExtInst %int %1 SAbs %13
      OpStore %B %14
```


## Fix

```
 %A = OpVariable %_ptr_Function_uint Function
 %B = OpVariable %_ptr_Function_uint Function
      OpStore %A %uint_4294967295
%13 = OpLoad %uint %A
      OpStore %B %13
```

which is equivalent to 
```
[numthreads(1,1,1)]
void main() {
  uint32_t A = uint32_t(0xffffffff);
  uint32_t B = A;
}
```
