### PR TITLE
Fix lit / taef integration

### DIFF
--- a/utils/lit/lit/formats/taef.py
+++ b/utils/lit/lit/formats/taef.py
@@ -184,7 +184,7 @@ def getTestResult(out, exitCode):
     not_run = int(match.group(4))
     skipped = int(match.group(5))
 
-    # TAEF docs claim that exitCode should be non-zero if a tests is skipped,
+    # TAEF docs claim that exitCode should be non-zero if a test is skipped,
     # but that doesn't seem to be the case with at least v10.88k. So we
     # explicitly look for skipped in the summary - and any other non-zero exit
     # codes after this are some kind of failure.


### PR DESCRIPTION
* TAEF writes everything to stdout, so don't worry about separate out/err streams
* Use a single regex match for the Summary string
* TAEF's exit code doesn't reliably indicate skipped tests, so look for these explicitly in the summary
* Always return the output with the result - so that `--show-all` will work correctly and we can see the output from tests regardless of their final result.