### PR TITLE
[NFC] Remove unnecessary copies of D3D_SHADER_MODEL_*

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -516,32 +516,6 @@ public:
   // Do not remove the following line - it is used by TranslateExecutionTest.py
   // MARKER: ExecutionTest/DxilConf Shared Implementation Start
 
-  // We define D3D_SHADER_MODEL enum values as we don't generally have access to
-  // the latest D3D headers when adding tests for a new SM being added.
-  using D3D_SHADER_MODEL = ExecTestUtils::D3D_SHADER_MODEL;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_0 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_0;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_1 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_1;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_2 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_2;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_3 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_3;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_4 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_4;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_5 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_5;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_6 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_6;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_7 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_7;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_8 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_8;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_SHADER_MODEL_6_9 =
-      ExecTestUtils::D3D_SHADER_MODEL_6_9;
-  static constexpr ExecTestUtils::D3D_SHADER_MODEL D3D_HIGHEST_SHADER_MODEL =
-      ExecTestUtils::D3D_HIGHEST_SHADER_MODEL;
-
   bool SaveImages() { return GetTestParamBool(L"SaveImages"); }
 
   // Base class used by raw gather test for polymorphic assignments
@@ -11793,7 +11767,7 @@ bool HelperLaneResultLogAndVerify(const wchar_t *testDesc,
   return matches;
 }
 
-bool VerifyHelperLaneWaveResults(ExecutionTest::D3D_SHADER_MODEL sm,
+bool VerifyHelperLaneWaveResults(D3D_SHADER_MODEL sm,
                                  HelperLaneWaveTestResult &testResults,
                                  HelperLaneWaveTestResult &expectedResults,
                                  bool verifyQuads) {
@@ -11861,7 +11835,7 @@ bool VerifyHelperLaneWaveResults(ExecutionTest::D3D_SHADER_MODEL sm,
         quad_tr_exp.is_helper_across_Diag, quad_tr.is_helper_across_Diag);
   }
 
-  if (sm >= ExecutionTest::D3D_SHADER_MODEL_6_5) {
+  if (sm >= D3D_SHADER_MODEL_6_5) {
     HelperLaneWaveTestResult65 &tr65 = testResults.sm65;
     HelperLaneWaveTestResult65 &tr65exp = expectedResults.sm65;
 
@@ -11893,7 +11867,7 @@ bool VerifyHelperLaneWaveResults(ExecutionTest::D3D_SHADER_MODEL sm,
 // to dispatch three waves that each process only a single vertex.
 // So instead of compare with fixed expected result, calculate the correct
 // result from ballot.
-bool VerifyHelperLaneWaveResultsForVS(ExecutionTest::D3D_SHADER_MODEL sm,
+bool VerifyHelperLaneWaveResultsForVS(D3D_SHADER_MODEL sm,
                                       HelperLaneWaveTestResult &testResults) {
   bool passed = true;
   XMUINT4 mask = testResults.sm60.ballot;
@@ -11955,7 +11929,7 @@ bool VerifyHelperLaneWaveResultsForVS(ExecutionTest::D3D_SHADER_MODEL sm,
                                            2 * (countBits - 1), tr60.prefixSum);
   }
 
-  if (sm >= ExecutionTest::D3D_SHADER_MODEL_6_5) {
+  if (sm >= D3D_SHADER_MODEL_6_5) {
     HelperLaneWaveTestResult65 &tr65 = testResults.sm65;
 
     passed &= HelperLaneResultLogAndVerify(

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -67,10 +67,9 @@ static UINT getD3D12SDKVersion(std::wstring SDKPath) {
   return SDKVersion;
 }
 
-bool createDevice(ID3D12Device **D3DDevice,
-                  ExecTestUtils::D3D_SHADER_MODEL TestModel,
+bool createDevice(ID3D12Device **D3DDevice, D3D_SHADER_MODEL TestModel,
                   bool SkipUnsupported) {
-  if (TestModel > ExecTestUtils::D3D_HIGHEST_SHADER_MODEL) {
+  if (TestModel > D3D_HIGHEST_SHADER_MODEL) {
     const UINT Minor = (UINT)TestModel & 0x0f;
     hlsl_test::LogCommentFmt(L"Installed SDK does not support "
                              L"shader model 6.%1u",
@@ -170,16 +169,10 @@ bool createDevice(ID3D12Device **D3DDevice,
     return false;
 
   if (!useDxbc()) {
-    // Check for DXIL support.
-    typedef struct D3D12_FEATURE_DATA_SHADER_MODEL {
-      ExecTestUtils::D3D_SHADER_MODEL HighestShaderModel;
-    } D3D12_FEATURE_DATA_SHADER_MODEL;
-    const UINT D3D12_FEATURE_SHADER_MODEL = 7;
     D3D12_FEATURE_DATA_SHADER_MODEL SMData;
     SMData.HighestShaderModel = TestModel;
-    if (FAILED(D3DDeviceCom->CheckFeatureSupport(
-            (D3D12_FEATURE)D3D12_FEATURE_SHADER_MODEL, &SMData,
-            sizeof(SMData))) ||
+    if (FAILED(D3DDeviceCom->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL,
+                                                 &SMData, sizeof(SMData))) ||
         SMData.HighestShaderModel < TestModel) {
       const UINT Minor = (UINT)TestModel & 0x0f;
       hlsl_test::LogCommentFmt(L"The selected device does not support "

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -6,32 +6,12 @@
 
 #include "dxc/Support/dxcapi.use.h"
 
-namespace ExecTestUtils {
-// This is defined in d3d.h for Windows 10 Anniversary Edition SDK, but we
-// only require the Windows 10 SDK.
-typedef enum D3D_SHADER_MODEL {
-  D3D_SHADER_MODEL_5_1 = 0x51,
-  D3D_SHADER_MODEL_6_0 = 0x60,
-  D3D_SHADER_MODEL_6_1 = 0x61,
-  D3D_SHADER_MODEL_6_2 = 0x62,
-  D3D_SHADER_MODEL_6_3 = 0x63,
-  D3D_SHADER_MODEL_6_4 = 0x64,
-  D3D_SHADER_MODEL_6_5 = 0x65,
-  D3D_SHADER_MODEL_6_6 = 0x66,
-  D3D_SHADER_MODEL_6_7 = 0x67,
-  D3D_SHADER_MODEL_6_8 = 0x68,
-  D3D_SHADER_MODEL_6_9 = 0x69,
-  D3D_HIGHEST_SHADER_MODEL = D3D_SHADER_MODEL_6_9
-} D3D_SHADER_MODEL;
-} // namespace ExecTestUtils
-
 bool useDxbc();
 HRESULT enableDebugLayer();
 HRESULT enableExperimentalMode(HMODULE Runtime);
 HRESULT enableAgilitySDK(HMODULE Runtime);
 bool createDevice(ID3D12Device **D3DDevice,
-                  ExecTestUtils::D3D_SHADER_MODEL TestModel =
-                      ExecTestUtils::D3D_SHADER_MODEL_6_0,
+                  D3D_SHADER_MODEL TestModel = D3D_SHADER_MODEL_6_0,
                   bool SkipUnsupported = true);
 
 void readHlslDataIntoNewStream(LPCWSTR RelativePath, IStream **Stream,

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1709,8 +1709,7 @@ public:
           L"FailIfRequirementsNotMet", FailIfRequirementsNotMet);
 
       const bool SkipUnsupported = !FailIfRequirementsNotMet;
-      createDevice(&D3DDevice, ExecTestUtils::D3D_SHADER_MODEL_6_9,
-                   SkipUnsupported);
+      createDevice(&D3DDevice, D3D_SHADER_MODEL_6_9, SkipUnsupported);
     }
 
     return true;
@@ -1722,8 +1721,7 @@ public:
     if (!D3DDevice || D3DDevice->GetDeviceRemovedReason() != S_OK) {
       hlsl_test::LogCommentFmt(
           L"Device was lost: Attempting to create a new D3D12 device.");
-      VERIFY_IS_TRUE(
-          createDevice(&D3DDevice, ExecTestUtils::D3D_SHADER_MODEL_6_9, false));
+      VERIFY_IS_TRUE(createDevice(&D3DDevice, D3D_SHADER_MODEL_6_9, false));
     }
 
     return true;


### PR DESCRIPTION
Now that we're using recent SDKs we don't need duplicate copies of these.