### PR TITLE
Execution Tests: Add test cases for Select

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -15,6 +15,7 @@ INPUT_SET(SplitDouble)
 INPUT_SET(BitShiftRhs)
 INPUT_SET(Positive)
 INPUT_SET(Bitwise)
+INPUT_SET(SelectCond)
 
 #undef INPUT_SET
 
@@ -126,5 +127,6 @@ OP_DEFAULT(BinaryComparison, NotEqual, 2, "", "!=")
 
 OP_DEFAULT(Binary, Logical_And, 2, "and", ",")
 OP_DEFAULT(Binary, Logical_Or, 2, "or", ",")
+OP(Ternary, Select, 3, "TestSelect", "", " -DFUNC_TEST_SELECT=1", SelectCond, Default2, Default3)
 
 #undef OP

--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -254,66 +254,73 @@ INPUT_SET(InputSet::Default1, false, true, false, false, false, false, true,
 INPUT_SET(InputSet::Default2, true, false, false, false, false, true, true,
           true, false, false);
 
-INPUT_SET(InputSet::Default3, true, false, false, false, false, true, true,
-          true, false, false);
+INPUT_SET(InputSet::Default3, true, false, true, false, true, true, true, true,
+          false, true);
+INPUT_SET(InputSet::SelectCond, false, true);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(int16_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
-INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
+INPUT_SET(InputSet::Default3, -5, 6, 3, 2, -9, -3, -1, 3, 7, -2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
 INPUT_SET(InputSet::Bitwise, std::numeric_limits<int16_t>::min(), -1, 0, 1, 3,
           6, 9, 0x5555, static_cast<int16_t>(0xAAAA),
           std::numeric_limits<int16_t>::max());
+INPUT_SET(InputSet::SelectCond, 0, 1);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(int32_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
-INPUT_SET(InputSet::Default3, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
+INPUT_SET(InputSet::Default3, -5, 6, 3, 2, -9, -3, -1, 3, 7, -2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
 INPUT_SET(InputSet::Bitwise, std::numeric_limits<int32_t>::min(), -1, 0, 1, 3,
           6, 9, 0x55555555, static_cast<int32_t>(0xAAAAAAAA),
           std::numeric_limits<int32_t>::max());
+INPUT_SET(InputSet::SelectCond, 0, 1);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(int64_t)
 INPUT_SET(InputSet::Default1, -6, 11, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
-INPUT_SET(InputSet::Default3, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
+INPUT_SET(InputSet::Default3, -5, 1337, 3, 2, -9, -3, -1, 3, -501, -2);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
 INPUT_SET(InputSet::Bitwise, std::numeric_limits<int64_t>::min(), -1, 0, 1, 3,
           6, 9, 0x5555555555555555LL, 0xAAAAAAAAAAAAAAAALL,
           std::numeric_limits<int64_t>::max());
+INPUT_SET(InputSet::SelectCond, 0, 1);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint16_t)
 INPUT_SET(InputSet::Default1, 1, 699, 3, 1023, 5, 6, 0, 8, 9, 10);
 INPUT_SET(InputSet::Default2, 2, 111, 3, 4, 5, 9, 21, 8, 9, 10);
-INPUT_SET(InputSet::Default3, 2, 111, 3, 4, 5, 9, 21, 8, 9, 10);
+INPUT_SET(InputSet::Default3, 4, 112, 4, 5, 3, 7, 21, 1, 11, 9);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 12, 13, 14, 15);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555, 0xAAAA, 0x8000, 127,
           std::numeric_limits<uint16_t>::max());
+INPUT_SET(InputSet::SelectCond, 0, 1);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint32_t)
 INPUT_SET(InputSet::Default1, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-INPUT_SET(InputSet::Default3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+INPUT_SET(InputSet::Default3, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x55555555, 0xAAAAAAAA, 0x80000000,
           127, std::numeric_limits<uint32_t>::max());
+INPUT_SET(InputSet::SelectCond, 0, 1);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(uint64_t)
 INPUT_SET(InputSet::Default1, 1, 2, 3, 4, 5, 0, 7, 1000, 9, 10);
 INPUT_SET(InputSet::Default2, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
-INPUT_SET(InputSet::Default3, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
+INPUT_SET(InputSet::Default3, 10, 20, 1338, 40, 50, 60, 70, 80, 90, 11);
 INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555555555555555,
           0xAAAAAAAAAAAAAAAA, 0x8000000000000000, 127,
           std::numeric_limits<uint64_t>::max());
+INPUT_SET(InputSet::SelectCond, 0, 1);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(HLSLHalf_t)
@@ -321,14 +328,15 @@ INPUT_SET(InputSet::Default1, -1.0, -1.0, 1.0, -0.01, 1.0, -0.01, 1.0, -0.01,
           1.0, -0.01);
 INPUT_SET(InputSet::Default2, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
-INPUT_SET(InputSet::Default3, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
-          -1.0);
+INPUT_SET(InputSet::Default3, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0,
+          1.0);
 INPUT_SET(InputSet::RangeHalfPi, -1.073, 0.044, -1.047, 0.313, 1.447, -0.865,
           1.364, -0.715, -0.800, 0.541);
 INPUT_SET(InputSet::RangeOne, 0.331, 0.727, -0.957, 0.677, -0.025, 0.495, 0.855,
           -0.673, -0.678, -0.905);
 INPUT_SET(InputSet::Positive, 1.0, 1.0, 342.0, 0.01, 5531.0, 0.01, 1.0, 0.01,
           331.2330, 3250.01);
+INPUT_SET(InputSet::SelectCond, 0.0, 1.0);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(float)
@@ -336,14 +344,15 @@ INPUT_SET(InputSet::Default1, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
 INPUT_SET(InputSet::Default2, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
-INPUT_SET(InputSet::Default3, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
-          -1.0);
+INPUT_SET(InputSet::Default3, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0,
+          1.0);
 INPUT_SET(InputSet::RangeHalfPi, 0.315f, -0.316f, 1.409f, -0.09f, -1.569f,
           1.302f, -0.326f, 0.781f, -1.235f, 0.623f);
 INPUT_SET(InputSet::RangeOne, 0.727f, 0.331f, -0.957f, 0.677f, -0.025f, 0.495f,
           0.855f, -0.673f, -0.678f, -0.905f);
 INPUT_SET(InputSet::Positive, 1.0f, 1.0f, 3424241.0f, 0.01f, 5531.0f, 0.01f,
           1.0f, 0.01f, 331.2330f, 3250.01f);
+INPUT_SET(InputSet::SelectCond, 0.0f, 1.0f);
 END_INPUT_SETS()
 
 BEGIN_INPUT_SETS(double)
@@ -351,8 +360,8 @@ INPUT_SET(InputSet::Default1, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
 INPUT_SET(InputSet::Default2, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
           -1.0);
-INPUT_SET(InputSet::Default3, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0,
-          -1.0);
+INPUT_SET(InputSet::Default3, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0,
+          1.0);
 INPUT_SET(InputSet::RangeHalfPi, 0.807, 0.605, 1.317, 0.188, 1.566, -1.507,
           0.67, -1.553, 0.194, -0.883);
 INPUT_SET(InputSet::RangeOne, 0.331, 0.277, -0.957, 0.677, -0.025, 0.495, 0.855,
@@ -361,6 +370,7 @@ INPUT_SET(InputSet::SplitDouble, 0.0, -1.0, 1.0, -1.0, 12345678.87654321, -1.0,
           1.0, -1.0, 1.0, -1.0);
 INPUT_SET(InputSet::Positive, 1.0, 1.0, 3424241.0, 0.01, 5531.0, 0.01, 1.0,
           0.01, 331.2330, 3250.01);
+INPUT_SET(InputSet::SelectCond, 0.0, 1.0);
 END_INPUT_SETS()
 
 #undef BEGIN_INPUT_SETS

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1005,11 +1005,17 @@ BINARY_COMPARISON_OP(OpType::Equal, (A == B));
 BINARY_COMPARISON_OP(OpType::NotEqual, (A != B));
 
 //
-// Binary
+// Binary Logical
 //
 
 DEFAULT_OP_2(OpType::Logical_And, (A && B));
 DEFAULT_OP_2(OpType::Logical_Or, (A || B));
+
+//
+// Ternary Logical
+//
+
+OP_3(OpType::Select, StrictValidation, (static_cast<bool>(A) ? B : C));
 
 //
 // dispatchTest
@@ -1757,12 +1763,24 @@ public:
   HLK_TEST(NotEqual, double, ScalarOp2);
   HLK_TEST(NotEqual, double, Vector);
 
-  // Binary
+  // Binary Logical
 
   HLK_TEST(Logical_And, HLSLBool_t, Vector);
   HLK_TEST(Logical_Or, HLSLBool_t, Vector);
   HLK_TEST(Logical_And, HLSLBool_t, ScalarOp2);
   HLK_TEST(Logical_Or, HLSLBool_t, ScalarOp2);
+
+  // Ternary Logical
+  HLK_TEST(Select, HLSLBool_t, Vector);
+  HLK_TEST(Select, int16_t, Vector);
+  HLK_TEST(Select, int32_t, Vector);
+  HLK_TEST(Select, int64_t, Vector);
+  HLK_TEST(Select, uint16_t, Vector);
+  HLK_TEST(Select, uint32_t, Vector);
+  HLK_TEST(Select, uint64_t, Vector);
+  HLK_TEST(Select, HLSLHalf_t, Vector);
+  HLK_TEST(Select, float, Vector);
+  HLK_TEST(Select, double, Vector);
 
 private:
   bool Initialized = false;

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3827,6 +3827,16 @@ void MSMain(uint GID : SV_GroupIndex,
         }
         #endif
 
+        #ifdef FUNC_TEST_SELECT
+        vector<OUT_TYPE, NUM> TestSelect(vector<TYPE, NUM> Vector1,
+                                         vector<TYPE, NUM> Vector2,
+                                         vector<TYPE, NUM> Vector3)
+        {
+          vector<bool, NUM> VectorCond = (Vector1 != 0);
+          return select(VectorCond, Vector2, Vector3);
+        }
+        #endif
+
         [numthreads(1,1,1)]
         void main(uint GI : SV_GroupIndex) {
 


### PR DESCRIPTION
This PR adds test cases for 'select'. I opted to keep all inputs the same type to make implementation of the test easier vs adding logic to our test framework to handle mixed input types.

New test cases validated against a private version of WARP.

Completion of this PR resolves #7468 