### PR TITLE
[SPIR-V] Fix incorrect [branch] gen on return.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -15225,11 +15225,11 @@ void SpirvEmitter::processSwitchStmtUsingIfStmts(const SwitchStmt *switchStmt) {
     // current case.
     std::vector<Stmt *> statements;
     unsigned i = curCaseIndex + 1;
-    for (; i < flatSwitch.size() && !isa<BreakStmt>(flatSwitch[i]) &&
-           !isa<ReturnStmt>(flatSwitch[i]);
-         ++i) {
+    for (; i < flatSwitch.size() && !isa<BreakStmt>(flatSwitch[i]); ++i) {
       if (!isa<CaseStmt>(flatSwitch[i]) && !isa<DefaultStmt>(flatSwitch[i]))
         statements.push_back(const_cast<Stmt *>(flatSwitch[i]));
+      if (isa<ReturnStmt>(flatSwitch[i]))
+        break;
     }
     if (!statements.empty())
       cs->setStmts(astContext, statements.data(), statements.size());

--- a/tools/clang/test/CodeGenSPIRV/cf.switch.ifstmt.early-return.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.switch.ifstmt.early-return.hlsl
@@ -1,5 +1,6 @@
 // RUN: %dxc -T cs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
+// CHECK:          %simple = OpFunction
 void simple() {
   uint a = 0;
 
@@ -9,7 +10,7 @@ void simple() {
 
 // CHECK:         %if_true = OpLabel
 // CHECK:                    OpStore %d1 %uint_0
-// CHECK:                    OpBranch %if_merge_0
+// CHECK:                    OpReturn
 // CHECK:        %if_false = OpLabel
 // CHECK:    [[a:%[0-9]+]] = OpLoad %uint %a
 // CHECK: [[cond:%[0-9]+]] = OpIEqual %bool [[a]] %uint_1
@@ -19,7 +20,7 @@ void simple() {
 // CHECK:                    OpStore %d1_0 %uint_1
 // CHECK:                    OpBranch %if_merge
 // CHECK:      %if_false_0 = OpLabel
-// CHECK:                    OpBranch %if_merge
+// CHECK:                    OpReturn
 
 // CHECK:        %if_merge = OpLabel
 // CHECK:                    OpBranch %if_merge_0
@@ -59,7 +60,7 @@ void simple() {
 // CHECK:                      OpStore %v2 %uint_1
 // CHECK:                      OpBranch %if_merge_1
 // CHECK:        %if_false_2 = OpLabel
-// CHECK:                      OpBranch %if_merge_1
+// CHECK:                      OpReturn
 
 // CHECK:        %if_merge_1 = OpLabel
 // CHECK:                      OpBranch %if_merge_2

--- a/tools/clang/test/CodeGenSPIRV/cf.switch.ifstmt.return-value.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.switch.ifstmt.return-value.hlsl
@@ -1,0 +1,77 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+cbuffer cb {
+  uint   index;
+  float4 f0;
+  float4 f1;
+};
+
+
+float4 fallthrough_switch(uint id) {
+// CHECK: %fallthrough_switch = OpFunction
+
+  switch (id) {
+// CHECK:    [[id:%[0-9]+]] = OpLoad %uint %id
+// CHECK:                     OpSwitch [[id]] %switch_default 0 %switch_0 1 %switch_1
+
+    case 0:
+      return f0;
+// CHECK:          %switch_0 = OpLabel
+// CHECK:    [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v4float %cb %int_1
+// CHECK:    [[val:%[0-9]+]] = OpLoad %v4float [[ptr]]
+// CHECK:                      OpReturnValue [[val]]
+
+    case 1:
+    default:
+      return f1;
+// CHECK:          %switch_1 = OpLabel
+// CHECK:                      OpBranch %switch_default
+// CHECK:    %switch_default = OpLabel
+// CHECK:    [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v4float %cb %int_2
+// CHECK:    [[val:%[0-9]+]] = OpLoad %v4float [[ptr]]
+// CHECK:                      OpReturnValue [[val]]
+  }
+}
+
+float4 fallthrough_branch(uint id) {
+// CHECK: %fallthrough_branch = OpFunction
+
+  [branch]
+  switch (id) {
+// CHECK:     [[id:%[0-9]+]] = OpLoad %uint %id_0
+// CHECK:   [[cond:%[0-9]+]] = OpIEqual %bool [[id]] %uint_0
+// CHECK:                      OpBranchConditional [[cond]] %if_true %if_false
+
+    case 0:
+      return f0;
+// CHECK:           %if_true = OpLabel
+// CHECK:    [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v4float %cb %int_1
+// CHECK:    [[val:%[0-9]+]] = OpLoad %v4float [[ptr]]
+// CHECK:                      OpReturnValue [[val]]
+
+    case 1:
+    default:
+      return f1;
+// CHECK:          %if_false = OpLabel
+// CHECK:     [[id:%[0-9]+]] = OpLoad %uint %id_0
+// CHECK:   [[cond:%[0-9]+]] = OpIEqual %bool [[id]] %uint_1
+// CHECK:                      OpBranchConditional [[cond]] %if_true_0 %if_false_0
+
+// CHECK:         %if_true_0 = OpLabel
+// CHECK:    [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v4float %cb %int_2
+// CHECK:    [[val:%[0-9]+]] = OpLoad %v4float [[ptr]]
+// CHECK:                      OpReturnValue [[val]]
+
+// CHECK:        %if_false_0 = OpLabel
+// CHECK:    [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v4float %cb %int_2
+// CHECK:    [[val:%[0-9]+]] = OpLoad %v4float [[ptr]]
+// CHECK:                      OpReturnValue [[val]]
+  }
+}
+
+float4 main() : SV_Target
+{
+  float4 a = fallthrough_switch(index);
+  float4 b = fallthrough_branch(index);
+  return a + b;
+}


### PR DESCRIPTION
PR #6756 tried to address an issue when variables were declared in a fallthrough, but contained a bug: the PR assumed return statements were leaves, and that no statement was associated with the node. This is not true if a value is returned as the return statements contains the expression describing the returned value.

Skipping this return statement means we'd generate invalid code when returning a value in a switch with the `[branch]` attribute. Moved the exit condition after recording the statement so early returns are still generated.

Fixes #7832