### PR TITLE
Execution Tests: Long Vector finish implementing unary operators

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -54,8 +54,30 @@ OP(Bitwise, RightShift, 2, "", ">>", "", Default1, BitShiftRhs, Default3)
 
 OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
                    " -DFUNC_INITIALIZE=1")
-OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
-" -DFUNC_TEST_CAST=1")
+
+#define OP_CAST_DEFAULT_DEFINES(GROUP, SYMBOL) \
+  OP_DEFAULT_DEFINES(GROUP, SYMBOL, 1, "TestCast", "",                         \
+                     "-DFUNC_TEST_CAST=1")
+#define OP_CAST(GROUP, SYMBOL, INPUT_SET_1)                                    \
+  OP(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1", INPUT_SET_1,      \
+     Default2, Default3)
+
+OP_CAST_DEFAULT_DEFINES(Unary, CastToBool)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToInt16)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToInt32)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToInt64)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToUint16)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToUint32)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToUint64)
+OP_CAST(Unary, CastToUint16_FromFP, Positive)
+OP_CAST(Unary, CastToUint32_FromFP, Positive)
+OP_CAST(Unary, CastToUint64_FromFP, Positive)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToFloat16)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToFloat32)
+OP_CAST_DEFAULT_DEFINES(Unary, CastToFloat64)
+
+#undef OP_CAST_DEFAULT_DEFINES
+#undef OP_CAST
 
 OP(Trigonometric, Acos, 1, "acos", "", "", RangeOne, Default2, Default3)
 OP(Trigonometric, Asin, 1, "asin", "", "", RangeHalfPi, Default2, Default3)

--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -62,19 +62,19 @@ OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
   OP(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1", INPUT_SET_1,      \
      Default2, Default3)
 
-OP_CAST_DEFAULT_DEFINES(Unary, CastToBool)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToInt16)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToInt32)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToInt64)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToUint16)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToUint32)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToUint64)
-OP_CAST(Unary, CastToUint16_FromFP, Positive)
-OP_CAST(Unary, CastToUint32_FromFP, Positive)
-OP_CAST(Unary, CastToUint64_FromFP, Positive)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToFloat16)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToFloat32)
-OP_CAST_DEFAULT_DEFINES(Unary, CastToFloat64)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToBool)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToInt16)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToInt32)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToInt64)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToUint16)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToUint32)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToUint64)
+OP_CAST(Cast, CastToUint16_FromFP, Positive)
+OP_CAST(Cast, CastToUint32_FromFP, Positive)
+OP_CAST(Cast, CastToUint64_FromFP, Positive)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToFloat16)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToFloat32)
+OP_CAST_DEFAULT_DEFINES(Cast, CastToFloat64)
 
 #undef OP_CAST_DEFAULT_DEFINES
 #undef OP_CAST

--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -16,6 +16,7 @@ INPUT_SET(RangeOne)
 INPUT_SET(RangeHalfPi)
 INPUT_SET(SplitDouble)
 INPUT_SET(BitShiftRhs)
+INPUT_SET(Positive)
 
 #undef INPUT_SET
 
@@ -48,13 +49,13 @@ OP_DEFAULT(BinaryMath, Ldexp, 2, "ldexp", ",")
 OP_DEFAULT(Bitwise, And, 2, "", "&")
 OP_DEFAULT(Bitwise, Or, 2, "", "|")
 OP_DEFAULT(Bitwise, Xor, 2, "", "^")
-OP_DEFAULT_DEFINES(Bitwise, Not, 1, "TestUnaryOperator", "~",
-                   " -DFUNC_UNARY_OPERATOR=1")
 OP(Bitwise, LeftShift, 2, "", "<<", "", Default1, BitShiftRhs, Default3)
 OP(Bitwise, RightShift, 2, "", ">>", "", Default1, BitShiftRhs, Default3)
 
 OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
                    " -DFUNC_INITIALIZE=1")
+OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
+" -DFUNC_TEST_CAST=1")
 
 OP(Trigonometric, Acos, 1, "acos", "", "", RangeOne, Default2, Default3)
 OP(Trigonometric, Asin, 1, "asin", "", "", RangeHalfPi, Default2, Default3)

--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -55,28 +55,27 @@ OP(Bitwise, RightShift, 2, "", ">>", "", Default1, BitShiftRhs, Default3)
 OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
                    " -DFUNC_INITIALIZE=1")
 
-#define OP_CAST_DEFAULT_DEFINES(GROUP, SYMBOL) \
-  OP_DEFAULT_DEFINES(GROUP, SYMBOL, 1, "TestCast", "",                         \
-                     "-DFUNC_TEST_CAST=1")
+#define OP_CAST_DEFAULT(GROUP, SYMBOL)                                         \
+  OP_DEFAULT_DEFINES(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1")
 #define OP_CAST(GROUP, SYMBOL, INPUT_SET_1)                                    \
   OP(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1", INPUT_SET_1,      \
      Default2, Default3)
 
-OP_CAST_DEFAULT_DEFINES(Cast, CastToBool)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToInt16)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToInt32)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToInt64)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToUint16)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToUint32)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToUint64)
+OP_CAST_DEFAULT(Cast, CastToBool)
+OP_CAST_DEFAULT(Cast, CastToInt16)
+OP_CAST_DEFAULT(Cast, CastToInt32)
+OP_CAST_DEFAULT(Cast, CastToInt64)
+OP_CAST_DEFAULT(Cast, CastToUint16)
+OP_CAST_DEFAULT(Cast, CastToUint32)
+OP_CAST_DEFAULT(Cast, CastToUint64)
 OP_CAST(Cast, CastToUint16_FromFP, Positive)
 OP_CAST(Cast, CastToUint32_FromFP, Positive)
 OP_CAST(Cast, CastToUint64_FromFP, Positive)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToFloat16)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToFloat32)
-OP_CAST_DEFAULT_DEFINES(Cast, CastToFloat64)
+OP_CAST_DEFAULT(Cast, CastToFloat16)
+OP_CAST_DEFAULT(Cast, CastToFloat32)
+OP_CAST_DEFAULT(Cast, CastToFloat64)
 
-#undef OP_CAST_DEFAULT_DEFINES
+#undef OP_CAST_DEFAULT
 #undef OP_CAST
 
 OP(Trigonometric, Acos, 1, "acos", "", "", RangeOne, Default2, Default3)

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -305,6 +305,7 @@ INPUT_SET(InputSet::SmoothStepMax, 10.0, -2.6, -2.3, -1.4, -2.2, 2.3, 2.9, 3.3,
           3.9, 4.2);
 INPUT_SET(InputSet::SmoothStepInput, -2.8, -4.9, -2.3, -3.3, -3.6, 0.6, 3.0,
           3.3, 1.9, 4.3);
+INPUT_SET(InputSet::Positive, 1.0, 1.0, 342.0, 0.01, 5531.0, 0.01, 1.0, 0.01, 331.2330, 3250.01);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(float)
@@ -324,6 +325,7 @@ INPUT_SET(InputSet::SmoothStepMax, -2.8f, -2.6f, -2.3f, -1.4f, -2.2f, 2.3f,
           2.9f, 3.3f, 3.9f, 4.2f);
 INPUT_SET(InputSet::SmoothStepInput, -2.8f, -4.9f, -2.3f, -3.3f, -3.6f, 0.6f,
           3.0f, 3.3f, 1.9f, 4.3f);
+INPUT_SET(InputSet::Positive, 1.0f, 1.0f, 3424241.0f, 0.01f, 5531.0f, 0.01f, 1.0f, 0.01f, 331.2330f, 3250.01f);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(double)
@@ -345,6 +347,7 @@ INPUT_SET(InputSet::SmoothStepMax, -2.8, -2.6, -2.3, -1.4, -2.0, 2.3, 2.9, 3.3,
           3.9, 4.2);
 INPUT_SET(InputSet::SmoothStepInput, -10.8, -4.9, -2.3, -3.3, -3.0, 0.6, 3.0,
           3.3, 1.9, 4.3);
+INPUT_SET(InputSet::Positive, 1.0, 1.0, 3424241.0, 0.01, 5531.0, 0.01, 1.0, 0.01, 331.2330, 3250.01);
 END_INPUT_SETS()
 
 #undef BEGIN_INPUT_SETS

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -67,6 +67,18 @@ struct HLSLBool_t {
     return HLSLBool_t(Val || Other.Val);
   }
 
+  bool AsBool() const { return static_cast<bool>(Val); }
+
+  operator bool() const { return AsBool(); }
+  operator int16_t() const { return (int16_t)(AsBool()); }
+  operator int32_t() const { return (int32_t)(AsBool()); }
+  operator int64_t() const { return (int64_t)(AsBool()); }
+  operator uint16_t() const { return (uint16_t)(AsBool()); }
+  operator uint32_t() const { return (uint32_t)(AsBool()); }
+  operator uint64_t() const { return (uint64_t)(AsBool()); }
+  operator float() const { return (float)(AsBool()); }
+  operator double() const { return (double)(AsBool()); }
+
   // So we can construct std::wstrings using std::wostream
   friend std::wostream &operator<<(std::wostream &Os, const HLSLBool_t &Obj) {
     Os << static_cast<bool>(Obj.Val);
@@ -305,7 +317,8 @@ INPUT_SET(InputSet::SmoothStepMax, 10.0, -2.6, -2.3, -1.4, -2.2, 2.3, 2.9, 3.3,
           3.9, 4.2);
 INPUT_SET(InputSet::SmoothStepInput, -2.8, -4.9, -2.3, -3.3, -3.6, 0.6, 3.0,
           3.3, 1.9, 4.3);
-INPUT_SET(InputSet::Positive, 1.0, 1.0, 342.0, 0.01, 5531.0, 0.01, 1.0, 0.01, 331.2330, 3250.01);
+INPUT_SET(InputSet::Positive, 1.0, 1.0, 342.0, 0.01, 5531.0, 0.01, 1.0, 0.01,
+          331.2330, 3250.01);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(float)
@@ -325,7 +338,8 @@ INPUT_SET(InputSet::SmoothStepMax, -2.8f, -2.6f, -2.3f, -1.4f, -2.2f, 2.3f,
           2.9f, 3.3f, 3.9f, 4.2f);
 INPUT_SET(InputSet::SmoothStepInput, -2.8f, -4.9f, -2.3f, -3.3f, -3.6f, 0.6f,
           3.0f, 3.3f, 1.9f, 4.3f);
-INPUT_SET(InputSet::Positive, 1.0f, 1.0f, 3424241.0f, 0.01f, 5531.0f, 0.01f, 1.0f, 0.01f, 331.2330f, 3250.01f);
+INPUT_SET(InputSet::Positive, 1.0f, 1.0f, 3424241.0f, 0.01f, 5531.0f, 0.01f,
+          1.0f, 0.01f, 331.2330f, 3250.01f);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(double)
@@ -347,7 +361,8 @@ INPUT_SET(InputSet::SmoothStepMax, -2.8, -2.6, -2.3, -1.4, -2.0, 2.3, 2.9, 3.3,
           3.9, 4.2);
 INPUT_SET(InputSet::SmoothStepInput, -10.8, -4.9, -2.3, -3.3, -3.0, 0.6, 3.0,
           3.3, 1.9, 4.3);
-INPUT_SET(InputSet::Positive, 1.0, 1.0, 3424241.0, 0.01, 5531.0, 0.01, 1.0, 0.01, 331.2330, 3250.01);
+INPUT_SET(InputSet::Positive, 1.0, 1.0, 3424241.0, 0.01, 5531.0, 0.01, 1.0,
+          0.01, 331.2330, 3250.01);
 END_INPUT_SETS()
 
 #undef BEGIN_INPUT_SETS

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -629,7 +629,7 @@ DEFAULT_OP_2(OpType::RightShift, (A >> B));
 DEFAULT_OP_1(OpType::Initialize, (A));
 
 //
-// Explicit Cast
+// Cast
 //
 
 #define CAST_OP(OP, TYPE, IMPL)                                                \

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -288,7 +288,7 @@ std::string getCompilerOptionsString(size_t VectorSize,
 
   std::stringstream CompilerOptions;
 
-  if (is16BitType<T>())
+  if (is16BitType<T>() || is16BitType<OUT_TYPE>())
     CompilerOptions << " -enable-16bit-types";
 
   CompilerOptions << " -DTYPE=" << getHLSLTypeString<T>();
@@ -627,6 +627,61 @@ DEFAULT_OP_2(OpType::RightShift, (A >> B));
 //
 
 DEFAULT_OP_1(OpType::Initialize, (A));
+
+//
+// Explicit Cast
+//
+
+#define CAST_OP(OP, TYPE, IMPL)                                                \
+  template <typename T> struct Op<OP, T> : StrictValidation {                  \
+    TYPE operator()(T A) { return IMPL; }                                      \
+  };
+
+template <typename T> HLSLBool_t CastToBool(T A) { return (bool)A; }
+template <> HLSLBool_t CastToBool(HLSLHalf_t A) { return (bool)((float)A); }
+
+template <typename T> HLSLHalf_t CastToFloat16(T A) {
+  return HLSLHalf_t(float(A));
+}
+
+template <typename T> float CastToFloat32(T A) { return (float)A; }
+
+template <typename T> double CastToFloat64(T A) { return (double)A; }
+template <> double CastToFloat64(HLSLHalf_t A) { return (double)((float)A); }
+
+template <typename T> int16_t CastToInt16(T A) { return (int16_t)A; }
+template <> int16_t CastToInt16(HLSLHalf_t A) { return (int16_t)((float)A); }
+
+template <typename T> int32_t CastToInt32(T A) { return (int32_t)A; }
+template <> int32_t CastToInt32(HLSLHalf_t A) { return (int32_t)((float)A); }
+
+template <typename T> int64_t CastToInt64(T A) { return (int64_t)A; }
+template <> int64_t CastToInt64(HLSLHalf_t A) { return (int64_t)((float)A); }
+
+template <typename T> uint16_t CastToUint16(T A) { return (uint16_t)A; }
+template <> uint16_t CastToUint16(HLSLHalf_t A) { return (uint16_t)((float)A); }
+
+template <typename T> uint32_t CastToUint32(T A) { return (uint32_t)A; }
+template <> uint32_t CastToUint32(HLSLHalf_t A) { return (uint32_t)((float)A); }
+
+template <typename T> uint64_t CastToUint64(T A) { return (uint64_t)A; }
+template <> uint64_t CastToUint64(HLSLHalf_t A) { return (uint64_t)((float)A); }
+
+CAST_OP(OpType::CastToBool, HLSLBool_t, (CastToBool(A)));
+CAST_OP(OpType::CastToInt16, int16_t, (CastToInt16(A)));
+CAST_OP(OpType::CastToInt32, int32_t, (CastToInt32(A)));
+CAST_OP(OpType::CastToInt64, int64_t, (CastToInt64(A)));
+CAST_OP(OpType::CastToUint16, uint16_t, (CastToUint16(A)));
+CAST_OP(OpType::CastToUint32, uint32_t, (CastToUint32(A)));
+CAST_OP(OpType::CastToUint64, uint64_t, (CastToUint64(A)));
+CAST_OP(OpType::CastToUint16_FromFP, uint16_t, (CastToUint16(A)));
+CAST_OP(OpType::CastToUint32_FromFP, uint32_t, (CastToUint32(A)));
+CAST_OP(OpType::CastToUint64_FromFP, uint64_t, (CastToUint64(A)));
+CAST_OP(OpType::CastToFloat16, HLSLHalf_t, (CastToFloat16(A)));
+CAST_OP(OpType::CastToFloat32, float, (CastToFloat32(A)));
+CAST_OP(OpType::CastToFloat64, double, (CastToFloat64(A)));
+
+#undef CAST_OP
 
 //
 // Trigonometric
@@ -1303,6 +1358,118 @@ public:
   HLK_TEST(Initialize, HLSLHalf_t, Vector);
   HLK_TEST(Initialize, float, Vector);
   HLK_TEST(Initialize, double, Vector);
+
+  // Explicit Cast
+
+  HLK_TEST(CastToBool, HLSLBool_t, Vector);
+  HLK_TEST(CastToInt16, HLSLBool_t, Vector);
+  HLK_TEST(CastToInt32, HLSLBool_t, Vector);
+  HLK_TEST(CastToInt64, HLSLBool_t, Vector);
+  HLK_TEST(CastToUint16, HLSLBool_t, Vector);
+  HLK_TEST(CastToUint32, HLSLBool_t, Vector);
+  HLK_TEST(CastToUint64, HLSLBool_t, Vector);
+  HLK_TEST(CastToFloat16, HLSLBool_t, Vector);
+  HLK_TEST(CastToFloat32, HLSLBool_t, Vector);
+  HLK_TEST(CastToFloat64, HLSLBool_t, Vector);
+
+  HLK_TEST(CastToBool, double, Vector);
+  HLK_TEST(CastToInt16, double, Vector);
+  HLK_TEST(CastToInt32, double, Vector);
+  HLK_TEST(CastToInt64, double, Vector);
+  HLK_TEST(CastToUint16_FromFP, double, Vector);
+  HLK_TEST(CastToUint32_FromFP, double, Vector);
+  HLK_TEST(CastToUint64_FromFP, double, Vector);
+  HLK_TEST(CastToFloat16, double, Vector);
+  HLK_TEST(CastToFloat32, double, Vector);
+  HLK_TEST(CastToFloat64, double, Vector);
+
+  HLK_TEST(CastToBool, float, Vector);
+  HLK_TEST(CastToInt16, float, Vector);
+  HLK_TEST(CastToInt32, float, Vector);
+  HLK_TEST(CastToInt64, float, Vector);
+  HLK_TEST(CastToUint16_FromFP, float, Vector);
+  HLK_TEST(CastToUint32_FromFP, float, Vector);
+  HLK_TEST(CastToUint64_FromFP, float, Vector);
+  HLK_TEST(CastToFloat16, float, Vector);
+  HLK_TEST(CastToFloat32, float, Vector);
+  HLK_TEST(CastToFloat64, float, Vector);
+
+  HLK_TEST(CastToBool, HLSLHalf_t, Vector);
+  HLK_TEST(CastToInt16, HLSLHalf_t, Vector);
+  HLK_TEST(CastToInt32, HLSLHalf_t, Vector);
+  HLK_TEST(CastToInt64, HLSLHalf_t, Vector);
+  HLK_TEST(CastToUint16_FromFP, HLSLHalf_t, Vector);
+  HLK_TEST(CastToUint32_FromFP, HLSLHalf_t, Vector);
+  HLK_TEST(CastToUint64_FromFP, HLSLHalf_t, Vector);
+  HLK_TEST(CastToFloat16, HLSLHalf_t, Vector);
+  HLK_TEST(CastToFloat32, HLSLHalf_t, Vector);
+  HLK_TEST(CastToFloat64, HLSLHalf_t, Vector);
+
+  HLK_TEST(CastToBool, uint16_t, Vector);
+  HLK_TEST(CastToInt16, uint16_t, Vector);
+  HLK_TEST(CastToInt32, uint16_t, Vector);
+  HLK_TEST(CastToInt64, uint16_t, Vector);
+  HLK_TEST(CastToUint16, uint16_t, Vector);
+  HLK_TEST(CastToUint32, uint16_t, Vector);
+  HLK_TEST(CastToUint64, uint16_t, Vector);
+  HLK_TEST(CastToFloat16, uint16_t, Vector);
+  HLK_TEST(CastToFloat32, uint16_t, Vector);
+  HLK_TEST(CastToFloat64, uint16_t, Vector);
+
+  HLK_TEST(CastToBool, uint32_t, Vector);
+  HLK_TEST(CastToInt16, uint32_t, Vector);
+  HLK_TEST(CastToInt32, uint32_t, Vector);
+  HLK_TEST(CastToInt64, uint32_t, Vector);
+  HLK_TEST(CastToUint16, uint32_t, Vector);
+  HLK_TEST(CastToUint32, uint32_t, Vector);
+  HLK_TEST(CastToUint64, uint32_t, Vector);
+  HLK_TEST(CastToFloat16, uint32_t, Vector);
+  HLK_TEST(CastToFloat32, uint32_t, Vector);
+  HLK_TEST(CastToFloat64, uint32_t, Vector);
+
+  HLK_TEST(CastToBool, uint64_t, Vector);
+  HLK_TEST(CastToInt16, uint64_t, Vector);
+  HLK_TEST(CastToInt32, uint64_t, Vector);
+  HLK_TEST(CastToInt64, uint64_t, Vector);
+  HLK_TEST(CastToUint16, uint64_t, Vector);
+  HLK_TEST(CastToUint32, uint64_t, Vector);
+  HLK_TEST(CastToUint64, uint64_t, Vector);
+  HLK_TEST(CastToFloat16, uint64_t, Vector);
+  HLK_TEST(CastToFloat32, uint64_t, Vector);
+  HLK_TEST(CastToFloat64, uint64_t, Vector);
+
+  HLK_TEST(CastToBool, int16_t, Vector);
+  HLK_TEST(CastToInt16, int16_t, Vector);
+  HLK_TEST(CastToInt32, int16_t, Vector);
+  HLK_TEST(CastToInt64, int16_t, Vector);
+  HLK_TEST(CastToUint16, int16_t, Vector);
+  HLK_TEST(CastToUint32, int16_t, Vector);
+  HLK_TEST(CastToUint64, int16_t, Vector);
+  HLK_TEST(CastToFloat16, int16_t, Vector);
+  HLK_TEST(CastToFloat32, int16_t, Vector);
+  HLK_TEST(CastToFloat64, int16_t, Vector);
+
+  HLK_TEST(CastToBool, int32_t, Vector);
+  HLK_TEST(CastToInt16, int32_t, Vector);
+  HLK_TEST(CastToInt32, int32_t, Vector);
+  HLK_TEST(CastToInt64, int32_t, Vector);
+  HLK_TEST(CastToUint16, int32_t, Vector);
+  HLK_TEST(CastToUint32, int32_t, Vector);
+  HLK_TEST(CastToUint64, int32_t, Vector);
+  HLK_TEST(CastToFloat16, int32_t, Vector);
+  HLK_TEST(CastToFloat32, int32_t, Vector);
+  HLK_TEST(CastToFloat64, int32_t, Vector);
+
+  HLK_TEST(CastToBool, int64_t, Vector);
+  HLK_TEST(CastToInt16, int64_t, Vector);
+  HLK_TEST(CastToInt32, int64_t, Vector);
+  HLK_TEST(CastToInt64, int64_t, Vector);
+  HLK_TEST(CastToUint16, int64_t, Vector);
+  HLK_TEST(CastToUint32, int64_t, Vector);
+  HLK_TEST(CastToUint64, int64_t, Vector);
+  HLK_TEST(CastToFloat16, int64_t, Vector);
+  HLK_TEST(CastToFloat32, int64_t, Vector);
+  HLK_TEST(CastToFloat64, int64_t, Vector);
 
   // Trigonometric
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1361,7 +1361,6 @@ public:
 
   // Explicit Cast
 
-  HLK_TEST(CastToBool, HLSLBool_t, Vector);
   HLK_TEST(CastToInt16, HLSLBool_t, Vector);
   HLK_TEST(CastToInt32, HLSLBool_t, Vector);
   HLK_TEST(CastToInt64, HLSLBool_t, Vector);
@@ -1372,16 +1371,15 @@ public:
   HLK_TEST(CastToFloat32, HLSLBool_t, Vector);
   HLK_TEST(CastToFloat64, HLSLBool_t, Vector);
 
-  HLK_TEST(CastToBool, double, Vector);
-  HLK_TEST(CastToInt16, double, Vector);
-  HLK_TEST(CastToInt32, double, Vector);
-  HLK_TEST(CastToInt64, double, Vector);
-  HLK_TEST(CastToUint16_FromFP, double, Vector);
-  HLK_TEST(CastToUint32_FromFP, double, Vector);
-  HLK_TEST(CastToUint64_FromFP, double, Vector);
-  HLK_TEST(CastToFloat16, double, Vector);
-  HLK_TEST(CastToFloat32, double, Vector);
-  HLK_TEST(CastToFloat64, double, Vector);
+  HLK_TEST(CastToBool, HLSLHalf_t, Vector);
+  HLK_TEST(CastToInt16, HLSLHalf_t, Vector);
+  HLK_TEST(CastToInt32, HLSLHalf_t, Vector);
+  HLK_TEST(CastToInt64, HLSLHalf_t, Vector);
+  HLK_TEST(CastToUint16_FromFP, HLSLHalf_t, Vector);
+  HLK_TEST(CastToUint32_FromFP, HLSLHalf_t, Vector);
+  HLK_TEST(CastToUint64_FromFP, HLSLHalf_t, Vector);
+  HLK_TEST(CastToFloat32, HLSLHalf_t, Vector);
+  HLK_TEST(CastToFloat64, HLSLHalf_t, Vector);
 
   HLK_TEST(CastToBool, float, Vector);
   HLK_TEST(CastToInt16, float, Vector);
@@ -1391,25 +1389,22 @@ public:
   HLK_TEST(CastToUint32_FromFP, float, Vector);
   HLK_TEST(CastToUint64_FromFP, float, Vector);
   HLK_TEST(CastToFloat16, float, Vector);
-  HLK_TEST(CastToFloat32, float, Vector);
   HLK_TEST(CastToFloat64, float, Vector);
 
-  HLK_TEST(CastToBool, HLSLHalf_t, Vector);
-  HLK_TEST(CastToInt16, HLSLHalf_t, Vector);
-  HLK_TEST(CastToInt32, HLSLHalf_t, Vector);
-  HLK_TEST(CastToInt64, HLSLHalf_t, Vector);
-  HLK_TEST(CastToUint16_FromFP, HLSLHalf_t, Vector);
-  HLK_TEST(CastToUint32_FromFP, HLSLHalf_t, Vector);
-  HLK_TEST(CastToUint64_FromFP, HLSLHalf_t, Vector);
-  HLK_TEST(CastToFloat16, HLSLHalf_t, Vector);
-  HLK_TEST(CastToFloat32, HLSLHalf_t, Vector);
-  HLK_TEST(CastToFloat64, HLSLHalf_t, Vector);
+  HLK_TEST(CastToBool, double, Vector);
+  HLK_TEST(CastToInt16, double, Vector);
+  HLK_TEST(CastToInt32, double, Vector);
+  HLK_TEST(CastToInt64, double, Vector);
+  HLK_TEST(CastToUint16_FromFP, double, Vector);
+  HLK_TEST(CastToUint32_FromFP, double, Vector);
+  HLK_TEST(CastToUint64_FromFP, double, Vector);
+  HLK_TEST(CastToFloat16, double, Vector);
+  HLK_TEST(CastToFloat32, double, Vector);
 
   HLK_TEST(CastToBool, uint16_t, Vector);
   HLK_TEST(CastToInt16, uint16_t, Vector);
   HLK_TEST(CastToInt32, uint16_t, Vector);
   HLK_TEST(CastToInt64, uint16_t, Vector);
-  HLK_TEST(CastToUint16, uint16_t, Vector);
   HLK_TEST(CastToUint32, uint16_t, Vector);
   HLK_TEST(CastToUint64, uint16_t, Vector);
   HLK_TEST(CastToFloat16, uint16_t, Vector);
@@ -1421,7 +1416,6 @@ public:
   HLK_TEST(CastToInt32, uint32_t, Vector);
   HLK_TEST(CastToInt64, uint32_t, Vector);
   HLK_TEST(CastToUint16, uint32_t, Vector);
-  HLK_TEST(CastToUint32, uint32_t, Vector);
   HLK_TEST(CastToUint64, uint32_t, Vector);
   HLK_TEST(CastToFloat16, uint32_t, Vector);
   HLK_TEST(CastToFloat32, uint32_t, Vector);
@@ -1433,13 +1427,11 @@ public:
   HLK_TEST(CastToInt64, uint64_t, Vector);
   HLK_TEST(CastToUint16, uint64_t, Vector);
   HLK_TEST(CastToUint32, uint64_t, Vector);
-  HLK_TEST(CastToUint64, uint64_t, Vector);
   HLK_TEST(CastToFloat16, uint64_t, Vector);
   HLK_TEST(CastToFloat32, uint64_t, Vector);
   HLK_TEST(CastToFloat64, uint64_t, Vector);
 
   HLK_TEST(CastToBool, int16_t, Vector);
-  HLK_TEST(CastToInt16, int16_t, Vector);
   HLK_TEST(CastToInt32, int16_t, Vector);
   HLK_TEST(CastToInt64, int16_t, Vector);
   HLK_TEST(CastToUint16, int16_t, Vector);
@@ -1451,7 +1443,6 @@ public:
 
   HLK_TEST(CastToBool, int32_t, Vector);
   HLK_TEST(CastToInt16, int32_t, Vector);
-  HLK_TEST(CastToInt32, int32_t, Vector);
   HLK_TEST(CastToInt64, int32_t, Vector);
   HLK_TEST(CastToUint16, int32_t, Vector);
   HLK_TEST(CastToUint32, int32_t, Vector);
@@ -1463,7 +1454,6 @@ public:
   HLK_TEST(CastToBool, int64_t, Vector);
   HLK_TEST(CastToInt16, int64_t, Vector);
   HLK_TEST(CastToInt32, int64_t, Vector);
-  HLK_TEST(CastToInt64, int64_t, Vector);
   HLK_TEST(CastToUint16, int64_t, Vector);
   HLK_TEST(CastToUint32, int64_t, Vector);
   HLK_TEST(CastToUint64, int64_t, Vector);

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -619,7 +619,6 @@ DEFAULT_OP_2(OpType::Ldexp, (A * static_cast<T>(std::pow(2.0f, B))));
 DEFAULT_OP_2(OpType::And, (A & B));
 DEFAULT_OP_2(OpType::Or, (A | B));
 DEFAULT_OP_2(OpType::Xor, (A ^ B));
-DEFAULT_OP_1(OpType::Not, (~A));
 DEFAULT_OP_2(OpType::LeftShift, (A << B));
 DEFAULT_OP_2(OpType::RightShift, (A >> B));
 
@@ -1237,7 +1236,6 @@ public:
   HLK_TEST(Or, uint16_t, ScalarOp2);
   HLK_TEST(Xor, uint16_t, Vector);
   HLK_TEST(Xor, uint16_t, ScalarOp2);
-  HLK_TEST(Not, uint16_t, Vector);
   HLK_TEST(LeftShift, uint16_t, Vector);
   HLK_TEST(LeftShift, uint16_t, ScalarOp2);
   HLK_TEST(RightShift, uint16_t, Vector);
@@ -1248,7 +1246,6 @@ public:
   HLK_TEST(Or, uint32_t, ScalarOp2);
   HLK_TEST(Xor, uint32_t, Vector);
   HLK_TEST(Xor, uint32_t, ScalarOp2);
-  HLK_TEST(Not, uint32_t, Vector);
   HLK_TEST(LeftShift, uint32_t, Vector);
   HLK_TEST(LeftShift, uint32_t, ScalarOp2);
   HLK_TEST(RightShift, uint32_t, Vector);
@@ -1259,7 +1256,6 @@ public:
   HLK_TEST(Or, uint64_t, ScalarOp2);
   HLK_TEST(Xor, uint64_t, Vector);
   HLK_TEST(Xor, uint64_t, ScalarOp2);
-  HLK_TEST(Not, uint64_t, Vector);
   HLK_TEST(LeftShift, uint64_t, Vector);
   HLK_TEST(LeftShift, uint64_t, ScalarOp2);
   HLK_TEST(RightShift, uint64_t, Vector);
@@ -1270,7 +1266,6 @@ public:
   HLK_TEST(Or, int16_t, ScalarOp2);
   HLK_TEST(Xor, int16_t, Vector);
   HLK_TEST(Xor, int16_t, ScalarOp2);
-  HLK_TEST(Not, int16_t, Vector);
   HLK_TEST(LeftShift, int16_t, Vector);
   HLK_TEST(LeftShift, int16_t, ScalarOp2);
   HLK_TEST(RightShift, int16_t, Vector);
@@ -1281,7 +1276,6 @@ public:
   HLK_TEST(Or, int32_t, ScalarOp2);
   HLK_TEST(Xor, int32_t, Vector);
   HLK_TEST(Xor, int32_t, ScalarOp2);
-  HLK_TEST(Not, int32_t, Vector);
   HLK_TEST(LeftShift, int32_t, Vector);
   HLK_TEST(LeftShift, int32_t, ScalarOp2);
   HLK_TEST(RightShift, int32_t, Vector);
@@ -1292,7 +1286,6 @@ public:
   HLK_TEST(Or, int64_t, ScalarOp2);
   HLK_TEST(Xor, int64_t, Vector);
   HLK_TEST(Xor, int64_t, ScalarOp2);
-  HLK_TEST(Not, int64_t, Vector);
   HLK_TEST(LeftShift, int64_t, Vector);
   HLK_TEST(LeftShift, int64_t, ScalarOp2);
   HLK_TEST(RightShift, int64_t, Vector);

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3776,18 +3776,18 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
+        #ifdef FUNC_CAST
+        vector<OUT_TYPE, NUM> TestCast(vector<TYPE, NUM> Vector)
+        {
+          return (vector<OUT_TYPE, NUM>)Vector;
+        }
+        #endif
+
         #ifdef FUNC_TERNARY_ASSIGNMENT
         vector<TYPE, NUM> TestTernaryAssignment(vector<TYPE, NUM> Vector,
         vector<TYPE, NUM> Vector2))
         {
           return (TERNARY_CONDITION ? Vector : Vector2);
-        }
-        #endif
-
-        #ifdef FUNC_UNARY_OPERATOR
-        vector<OUT_TYPE, NUM> TestUnaryOperator(vector<TYPE, NUM> Vector)
-        {
-          return OPERATOR(Vector);
         }
         #endif
 

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3786,9 +3786,7 @@ void MSMain(uint GID : SV_GroupIndex,
 
         #ifdef FUNC_TERNARY_ASSIGNMENT
         vector<TYPE, NUM> TestTernaryAssignment(vector<TYPE, NUM> Vector,
-        vector<TYPE, NUM> Vector2))
-        #ifdef FUNC_UNARY_OPERATOR
-        vector<OUT_TYPE, NUM> TestUnaryOperator(vector<TYPE, NUM> Vector)
+                                                vector<TYPE, NUM> Vector2))
         {
           return (TERNARY_CONDITION ? Vector : Vector2);
         }

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3776,7 +3776,7 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
-        #ifdef FUNC_CAST
+        #ifdef FUNC_TEST_CAST
         vector<OUT_TYPE, NUM> TestCast(vector<TYPE, NUM> Vector)
         {
           return (vector<OUT_TYPE, NUM>)Vector;


### PR DESCRIPTION
This PR adds test cases for explicit casts of long vectors. Bitwise NOT was removed as I realized it resolves to XOR and comparison ops that already have coverage. Other unary ops listed in the issue have a similar story.

Resolves https://github.com/microsoft/DirectXShaderCompiler/issues/7617