### PR TITLE
Workaround broken ARM64X / MSVC_BUILD_AS_X builds

### DIFF
--- a/cmake/modules/AddLLVM.cmake
+++ b/cmake/modules/AddLLVM.cmake
@@ -225,10 +225,10 @@ function(set_output_directory target bindir libdir)
     # HLSL change begin: work around broken MSVC_BUILD_AS_X
     get_target_property(target_type ${target} TYPE)
     if(target_type STREQUAL "SHARED_LIBRARY" AND MSVC_BUILD_AS_X EQUAL 1)
-      set(workaround 1)
+      set(arm64x_workaround 1)
       message(NOTICE "Working around ARM64X / MSVC_BUILD_AS_X bug for ${target}")
     else()
-      set(workaround 0)
+      set(arm64x_workaround 0)
     endif()
     # HLSL change end
 
@@ -246,8 +246,7 @@ function(set_output_directory target bindir libdir)
       # location, which means it's a race for if we get the ARM64 or ARM64X
       # version there.  The appended $(PLATFORM) is evaluated by msbuild at
       # build time to separate the ARM64EC from ARM64 builds.
-      if(workaround EQUAL 1)
-        set(original_li ${li})
+      if(arm64x_workaround EQUAL 1)
         string(APPEND li "/$(PLATFORM)")
       endif()
       # HLSL change end


### PR DESCRIPTION
Currently, when internal pipelines build for ARM64X we use the older experimental `MSVC_BUILD_AS_X` feature.  The latest VS release has regressed this functionality, resulting in the import libs for the ARM64 and ARM64X DLLs being written to the same location.

Remember that ARM64X binaries are fat binaries containing both ARM64 and ARM64EC code.  When building for ARM64 with MSVC_BUILD_AS_X, the Visual Studio cmake generator actually generates vcxproj files that build ARM64 and ARM64EC (with the ARM64EC version being the one that becomes the combined ARM64X binary.  The generated project knows how to ensure that the ARM64 DLL is built to one location and the ARM64X one goes into the destination specified in the cmake scripts.  However, the import libraries end up being configured to go into the same location, resulting in a race condition.

Our cmake scripts have no knowledge of these two platforms, and so there's no direct way to address this.  This workaround makes it so that when building in this mode the import libraries are written to a location containing `$(PLATFORM)`.  This is a msbuild variable that's evaluated at build time.

This is a short-term fix that allows us to unblock our internal pipelines.  Longer-term we should move to using the [documented ARM64X approach](https://learn.microsoft.com/en-us/windows/arm/arm64x-build#building-an-arm64x-dll-with-cmake), at which point this change should be reverted.