### PR TITLE
[SPIRV] Folding global constant variables

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -351,13 +351,14 @@ public:
   /// \brief Sets the entry function.
   void setEntryFunction(SpirvFunction *fn) { entryFunction = fn; }
 
-  /// \brief If the given decl is an implicit VarDecl that evaluates to a
-  /// constant, it evaluates the constant and registers the resulting SPIR-V
-  /// instruction in the astDecls map. Otherwise returns without doing anything.
+  /// \brief If the given decl is a VarDecl that evaluates to a constant, it
+  /// evaluates the constant and registers the resulting SPIR-V instruction in
+  /// the astDecls map. Otherwise returns without doing anything. The typical
+  /// cases are implicit VarDecls and global static constant variables.
   ///
   /// Note: There are many cases where the front-end might create such implicit
   /// VarDecls (such as some ray tracing enums).
-  void tryToCreateImplicitConstVar(const ValueDecl *);
+  bool tryToCreateConstantVar(const ValueDecl *);
 
   /// \brief Creates instructions to copy output stage variables defined by
   /// outputPatchDecl to hullMainOutputPatch that is a variable for the

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2148,9 +2148,12 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
     // We already know the variable is not externally visible here. If it does
     // not have local storage, it should be file scope variable.
     const bool isFileScopeVar = !decl->hasLocalStorage();
-    if (isFileScopeVar)
+    if (isFileScopeVar) {
+      if (decl->getType().isConstQualified() &&
+          declIdMapper.tryToCreateConstantVar(decl))
+        return;
       var = declIdMapper.createFileVar(decl, llvm::None);
-    else
+    } else
       var = declIdMapper.createFnVar(decl, llvm::None);
 
     // Emit OpStore to initialize the variable

--- a/tools/clang/test/CodeGenSPIRV/nested.static.var.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/nested.static.var.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T cs_6_0 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
-// Check that the variable `value` is defined, and set to 6 in the entry point wrapper.
-// CHECK: %value = OpVariable %_ptr_Private_uint Private
-// CHECK: %main = OpFunction %void None
+// Check that the folded constant value `6u` is stored into buffer.
+// CHECK: %src_main = OpFunction %void None
 // CHECK-NEXT: OpLabel
-// CHECK-NEXT: OpStore %value %uint_6
+// CHECK-NEXT: [[BUFFER_A_0:%.*]] = OpAccessChain %_ptr_Uniform_uint %a %int_0 %uint_0
+// CHECK-NEXT: OpStore [[BUFFER_A_0]] %uint_6
 
 struct A {
     struct B { static const uint value = 6u; };

--- a/tools/clang/test/CodeGenSPIRV/oo.static.member.init.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.static.member.init.hlsl
@@ -14,26 +14,24 @@ class T {
 
 const int T::SIX = 6;
 
+// CHECK-DAG: %int_5 = OpConstant %int 5
+// CHECK-DAG: %int_6 = OpConstant %int 6
+
 int foo(int val) { return val; }
 
-// CHECK:   %FIVE = OpVariable %_ptr_Private_int Private
-// CHECK:    %SIX = OpVariable %_ptr_Private_int Private
-// CHECK: %FIVE_0 = OpVariable %_ptr_Private_int Private
-// CHECK:  %SIX_0 = OpVariable %_ptr_Private_int Private
 int main() : A {
-// CHECK-LABEL: %main = OpFunction
-
-// CHECK: OpStore %FIVE %int_5
-// CHECK: OpStore %SIX %int_6
-// CHECK: OpStore %FIVE_0 %int_5
-// CHECK: OpStore %SIX_0 %int_6
-// CHECK: OpFunctionCall %int %src_main
-
 // CHECK-LABEL: %src_main = OpFunction
-
-// CHECK: OpLoad %int %FIVE
-// CHECK: OpLoad %int %SIX
-// CHECK: OpLoad %int %FIVE_0
-// CHECK: OpLoad %int %SIX_0
-    return foo(S::FIVE) + foo(S::SIX) + foo(T::FIVE) + foo(T::SIX);
+    return
+        // CHECK: OpStore [[FOO_PARAM_0:%.*]] %int_5
+        // CHECK-NEXT: [[FOO_RETURN_0:%.*]] = OpFunctionCall %int %foo [[FOO_PARAM_0]]
+        foo(S::FIVE) +
+        // CHECK: OpStore [[FOO_PARAM_1:%.*]] %int_6
+        // CHECK-NEXT: [[FOO_RETURN_1:%.*]] = OpFunctionCall %int %foo [[FOO_PARAM_1]]
+        foo(S::SIX) +
+        // CHECK: OpStore [[FOO_PARAM_2:%.*]] %int_5
+        // CHECK-NEXT: [[FOO_RETURN_2:%.*]] = OpFunctionCall %int %foo [[FOO_PARAM_2]]
+        foo(T::FIVE) +
+        // CHECK: OpStore [[FOO_PARAM_3:%.*]] %int_6
+        // CHECK-NEXT: [[FOO_RETURN_3:%.*]] = OpFunctionCall %int %foo [[FOO_PARAM_3]]
+        foo(T::SIX);
 }

--- a/tools/clang/test/CodeGenSPIRV/spv.constant-folding.static_const.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.constant-folding.static_const.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -O3 -T lib_6_8 -HV 2021 -spirv -fcgl -fspv-target-env=universal1.5 %s | FileCheck %s
+
+static const uint32_t kIterCnt = 1024;
+static const uint32_t kSizeShared = 4096;
+static const uint32_t kOffset = 2048;
+
+groupshared uint32_t sharedMem[kSizeShared * sizeof(uint32_t)];
+
+export void testcase(uint32_t threadIdInGroup, uint32_t threadGroupSize) {
+  // CHECK: OpULessThan %bool %{{.*}} %uint_1024
+  for (uint32_t i = threadIdInGroup; i < kIterCnt; i += threadGroupSize) {
+    // CHECK: [[INDEX:%.*]] = OpIAdd %uint %uint_2048
+    // CHECK: OpAccessChain %_ptr_Workgroup_uint %sharedMem [[INDEX]]
+    sharedMem[kOffset + i] = 0xffu;
+  }
+}

--- a/tools/clang/test/CodeGenSPIRV/spv.constant-folding.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.constant-folding.template.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -O3 -T lib_6_8 -HV 2021 -spirv -fcgl -fspv-target-env=universal1.5 -enable-16bit-types -Wno-gnu-static-float-init %s | FileCheck %s
+
+template <typename S> struct Trait;
+template <> struct Trait<half> {
+  using type = half;
+  static const uint32_t size = 2;
+  static const half value = 1.0;
+};
+
+uint32_t get_size() { return Trait<half>::size; }
+float cvt(half x) { return float(x); }
+
+// CHECK-LABEL: %testcase = OpFunction %float
+export float testcase(int x) {
+  if (x == 2) {
+    // CHECK: OpReturnValue %float_2
+    return float(Trait<half>::size);
+  } else if (x == 4) {
+    // CHECK: OpStore %param_var_x %half_0x1p_0
+    // CHECK-NEXT: OpFunctionCall %float %cvt %param_var_x
+    return cvt(Trait<half>::value);
+  } else if (x == 8) {
+    return get_size();
+  }
+  return 0.f;
+}
+
+// CHECK-LABEL: %get_size = OpFunction %uint
+// CHECK: OpReturnValue %uint_2

--- a/tools/clang/test/CodeGenSPIRV/template.class.partial.specialization.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/template.class.partial.specialization.hlsl
@@ -18,16 +18,6 @@ uint32_t elementCount()
 
 RWBuffer<int> o;
 
-// Initialize the static members at the start of wrapper
-// CHECK: %main = OpFunction %void None 
-// CHECK: OpStore %RowCount %uint_4
-// CHECK: OpStore %ColumnCount %uint_4
-// CHECK: OpStore %RowCount_0 %uint_3
-// CHECK: OpStore %ColumnCount_0 %uint_2
-// CHECK: OpFunctionEnd
-
-
-
 // CHECK: %src_main = OpFunction %void None
 [numthreads(64,1,1)]
 void main()
@@ -40,16 +30,12 @@ void main()
 
 // CHECK: %elementCount = OpFunction %uint None
 // CHECK-NEXT: OpLabel
-// CHECK-NEXT: [[rc:%[0-9]+]] = OpLoad %uint %RowCount
-// CHECK-NEXT: [[cc:%[0-9]+]] = OpLoad %uint %ColumnCount
-// CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %uint [[rc]] [[cc]]
+// CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %uint %uint_4 %uint_4
 // CHECK-NEXT: OpReturnValue [[mul]]
 // CHECK-NEXT: OpFunctionEnd
 
 // CHECK: %elementCount_0 = OpFunction %uint None
 // CHECK-NEXT: %bb_entry_1 = OpLabel
-// CHECK-NEXT: [[rc:%[0-9]+]] = OpLoad %uint %RowCount_0
-// CHECK-NEXT: [[cc:%[0-9]+]] = OpLoad %uint %ColumnCount_0
-// CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %uint [[rc]] [[cc]]
+// CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %uint %uint_3 %uint_2
 // CHECK-NEXT: OpReturnValue [[mul]]
 // CHECK-NEXT: OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/type.template.struct.template-instance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.template.struct.template-instance.hlsl
@@ -13,12 +13,8 @@ struct Foo {
 };
 
 void main() {
-// CHECK: [[bar_int:%[a-zA-Z0-9_]+]] = OpVariable %_ptr_Private_int Private
-// CHECK: [[bar_float:%[a-zA-Z0-9_]+]] = OpVariable %_ptr_Private_float Private
-
-// CHECK: OpStore [[bar_int]] %int_0
-// CHECK: OpStore [[bar_float]] %float_0
-
+// `Foo<int>::bar` is a global constant value,
+// it's folded at compile-time and no longer declare variable.
     Foo<int>::bar;
 
 // CHECK: %x = OpVariable %_ptr_Function_int Function

--- a/tools/clang/test/CodeGenSPIRV/type.type-alias.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.type-alias.template.hlsl
@@ -8,12 +8,11 @@ struct integral_constant {
 template <bool val>
 using bool_constant = integral_constant<bool, val>;
 
+// CHECK: %true = OpConstantTrue %bool
 bool main(): SV_Target {
-// CHECK: OpStore %value %true
 // CHECK: %tru = OpVariable %_ptr_Function_integral_constant Function
   bool_constant<true> tru;
 
-// CHECK: [[value:%[0-9]+]] = OpLoad %bool %value
-// CHECK: OpReturnValue [[value]]
+// CHECK: OpReturnValue %true
   return tru.value;
 }

--- a/tools/clang/test/CodeGenSPIRV/var.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.template.hlsl
@@ -1,24 +1,20 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
-// CHECK: OpStore %is_same_v_0 %false
 template <class, class>
 static const bool is_same_v = false;
 
-// CHECK: OpStore %is_same_v_1 %true
 template <class T>
 static const bool is_same_v<T, T> = true;
 
 RWStructuredBuffer<bool> outs;
 
 void main() {
-// CHECK: [[inequal:%[0-9]+]] = OpLoad %bool %is_same_v_0
 // CHECK:  [[outs_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %outs %int_0 %uint_0
-// CHECK: [[as_uint:%[0-9]+]] = OpSelect %uint [[inequal]] %uint_1 %uint_0
+// CHECK: [[as_uint:%[0-9]+]] = OpSelect %uint %false %uint_1 %uint_0
 // CHECK:                         OpStore [[outs_0]] [[as_uint]]
   outs[0] = is_same_v<int, bool>;
-// CHECK:   [[equal:%[0-9]+]] = OpLoad %bool %is_same_v_1
 // CHECK:  [[outs_1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %outs %int_0 %uint_1
-// CHECK: [[as_uint:%[0-9]+]] = OpSelect %uint [[equal]] %uint_1 %uint_0
+// CHECK: [[as_uint:%[0-9]+]] = OpSelect %uint %true %uint_1 %uint_0
 // CHECK:                         OpStore [[outs_1]] [[as_uint]]
   outs[1] = is_same_v<int, int>;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.push-constant.static.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.push-constant.static.hlsl
@@ -11,10 +11,7 @@ struct S
 // CHECK: %_ptr_PushConstant_type_PushConstant_S = OpTypePointer PushConstant %type_PushConstant_S
 
 [[vk::push_constant]] S s;
-// CHECK: %a = OpVariable %_ptr_Private_uint Private
 // CHECK: %s = OpVariable %_ptr_PushConstant_type_PushConstant_S PushConstant
-
-// CHECK: OpStore %a %uint_1
 
 [numthreads(1,1,1)]
 void main()
@@ -29,6 +26,5 @@ void main()
 // CHECK:                    OpStore %w %uint_1
 
   uint32_t x = s.a;
-// CHECK: [[load:%[0-9]+]] = OpLoad %uint %a
-// CHECK:                    OpStore %x [[load]]
+// CHECK:                    OpStore %x %uint_1
 }


### PR DESCRIPTION
At the beginning, if we use static constant variables of template structures with library profile, we might get undefined values. We considered this is a bug.

After thorough debugging, this appears to be expected behavior -- we need to initialize global static variables at the right time. In the common stage (non-library profile), these variables are initialized at the start of the main function before calling the user's main function. But in the library profile, we cannot easily initialize them... hence the undefined values.

What if global variables were compile-time constants? We don't care how they're initialized -- they're COMPILE-TIME CONSTANTS! Fold them and promote them! On the other hand, this seems benefits all shaders, not just library profile. We can generate smaller SPIR-V code with constant folding.

This change cannot fix all global static variables initialization issues; it only addresses problems for global compile-time constant variables.

Fixes: #7049