### PR TITLE
Add hctbuild.cmd parameter to specify the nuget config file

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -47,6 +47,7 @@ set INSTALL_DIR=
 set DEFAULT_EXEC_ADAPTER=-DTAEF_EXEC_ADAPTER=
 set LIT_ARGS=
 set FRESH=
+set NUGET_WARP_EXTRA_ARGS=
 
 :parse_args
 if "%1"=="" (
@@ -213,6 +214,11 @@ if "%1"=="-fresh" (
   set FRESH="--fresh"
   shift /1 & goto :parse_args
 )
+if "%1"=="-nuget-config" (
+  set NUGET_WARP_EXTRA_ARGS="-Config %~2"
+  shift /1
+  shift /1 & goto :parse_args
+)
 
 
 rem Begin SPIRV change
@@ -353,6 +359,8 @@ set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_BUILD_EXAMPLES:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_CL:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_SYSTEM_VERSION=%DXC_CMAKE_SYSTEM_VERSION%
 set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR%
+
+set CMAKE_OPTS=%CMAKE_OPTS% -DNUGET_WARP_EXTRA_ARGS=%NUGET_WARP_EXTRA_ARGS%
 
 if "%LIT_ARGS%" NEQ "" (
   set CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_LIT_ARGS="%LIT_ARGS%"


### PR DESCRIPTION
This change allows us to control which nuget.config is used.

This is to allow internal builds to override the nuget feed that's used.
