### PR TITLE
Add missing REQUIRES: spirv

### DIFF
--- a/tools/clang/test/SemaHLSL/spirv-boolean-bitfield.hlsl
+++ b/tools/clang/test/SemaHLSL/spirv-boolean-bitfield.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv
 // RUN: %dxc -T cs_6_0 -E main -spirv -verify %s
 
 struct Test {


### PR DESCRIPTION
#7822 added a new test for spirv.  This needs a `REQUIRES: spirv` to prevent it running in cases where the compiler doesn't support spirv.