### PR TITLE
[SM 6.9] Vector lower Quad Broadcast intrinsics

### DIFF
--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -1099,16 +1099,16 @@ const OP::OpCodeProperty OP::m_OpCodeProps[(unsigned)OP::OpCode::NumOpCodes] = {
      "quadReadLaneAt",
      Attribute::None,
      1,
-     {{0xff}},
-     {{0x0}}}, // Overloads: hfd18wil
+     {{0x4ff}},
+     {{0xff}}}, // Overloads: hfd18wil<hfd18wil
     {OC::QuadOp,
      "QuadOp",
      OCC::QuadOp,
      "quadOp",
      Attribute::None,
      1,
-     {{0xf7}},
-     {{0x0}}}, // Overloads: hfd8wil
+     {{0x4f7}},
+     {{0xf7}}}, // Overloads: hfd8wil<hfd8wil
 
     // Bitcasts with different sizes
     {OC::BitcastI16toF16,

--- a/lib/HLSL/DxilScalarizeVectorIntrinsics.cpp
+++ b/lib/HLSL/DxilScalarizeVectorIntrinsics.cpp
@@ -296,6 +296,7 @@ static void scalarizeVectorIntrinsic(hlsl::OP *HlslOP, CallInst *CI) {
     RetVal = Builder.CreateInsertElement(RetVal, ElCI, ElIx);
   }
   CI->replaceAllUsesWith(RetVal);
+  CI->eraseFromParent();
 }
 
 char DxilScalarizeVectorIntrinsics::ID = 0;

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-intrinsics.hlsl
@@ -541,6 +541,8 @@ void main() {
   float fResScalar = dot(fVec1, fVec2);
   fRes[0] += fResScalar;
 
+  // Insert QuadOp tests here.
+
   // CHECK-NOT: extractelement
   // CHECK-NOT: insertelement
   buf.Store<vector<float16_t, NUM> >(0, hRes);

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-intrinsics.hlsl
@@ -541,8 +541,6 @@ void main() {
   float fResScalar = dot(fVec1, fVec2);
   fRes[0] += fResScalar;
 
-  // Insert QuadOp tests here.
-
   // CHECK-NOT: extractelement
   // CHECK-NOT: insertelement
   buf.Store<vector<float16_t, NUM> >(0, hRes);

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-trivial-scalarized-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-trivial-scalarized-intrinsics.hlsl
@@ -5,10 +5,6 @@
 // The binary part of some of these is all just a vector math ops with as many unary dxops as elements.
 // These will have apparent mismatches between the ARITY define and the check prefix.
 
-// RUN: %dxc -DFUNC=QuadReadLaneAt         -DARITY=4 -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,QUAD
-// RUN: %dxc -DFUNC=QuadReadAcrossX        -DARITY=1 -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,QUAD
-// RUN: %dxc -DFUNC=QuadReadAcrossY        -DARITY=1 -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,QUAD
-// RUN: %dxc -DFUNC=QuadReadAcrossDiagonal -DARITY=1 -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,QUAD
 // RUN: %dxc -DFUNC=WaveActiveBitAnd       -DARITY=1 -DTYPE=uint -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,WAVE
 // RUN: %dxc -DFUNC=WaveActiveBitOr        -DARITY=1 -DTYPE=uint -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,WAVE
 // RUN: %dxc -DFUNC=WaveActiveBitXor       -DARITY=1 -DTYPE=uint -T ps_6_9 %s | FileCheck %s --check-prefixes=CHECK,WAVE
@@ -54,7 +50,6 @@ float4 main(uint i : SV_PrimitiveID, uint4 m : M) : SV_Target {
   vector<TYPE, 8> arg3 = rbuf.Load< vector<TYPE, 8> >(i++*32);
 
   // UNARY: call {{.*}} [[DXOP:@dx.op.unary]]
-  // QUAD: call {{.*}} [[DXOP:@dx.op.quad]]
   // WAVE: call {{.*}} [[DXOP:@dx.op.wave]]
   // CHECK: call {{.*}} [[DXOP]]
   // CHECK: call {{.*}} [[DXOP]]

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-wave-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-wave-intrinsics.hlsl
@@ -9,7 +9,6 @@ float4 main(uint4 id: IN0) : SV_Target
   // CHECK: call <256 x float> @dx.op.quadReadLaneAt.v256f32(i32 122, <256 x float> %{{.*}}, i32 %{{.*}})  ; QuadReadLaneAt(value,quadLane)
   fVec = QuadReadLaneAt(fVec, id.x);
 
-
   // CHECK: call <256 x float> @dx.op.quadOp.v256f32(i32 123, <256 x float> %{{.*}}, i8 0)  ; QuadOp(value,op)
   fVec = QuadReadAcrossX(fVec);
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-wave-intrinsics.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/longvec-wave-intrinsics.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T ps_6_9 %s | FileCheck %s
+
+RWByteAddressBuffer buf;
+
+float4 main(uint4 id: IN0) : SV_Target
+{
+  vector<float, 256> fVec = buf.Load<vector<float, 256> >(0);
+
+  // CHECK: call <256 x float> @dx.op.quadReadLaneAt.v256f32(i32 122, <256 x float> %{{.*}}, i32 %{{.*}})  ; QuadReadLaneAt(value,quadLane)
+  fVec = QuadReadLaneAt(fVec, id.x);
+
+
+  // CHECK: call <256 x float> @dx.op.quadOp.v256f32(i32 123, <256 x float> %{{.*}}, i8 0)  ; QuadOp(value,op)
+  fVec = QuadReadAcrossX(fVec);
+
+  // CHECK: call <256 x float> @dx.op.quadOp.v256f32(i32 123, <256 x float> %{{.*}}, i8 1)  ; QuadOp(value,op)
+  fVec = QuadReadAcrossY(fVec);
+
+  // CHECK: call <256 x float> @dx.op.quadOp.v256f32(i32 123, <256 x float> %{{.*}}, i8 2)  ; QuadOp(value,op)
+  fVec = QuadReadAcrossDiagonal(fVec);
+
+  float4 ret = { fVec[id.x], fVec[id.y], fVec[id.z], fVec[id.w]};
+
+  return ret;
+}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -3253,7 +3253,7 @@ class db_dxil(object):
             next_op_idx,
             "QuadReadLaneAt",
             "reads from a lane in the quad",
-            "hfd18wil",
+            "hfd18wil<",
             "",
             [
                 db_dxil_param(0, "$o", "", "operation result"),
@@ -3290,7 +3290,7 @@ class db_dxil(object):
             next_op_idx,
             "QuadOp",
             "returns the result of a quad-level operation",
-            "hfd8wil",
+            "hfd8wil<",
             "",
             [
                 db_dxil_param(0, "$o", "", "operation result"),


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7714

Vectorize Quad Broadcast intrinsics

Note: The tests were already written for the SM6.9 library being linked to SM6.8 so no new test was added there. The existing code (nearly) already handling the lowering as if it was a "trivial" intrinsic