### PR TITLE
Replaces narrow strings with wide ones in long vector test execution tests.

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -257,7 +257,7 @@ template <typename T> const std::vector<T> &getInputSet(InputSet InputSet) {
   default:                                                                     \
     break;                                                                     \
     }                                                                          \
-    VERIFY_FAIL("Missing input set");                                          \
+    VERIFY_FAIL(L"Missing input set");                                         \
     std::abort();                                                              \
     }
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1345,14 +1345,15 @@ using namespace LongVector;
 class DxilConf_SM69_Vectorized {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM69_Vectorized)
-  TEST_CLASS_PROPERTY("Kits.TestName",
-                      "D3D12 - Shader Model 6.9 - Vectorized DXIL - Core Tests")
-  TEST_CLASS_PROPERTY("Kits.TestId", "81db1ff8-5bc5-48a1-8d7b-600fc600a677")
-  TEST_CLASS_PROPERTY("Kits.Description",
-                      "Validates required SM 6.9 vectorized DXIL operations")
   TEST_CLASS_PROPERTY(
-      "Kits.Specification",
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")
+      L"Kits.TestName",
+      L"D3D12 - Shader Model 6.9 - Vectorized DXIL - Core Tests")
+  TEST_CLASS_PROPERTY(L"Kits.TestId", L"81db1ff8-5bc5-48a1-8d7b-600fc600a677")
+  TEST_CLASS_PROPERTY(L"Kits.Description",
+                      L"Validates required SM 6.9 vectorized DXIL operations")
+  TEST_CLASS_PROPERTY(
+      L"Kits.Specification",
+      L"Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")
   END_TEST_CLASS()
 
   TEST_CLASS_SETUP(classSetup) {


### PR DESCRIPTION
Fixes #7881.