### PR TITLE
[SM6.9] Lower vector `any`/`all` calls to vector op

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -2423,8 +2423,8 @@ ID  Name                                                  Description
 306 MatVecMulAdd                                          multiplies a MxK dimension matrix and a K sized input vector and adds an M-sized bias vector
 307 OuterProductAccumulate                                Computes the outer product between column vectors and an MxN matrix is accumulated component-wise atomically (with device scope) in memory
 308 VectorAccumulate                                      Accumulates the components of a vector component-wise atomically (with device scope) to the corresponding elements of an array in memory
-309 ReservedD0                                            reserved
-310 ReservedD1                                            reserved
+309 VectorReduceAnd                                       Bitwise and reduction of the vector returning a scalar
+310 VectorReduceOr                                        Bitwise or reduction of the vector returning a scalar
 311 FDot                                                  computes the n-dimensional vector dot-product
 === ===================================================== =======================================================================================================================================================================================================================
 

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -524,8 +524,6 @@ enum class OpCode : unsigned {
   ReservedC7 = 300,  // reserved
   ReservedC8 = 301,  // reserved
   ReservedC9 = 302,  // reserved
-  ReservedD0 = 309,  // reserved
-  ReservedD1 = 310,  // reserved
 
   // Amplification shader instructions
   DispatchMesh = 173, // Amplification shader intrinsic DispatchMesh
@@ -1037,6 +1035,11 @@ enum class OpCode : unsigned {
   Unpack4x8 = 219, // unpacks 4 8-bit signed or unsigned values into int32 or
                    // int16 vector
 
+  // Vector reduce to scalar
+  VectorReduceAnd =
+      309, // Bitwise and reduction of the vector returning a scalar
+  VectorReduceOr = 310, // Bitwise or reduction of the vector returning a scalar
+
   // Wave
   WaveActiveAllEqual = 115, // returns 1 if all the lanes have the same value
   WaveActiveBallot = 116, // returns a struct with a bit set for each lane where
@@ -1381,6 +1384,9 @@ enum class OpCodeClass : unsigned {
   // Unpacking intrinsics
   Unpack4x8,
 
+  // Vector reduce to scalar
+  VectorReduce,
+
   // Wave
   WaveActiveAllEqual,
   WaveActiveBallot,
@@ -1417,7 +1423,7 @@ enum class OpCodeClass : unsigned {
   NumOpClasses_Dxil_1_7 = 153,
   NumOpClasses_Dxil_1_8 = 174,
 
-  NumOpClasses = 195 // exclusive last value of enumeration
+  NumOpClasses = 196 // exclusive last value of enumeration
 };
 // OPCODECLASS-ENUM:END
 

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -10149,6 +10149,60 @@ struct DxilInst_VectorAccumulate {
   void set_arrayOffset(llvm::Value *val) { Instr->setOperand(3, val); }
 };
 
+/// This instruction Bitwise and reduction of the vector returning a scalar
+struct DxilInst_VectorReduceAnd {
+  llvm::Instruction *Instr;
+  // Construction and identification
+  DxilInst_VectorReduceAnd(llvm::Instruction *pInstr) : Instr(pInstr) {}
+  operator bool() const {
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr,
+                                          hlsl::OP::OpCode::VectorReduceAnd);
+  }
+  // Validation support
+  bool isAllowed() const { return true; }
+  bool isArgumentListValid() const {
+    if (2 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+      return false;
+    return true;
+  }
+  // Metadata
+  bool requiresUniformInputs() const { return false; }
+  // Operand indexes
+  enum OperandIdx {
+    arg_a = 1,
+  };
+  // Accessors
+  llvm::Value *get_a() const { return Instr->getOperand(1); }
+  void set_a(llvm::Value *val) { Instr->setOperand(1, val); }
+};
+
+/// This instruction Bitwise or reduction of the vector returning a scalar
+struct DxilInst_VectorReduceOr {
+  llvm::Instruction *Instr;
+  // Construction and identification
+  DxilInst_VectorReduceOr(llvm::Instruction *pInstr) : Instr(pInstr) {}
+  operator bool() const {
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr,
+                                          hlsl::OP::OpCode::VectorReduceOr);
+  }
+  // Validation support
+  bool isAllowed() const { return true; }
+  bool isArgumentListValid() const {
+    if (2 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+      return false;
+    return true;
+  }
+  // Metadata
+  bool requiresUniformInputs() const { return false; }
+  // Operand indexes
+  enum OperandIdx {
+    arg_a = 1,
+  };
+  // Accessors
+  llvm::Value *get_a() const { return Instr->getOperand(1); }
+  void set_a(llvm::Value *val) { Instr->setOperand(1, val); }
+};
+
 /// This instruction computes the n-dimensional vector dot-product
 struct DxilInst_FDot {
   llvm::Instruction *Instr;

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -2687,22 +2687,23 @@ const OP::OpCodeProperty OP::m_OpCodeProps[(unsigned)OP::OpCode::NumOpCodes] = {
      {{0x400}},
      {{0x63}}}, // Overloads: <hfwi
 
-    {OC::ReservedD0,
-     "ReservedD0",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::ReservedD1,
-     "ReservedD1",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+    // Vector reduce to scalar
+    {OC::VectorReduceAnd,
+     "VectorReduceAnd",
+     OCC::VectorReduce,
+     "vectorReduce",
+     Attribute::ReadNone,
+     1,
+     {{0x400}},
+     {{0xf8}}}, // Overloads: <18wil
+    {OC::VectorReduceOr,
+     "VectorReduceOr",
+     OCC::VectorReduce,
+     "vectorReduce",
+     Attribute::ReadNone,
+     1,
+     {{0x400}},
+     {{0xf8}}}, // Overloads: <18wil
 
     // Dot
     {OC::FDot,
@@ -6018,14 +6019,16 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     break;
 
-    //
-  case OpCode::ReservedD0:
-    A(pV);
+    // Vector reduce to scalar
+  case OpCode::VectorReduceAnd:
+    A(pVecElt);
     A(pI32);
+    A(pETy);
     break;
-  case OpCode::ReservedD1:
-    A(pV);
+  case OpCode::VectorReduceOr:
+    A(pVecElt);
     A(pI32);
+    A(pETy);
     break;
 
     // Dot
@@ -6207,6 +6210,8 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::CreateHandleForLib:
   case OpCode::WaveMatch:
   case OpCode::VectorAccumulate:
+  case OpCode::VectorReduceAnd:
+  case OpCode::VectorReduceOr:
   case OpCode::FDot:
     if (FT->getNumParams() <= 1)
       return nullptr;
@@ -6324,8 +6329,6 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::ReservedC7:
   case OpCode::ReservedC8:
   case OpCode::ReservedC9:
-  case OpCode::ReservedD0:
-  case OpCode::ReservedD1:
     return Type::getVoidTy(Ctx);
   case OpCode::CheckAccessFullyMapped:
   case OpCode::SampleIndex:

--- a/lib/HLSL/DxilScalarizeVectorIntrinsics.cpp
+++ b/lib/HLSL/DxilScalarizeVectorIntrinsics.cpp
@@ -9,11 +9,14 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/HLSL/DxilGenerationPass.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -29,6 +32,7 @@ static void scalarizeVectorLoad(hlsl::OP *HlslOP, const DataLayout &DL,
 static void scalarizeVectorStore(hlsl::OP *HlslOP, const DataLayout &DL,
                                  CallInst *CI);
 static void scalarizeVectorIntrinsic(hlsl::OP *HlslOP, CallInst *CI);
+static void scalarizeVectorReduce(hlsl::OP *HlslOP, CallInst *CI);
 
 class DxilScalarizeVectorIntrinsics : public ModulePass {
 public:
@@ -53,24 +57,31 @@ public:
     for (auto F = M.functions().begin(); F != M.functions().end();) {
       Function *Func = &*(F++);
       DXIL::OpCodeClass OpClass;
-      if (HlslOP->GetOpCodeClass(Func, OpClass)) {
+      if (!HlslOP->GetOpCodeClass(Func, OpClass))
+        continue;
+
+      bool NeedsRewrite = (Func->getReturnType()->isVectorTy() ||
+                           OpClass == DXIL::OpCodeClass::RawBufferVectorLoad ||
+                           OpClass == DXIL::OpCodeClass::RawBufferVectorStore ||
+                           OpClass == DXIL::OpCodeClass::VectorReduce);
+      if (!NeedsRewrite)
+        continue;
+
+      for (auto U = Func->user_begin(), UE = Func->user_end(); U != UE;) {
+        CallInst *CI = cast<CallInst>(*(U++));
+
         if (OpClass == DXIL::OpCodeClass::RawBufferVectorLoad)
-          for (auto U = Func->user_begin(), UE = Func->user_end(); U != UE;) {
-            CallInst *CI = cast<CallInst>(*(U++));
-            scalarizeVectorLoad(HlslOP, M.getDataLayout(), CI);
-            Changed = true;
-          }
+          scalarizeVectorLoad(HlslOP, M.getDataLayout(), CI);
         else if (OpClass == DXIL::OpCodeClass::RawBufferVectorStore)
-          for (auto U = Func->user_begin(), UE = Func->user_end(); U != UE;) {
-            CallInst *CI = cast<CallInst>(*(U++));
-            scalarizeVectorStore(HlslOP, M.getDataLayout(), CI);
-            Changed = true;
-          }
+          scalarizeVectorStore(HlslOP, M.getDataLayout(), CI);
+        else if (OpClass == DXIL::OpCodeClass::VectorReduce)
+          scalarizeVectorReduce(HlslOP, CI);
         else if (Func->getReturnType()->isVectorTy())
-          for (auto U = Func->user_begin(), UE = Func->user_end(); U != UE;) {
-            CallInst *CI = cast<CallInst>(*(U++));
-            scalarizeVectorIntrinsic(HlslOP, CI);
-          }
+          scalarizeVectorIntrinsic(HlslOP, CI);
+        else
+          continue;
+
+        Changed = true;
       }
     }
     return Changed;
@@ -224,6 +235,34 @@ static void scalarizeVectorStore(hlsl::OP *HlslOP, const DataLayout &DL,
     Builder.CreateCall(F, Args);
   }
   CI->eraseFromParent();
+}
+
+static void scalarizeVectorReduce(hlsl::OP *HlslOP, CallInst *CI) {
+  IRBuilder<> Builder(CI);
+
+  ConstantInt *ReduceOp = dyn_cast<ConstantInt>(CI->getArgOperand(0));
+  assert(ReduceOp && "Arg0 must be a constant int");
+
+  Value *VecArg = CI->getArgOperand(1);
+  Type *VecTy = VecArg->getType();
+
+  Value *Result = Builder.CreateExtractElement(VecArg, 0ul);
+  for (unsigned I = 1; I < VecTy->getVectorNumElements(); I++) {
+    Value *Elt = Builder.CreateExtractElement(VecArg, I);
+
+    switch (ReduceOp->getLimitedValue()) {
+    case (unsigned)DXIL::OpCode::VectorReduceAnd:
+      Result = Builder.CreateAnd(Result, Elt);
+      break;
+    case (unsigned)DXIL::OpCode::VectorReduceOr:
+      Result = Builder.CreateOr(Result, Elt);
+      break;
+    default:
+      assert(false && "Unexpected VectorReduce OpCode");
+    }
+  }
+
+  CI->replaceAllUsesWith(Result);
 }
 
 // Scalarize native vector operation represented by `CI`, generating

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-intrinsics.hlsl
@@ -519,6 +519,19 @@ void main() {
   // CHECK: select <[[NUM]] x i1> [[bvec1]], <[[NUM]] x i16> [[svec2]], <[[NUM]] x i16> [[svec3]]
   sRes += select(sVec1, sVec2, sVec3);
 
+  // CHECK: [[vecreduceand:%.*]] = call i16 @dx.op.vectorReduce.v[[NUM]]i16(i32 309, <[[NUM]] x i16> [[svec1]])  ; VectorReduceAnd(a)
+  // CHECK: [[allres1:%.*]] = icmp ne i16 [[vecreduceand]], 0
+  // Upcast the i1 result to the correct vector size
+  // CHECK: [[allres16:%.*]] = zext i1 [[allres1]] to i16
+  // CHECK: insertelement <[[NUM]] x i16> undef, i16 [[allres16]], i32 0
+  sRes += all(sVec1);
+
+  // CHECK: [[vecreduceor:%.*]] = call i16 @dx.op.vectorReduce.v[[NUM]]i16(i32 310, <[[NUM]] x i16> [[svec1]])  ; VectorReduceOr(a)
+  // CHECK: [[anyres1:%.*]] = icmp ne i16 [[vecreduceor]], 0
+  // Upcast the i1 result to the correct vector size
+  // CHECK: [[anyres16:%.*]] = zext i1 [[anyres1]] to i16
+  // CHECK: insertelement <[[NUM]] x i16> undef, i16 [[anyres16]], i32 0
+  sRes += any(sVec1);
 
   // CHECK-NOT: extractelement
   // CHECK-NOT: insertelement

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-scalarized-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-scalarized-intrinsics.hlsl
@@ -65,30 +65,6 @@ export void test_modf(inout vector<float, 8> vec1, vector<float, 8> vec2) {
   vec1 = modf(vec1, vec2);
 }
 
-// CHECK-LABEL: test_any
-// CHECK: or i1
-// CHECK: or i1
-// CHECK: or i1
-// CHECK: or i1
-// CHECK: or i1
-// CHECK: or i1
-// CHECK: or i1
-export void test_any(vector<float, 8> vec1, inout vector<bool, 8> bvec) {
-  bvec &= any(vec1);
-}
-
-// CHECK-LABEL: test_all
-// CHECK: and i1
-// CHECK: and i1
-// CHECK: and i1
-// CHECK: and i1
-// CHECK: and i1
-// CHECK: and i1
-// CHECK: and i1
-export void test_all(vector<float, 8> vec1, inout vector<bool, 8> bvec) {
-  bvec &= all(vec1);
-}
-
 // CHECK-LABEL: test_WaveMatch
 // CHECK: call {{.*}} @dx.op.waveMatch
 // CHECK: call {{.*}} @dx.op.waveMatch

--- a/tools/clang/test/CodeGenDXIL/passes/longvec-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/passes/longvec-intrinsics.hlsl
@@ -23,7 +23,7 @@ void main() {
   vector<float, NUM> fVec1 = fBuf[11];
   vector<float, NUM> fVec2 = fBuf[12];
   vector<float, NUM> fVec3 = fBuf[13];
-  
+
   // CHECK: [[tmp:%.*]] = call <13 x float> @dx.op.binary.v13f32(i32 35, <13 x float> [[fvec1]], <13 x float> [[fvec2]])  ; FMax(a,b)
   // CHECK: call <13 x float> @dx.op.binary.v13f32(i32 36, <13 x float> [[tmp]], <13 x float> [[fvec3]])  ; FMin(a,b)
   vector<float, NUM> fRes = clamp(fVec1, fVec2, fVec3);
@@ -149,6 +149,14 @@ void main() {
   // CHECK: [[bvec3:%.*]] = icmp ne <13 x i32> [[vec3]], zeroinitializer
   // CHECK: and <13 x i1> [[bvec3]], [[bvec2]]
   uRes += and(bVec2, bVec3);
+
+  // CHECK: [[reduceand:%.*]] = call i64 @dx.op.vectorReduce.v13i64(i32 309, <13 x i64> [[lvec1]])  ; VectorReduceAnd(a)
+  // CHECK: icmp ne i64 [[reduceand]], 0
+  uRes += all(lVec1);
+
+  // CHECK: [[reduceor:%.*]] = call i64 @dx.op.vectorReduce.v13i64(i32 310, <13 x i64> [[lvec1]])  ; VectorReduceOr(a)
+  // CHECK: icmp ne i64 [[reduceor]], 0
+  uRes += any(lVec1);
 
   // CHECK: select <13 x i1> [[bvec3]], <13 x i64> [[lvec1]], <13 x i64> [[lvec2]]
   vector<int64_t, NUM> lRes = select(bVec3, lVec1, lVec2);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -465,6 +465,8 @@ class db_dxil(object):
             self.name_idx[i].category = "Binary uint with two outputs"
         for i in "UAddc,USubb".split(","):
             self.name_idx[i].category = "Binary uint with carry or borrow"
+        for i in "VectorReduceAnd,VectorReduceOr".split(","):
+            self.name_idx[i].category = "Vector reduce to scalar"
         for i in "FMad,Fma".split(","):
             self.name_idx[i].category = "Tertiary float"
         for i in "IMad,Msad,Ibfe".split(","):
@@ -6322,9 +6324,35 @@ class db_dxil(object):
         )
         next_op_idx += 1
 
-        # TODO: Replace with vector reduction ops.
-        # https://github.com/microsoft/DirectXShaderCompiler/issues/7687
-        next_op_idx = self.reserve_dxil_op_range("ReservedD", next_op_idx, 2)
+        # Long Vector Reduction
+        self.add_dxil_op(
+            "VectorReduceAnd",
+            next_op_idx,
+            "VectorReduce",
+            "Bitwise and reduction of the vector returning a scalar",
+            "<18wil",
+            "rn",
+            [
+                db_dxil_param(0, "$elt", "", "operation result"),
+                db_dxil_param(2, "$o", "a", "input value"),
+            ],
+            counters=("ints", "uints",),
+        )
+        next_op_idx += 1
+        self.add_dxil_op(
+            "VectorReduceOr",
+            next_op_idx,
+            "VectorReduce",
+            "Bitwise or reduction of the vector returning a scalar",
+            "<18wil",
+            "rn",
+            [
+                db_dxil_param(0, "$elt", "", "operation result"),
+                db_dxil_param(2, "$o", "a", "input value"),
+            ],
+            counters=("ints", "uints",),
+        )
+        next_op_idx += 1
 
         # Long Vector Dot
         self.add_dxil_op(


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7687

Implement vector reduction lowing for calls to `any` and `all`