### PR TITLE
[Fix] Renaming macro to match DXC existing one, __HLSL_ENABLE_16_BIT

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -321,10 +321,8 @@ std::string getCompilerOptionsString(
     std::optional<std::string> AdditionalOptions = std::nullopt) {
   std::stringstream CompilerOptions;
 
-  if (OpDataType.Is16Bit || OutDataType.Is16Bit) {
+  if (OpDataType.Is16Bit || OutDataType.Is16Bit)
     CompilerOptions << " -enable-16bit-types";
-    CompilerOptions << " -DNATIVE_16BIT_TYPES_ENABLED=1";
-  }
 
   CompilerOptions << " -DTYPE=" << OpDataType.HLSLTypeString;
   CompilerOptions << " -DNUM=" << VectorSize;

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -4156,7 +4156,7 @@ void MSMain(uint GID : SV_GroupIndex,
         float MakeDifferent(float A) { return A + 1.0f; }
         double MakeDifferent(double A) { return A + 1.0; }
 
-        #if NATIVE_16BIT_TYPES_ENABLED
+        #if __HLSL_ENABLE_16_BIT
         uint16_t MakeDifferent(uint16_t A) { return A ^ 1; }
         int16_t MakeDifferent(int16_t A) { return A ^ 1; }
         #endif


### PR DESCRIPTION
A bug was found when running WaveActiveAllEqual tests, the macro being used didn't match the existing on in DXC, so this patch fixed it and use the correct one `__HLSL_ENABLE_16_BIT`