### PR TITLE
[NFC] Execution Tests: Long Vector - fix typo in OP_CAST macro

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorOps.def
+++ b/tools/clang/unittests/HLSLExec/LongVectorOps.def
@@ -66,7 +66,7 @@ OP_DEFAULT_DEFINES(Unary, Initialize, 1, "TestInitialize", "",
 #define OP_CAST_DEFAULT(GROUP, SYMBOL)                                         \
   OP_DEFAULT_DEFINES(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1")
 #define OP_CAST(GROUP, SYMBOL, INPUT_SET_1)                                    \
-  OP(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1", "LongVectorOP",   \
+  OP(GROUP, SYMBOL, 1, "TestCast", "", "-DFUNC_TEST_CAST=1", "LongVectorOp",   \
     INPUT_SET_1, Default2, Default3)
 
 OP_CAST_DEFAULT(Cast, CastToBool)


### PR DESCRIPTION
Didn't cause any issues, but the shader name in the OP_CAST macro had a capital 'P' when it should be lowercase.