### PR TITLE
[SPIR-V]: Fix codegen for `reversebits` on 16bit and 64bit width integers.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9697,10 +9697,13 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     emitError("uabs intrinsic requires unsigned integer input type", srcLoc);
     return nullptr;
   }
+  case hlsl::IntrinsicOp::IOP_reversebits: {
+    retVal = processReverseBitsIntrinsic(callExpr, srcLoc);
+    break;
+  }
     INTRINSIC_SPIRV_OP_CASE(countbits, BitCount, false);
     INTRINSIC_SPIRV_OP_CASE(fmod, FRem, true);
     INTRINSIC_SPIRV_OP_CASE(fwidth, Fwidth, true);
-    INTRINSIC_SPIRV_OP_CASE(reversebits, BitReverse, false);
     INTRINSIC_SPIRV_OP_CASE(and, LogicalAnd, false);
     INTRINSIC_SPIRV_OP_CASE(or, LogicalOr, false);
     INTRINSIC_OP_CASE(round, RoundEven, true);
@@ -9857,6 +9860,141 @@ SpirvInstruction *SpirvEmitter::processDerivativeIntrinsic(
   return result;
 }
 
+SpirvInstruction *
+SpirvEmitter::processReverseBitsIntrinsic(const CallExpr *callExpr,
+                                          clang::SourceLocation srcLoc) {
+  const QualType argType = callExpr->getArg(0)->getType();
+  const uint32_t bitwidth = getElementSpirvBitwidth(
+      astContext, argType, spirvOptions.enable16BitTypes);
+
+  // SPIRV only supports 32 bit integers for `OpBitReverse`. We need to
+  // unfold and add extra instructions to support reversing non-32bit integers.
+  if (bitwidth == 32) {
+    return processIntrinsicUsingSpirvInst(callExpr, spv::Op::OpBitReverse,
+                                          /* actPerRowForMatrices= */ false);
+  } else if (bitwidth == 16) {
+    // Load the 16-bit value
+    auto *loadInst = doExpr(callExpr->getArg(0));
+    bool isVector = isVectorType(argType);
+    uint32_t count = isVector ? hlsl::GetHLSLVecSize(argType) : 1;
+    QualType uintType =
+        isVector ? astContext.getExtVectorType(astContext.UnsignedIntTy, count)
+                 : astContext.UnsignedIntTy;
+    QualType resultType =
+        isVector
+            ? astContext.getExtVectorType(astContext.UnsignedShortTy, count)
+            : astContext.UnsignedShortTy;
+
+    // Extend to 32-bit.
+    auto *extended = spvBuilder.createUnaryOp(spv::Op::OpUConvert, uintType,
+                                              loadInst, srcLoc);
+    // Reverse the bits.
+    auto *reversed = spvBuilder.createUnaryOp(spv::Op::OpBitReverse, uintType,
+                                              extended, srcLoc);
+
+    // Shift right by 16 bits.
+    SpirvInstruction *shifted = nullptr;
+    if (count == 1) {
+      auto *constUint16 = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
+                                                    llvm::APInt(32, 16));
+      shifted =
+          spvBuilder.createBinaryOp(spv::Op::OpShiftRightLogical, uintType,
+                                    reversed, constUint16, srcLoc);
+    } else {
+      auto *constUint16 = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
+                                                    llvm::APInt(32, 16));
+      std::vector<clang::spirv::SpirvConstant *> arr(count, constUint16);
+      auto *constUintVec = spvBuilder.getConstantComposite(uintType, arr);
+      shifted =
+          spvBuilder.createBinaryOp(spv::Op::OpShiftRightLogical, uintType,
+                                    reversed, constUintVec, srcLoc);
+    }
+
+    // Truncate to short.
+    return spvBuilder.createUnaryOp(spv::Op::OpUConvert, resultType, shifted,
+                                    srcLoc);
+  } else if (bitwidth == 64) {
+    // Load the 64-bit value.
+    auto *loadInst = doExpr(callExpr->getArg(0));
+    auto count = isVectorType(argType) ? hlsl::GetHLSLVecSize(argType) : 1;
+
+    // Get the lower half bits by casting.
+    clang::spirv::SpirvUnaryOp *lowerUint = spvBuilder.createUnaryOp(
+        spv::Op::OpUConvert,
+        astContext.getExtVectorType(astContext.UnsignedIntTy, count), loadInst,
+        srcLoc);
+
+    // Higher bits need to be right shifted.
+    clang::spirv::SpirvUnaryOp *higherUint;
+    auto *constUlong32 = spvBuilder.getConstantInt(
+        astContext.UnsignedLongLongTy, llvm::APInt(64, 32));
+    clang::spirv::SpirvConstant *constUlongVec = nullptr;
+    if (isVectorType(argType)) {
+      std::vector<clang::spirv::SpirvConstant *> arr(count, constUlong32);
+      constUlongVec = spvBuilder.getConstantComposite(
+          astContext.getExtVectorType(astContext.UnsignedLongLongTy, count),
+          arr);
+      auto *rightShifted = spvBuilder.createBinaryOp(
+          spv::Op::OpShiftRightLogical,
+          astContext.getExtVectorType(astContext.UnsignedLongLongTy, count),
+          loadInst, constUlongVec, srcLoc);
+      higherUint = spvBuilder.createUnaryOp(
+          spv::Op::OpUConvert,
+          astContext.getExtVectorType(astContext.UnsignedIntTy, count),
+          rightShifted, srcLoc);
+    } else {
+      auto *rightShifted = spvBuilder.createBinaryOp(
+          spv::Op::OpShiftRightLogical, astContext.UnsignedLongLongTy, loadInst,
+          constUlong32, srcLoc);
+      higherUint = spvBuilder.createUnaryOp(
+          spv::Op::OpUConvert,
+          astContext.getExtVectorType(astContext.UnsignedIntTy, count),
+          rightShifted, srcLoc);
+    }
+
+    // Reverse the bits of each value.
+    auto *lowerReversed = spvBuilder.createUnaryOp(
+        spv::Op::OpBitReverse,
+        astContext.getExtVectorType(astContext.UnsignedIntTy, count), lowerUint,
+        srcLoc);
+    auto *higherReversed = spvBuilder.createUnaryOp(
+        spv::Op::OpBitReverse,
+        astContext.getExtVectorType(astContext.UnsignedIntTy, count),
+        higherUint, srcLoc);
+
+    // Cast back to long values.
+    auto *lowerUlong = spvBuilder.createUnaryOp(
+        spv::Op::OpUConvert,
+        astContext.getExtVectorType(astContext.UnsignedLongLongTy, count),
+        lowerReversed, srcLoc);
+    auto *higherUlong = spvBuilder.createUnaryOp(
+        spv::Op::OpUConvert,
+        astContext.getExtVectorType(astContext.UnsignedLongLongTy, count),
+        higherReversed, srcLoc);
+
+    // Lower bits need to be left shifted.
+    clang::spirv::SpirvBinaryOp *lowerLeftShifted;
+    if (isVectorType(argType)) {
+      lowerLeftShifted = spvBuilder.createBinaryOp(
+          spv::Op::OpShiftLeftLogical,
+          astContext.getExtVectorType(astContext.UnsignedLongLongTy, count),
+          lowerUlong, constUlongVec, srcLoc);
+    } else {
+      lowerLeftShifted = spvBuilder.createBinaryOp(
+          spv::Op::OpShiftLeftLogical, astContext.UnsignedLongLongTy,
+          lowerUlong, constUlong32, srcLoc);
+    }
+
+    // Combine the 2 values.
+    return spvBuilder.createBinaryOp(spv::Op::OpBitwiseOr, argType,
+                                     lowerLeftShifted, higherUlong, srcLoc);
+  }
+  emitError("reversebits currently only supports 16, 32, and 64-bit "
+            "width components when targeting SPIR-V",
+            srcLoc);
+  return nullptr;
+}
+
 // Returns true is the given expression can be used as an output parameter.
 //
 // Warning: this function could return false negatives.
@@ -9913,12 +10051,12 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
   // 'value'. Meaning, T is forced to be 'unsigned int'. If the provided
   // parameter is not an unsigned integer, the frontend inserts an
   // 'ImplicitCastExpr' to convert it to unsigned integer. OpAtomicIAdd (and
-  // other SPIR-V OpAtomic* instructions) require that the pointee in 'dest' to
-  // be of the same type as T. This will result in an invalid SPIR-V if 'dest'
-  // is a signed integer typed resource such as RWTexture1D<int>. For example,
-  // the following OpAtomicIAdd is invalid because the pointee type defined in
-  // %1 is a signed integer, while the value passed to atomic add (%3) is an
-  // unsigned integer.
+  // other SPIR-V OpAtomic* instructions) require that the pointee in 'dest'
+  // to be of the same type as T. This will result in an invalid SPIR-V if
+  // 'dest' is a signed integer typed resource such as RWTexture1D<int>. For
+  // example, the following OpAtomicIAdd is invalid because the pointee type
+  // defined in %1 is a signed integer, while the value passed to atomic add
+  // (%3) is an unsigned integer.
   //
   //  %_ptr_Image_int = OpTypePointer Image %int
   //  %1 = OpImageTexelPointer %_ptr_Image_int %RWTexture1D_int %index %uint_0
@@ -9964,9 +10102,9 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
                                        uint32_t outputArgIndex) {
     const auto outputArg = callExpr->getArg(outputArgIndex);
     if (!isValidOutputArgument(outputArg)) {
-      emitError(
-          "InterlockedCompareExchange requires a reference as output parameter",
-          outputArg->getExprLoc());
+      emitError("InterlockedCompareExchange requires a reference as output "
+                "parameter",
+                outputArg->getExprLoc());
       return;
     }
 
@@ -10082,8 +10220,8 @@ SpirvEmitter::processIntrinsicNonUniformResourceIndex(const CallExpr *expr) {
   // status to the usages of this expression. This is done by the
   // NonUniformVisitor class.
   //
-  // The decoration shouldn't be applied to the operand, rather to a copy of the
-  // result. Even though applying the decoration to the operand may not be
+  // The decoration shouldn't be applied to the operand, rather to a copy of
+  // the result. Even though applying the decoration to the operand may not be
   // functionally incorrect (since adding NonUniform is more conservative), it
   // could affect performance and isn't the intent of the shader.
   auto *copyInstr =
@@ -10247,8 +10385,8 @@ SpirvEmitter::processIntrinsicMsad4(const CallExpr *callExpr) {
           loc);
 
       // As pointed out by the DXIL reference above, it is *not* required to
-      // saturate the output to UINT_MAX in case of overflow. Wrapping around is
-      // also allowed. For simplicity, we will wrap around at this point.
+      // saturate the output to UINT_MAX in case of overflow. Wrapping around
+      // is also allowed. For simplicity, we will wrap around at this point.
       accums[msadNum] = spvBuilder.createBinaryOp(spv::Op::OpIAdd, uintType,
                                                   accums[msadNum], diff, loc);
     }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -853,6 +853,14 @@ private:
   SpirvInstruction *processReverseBitsIntrinsic(const CallExpr *expr,
                                                 clang::SourceLocation srcLoc);
 
+  // Processes the `reversebits` intrinsic for 16-bit integer types
+  SpirvInstruction *generate16BitReverse(const CallExpr *expr,
+                                         clang::SourceLocation srcLoc);
+
+  // Processes the `reversebits` intrinsic for 64-bit integer types
+  SpirvInstruction *generate64BitReverse(const CallExpr *expr,
+                                         clang::SourceLocation srcLoc);
+
 private:
   /// Returns the <result-id> for constant value 0 of the given type.
   SpirvConstant *getValueZero(QualType type);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -849,6 +849,10 @@ private:
                                                SourceLocation loc,
                                                SourceRange range);
 
+  // Processes the `reversebits` intrinsic
+  SpirvInstruction *processReverseBitsIntrinsic(const CallExpr *expr,
+                                                clang::SourceLocation srcLoc);
+
 private:
   /// Returns the <result-id> for constant value 0 of the given type.
   SpirvConstant *getValueZero(QualType type);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.reversebits.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.reversebits.hlsl
@@ -1,17 +1,62 @@
-// RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T ps_6_2 -E main -enable-16bit-types  -fcgl  %s -spirv | FileCheck %s
 
-// According to HLSL reference:
-// The 'reversebits' function can only operate on scalar or vector of uints.
+// The 'reversebits' function can only operate on scalar or vector of integers.
 
+// CHECK: [[shift:%[0-9]+]] = OpConstantComposite %v4uint %uint_16 %uint_16 %uint_16 %uint_16
+// CHECK: [[v4ulong_32:%[0-9]+]] = OpConstantComposite %v4ulong %ulong_32 %ulong_32 %ulong_32 %ulong_32
 void main() {
   uint a;
   uint4 b;
+  uint16_t c;
+  uint16_t4 d;
+  uint64_t e;
+  uint64_t4 f;
   
 // CHECK:      [[a:%[0-9]+]] = OpLoad %uint %a
 // CHECK-NEXT:   {{%[0-9]+}} = OpBitReverse %uint [[a]]
-  uint  cb  = reversebits(a);
+  uint  ar  = reversebits(a);
 
 // CHECK:      [[b:%[0-9]+]] = OpLoad %v4uint %b
 // CHECK-NEXT:   {{%[0-9]+}} = OpBitReverse %v4uint [[b]]
-  uint4 cb4 = reversebits(b);
+  uint4 br = reversebits(b);
+
+// CHECK:      [[c:%[0-9]+]] = OpLoad %ushort %c
+// CHECK-NEXT: [[c32:%[0-9]+]] = OpUConvert %uint [[c]]
+// CHECK-NEXT: [[rev:%[0-9]+]] = OpBitReverse %uint [[c32]]
+// CHECK-NEXT: [[shr:%[0-9]+]] = OpShiftRightLogical %uint [[rev]] %uint_16
+// CHECK-NEXT: {{%[0-9]+}} = OpUConvert %ushort [[shr]]
+  uint16_t cr = reversebits(c);
+
+
+// CHECK:      [[d:%[0-9]+]] = OpLoad %v4ushort %d
+// CHECK-NEXT: [[d32:%[0-9]+]] = OpUConvert %v4uint [[d]]
+// CHECK-NEXT: [[rev:%[0-9]+]] = OpBitReverse %v4uint [[d32]]
+// CHECK-NEXT: [[shr:%[0-9]+]] = OpShiftRightLogical %v4uint [[rev]] [[shift]]
+// CHECK-NEXT: {{%[0-9]+}} = OpUConvert %v4ushort [[shr]]
+  uint16_t4 dr = reversebits(d);
+
+
+// CHECK:      [[e:%[0-9]+]] = OpLoad %ulong %e
+// CHECK-NEXT: [[uconv1:%[0-9]+]] = OpUConvert %uint [[e]]
+// CHECK-NEXT: [[shr:%[0-9]+]] = OpShiftRightLogical %ulong [[e]] %ulong_32
+// CHECK-NEXT: [[uconv2:%[0-9]+]] = OpUConvert %uint [[shr]]
+// CHECK-NEXT: [[rev1:%[0-9]+]] = OpBitReverse %uint [[uconv1]]
+// CHECK-NEXT: [[rev2:%[0-9]+]] = OpBitReverse %uint [[uconv2]]
+// CHECK-NEXT: [[uconv3:%[0-9]+]] = OpUConvert %ulong [[rev1]]
+// CHECK-NEXT: [[uconv4:%[0-9]+]] = OpUConvert %ulong [[rev2]]
+// CHECK-NEXT: [[shl:%[0-9]+]] = OpShiftLeftLogical %ulong [[uconv3]] %ulong_32
+// CHECK-NEXT: {{%[0-9]+}} = OpBitwiseOr %ulong [[shl]] [[uconv4]]
+  uint64_t er = reversebits(e);
+
+// CHECK:      [[f:%[0-9]+]] = OpLoad %v4ulong %f
+// CHECK-NEXT: [[uconv1:%[0-9]+]] = OpUConvert %v4uint [[f]]
+// CHECK-NEXT: [[shr:%[0-9]+]] = OpShiftRightLogical %v4ulong [[f]] [[v4ulong_32]]
+// CHECK-NEXT: [[uconv2:%[0-9]+]] = OpUConvert %v4uint [[shr]]
+// CHECK-NEXT: [[rev1:%[0-9]+]] = OpBitReverse %v4uint [[uconv1]]
+// CHECK-NEXT: [[rev2:%[0-9]+]] = OpBitReverse %v4uint [[uconv2]]
+// CHECK-NEXT: [[uconv3:%[0-9]+]] = OpUConvert %v4ulong [[rev1]]
+// CHECK-NEXT: [[uconv4:%[0-9]+]] = OpUConvert %v4ulong [[rev2]]
+// CHECK-NEXT: [[shl:%[0-9]+]] = OpShiftLeftLogical %v4ulong [[uconv3]] [[v4ulong_32]]
+// CHECK-NEXT: {{%[0-9]+}} = OpBitwiseOr %v4ulong [[shl]] [[uconv4]]
+  uint64_t4 fr = reversebits(f);
 }


### PR DESCRIPTION
Fix SPIRV codegen for `reversebits` HLSL intrinsic  on 16- and 64- bit integers. From the [validator specs](https://vulkan.lunarg.com/doc/view/1.4.313.1/windows/antora/spec/latest/appendices/spirvenv.html#VUID-StandaloneSpirv-Base-04781), `OpBitReverse` requires all arguments to be 32-bit integers.

Tested SPIRV correctness in https://github.com/luciechoi/amber/commit/02d1a357fe24f9765fe1683a741160557add63d6

# Fix 
## 16-bit
1) Cast `ushort` to `uint`
2) Reverse bits
3) Right shift by 16
4) Cast back to `ushort`

which is similar to 
```
[numthreads(1,1,1)]
void main() {
    uint16_t s = 1;
    s = uint16_t(reversebits(uint(i)) >> 16);
}
```
## 64-bit
1) Get the lower half `uint` by casting `ulong` to `uint`
2) Right shift the original `ulong` by 32 and get the upper half bits. Cast to `uint`
3) Reverse both `uint`s
4) Cast both back to `ulong`
5) Left shift the reversed lower half by 32
6) Combine them through bitwise `OR`

which is similar to

```
[numthreads(1,1,1)]
void main() {
    uint64_t s = 1;
    uint low = reversebits(uint(s));
    uint high = reversebits(uint(s >> 32));
    s = (uint64_t(low) << 32) | uint64_t(high);
}
```

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7680.