### PR TITLE
Execution Tests: Long Vector - Fix off by 1 bug in WaveActiveAllEqual

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1373,7 +1373,7 @@ template <typename T> struct ExpectedBuilder<OpType::WaveActiveAllEqual, T> {
 
     std::vector<HLSLBool_t> Expected;
     const size_t VectorSize = Inputs[0].size();
-    Expected.assign(VectorSize - 1, static_cast<HLSLBool_t>(true));
+    Expected.assign(VectorSize, static_cast<HLSLBool_t>(true));
     // We set the last element to a different value on a single lane.
     Expected[VectorSize - 1] = static_cast<HLSLBool_t>(false);
 


### PR DESCRIPTION
This PR fixes an off by 1 error when filling the expected output vector for WaveActiveAllEqual tests. 