### PR TITLE
Execution Tests: Long Vectors Remove ternary assignment

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -102,8 +102,4 @@ OP_DEFAULT(BinaryComparison, NotEqual, 2, "", "!=")
 
 OP_DEFAULT(Binary, Logical_And, 2, "and", ",")
 OP_DEFAULT(Binary, Logical_Or, 2, "or", ",")
-OP_DEFAULT_DEFINES(Binary, TernaryAssignment_True, 2, "TestTernaryAssignment",
-                   ",", " -DTERNARY_CONDITION=1 -DFUNC_TERNARY_ASSIGNMENT=1")
-OP_DEFAULT_DEFINES(Binary, TernaryAssignment_False, 2, "TestTernaryAssignment",
-                   ",", " -DTERNARY_CONDITION=0 -DFUNC_TERNARY_ASSIGNMENT=1")
 #undef OP

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -895,8 +895,6 @@ BINARY_COMPARISON_OP(OpType::NotEqual, (A != B));
 
 DEFAULT_OP_2(OpType::Logical_And, (A && B));
 DEFAULT_OP_2(OpType::Logical_Or, (A || B));
-DEFAULT_OP_2(OpType::TernaryAssignment_True, (true ? A : B));
-DEFAULT_OP_2(OpType::TernaryAssignment_False, (false ? A : B));
 
 //
 // dispatchTest
@@ -1518,9 +1516,6 @@ public:
   HLK_TEST(Logical_Or, HLSLBool_t, Vector);
   HLK_TEST(Logical_And, HLSLBool_t, ScalarOp2);
   HLK_TEST(Logical_Or, HLSLBool_t, ScalarOp2);
-
-  // NOTE: TernaryAssignment_True and TernaryAssignment_False don't have tests.
-  // Do we want them?
 
 private:
   bool Initialized = false;

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3776,14 +3776,6 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
-        #ifdef FUNC_TERNARY_ASSIGNMENT
-        vector<TYPE, NUM> TestTernaryAssignment(vector<TYPE, NUM> Vector,
-        vector<TYPE, NUM> Vector2))
-        {
-          return (TERNARY_CONDITION ? Vector : Vector2);
-        }
-        #endif
-
         #ifdef FUNC_UNARY_OPERATOR
         vector<OUT_TYPE, NUM> TestUnaryOperator(vector<TYPE, NUM> Vector)
         {


### PR DESCRIPTION
Remove the test cases for ternary assignment. Upon closer inspection I realized that there are no unique DXIL ops or LLVM instructions exercised via ternary assignment (or select for that matter). 