### PR TITLE
[SM6.9] Add vector slice to hlsl stdlib

### DIFF
--- a/tools/clang/lib/Headers/hlsl/enable_if.h
+++ b/tools/clang/lib/Headers/hlsl/enable_if.h
@@ -1,0 +1,17 @@
+// Header for enable_if APIs.
+
+#if ((__SHADER_TARGET_MAJOR > 6) ||                                            \
+     (__SHADER_TARGET_MAJOR == 6 && __SHADER_TARGET_MINOR >= 9)) &&            \
+    (__HLSL_VERSION >= 2021)
+
+namespace hlsl {
+
+template <bool B, typename T> struct enable_if {};
+
+template <typename T> struct enable_if<true, T> {
+  using type = T;
+};
+
+} // namespace hlsl
+
+#endif

--- a/tools/clang/lib/Headers/hlsl/vector_utils.h
+++ b/tools/clang/lib/Headers/hlsl/vector_utils.h
@@ -4,22 +4,12 @@
      (__SHADER_TARGET_MAJOR == 6 && __SHADER_TARGET_MINOR >= 9)) &&            \
     (__HLSL_VERSION >= 2021)
 
-namespace hlsl {
-
-// TODO: Make a dedicated file for this
-template <bool B, typename T> struct enable_if {};
-
-template <typename T> struct enable_if<true, T> {
-  using type = T;
-};
-
-} // namespace hlsl
+#include <enable_if.h>
 
 namespace hlsl {
-namespace vec {
 
 template <int Off, int OSz, typename T, int ISz>
-typename hlsl::enable_if<Off + OSz <= ISz, vector<T, OSz>>::type
+typename hlsl::enable_if<Off + OSz <= ISz, vector<T, OSz> >::type
 slice(vector<T, ISz> In) {
   vector<T, OSz> Result = (vector<T, OSz>)0;
   [unroll] for (int I = 0; I < OSz; ++I) Result[I] = In[I + Off];
@@ -31,7 +21,6 @@ vector<T, OSz> slice(vector<T, ISz> In) {
   return slice<0, OSz, T, ISz>(In);
 }
 
-} // namespace vec
 } // namespace hlsl
 
-#endif // SM 6.9 check and HV version check
+#endif

--- a/tools/clang/lib/Headers/hlsl/vector_utils.h
+++ b/tools/clang/lib/Headers/hlsl/vector_utils.h
@@ -13,7 +13,11 @@ template <int Off, int OSz, typename T, int ISz>
 typename hlsl::enable_if<Off + OSz <= ISz, vector<T, OSz> >::type
 slice(vector<T, ISz> In) {
   vector<T, OSz> Result = (vector<T, OSz>)0;
-  [unroll] for (int I = 0; I < OSz; ++I) Result[I] = In[I + Off];
+
+  [unroll]
+  for (int I = 0; I < OSz; ++I)
+    Result[I] = In[I + Off];
+
   return Result;
 }
 // clang-format on

--- a/tools/clang/lib/Headers/hlsl/vector_utils.h
+++ b/tools/clang/lib/Headers/hlsl/vector_utils.h
@@ -8,6 +8,7 @@
 
 namespace hlsl {
 
+// clang-format off
 template <int Off, int OSz, typename T, int ISz>
 typename hlsl::enable_if<Off + OSz <= ISz, vector<T, OSz> >::type
 slice(vector<T, ISz> In) {
@@ -15,6 +16,7 @@ slice(vector<T, ISz> In) {
   [unroll] for (int I = 0; I < OSz; ++I) Result[I] = In[I + Off];
   return Result;
 }
+// clang-format on
 
 template <int OSz, typename T, int ISz>
 vector<T, OSz> slice(vector<T, ISz> In) {

--- a/tools/clang/lib/Headers/hlsl/vectors.h
+++ b/tools/clang/lib/Headers/hlsl/vectors.h
@@ -1,0 +1,37 @@
+// Header for long vector APIs.
+
+#if ((__SHADER_TARGET_MAJOR > 6) ||                                            \
+     (__SHADER_TARGET_MAJOR == 6 && __SHADER_TARGET_MINOR >= 9)) &&            \
+    (__HLSL_VERSION >= 2021)
+
+namespace hlsl {
+
+// TODO: Make a dedicated file for this
+template <bool B, typename T> struct enable_if {};
+
+template <typename T> struct enable_if<true, T> {
+  using type = T;
+};
+
+} // namespace hlsl
+
+namespace hlsl {
+namespace vec {
+
+template <int Off, int OSz, typename T, int ISz>
+typename hlsl::enable_if<Off + OSz <= ISz, vector<T, OSz>>::type
+slice(vector<T, ISz> In) {
+  vector<T, OSz> Result = (vector<T, OSz>)0;
+  [unroll] for (int I = 0; I < OSz; ++I) Result[I] = In[I + Off];
+  return Result;
+}
+
+template <int OSz, typename T, int ISz>
+vector<T, OSz> slice(vector<T, ISz> In) {
+  return slice<0, OSz, T, ISz>(In);
+}
+
+} // namespace vec
+} // namespace hlsl
+
+#endif // SM 6.9 check and HV version check

--- a/tools/clang/test/SemaHLSL/hlsl/vectors/slice-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/vectors/slice-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -I %hlsl_headers -T ps_6_9 -E main -verify -verify-ignore-unexpected %s
+// RUN: %dxc -I %hlsl_headers -T ps_6_9 -E main -verify %s
 
 #include <vector_utils.h>
 

--- a/tools/clang/test/SemaHLSL/hlsl/vectors/slice-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/vectors/slice-errors.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -I %hlsl_headers -T ps_6_9 -E main -verify -verify-ignore-unexpected %s
+
+#include <vector_utils.h>
+
+RWByteAddressBuffer buf;
+
+float4 main(uint4 id: IN0) : SV_Target
+{
+  float4 fVec = buf.Load<vector<float, 4> >(0);
+
+  // Ensure out-of-bounds calls raise a compiler error
+
+  float4 lhs = hlsl::slice<4>(fVec);
+
+  // expected-error@+1 {{no matching function for call to 'slice'}}
+  float4 rhs = hlsl::slice<2, 4>(fVec);
+
+  // expected-note@vector_utils.h:13 {{candidate template ignored: disabled by 'enable_if' [with Off = 2, OSz = 4, T = float, ISz = 4]}}
+  // expected-note@vector_utils.h:26 {{candidate template ignored: invalid explicitly-specified argument for template parameter 'T'}}
+
+  return lhs + rhs;
+}
+

--- a/tools/clang/test/SemaHLSL/hlsl/vectors/slice.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/vectors/slice.hlsl
@@ -6,7 +6,7 @@ RWByteAddressBuffer buf;
 
 float4 main(uint4 id: IN0) : SV_Target
 {
-  vector<float, 256> fVec = buf.Load<vector<float, 256> >(256 * 0);
+  vector<float, 256> fVec = buf.Load<vector<float, 256> >(0);
 
   // Ensure calls are lowered to a single shufflevector
 

--- a/tools/clang/test/SemaHLSL/hlsl/vectors/slice.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/vectors/slice.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -I %hlsl_headers -T ps_6_9 -E main %s | FileCheck %s
 
-#include <vectors.h>
+#include <vector_utils.h>
 
 RWByteAddressBuffer buf;
 
@@ -11,10 +11,10 @@ float4 main(uint4 id: IN0) : SV_Target
   // Ensure calls are lowered to a single shufflevector
 
   // CHECK: shufflevector <256 x float> %{{.*}}, <256 x float> undef, <4 x i32> <i32 7, i32 8, i32 9, i32 10>
-  float4 lhs = hlsl::vec::slice<7, 4>(fVec);
+  float4 lhs = hlsl::slice<7, 4>(fVec);
 
   // CHECK: shufflevector <256 x float> %{{.*}}, <256 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  float4 rhs = hlsl::vec::slice<4>(fVec);
+  float4 rhs = hlsl::slice<4>(fVec);
 
   return lhs + rhs;
 }

--- a/tools/clang/test/SemaHLSL/hlsl/vectors/slice.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/vectors/slice.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -I %hlsl_headers -T ps_6_9 -E main %s | FileCheck %s
+
+#include <vectors.h>
+
+RWByteAddressBuffer buf;
+
+float4 main(uint4 id: IN0) : SV_Target
+{
+  vector<float, 256> fVec = buf.Load<vector<float, 256> >(256 * 0);
+
+  // Ensure calls are lowered to a single shufflevector
+
+  // CHECK: shufflevector <256 x float> %{{.*}}, <256 x float> undef, <4 x i32> <i32 7, i32 8, i32 9, i32 10>
+  float4 lhs = hlsl::vec::slice<7, 4>(fVec);
+
+  // CHECK: shufflevector <256 x float> %{{.*}}, <256 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  float4 rhs = hlsl::vec::slice<4>(fVec);
+
+  return lhs + rhs;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7688

Adds a new stdlib function for slicing a long vector into a smaller one in a single instruction. Can be used similarly to vector swizzles which are not allowed for long vectors.

Also ensures at compile time that slicing out of bounds doesn't occur