### PR TITLE
Execution Tests: Remove Long Vector tests for smoothstep and ternary assignment

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -9,9 +9,6 @@
 INPUT_SET(Default1)
 INPUT_SET(Default2)
 INPUT_SET(Default3)
-INPUT_SET(SmoothStepMin)
-INPUT_SET(SmoothStepMax)
-INPUT_SET(SmoothStepInput)
 INPUT_SET(RangeOne)
 INPUT_SET(RangeHalfPi)
 INPUT_SET(SplitDouble)
@@ -32,8 +29,6 @@ INPUT_SET(BitShiftRhs)
   OP_DEFAULT_DEFINES(GROUP, SYMBOL, ARITY, INTRINSIC, OPERATOR, "")
 
 OP_DEFAULT(TernaryMath, Mad, 3, "mad", "")
-OP(TernaryMath, SmoothStep, 3, "smoothstep", "", "", SmoothStepMin,
-   SmoothStepMax, SmoothStepInput)
 OP_DEFAULT(TernaryMath, Fma, 3, "fma", "")
 
 OP_DEFAULT(BinaryMath, Add, 2, "", "+")
@@ -102,8 +97,5 @@ OP_DEFAULT(BinaryComparison, NotEqual, 2, "", "!=")
 
 OP_DEFAULT(Binary, Logical_And, 2, "and", ",")
 OP_DEFAULT(Binary, Logical_Or, 2, "or", ",")
-OP_DEFAULT_DEFINES(Binary, TernaryAssignment_True, 2, "TestTernaryAssignment",
-                   ",", " -DTERNARY_CONDITION=1 -DFUNC_TERNARY_ASSIGNMENT=1")
-OP_DEFAULT_DEFINES(Binary, TernaryAssignment_False, 2, "TestTernaryAssignment",
-                   ",", " -DTERNARY_CONDITION=0 -DFUNC_TERNARY_ASSIGNMENT=1")
+
 #undef OP

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -299,12 +299,6 @@ INPUT_SET(InputSet::RangeHalfPi, -1.073, 0.044, -1.047, 0.313, 1.447, -0.865,
           1.364, -0.715, -0.800, 0.541);
 INPUT_SET(InputSet::RangeOne, 0.331, 0.727, -0.957, 0.677, -0.025, 0.495, 0.855,
           -0.673, -0.678, -0.905);
-INPUT_SET(InputSet::SmoothStepMin, -4.3, -4.9, -4.2, -3.3, -3.7, 0.6, 1.2, 1.5,
-          2.1, 2.3);
-INPUT_SET(InputSet::SmoothStepMax, 10.0, -2.6, -2.3, -1.4, -2.2, 2.3, 2.9, 3.3,
-          3.9, 4.2);
-INPUT_SET(InputSet::SmoothStepInput, -2.8, -4.9, -2.3, -3.3, -3.6, 0.6, 3.0,
-          3.3, 1.9, 4.3);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(float)
@@ -318,12 +312,6 @@ INPUT_SET(InputSet::RangeHalfPi, 0.315f, -0.316f, 1.409f, -0.09f, -1.569f,
           1.302f, -0.326f, 0.781f, -1.235f, 0.623f);
 INPUT_SET(InputSet::RangeOne, 0.727f, 0.331f, -0.957f, 0.677f, -0.025f, 0.495f,
           0.855f, -0.673f, -0.678f, -0.905f);
-INPUT_SET(InputSet::SmoothStepMin, -4.3f, -4.9f, -4.2f, -3.3f, -3.7f, 0.6f,
-          1.2f, 1.5f, 2.1f, 2.3f);
-INPUT_SET(InputSet::SmoothStepMax, -2.8f, -2.6f, -2.3f, -1.4f, -2.2f, 2.3f,
-          2.9f, 3.3f, 3.9f, 4.2f);
-INPUT_SET(InputSet::SmoothStepInput, -2.8f, -4.9f, -2.3f, -3.3f, -3.6f, 0.6f,
-          3.0f, 3.3f, 1.9f, 4.3f);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(double)
@@ -339,12 +327,6 @@ INPUT_SET(InputSet::RangeOne, 0.331, 0.277, -0.957, 0.677, -0.025, 0.495, 0.855,
           -0.673, -0.678, -0.905);
 INPUT_SET(InputSet::SplitDouble, 0.0, -1.0, 1.0, -1.0, 12345678.87654321, -1.0,
           1.0, -1.0, 1.0, -1.0);
-INPUT_SET(InputSet::SmoothStepMin, -4.3, -4.9, -4.2, -3.3, -3.0, 0.6, 1.2, 1.5,
-          2.1, 2.3);
-INPUT_SET(InputSet::SmoothStepMax, -2.8, -2.6, -2.3, -1.4, -2.0, 2.3, 2.9, 3.3,
-          3.9, 4.2);
-INPUT_SET(InputSet::SmoothStepInput, -10.8, -4.9, -2.3, -3.3, -3.0, 0.6, 3.0,
-          3.3, 1.9, 4.3);
 END_INPUT_SETS()
 
 #undef BEGIN_INPUT_SETS

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -572,22 +572,6 @@ struct StrictValidation {
 //
 
 DEFAULT_OP_3(OpType::Mad, (A * B + C));
-
-template <typename T> struct Op<OpType::SmoothStep, T> : DefaultValidation<T> {
-  T operator()(T Min, T Max, T X) {
-    DXASSERT_NOMSG(Min < Max);
-
-    if (X <= Min)
-      return 0.0;
-    if (X >= Max)
-      return 1.0;
-
-    T NormalizedX = (X - Min) / (Max - Min);
-    NormalizedX = std::clamp(NormalizedX, T(0.0), T(1.0));
-    return NormalizedX * NormalizedX * (T(3.0) - T(2.0) * NormalizedX);
-  }
-};
-
 DEFAULT_OP_3(OpType::Fma, (A * B + C));
 
 //
@@ -895,8 +879,6 @@ BINARY_COMPARISON_OP(OpType::NotEqual, (A != B));
 
 DEFAULT_OP_2(OpType::Logical_And, (A && B));
 DEFAULT_OP_2(OpType::Logical_Or, (A || B));
-DEFAULT_OP_2(OpType::TernaryAssignment_True, (true ? A : B));
-DEFAULT_OP_2(OpType::TernaryAssignment_False, (false ? A : B));
 
 //
 // dispatchTest
@@ -1083,12 +1065,8 @@ public:
   HLK_TEST(Mad, int64_t, ScalarOp3);
   HLK_TEST(Mad, HLSLHalf_t, Vector);
   HLK_TEST(Mad, HLSLHalf_t, ScalarOp2);
-  HLK_TEST(SmoothStep, HLSLHalf_t, Vector);
-  HLK_TEST(SmoothStep, HLSLHalf_t, ScalarOp2);
   HLK_TEST(Mad, float, Vector);
   HLK_TEST(Mad, float, ScalarOp2);
-  HLK_TEST(SmoothStep, float, Vector);
-  HLK_TEST(SmoothStep, float, ScalarOp3);
   HLK_TEST(Fma, double, Vector);
   HLK_TEST(Fma, double, ScalarOp2);
   HLK_TEST(Mad, double, Vector);
@@ -1518,9 +1496,6 @@ public:
   HLK_TEST(Logical_Or, HLSLBool_t, Vector);
   HLK_TEST(Logical_And, HLSLBool_t, ScalarOp2);
   HLK_TEST(Logical_Or, HLSLBool_t, ScalarOp2);
-
-  // NOTE: TernaryAssignment_True and TernaryAssignment_False don't have tests.
-  // Do we want them?
 
 private:
   bool Initialized = false;

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3776,14 +3776,6 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
-        #ifdef FUNC_TERNARY_ASSIGNMENT
-        vector<TYPE, NUM> TestTernaryAssignment(vector<TYPE, NUM> Vector,
-        vector<TYPE, NUM> Vector2))
-        {
-          return (TERNARY_CONDITION ? Vector : Vector2);
-        }
-        #endif
-
         #ifdef FUNC_UNARY_OPERATOR
         vector<OUT_TYPE, NUM> TestUnaryOperator(vector<TYPE, NUM> Vector)
         {


### PR DESCRIPTION
This PR removes two ops from the execution tests as coverage is not required for them in the HLK. 
All DXIL Ops/LLVM instructions used get coverage via other tests cases. That is, these test cases are redundant.