### PR TITLE
ExecutionTests: add option to not load lit.cfg

### DIFF
--- a/tools/clang/test/taef_exec/lit.site.cfg.in
+++ b/tools/clang/test/taef_exec/lit.site.cfg.in
@@ -20,6 +20,6 @@ except KeyError:
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
-if not config.do_not_load_lit_cfg:
+if not getattr(config, 'do_not_load_lit_cfg', False):
     # Let the main config do the real work.
     lit_config.load_config(config, "@CLANG_SOURCE_DIR@/test/taef_exec/lit.cfg")


### PR DESCRIPTION
This is to allow external test runs to get the configuration from the generated lit.site.cfg, and then override these values before loading lit.cfg themselves.