### PR TITLE
LongVectors tests: Fix device leak and improve logging

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -69,6 +69,11 @@ static UINT getD3D12SDKVersion(std::wstring SDKPath) {
 
 bool createDevice(ID3D12Device **D3DDevice, D3D_SHADER_MODEL TestModel,
                   bool SkipUnsupported) {
+
+  if (*D3DDevice)
+    hlsl_test::LogWarningFmt(L"createDevice called with non-null *D3DDevice - "
+                             L"this will likely leak the previous device");
+
   if (TestModel > D3D_HIGHEST_SHADER_MODEL) {
     const UINT Minor = (UINT)TestModel & 0x0f;
     hlsl_test::LogCommentFmt(L"Installed SDK does not support "


### PR DESCRIPTION
Previously, if a device is removed then the code that recreates it wouldn't release the old device pointer, resulting in the device leaking. This actually prevents removed device recovery entirely, since all references to a removed device need to be released before a new one can be created.  This change fixes that.

Also:

* improve logging in situations where requirements aren't met (eg trying to create a SM 6.9 device on a system that doesn't support SM 6.9)
* return false from class setup if we couldn't create a device - this will cause all the tests in the class to be skipped or failed (depending on the FailIfRequirementsNotMet setting) - reducing log noise, and saving the time that would be taken to run tests that we know are going to fail
* improve logging when recreating a device so we can tell the difference between "device was removed" and "there wasn't a device set"
* add a warning log if createDevice is called with something that looks like it already has a value set


Fixes #7949