### PR TITLE
[NFC] Fix unused variable warning

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -351,7 +351,7 @@ void fillShaderBufferFromLongVectorData(std::vector<BYTE> &ShaderBuffer,
   // underlying type in some cases. Thats fine. Resize just makes sure we have
   // enough space.
   const size_t NumElements = TestData.size();
-  const size_t DataSize = sizeof(T) * NumElements;
+  [[maybe_unused]] const size_t DataSize = sizeof(T) * NumElements;
 
   // Ensure the shader buffer is large enough. It should be pre-sized based on
   // the D3D12_RESOURCE_DESC for the associated D3D12_RESOURCE.


### PR DESCRIPTION
DataSize is only used in a DXASSERT, which is compile out in some configurations resulting in a unused variable warning. This change adds a [[maybe_unused]] attribute to suppress that warning.