### PR TITLE
Make LongVectors tests run as part of standard test passes

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1422,7 +1422,7 @@ public:
 
       bool FailIfRequirementsNotMet = false;
 #ifdef _HLK_CONF
-      FailIsRequirementsNotMet = true;
+      FailIfRequirementsNotMet = true;
 #endif
       WEX::TestExecution::RuntimeParameters::TryGetValue(
           L"FailIfRequirementsNotMet", FailIfRequirementsNotMet);


### PR DESCRIPTION
Currently, the various test runners (lit, hcttest.cmd) only run execution tests where the Priority metadata is <2.

Previously, the LongVectors tests didn't set a value for priority, and this resulted in them never being selected.  This change adds the missing priority metadata - and then fixes up the tests so they don't immediately fail if the runtime/device doesn't support SM 6.9!