### PR TITLE
Execution Tests: Long Vector finish implementing unary operators

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
+++ b/tools/clang/unittests/HLSLExec/LongVectorOpTable.xml
@@ -799,10 +799,6 @@
         <Parameter Name="DataType">uint16</Parameter>
         <Parameter Name="ScalarInputFlags">0x2</Parameter>
       </Row>
-      <Row Name="Bitwise_Not_uint16">
-        <Parameter Name="OpTypeEnum">BitwiseOpType_Not</Parameter>
-        <Parameter Name="DataType">uint16</Parameter>
-      </Row>
       <Row Name="Bitwise_LeftShift_uint16">
         <Parameter Name="OpTypeEnum">BitwiseOpType_LeftShift</Parameter>
         <Parameter Name="DataType">uint16</Parameter>
@@ -852,10 +848,6 @@
         <Parameter Name="OpTypeEnum">BitwiseOpType_Xor</Parameter>
         <Parameter Name="DataType">uint32</Parameter>
         <Parameter Name="ScalarInputFlags">0x2</Parameter>
-      </Row>
-      <Row Name="Bitwise_Not_uint32">
-        <Parameter Name="OpTypeEnum">BitwiseOpType_Not</Parameter>
-        <Parameter Name="DataType">uint32</Parameter>
       </Row>
       <Row Name="Bitwise_LeftShift_uint32">
         <Parameter Name="OpTypeEnum">BitwiseOpType_LeftShift</Parameter>
@@ -907,10 +899,6 @@
         <Parameter Name="DataType">uint64</Parameter>
         <Parameter Name="ScalarInputFlags">0x2</Parameter>
       </Row>
-      <Row Name="Bitwise_Not_uint64">
-        <Parameter Name="OpTypeEnum">BitwiseOpType_Not</Parameter>
-        <Parameter Name="DataType">uint64</Parameter>
-      </Row>
       <Row Name="Bitwise_LeftShift_uint64">
         <Parameter Name="OpTypeEnum">BitwiseOpType_LeftShift</Parameter>
         <Parameter Name="DataType">uint64</Parameter>
@@ -960,10 +948,6 @@
         <Parameter Name="OpTypeEnum">BitwiseOpType_Xor</Parameter>
         <Parameter Name="DataType">int16</Parameter>
         <Parameter Name="ScalarInputFlags">0x2</Parameter>
-      </Row>
-      <Row Name="Bitwise_Not_int16">
-        <Parameter Name="OpTypeEnum">BitwiseOpType_Not</Parameter>
-        <Parameter Name="DataType">int16</Parameter>
       </Row>
       <Row Name="Bitwise_LeftShift_int16">
         <Parameter Name="OpTypeEnum">BitwiseOpType_LeftShift</Parameter>
@@ -1015,10 +999,6 @@
         <Parameter Name="DataType">int32</Parameter>
         <Parameter Name="ScalarInputFlags">0x2</Parameter>
       </Row>
-      <Row Name="Bitwise_Not_int32">
-        <Parameter Name="OpTypeEnum">BitwiseOpType_Not</Parameter>
-        <Parameter Name="DataType">int32</Parameter>
-      </Row>
       <Row Name="Bitwise_LeftShift_int32">
         <Parameter Name="OpTypeEnum">BitwiseOpType_LeftShift</Parameter>
         <Parameter Name="DataType">int32</Parameter>
@@ -1069,10 +1049,6 @@
         <Parameter Name="DataType">int64</Parameter>
         <Parameter Name="ScalarInputFlags">0x2</Parameter>
       </Row>
-      <Row Name="Bitwise_Not_int64">
-        <Parameter Name="OpTypeEnum">BitwiseOpType_Not</Parameter>
-        <Parameter Name="DataType">int64</Parameter>
-      </Row>
       <Row Name="Bitwise_LeftShift_int64">
         <Parameter Name="OpTypeEnum">BitwiseOpType_LeftShift</Parameter>
         <Parameter Name="DataType">int64</Parameter>
@@ -1111,9 +1087,89 @@
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
         <Parameter Name="DataType">bool</Parameter>
       </Row>
+      <Row Name="CastToBool_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToInt16_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToInt32_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToInt64_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToUint16_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToUint32_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToUint64_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_bool">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
+        <Parameter Name="DataType">bool</Parameter>
+      </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: int16 -->
       <Row Name="Initialize_int16">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToBool_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToInt16_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToInt32_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToInt64_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToUint16_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToUint32_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToUint64_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">int16</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_int16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
         <Parameter Name="DataType">int16</Parameter>
       </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: int32 -->
@@ -1121,9 +1177,89 @@
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
         <Parameter Name="DataType">int32</Parameter>
       </Row>
+      <Row Name="CastToBool_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToInt16_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToInt32_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToInt64_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToUint16_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToUint32_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToUint64_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_int32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
+        <Parameter Name="DataType">int32</Parameter>
+      </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: int64 -->
       <Row Name="Initialize_int64">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToBool_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToInt16_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToInt32_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToInt64_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToUint16_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToUint32_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToUint64_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">int64</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_int64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
         <Parameter Name="DataType">int64</Parameter>
       </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: uint16 -->
@@ -1131,9 +1267,89 @@
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
         <Parameter Name="DataType">uint16</Parameter>
       </Row>
+      <Row Name="CastToBool_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToInt16_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToInt32_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToInt64_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToUint16_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToUint32_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToUint64_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_uint16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
+        <Parameter Name="DataType">uint16</Parameter>
+      </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: uint32 -->
       <Row Name="Initialize_uint32">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToBool_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToInt16_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToInt32_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToInt64_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToUint16_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToUint32_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToUint64_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">uint32</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_uint32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
         <Parameter Name="DataType">uint32</Parameter>
       </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: uint64 -->
@@ -1141,9 +1357,92 @@
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
         <Parameter Name="DataType">uint64</Parameter>
       </Row>
+      <Row Name="CastToBool_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToInt16_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToInt32_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToInt64_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToUint16_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToUint32_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToUint64_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_uint64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
+        <Parameter Name="DataType">uint64</Parameter>
+      </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: float16 -->
       <Row Name="Initialize_float16">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToBool_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToInt16_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToInt32_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToInt64_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToUint16_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToUint32_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToUint64_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">float16</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_float16">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
         <Parameter Name="DataType">float16</Parameter>
       </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: float32 -->
@@ -1151,9 +1450,99 @@
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
         <Parameter Name="DataType">float32</Parameter>
       </Row>
+      <Row Name="CastToBool_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToInt16_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToInt32_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToInt64_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToUint16_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToUint32_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToUint64_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_float32">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
+        <Parameter Name="DataType">float32</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
       <!-- LongVectorUnaryOpTypeTable DataType: float64 -->
       <Row Name="Initialize_float64">
         <Parameter Name="OpTypeEnum">UnaryOpType_Initialize</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToBool_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToBool</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToInt16_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt16</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToInt32_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt32</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToInt64_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToInt64</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToUint16_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint16</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToUint32_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint32</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToUint64_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToUint64</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+        <Parameter Name="InputValueSetName1">Positive</Parameter>
+      </Row>
+      <Row Name="CastToFloat16_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat16</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToFloat32_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat32</Parameter>
+        <Parameter Name="DataType">float64</Parameter>
+      </Row>
+      <Row Name="CastToFloat64_float64">
+        <Parameter Name="OpTypeEnum">UnaryOpType_CastToFloat64</Parameter>
         <Parameter Name="DataType">float64</Parameter>
       </Row>
     </Table>

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -39,6 +39,8 @@ struct HLSLBool_t {
 
   bool operator>=(const HLSLBool_t &Other) const { return Val >= Other.Val; }
 
+  HLSLBool_t operator!() const { return HLSLBool_t(!static_cast<bool>(Val)); }
+
   HLSLBool_t operator*(const HLSLBool_t &Other) const {
     return HLSLBool_t(Val * Other.Val);
   }
@@ -66,6 +68,18 @@ struct HLSLBool_t {
   HLSLBool_t operator||(const HLSLBool_t &Other) const {
     return HLSLBool_t(Val || Other.Val);
   }
+
+  bool AsBool() const { return static_cast<bool>(Val); }
+
+  operator bool() const { return AsBool(); }
+  operator int16_t() const { return (int16_t)(AsBool()); }
+  operator int32_t() const { return (int32_t)(AsBool()); }
+  operator int64_t() const { return (int64_t)(AsBool()); }
+  operator uint16_t() const { return (uint16_t)(AsBool()); }
+  operator uint32_t() const { return (uint32_t)(AsBool()); }
+  operator uint64_t() const { return (uint64_t)(AsBool()); }
+  operator float() const { return (float)(AsBool()); }
+  operator double() const { return (double)(AsBool()); }
 
   // So we can construct std::wstrings using std::wostream
   friend std::wostream &operator<<(std::wostream &Os, const HLSLBool_t &Obj) {
@@ -191,6 +205,18 @@ struct HLSLHalf_t {
     return FromHALF(DirectX::PackedVector::XMConvertFloatToHalf(C));
   }
 
+  // Prefix operator
+  HLSLHalf_t operator++() const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    return FromHALF(DirectX::PackedVector::XMConvertFloatToHalf(A + 1.0f));
+  }
+
+  // Prefix operator
+  HLSLHalf_t operator--() const {
+    const float A = DirectX::PackedVector::XMConvertHalfToFloat(Val);
+    return FromHALF(DirectX::PackedVector::XMConvertFloatToHalf(A - 1.0f));
+  }
+
   // So we can construct std::wstrings using std::wostream
   friend std::wostream &operator<<(std::wostream &Os, const HLSLHalf_t &Obj) {
     Os << DirectX::PackedVector::XMConvertHalfToFloat(Obj.Val);
@@ -201,6 +227,10 @@ struct HLSLHalf_t {
   friend std::ostream &operator<<(std::ostream &Os, const HLSLHalf_t &Obj) {
     Os << DirectX::PackedVector::XMConvertHalfToFloat(Obj.Val);
     return Os;
+  }
+
+  float AsFloat() const {
+    return DirectX::PackedVector::XMConvertHalfToFloat(Val);
   }
 
   // HALF is an alias to uint16_t
@@ -296,6 +326,8 @@ template <> struct TestData<HLSLHalf_t> {
        {10.0, -2.6, -2.3, -1.4, -2.2, 2.3, 2.9, 3.3, 3.9, 4.2}},
       {L"SmoothStepInputValueSet",
        {-2.8, -4.9, -2.3, -3.3, -3.6, 0.6, 3.0, 3.3, 1.9, 4.3}},
+      {L"Positive",
+       {1.0, 1.0, 3441.0, 0.01, 5531.0, 0.01, 1.0, 0.01, 331.2330, 3250.01}},
   };
 };
 
@@ -320,6 +352,9 @@ template <> struct TestData<float> {
        {-2.8f, -2.6f, -2.3f, -1.4f, -2.2f, 2.3f, 2.9f, 3.3f, 3.9f, 4.2f}},
       {L"SmoothStepInputValueSet",
        {-2.8f, -4.9f, -2.3f, -3.3f, -3.6f, 0.6f, 3.0f, 3.3f, 1.9f, 4.3f}},
+      {L"Positive",
+       {1.0f, 1.0f, 3424241.0f, 0.01f, 5531.0f, 0.01f, 1.0f, 0.01f, 331.2330f,
+        3250.01f}},
   };
 };
 
@@ -346,6 +381,8 @@ template <> struct TestData<double> {
        {-2.8, -2.6, -2.3, -1.4, -2.0, 2.3, 2.9, 3.3, 3.9, 4.2}},
       {L"SmoothStepInputValueSet",
        {-10.8, -4.9, -2.3, -3.3, -3.0, 0.6, 3.0, 3.3, 1.9, 4.3}},
+      {L"Positive",
+       {1.0, 1.0, 3424241.0, 0.01, 5531.0, 0.01, 1.0, 0.01, 331.2330, 3250.01}},
   };
 };
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1065,9 +1065,7 @@ template <> struct UnaryOps<HLSLHalf_t> {
   static uint16_t CastToUint16(HLSLHalf_t V) { return (uint16_t)V.AsFloat(); }
   static uint32_t CastToUint32(HLSLHalf_t V) { return (uint32_t)V.AsFloat(); }
   static uint64_t CastToUint64(HLSLHalf_t V) { return (uint64_t)V.AsFloat(); }
-  static HLSLHalf_t CastToFloat16(HLSLHalf_t V) {
-    return HLSLHalf_t((float)V.AsFloat());
-  }
+  static HLSLHalf_t CastToFloat16(HLSLHalf_t V) { return V; }
   static float CastToFloat32(HLSLHalf_t V) { return (float)V.AsFloat(); }
   static double CastToFloat64(HLSLHalf_t V) { return (double)V.AsFloat(); }
 };
@@ -1234,7 +1232,6 @@ void dispatchTestByOpTypeAndVectorSize(const TestConfig &Config,
 
 #undef DISPATCH
 #undef DISPATCH_INITIALIZE
-#undef DISPATCH_POSTFIX
 
   LOG_ERROR_FMT_THROW(L"DataType '%s' not supported for UnaryOpType '%s'",
                       (const wchar_t *)Config.DataType,

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -32,25 +32,20 @@ template <typename T> const char *getHLSLTypeString() {
   static_assert(false && "Missing HLSL type string");
 }
 
-template <typename T> size_t getHLSLDataTypeSize() {
-  static_assert(false && "Missing HLSL Data Type size");
-}
-
-#define DATA_TYPE_NAME(TYPE, NAME, HLSL_STRING, SIZE)                          \
+#define DATA_TYPE_NAME(TYPE, NAME, HLSL_STRING)                                \
   template <> const wchar_t *getDataTypeName<TYPE>() { return NAME; }          \
-  template <> const char *getHLSLTypeString<TYPE>() { return HLSL_STRING; }    \
-  template <> size_t getHLSLDataTypeSize<TYPE>() { return (size_t)SIZE; }
+  template <> const char *getHLSLTypeString<TYPE>() { return HLSL_STRING; }
 
-DATA_TYPE_NAME(HLSLBool_t, L"bool", "bool", 4);
-DATA_TYPE_NAME(int16_t, L"int16", "int16_t", 2);
-DATA_TYPE_NAME(int32_t, L"int32", "int", 4);
-DATA_TYPE_NAME(int64_t, L"int64", "int64_t", 8);
-DATA_TYPE_NAME(uint16_t, L"uint16", "uint16_t", 2);
-DATA_TYPE_NAME(uint32_t, L"uint32", "uint32_t", 4);
-DATA_TYPE_NAME(uint64_t, L"uint64", "uint64_t", 8);
-DATA_TYPE_NAME(HLSLHalf_t, L"float16", "half", 2);
-DATA_TYPE_NAME(float, L"float32", "float", 4);
-DATA_TYPE_NAME(double, L"float64", "double", 8);
+DATA_TYPE_NAME(HLSLBool_t, L"bool", "bool");
+DATA_TYPE_NAME(int16_t, L"int16", "int16_t");
+DATA_TYPE_NAME(int32_t, L"int32", "int");
+DATA_TYPE_NAME(int64_t, L"int64", "int64_t");
+DATA_TYPE_NAME(uint16_t, L"uint16", "uint16_t");
+DATA_TYPE_NAME(uint32_t, L"uint32", "uint32_t");
+DATA_TYPE_NAME(uint64_t, L"uint64", "uint64_t");
+DATA_TYPE_NAME(HLSLHalf_t, L"float16", "half");
+DATA_TYPE_NAME(float, L"float32", "float");
+DATA_TYPE_NAME(double, L"float64", "double");
 
 #undef DATA_TYPE_NAME
 
@@ -456,7 +451,6 @@ std::string getCompilerOptionsString(OP_TYPE OpType, size_t VectorSize,
   CompilerOptions << " " << ExtraDefines;
 
   CompilerOptions << " -DOUT_TYPE=" << getHLSLTypeString<OUT_TYPE>();
-  CompilerOptions << " -DOUT_TYPE_SIZE=" << getHLSLDataTypeSize<OUT_TYPE>();
 
   CompilerOptions << " -DBASIC_OP_TYPE=0x" << std::hex << ARITY;
 
@@ -1056,6 +1050,9 @@ template <typename T> struct UnaryOps {
   static double CastToFloat64(T V) { return (double)V; }
 };
 
+// Specialization for handling HLSLHalf_t. Chosen instead of overloading in the
+// struct as that leads to ambiguous implicit conversions when using std math
+// and trig function with an HLSLHalf_t argument.
 template <> struct UnaryOps<HLSLHalf_t> {
   static HLSLHalf_t Initialize(HLSLHalf_t V) { return V; }
   static HLSLBool_t CastToBool(HLSLHalf_t V) { return HLSLBool_t((bool)V); }

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3776,18 +3776,18 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
+        #ifdef FUNC_CAST
+        vector<OUT_TYPE, NUM> TestCast(vector<TYPE, NUM> Vector)
+        {
+          return (vector<OUT_TYPE, NUM>)Vector;
+        }
+        #endif
+
         #ifdef FUNC_TERNARY_ASSIGNMENT
         vector<TYPE, NUM> TestTernaryAssignment(vector<TYPE, NUM> Vector,
         vector<TYPE, NUM> Vector2))
         {
           return (TERNARY_CONDITION ? Vector : Vector2);
-        }
-        #endif
-
-        #ifdef FUNC_UNARY_OPERATOR
-        vector<OUT_TYPE, NUM> TestUnaryOperator(vector<TYPE, NUM> Vector)
-        {
-          return OPERATOR(Vector);
         }
         #endif
 
@@ -3799,9 +3799,7 @@ void MSMain(uint GID : SV_GroupIndex,
           asuint(Vector, LowBits, HighBits);
 
           // Store the high bits in the second half of the output vector.
-          // Because we know the outputs of asuint are always 32 bits, we can
-          // use 4 bytes per element for our offset.
-          g_OutputVector.Store< vector<OUT_TYPE, NUM> >(4 * NUM, HighBits);
+          g_OutputVector.Store< vector<OUT_TYPE, NUM> >(OUT_TYPE_SIZE * NUM, HighBits);
 
           // Generic store logic in main handles storing LowBits in
           // g_OutputVector.

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3799,7 +3799,9 @@ void MSMain(uint GID : SV_GroupIndex,
           asuint(Vector, LowBits, HighBits);
 
           // Store the high bits in the second half of the output vector.
-          g_OutputVector.Store< vector<OUT_TYPE, NUM> >(OUT_TYPE_SIZE * NUM, HighBits);
+          // Because we know the outputs of asuint are always 32 bits, we can
+          // use 4 bytes per element for our offset.
+          g_OutputVector.Store< vector<OUT_TYPE, NUM> >(4 * NUM, HighBits);
 
           // Generic store logic in main handles storing LowBits in
           // g_OutputVector.


### PR DESCRIPTION
This PR adds test cases for explicit casts of long vectors. Bitwise NOT was removed as I realized it resolves to XOR and comparison ops that already have coverage. Other unary ops listed in the issue have a similar story.

Resolves #7617 
