### PR TITLE
[SPIR-V] Fix layout rule on ConstantBuffer alias

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1064,6 +1064,9 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
   (void)getTypeAndCreateCounterForPotentialAliasVar(param, &isAlias);
   fnParamInstr->setContainsAliasComponent(isAlias);
 
+  if (isConstantTextureBuffer(type))
+    fnParamInstr->setLayoutRule(spirvOptions.cBufferLayoutRule);
+
   assert(astDecls[param].instr == nullptr);
   registerVariableForDecl(param, fnParamInstr);
 

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.pass.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.pass.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+// CHECK-DAG: OpMemberDecorate %Inner 0 Offset 0
+
+// CHECK-DAG:                   %Inner = OpTypeStruct %float
+// CHECK-DAG: %type_ConstantBuffer_CBS = OpTypeStruct %Inner
+// CHECK-DAG:                 %Inner_0 = OpTypeStruct %float
+// CHECK-DAG:                     %CBS = OpTypeStruct %Inner_0
+struct Inner
+{
+    float field;
+};
+
+struct CBS
+{
+    Inner entry;
+};
+
+float foo(ConstantBuffer<CBS> param)
+{
+    CBS alias = param;
+// CHECK: [[copy:%[0-9]+]] = OpLoad %type_ConstantBuffer_CBS %param
+// CHECK:   [[e1:%[0-9]+]] = OpCompositeExtract %Inner [[copy]]
+// CHECK:   [[e2:%[0-9]+]] = OpCompositeExtract %float [[e1]]
+// CHECK:   [[c2:%[0-9]+]] = OpCompositeConstruct %Inner_0 [[e2]]
+// CHECK:   [[c1:%[0-9]+]] = OpCompositeConstruct %CBS [[c2]]
+// CHECK:                    OpStore %alias [[c1]]
+    return alias.entry.field;
+}
+
+ConstantBuffer<CBS> input;
+
+float main() : A
+{
+    return foo(input);
+}

--- a/tools/clang/test/CodeGenSPIRV/type.texture-buffer.pass.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.texture-buffer.pass.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+// CHECK-DAG: OpMemberDecorate %Inner 0 Offset 0
+
+// CHECK-DAG:                   %Inner = OpTypeStruct %float
+// CHECK-DAG:  %type_TextureBuffer_CBS = OpTypeStruct %Inner
+// CHECK-DAG:                 %Inner_0 = OpTypeStruct %float
+// CHECK-DAG:                     %CBS = OpTypeStruct %Inner_0
+struct Inner
+{
+    float field;
+};
+
+struct CBS
+{
+    Inner entry;
+};
+
+float foo(TextureBuffer<CBS> param)
+{
+    CBS alias = param;
+// CHECK: [[copy:%[0-9]+]] = OpLoad %type_TextureBuffer_CBS %param
+// CHECK:   [[e1:%[0-9]+]] = OpCompositeExtract %Inner [[copy]]
+// CHECK:   [[e2:%[0-9]+]] = OpCompositeExtract %float [[e1]]
+// CHECK:   [[c2:%[0-9]+]] = OpCompositeConstruct %Inner_0 [[e2]]
+// CHECK:   [[c1:%[0-9]+]] = OpCompositeConstruct %CBS [[c2]]
+// CHECK:                    OpStore %alias [[c1]]
+    return alias.entry.field;
+}
+
+TextureBuffer<CBS> input;
+
+float main() : A
+{
+    return foo(input);
+}
+


### PR DESCRIPTION
When a CB or derivative was passed as parameter, the layout rules were not passed, meaning the loaded type would get extracted, but to the wrong type.

Fixes #7954 