### PR TITLE
[ubsan] Prevent miniz from performing unaligned load / stores

### DIFF
--- a/lib/DxilCompression/CMakeLists.txt
+++ b/lib/DxilCompression/CMakeLists.txt
@@ -9,5 +9,9 @@ add_llvm_library(LLVMDxilCompression
   ADDITIONAL_HEADER_DIRS
 )
 
+# By default, miniz performs unaligned loads/stores in x86/x64 platforms. This
+# is undefined behavior in C, and so we explicitly disable it.
+target_compile_definitions(LLVMDxilCompression PRIVATE MINIZ_USE_UNALIGNED_LOADS_AND_STORES=0)
+
 add_dependencies(LLVMDxilCompression intrinsics_gen)
 


### PR DESCRIPTION
By default, miniz performs unaligned loads/stores in x86/x64 platforms. This is undefined behavior in C, and so we explicitly disable it.


Fixes 98 ubsan / alignment errors when building check-all.