### PR TITLE
Revert "Add execution test for required SM 6.9 features (#7800)"

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -563,19 +563,6 @@ public:
   // Do not remove the following line - it is used by TranslateExecutionTest.py
   // MARKER: ExecutionTest/DxilConf Shared Implementation Start
 
-  BEGIN_TEST_METHOD(ShaderModel69RequiredFeatures)
-  TEST_METHOD_PROPERTY(
-      L"Kits.Description",
-      L"Verifies that the required features for Shader Model 6.9 are supported")
-  TEST_METHOD_PROPERTY(L"Kits.TestId", L"cfdb377e-7e3e-4c1c-8660-808528b5cf8e")
-  TEST_METHOD_PROPERTY(
-      L"Kits.TestName",
-      L"D3D12 - DXIL Core Test - Shader Model 6.9 - Required Features")
-  TEST_CLASS_PROPERTY(
-      "Kits.Specification",
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")
-  END_TEST_METHOD()
-
   // We define D3D_SHADER_MODEL enum values as we don't generally have access to
   // the latest D3D headers when adding tests for a new SM being added.
   using D3D_SHADER_MODEL = ExecTestUtils::D3D_SHADER_MODEL;
@@ -12637,32 +12624,6 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
   };
 
   return ShaderInitFn;
-}
-
-TEST_F(ExecutionTest, ShaderModel69RequiredFeatures) {
-  // See
-  // https://github.com/microsoft/hlsl-specs/blob/main/proposals/0044-sm69-required-features.md
-
-  // For devices that support SM 6.9, they must also report true for:
-  //
-  // - D3D12_FEATURE_DATA_D3D12_OPTIONS4.Native16BitShaderOpsSupported
-  // - D3D12_FEATURE_DATA_D3D12_OPTIONS1.WaveOps
-  // - D3D12_FEATURE_DATA_D3D12_OPTIONS1.Int64ShaderOps
-  //
-
-  CComPtr<ID3D12Device> Device;
-  bool ShaderModel69Supported =
-      createDevice(&Device, D3D_SHADER_MODEL_6_9, false);
-  if (!ShaderModel69Supported) {
-    WEX::Logging::Log::Comment(
-        "Device does not support SM 6.9. Can't run these tests.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
-
-  VERIFY_IS_TRUE(DoesDeviceSupportNative16bitOps(Device));
-  VERIFY_IS_TRUE(DoesDeviceSupportWaveOps(Device));
-  VERIFY_IS_TRUE(DoesDeviceSupportInt64(Device));
 }
 
 struct FloatInputUintOutput {


### PR DESCRIPTION
This reverts commit 52c7c332af9f6648c246546af3e8ea9b81a3c7eb.

The D3D runtime verifies this on device creation, which means that it would be impossible for this test to ever fail.