### PR TITLE
Execution Tests: Long Vector Bitwise intrinsics

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -56,8 +56,8 @@ OP(Bitwise, RightShift, 2, "", ">>", "", Default1, BitShiftRhs, Default3)
 OP_DEFAULT(Bitwise, Saturate, 1, "saturate", "")
 OP_DEFAULT(Bitwise, ReverseBits, 1, "reversebits", "")
 OP(Bitwise, CountBits, 1, "countbits", "", "", Bitwise, Default1, Default2)
-OP(Bitwise, FirstBitHigh, 1, "firstbithigh", "", "", 
-   Bitwise, Default1, Default2)
+OP(Bitwise, FirstBitHigh, 1, "firstbithigh", "", "", Bitwise, Default1,
+   Default2)
 OP(Bitwise, FirstBitLow, 1, "firstbitlow", "", "", Bitwise, Default1, Default2)
 
 OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",

--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -55,10 +55,10 @@ OP(Bitwise, LeftShift, 2, "", "<<", "", Default1, BitShiftRhs, Default3)
 OP(Bitwise, RightShift, 2, "", ">>", "", Default1, BitShiftRhs, Default3)
 OP_DEFAULT(Bitwise, Saturate, 1, "saturate", "")
 OP_DEFAULT(Bitwise, ReverseBits, 1, "reversebits", "")
-OP(Bitwise, CountBits, 1, "countbits", "", "", Bitwise, Default1, Default2)
-OP(Bitwise, FirstBitHigh, 1, "firstbithigh", "", "", Bitwise, Default1,
-   Default2)
-OP(Bitwise, FirstBitLow, 1, "firstbitlow", "", "", Bitwise, Default1, Default2)
+OP(Bitwise, CountBits, 1, "countbits", "", "", Bitwise, Default2, Default3)
+OP(Bitwise, FirstBitHigh, 1, "firstbithigh", "", "", Bitwise, Default2,
+   Default3)
+OP(Bitwise, FirstBitLow, 1, "firstbitlow", "", "", Bitwise, Default2, Default3)
 
 OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
                    " -DFUNC_INITIALIZE=1")

--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -16,6 +16,7 @@ INPUT_SET(RangeOne)
 INPUT_SET(RangeHalfPi)
 INPUT_SET(SplitDouble)
 INPUT_SET(BitShiftRhs)
+INPUT_SET(Bitwise)
 
 #undef INPUT_SET
 
@@ -52,6 +53,12 @@ OP_DEFAULT_DEFINES(Bitwise, Not, 1, "TestUnaryOperator", "~",
                    " -DFUNC_UNARY_OPERATOR=1")
 OP(Bitwise, LeftShift, 2, "", "<<", "", Default1, BitShiftRhs, Default3)
 OP(Bitwise, RightShift, 2, "", ">>", "", Default1, BitShiftRhs, Default3)
+OP_DEFAULT(Bitwise, Saturate, 1, "saturate", "")
+OP_DEFAULT(Bitwise, ReverseBits, 1, "reversebits", "")
+OP(Bitwise, CountBits, 1, "countbits", "", "", Bitwise, Default1, Default2)
+OP(Bitwise, FirstBitHigh, 1, "firstbithigh", "", "", 
+   Bitwise, Default1, Default2)
+OP(Bitwise, FirstBitLow, 1, "firstbitlow", "", "", Bitwise, Default1, Default2)
 
 OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
                    " -DFUNC_INITIALIZE=1")

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -252,7 +252,7 @@ INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
-INPUT_SET(InputSet::Bitwise, -32768, -1, 0, 1, 3, 6, 9, I16(0x5555), 
+INPUT_SET(InputSet::Bitwise, -32768, -1, 0, 1, 3, 6, 9, I16(0x5555),
           I16(0xAAAA), 32767);
 END_INPUT_SETS()
 #undef I16
@@ -263,7 +263,7 @@ INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
-INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 12, 13, 14, 15, 
+INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 12, 13, 14, 15,
           I32(18446744073709551615));
 END_INPUT_SETS()
 #undef I32
@@ -274,8 +274,9 @@ INPUT_SET(InputSet::Default1, -6, 11, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::Default3, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
-INPUT_SET(InputSet::Bitwise, -9223372036854775807 - 1, -1, 0, 1, 3, 6, 9, 
-          I64(0x5555555555555555), I64(0xAAAAAAAAAAAAAAAA), 9223372036854775807);
+INPUT_SET(InputSet::Bitwise, -9223372036854775807 - 1, -1, 0, 1, 3, 6, 9,
+          I64(0x5555555555555555), I64(0xAAAAAAAAAAAAAAAA),
+          9223372036854775807);
 END_INPUT_SETS()
 #undef I64
 

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -246,46 +246,43 @@ INPUT_SET(InputSet::Default3, true, false, false, false, false, true, true,
           true, false, false);
 END_INPUT_SETS()
 
-#define I16(x) static_cast<int16_t>(x)
 BEGIN_INPUT_SETS(int16_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
-INPUT_SET(InputSet::Bitwise, -32768, -1, 0, 1, 3, 6, 9, I16(0x5555),
-          I16(0xAAAA), 32767);
+INPUT_SET(InputSet::Bitwise, std::numeric_limits<int16_t>::min(), -1, 0, 1, 3,
+          6, 9, 0x5555, static_cast<int16_t>(0xAAAA),
+          std::numeric_limits<int16_t>::max());
 END_INPUT_SETS()
-#undef I16
 
-#define I32(x) static_cast<int32_t>(x)
 BEGIN_INPUT_SETS(int32_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
-INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 12, 13, 14, 15,
-          I32(18446744073709551615));
+INPUT_SET(InputSet::Bitwise, std::numeric_limits<int32_t>::min(), -1, 0, 1, 3,
+          6, 9, 0x55555555, static_cast<int32_t>(0xAAAAAAAA),
+          std::numeric_limits<int32_t>::max());
 END_INPUT_SETS()
-#undef I32
 
-#define I64(x) static_cast<int64_t>(x)
 BEGIN_INPUT_SETS(int64_t)
 INPUT_SET(InputSet::Default1, -6, 11, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::Default3, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
-INPUT_SET(InputSet::Bitwise, -9223372036854775807 - 1, -1, 0, 1, 3, 6, 9,
-          I64(0x5555555555555555), I64(0xAAAAAAAAAAAAAAAA),
-          9223372036854775807);
+INPUT_SET(InputSet::Bitwise, std::numeric_limits<int64_t>::min(), -1, 0, 1, 3,
+          6, 9, 0x5555555555555555LL, 0xAAAAAAAAAAAAAAAALL,
+          std::numeric_limits<int64_t>::max());
 END_INPUT_SETS()
-#undef I64
 
 BEGIN_INPUT_SETS(uint16_t)
 INPUT_SET(InputSet::Default1, 1, 699, 3, 1023, 5, 6, 0, 8, 9, 10);
 INPUT_SET(InputSet::Default2, 2, 111, 3, 4, 5, 9, 21, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 2, 111, 3, 4, 5, 9, 21, 8, 9, 10);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
-INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555, 0xAAAA, 0x8000, 127, 65535);
+INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555, 0xAAAA, 0x8000, 127,
+          std::numeric_limits<uint16_t>::max());
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint32_t)
@@ -294,7 +291,7 @@ INPUT_SET(InputSet::Default2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x55555555, 0xAAAAAAAA, 0x80000000,
-          127, 4294967295);
+          127, std::numeric_limits<uint32_t>::max());
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint64_t)
@@ -303,7 +300,8 @@ INPUT_SET(InputSet::Default2, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555555555555555,
-          0xAAAAAAAAAAAAAAAA, 0x8000000000000000, 127, 18446744073709551615);
+          0xAAAAAAAAAAAAAAAA, 0x8000000000000000, 127,
+          std::numeric_limits<uint64_t>::max());
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(HLSLHalf_t)

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -328,7 +328,6 @@ END_INPUT_SETS()
 BEGIN_INPUT_SETS(float)
 INPUT_SET(InputSet::Default1, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
-
 INPUT_SET(InputSet::Default2, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
 INPUT_SET(InputSet::Default3, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -246,32 +246,45 @@ INPUT_SET(InputSet::Default3, true, false, false, false, false, true, true,
           true, false, false);
 END_INPUT_SETS()
 
+#define I16(x) static_cast<int16_t>(x)
 BEGIN_INPUT_SETS(int16_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
+INPUT_SET(InputSet::Bitwise, -32768, -1, 0, 1, 3, 6, 9, I16(0x5555), 
+          I16(0xAAAA), 32767);
 END_INPUT_SETS()
+#undef I16
 
+#define I32(x) static_cast<int32_t>(x)
 BEGIN_INPUT_SETS(int32_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
+INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 12, 13, 14, 15, 
+          I32(18446744073709551615));
 END_INPUT_SETS()
+#undef I32
 
+#define I64(x) static_cast<int64_t>(x)
 BEGIN_INPUT_SETS(int64_t)
 INPUT_SET(InputSet::Default1, -6, 11, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::Default3, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
+INPUT_SET(InputSet::Bitwise, -9223372036854775807 - 1, -1, 0, 1, 3, 6, 9, 
+          I64(0x5555555555555555), I64(0xAAAAAAAAAAAAAAAA), 9223372036854775807);
 END_INPUT_SETS()
+#undef I64
 
 BEGIN_INPUT_SETS(uint16_t)
 INPUT_SET(InputSet::Default1, 1, 699, 3, 1023, 5, 6, 0, 8, 9, 10);
 INPUT_SET(InputSet::Default2, 2, 111, 3, 4, 5, 9, 21, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 2, 111, 3, 4, 5, 9, 21, 8, 9, 10);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
+INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555, 0xAAAA, 0x8000, 127, 65535);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint32_t)
@@ -279,6 +292,8 @@ INPUT_SET(InputSet::Default1, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
+INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x55555555, 0xAAAAAAAA, 0x80000000,
+          127, 4294967295);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint64_t)
@@ -286,6 +301,8 @@ INPUT_SET(InputSet::Default1, 1, 2, 3, 4, 5, 0, 7, 1000, 9, 10);
 INPUT_SET(InputSet::Default2, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
+INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555555555555555,
+          0xAAAAAAAAAAAAAAAA, 0x8000000000000000, 127, 18446744073709551615);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(HLSLHalf_t)
@@ -310,6 +327,7 @@ END_INPUT_SETS()
 BEGIN_INPUT_SETS(float)
 INPUT_SET(InputSet::Default1, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
+
 INPUT_SET(InputSet::Default2, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
 INPUT_SET(InputSet::Default3, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -624,8 +624,7 @@ template <typename T> T Saturate(T A) {
   return A;
 }
 
-template <>
-HLSLHalf_t Saturate<HLSLHalf_t>(HLSLHalf_t A) {
+template <> HLSLHalf_t Saturate<HLSLHalf_t>(HLSLHalf_t A) {
   if (A < HLSLHalf_t(0.0f))
     return HLSLHalf_t(0.0f);
   if (A > HLSLHalf_t(1.0f))
@@ -644,8 +643,7 @@ template <typename T> T ReverseBits(T A) {
   return Result;
 }
 
-template <typename T> 
-uint32_t CountBits(T A) {
+template <typename T> uint32_t CountBits(T A) {
   uint32_t Count = 0;
   const size_t NumBits = sizeof(T) * 8;
   for (size_t I = 0; I < NumBits; I++) {
@@ -656,8 +654,7 @@ uint32_t CountBits(T A) {
   return Count;
 }
 
-template <typename T>
-uint32_t FirstBitHigh(T A) {
+template <typename T> uint32_t FirstBitHigh(T A) {
   constexpr uint32_t NumBits = sizeof(T) * 8;
 
   if (A == 0)
@@ -682,8 +679,7 @@ uint32_t FirstBitHigh(T A) {
   return static_cast<uint32_t>(-1);
 }
 
-template <typename T>
-uint32_t FirstBitLow(T A) {
+template <typename T> uint32_t FirstBitLow(T A) {
   const uint32_t NumBits = sizeof(T) * 8;
 
   if (A == 0)

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -13,6 +13,7 @@
 #include "HlslExecTestUtils.h"
 
 #include <array>
+#include <bitset>
 #include <iomanip>
 #include <optional>
 #include <sstream>
@@ -617,18 +618,10 @@ DEFAULT_OP_2(OpType::Ldexp, (A * static_cast<T>(std::pow(2.0f, B))));
 //
 
 template <typename T> T Saturate(T A) {
-  if (A < static_cast<T>(0.0))
-    return static_cast<T>(0.0);
-  if (A > static_cast<T>(1.0))
-    return static_cast<T>(1.0);
-  return A;
-}
-
-template <> HLSLHalf_t Saturate<HLSLHalf_t>(HLSLHalf_t A) {
-  if (A < HLSLHalf_t(0.0f))
-    return HLSLHalf_t(0.0f);
-  if (A > HLSLHalf_t(1.0f))
-    return HLSLHalf_t(1.0f);
+  if (A < static_cast<T>(0.0f))
+    return static_cast<T>(0.0f);
+  if (A > static_cast<T>(1.0f))
+    return static_cast<T>(1.0f);
   return A;
 }
 
@@ -644,14 +637,7 @@ template <typename T> T ReverseBits(T A) {
 }
 
 template <typename T> uint32_t CountBits(T A) {
-  uint32_t Count = 0;
-  const size_t NumBits = sizeof(T) * 8;
-  for (size_t I = 0; I < NumBits; I++) {
-    if (A & 1)
-      Count++;
-    A >>= 1;
-  }
-  return Count;
+  return static_cast<uint32_t>(std::bitset<sizeof(T) * 8>(A).count());
 }
 
 // General purpose bit scan from the MSB. Based on the value of LookingForZero

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -616,12 +616,106 @@ DEFAULT_OP_2(OpType::Ldexp, (A * static_cast<T>(std::pow(2.0f, B))));
 // Bitwise
 //
 
+template <typename T> T Saturate(T A) {
+  if (A < static_cast<T>(0.0))
+    return static_cast<T>(0.0);
+  if (A > static_cast<T>(1.0))
+    return static_cast<T>(1.0);
+  return A;
+}
+
+template <>
+HLSLHalf_t Saturate<HLSLHalf_t>(HLSLHalf_t A) {
+  if (A < HLSLHalf_t(0.0f))
+    return HLSLHalf_t(0.0f);
+  if (A > HLSLHalf_t(1.0f))
+    return HLSLHalf_t(1.0f);
+  return A;
+}
+
+template <typename T> T ReverseBits(T A) {
+  T Result = 0;
+  const size_t NumBits = sizeof(T) * 8;
+  for (size_t I = 0; I < NumBits; I++) {
+    Result <<= 1;
+    Result |= (A & 1);
+    A >>= 1;
+  }
+  return Result;
+}
+
+template <typename T> 
+uint32_t CountBits(T A) {
+  uint32_t Count = 0;
+  const size_t NumBits = sizeof(T) * 8;
+  for (size_t I = 0; I < NumBits; I++) {
+    if (A & 1)
+      Count++;
+    A >>= 1;
+  }
+  return Count;
+}
+
+template <typename T>
+uint32_t FirstBitHigh(T A) {
+  constexpr uint32_t NumBits = sizeof(T) * 8;
+
+  if (A == 0)
+    return static_cast<uint32_t>(-1);
+
+  if constexpr (std::is_signed<T>::value) {
+    // For negative values we return the bit number of the MSB 0-bit.
+    if (A < 0) {
+      for (int32_t I = NumBits - 1; I >= 0; --I) {
+        if (!(A & (static_cast<T>(1) << I)))
+          return static_cast<uint32_t>(I);
+      }
+      return static_cast<uint32_t>(-1);
+    }
+  }
+
+  for (int32_t I = NumBits - 1; I >= 0; --I) {
+    if (A & (static_cast<T>(1) << I))
+      return static_cast<uint32_t>(I);
+  }
+
+  return static_cast<uint32_t>(-1);
+}
+
+template <typename T>
+uint32_t FirstBitLow(T A) {
+  const uint32_t NumBits = sizeof(T) * 8;
+
+  if (A == 0)
+    return ~0;
+
+  for (uint32_t I = 0; I < NumBits; ++I) {
+    if (A & (static_cast<T>(1) << I))
+      return static_cast<T>(I);
+  }
+
+  return ~0;
+}
+
 DEFAULT_OP_2(OpType::And, (A & B));
 DEFAULT_OP_2(OpType::Or, (A | B));
 DEFAULT_OP_2(OpType::Xor, (A ^ B));
 DEFAULT_OP_1(OpType::Not, (~A));
 DEFAULT_OP_2(OpType::LeftShift, (A << B));
 DEFAULT_OP_2(OpType::RightShift, (A >> B));
+DEFAULT_OP_1(OpType::Saturate, (Saturate(A)));
+DEFAULT_OP_1(OpType::ReverseBits, (ReverseBits(A)));
+
+#define BITWISE_OP(OP, IMPL)                                                   \
+  template <typename T> struct Op<OP, T> : StrictValidation {                  \
+    uint32_t operator()(T A) { return IMPL; }                                  \
+  }
+
+BITWISE_OP(OpType::CountBits, (CountBits(A)));
+BITWISE_OP(OpType::FirstBitHigh, (FirstBitHigh(A)));
+BITWISE_OP(OpType::FirstBitLow, (FirstBitLow(A)));
+
+#undef BITWISE_OP
 
 //
 // Unary
@@ -1238,6 +1332,10 @@ public:
   HLK_TEST(Xor, uint16_t, Vector);
   HLK_TEST(Xor, uint16_t, ScalarOp2);
   HLK_TEST(Not, uint16_t, Vector);
+  HLK_TEST(ReverseBits, uint16_t, Vector);
+  HLK_TEST(CountBits, uint16_t, Vector);
+  HLK_TEST(FirstBitHigh, uint16_t, Vector);
+  HLK_TEST(FirstBitLow, uint16_t, Vector);
   HLK_TEST(LeftShift, uint16_t, Vector);
   HLK_TEST(LeftShift, uint16_t, ScalarOp2);
   HLK_TEST(RightShift, uint16_t, Vector);
@@ -1253,6 +1351,10 @@ public:
   HLK_TEST(LeftShift, uint32_t, ScalarOp2);
   HLK_TEST(RightShift, uint32_t, Vector);
   HLK_TEST(RightShift, uint32_t, ScalarOp2);
+  HLK_TEST(ReverseBits, uint32_t, Vector);
+  HLK_TEST(CountBits, uint32_t, Vector);
+  HLK_TEST(FirstBitHigh, uint32_t, Vector);
+  HLK_TEST(FirstBitLow, uint32_t, Vector);
   HLK_TEST(And, uint64_t, Vector);
   HLK_TEST(And, uint64_t, ScalarOp2);
   HLK_TEST(Or, uint64_t, Vector);
@@ -1264,6 +1366,10 @@ public:
   HLK_TEST(LeftShift, uint64_t, ScalarOp2);
   HLK_TEST(RightShift, uint64_t, Vector);
   HLK_TEST(RightShift, uint64_t, ScalarOp2);
+  HLK_TEST(ReverseBits, uint64_t, Vector);
+  HLK_TEST(CountBits, uint64_t, Vector);
+  HLK_TEST(FirstBitHigh, uint64_t, Vector);
+  HLK_TEST(FirstBitLow, uint64_t, Vector);
   HLK_TEST(And, int16_t, Vector);
   HLK_TEST(And, int16_t, ScalarOp2);
   HLK_TEST(Or, int16_t, Vector);
@@ -1275,6 +1381,10 @@ public:
   HLK_TEST(LeftShift, int16_t, ScalarOp2);
   HLK_TEST(RightShift, int16_t, Vector);
   HLK_TEST(RightShift, int16_t, ScalarOp2);
+  HLK_TEST(ReverseBits, int16_t, Vector);
+  HLK_TEST(CountBits, int16_t, Vector);
+  HLK_TEST(FirstBitHigh, int16_t, Vector);
+  HLK_TEST(FirstBitLow, int16_t, Vector);
   HLK_TEST(And, int32_t, Vector);
   HLK_TEST(And, int32_t, ScalarOp2);
   HLK_TEST(Or, int32_t, Vector);
@@ -1286,6 +1396,10 @@ public:
   HLK_TEST(LeftShift, int32_t, ScalarOp2);
   HLK_TEST(RightShift, int32_t, Vector);
   HLK_TEST(RightShift, int32_t, ScalarOp2);
+  HLK_TEST(ReverseBits, int32_t, Vector);
+  HLK_TEST(CountBits, int32_t, Vector);
+  HLK_TEST(FirstBitHigh, int32_t, Vector);
+  HLK_TEST(FirstBitLow, int32_t, Vector);
   HLK_TEST(And, int64_t, Vector);
   HLK_TEST(And, int64_t, ScalarOp2);
   HLK_TEST(Or, int64_t, Vector);
@@ -1297,6 +1411,13 @@ public:
   HLK_TEST(LeftShift, int64_t, ScalarOp2);
   HLK_TEST(RightShift, int64_t, Vector);
   HLK_TEST(RightShift, int64_t, ScalarOp2);
+  HLK_TEST(ReverseBits, int64_t, Vector);
+  HLK_TEST(CountBits, int64_t, Vector);
+  HLK_TEST(FirstBitHigh, int64_t, Vector);
+  HLK_TEST(FirstBitLow, int64_t, Vector);
+  HLK_TEST(Saturate, HLSLHalf_t, Vector);
+  HLK_TEST(Saturate, float, Vector);
+  HLK_TEST(Saturate, double, Vector);
 
   // Unary
 


### PR DESCRIPTION
This PR adds tests for the bitwise intrinsics saturate, reversebits, countbits, firstbithigh, and firstbitlow.
A new input value set 'Bitwise' was added to include bounadry cases for the respective types.

Resolves #7467 