### PR TITLE
Diagnose out <> 'const udt' mismatches in builtins (RT payloads)

### DIFF
--- a/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject-const-pld.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/HitObject/hitobject-const-pld.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T lib_6_9 %s -verify
+
+struct Payload {
+    float value : write(caller) : read(caller);
+};
+
+[shader("raygeneration")]
+void RayGen()
+{
+    RayDesc ray;
+    const Payload p = {0.0};
+    dx::HitObject obj = dx::HitObject::MakeMiss(0, 0, ray);
+    dx::HitObject::Invoke(obj, p); // expected-error{{no matching function for call to 'Invoke'}}
+}


### PR DESCRIPTION
Partial fix for #7761

Makes sure that DXC will at least report that no matching function was found (instead of failing during codegen).
Pointing out the exact 'const udt param' that mismatches the 'out' arg would likely require more invasive changes.