### PR TITLE
ExecutionTests: Long Vectors - Fix WaveActiveAllEqual for bools

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -4147,25 +4147,26 @@ void MSMain(uint GID : SV_GroupIndex,
         #endif
 
         #ifdef FUNC_WAVE_ACTIVE_ALL_EQUAL
-        inline bool ToggleScalar(bool A) { return !A; }
-        inline uint ToggleScalar(uint A) { return A ^ 1; }
-        inline uint64_t ToggleScalar(uint64_t A) { return A ^ 1; }
-        inline int ToggleScalar(int A) { return A ^ 1; }
-        inline int64_t ToggleScalar(int64_t A) { return A ^ 1; }
-        inline half ToggleScalar(half A) { return A + (half)1.0h; }
-        inline float ToggleScalar(float A) { return A + 1.0f; }
-        inline double ToggleScalar(double A) { return A + 1.0; }
+        bool MakeDifferent(bool A) { return !A; }
+        uint MakeDifferent(uint A) { return A ^ 1; }
+        uint64_t MakeDifferent(uint64_t A) { return A ^ 1; }
+        int MakeDifferent(int A) { return A ^ 1; }
+        int64_t MakeDifferent(int64_t A) { return A ^ 1; }
+        half MakeDifferent(half A) { return A + (half)1.0h; }
+        float MakeDifferent(float A) { return A + 1.0f; }
+        double MakeDifferent(double A) { return A + 1.0; }
 
         #if defined(__HLSL_ENABLE_16BIT_TYPES)
-        inline uint16_t ToggleScalar(uint16_t A) { return A ^ 1; }
-        inline int16_t ToggleScalar(int16_t A) { return A ^ 1; }
+        uint16_t MakeDifferent(uint16_t A) { return A ^ 1; }
+        int16_t MakeDifferent(int16_t A) { return A ^ 1; }
         #endif // defined(__HLSL_ENABLE_16BIT_TYPES)
 
         vector<OUT_TYPE, NUM> TestWaveActiveAllEqual(vector<TYPE, NUM> Vector)
         {
           if(WaveGetLaneIndex() == (WaveGetLaneCount() - 1))
           {
-            Vector[NUM - 1] = ToggleScalar(Vector[NUM - 1]);
+            // We just want to set the last element to any different value.
+            Vector[NUM - 1] = MakeDifferent(Vector[NUM - 1]);
           }
 
           return WaveActiveAllEqual(Vector);


### PR DESCRIPTION
Fixes a bug in the WaveActiveAllEqual hlsl test code where we intended to make the last value of the input vector anything but the input value. The logic was broken for bools. Updated by adding helper functions for each possible type to handle accordingly.