### PR TITLE
[SPIR-V] Support  `asdouble()` for `uint3` argument type.

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/intrinsics.asdouble.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.asdouble.hlsl
@@ -19,33 +19,37 @@ void main() {
 
 // CHECK:         [[low2:%[0-9]+]] = OpLoad %v2uint %low2
 // CHECK-NEXT:   [[high2:%[0-9]+]] = OpLoad %v2uint %high2
-// CHECK-NEXT:   [[lowbit1:%[0-9]+]] = OpCompositeExtract %uint [[low2]] 0
-// CHECK-NEXT:   [[highbit1:%[0-9]+]] = OpCompositeExtract %uint [[high2]] 0
-// CHECK-NEXT:   [[comp1:%[0-9]+]] = OpCompositeConstruct %v2uint [[lowbit1]] [[highbit1]]
-// CHECK-NEXT:      [[double1:%[0-9]+]] = OpBitcast %double [[comp1]]
-// CHECK-NEXT:   [[lowbit2:%[0-9]+]] = OpCompositeExtract %uint [[low2]] 1
-// CHECK-NEXT:   [[highbit2:%[0-9]+]] = OpCompositeExtract %uint [[high2]] 1
-// CHECK-NEXT:   [[comp2:%[0-9]+]] = OpCompositeConstruct %v2uint [[lowbit2]] [[highbit2]]
-// CHECK-NEXT:      [[double2:%[0-9]+]] = OpBitcast %double [[comp2]]
+// CHECK-NEXT:  [[elem1:%[0-9]+]] = OpVectorShuffle %v2uint [[low2]] [[high2]] 0 2
+// CHECK-NEXT:      [[double1:%[0-9]+]] = OpBitcast %double [[elem1]]
+// CHECK-NEXT:  [[elem2:%[0-9]+]] = OpVectorShuffle %v2uint [[low2]] [[high2]] 1 3
+// CHECK-NEXT:      [[double2:%[0-9]+]] = OpBitcast %double [[elem2]]
 // CHECK-NEXT:   {{%[0-9]+}} = OpCompositeConstruct %v2double [[double1]] [[double2]]
   uint2 low2, high2;
   double2 c = asdouble(low2, high2);
 
 // CHECK:         [[low3:%[0-9]+]] = OpLoad %v3uint %low3
 // CHECK-NEXT:   [[high3:%[0-9]+]] = OpLoad %v3uint %high3
-// CHECK-NEXT:   [[lowbit1:%[0-9]+]] = OpCompositeExtract %uint [[low3]] 0
-// CHECK-NEXT:   [[highbit1:%[0-9]+]] = OpCompositeExtract %uint [[high3]] 0
-// CHECK-NEXT:   [[comp1:%[0-9]+]] = OpCompositeConstruct %v2uint [[lowbit1]] [[highbit1]]
-// CHECK-NEXT:      [[double1:%[0-9]+]] = OpBitcast %double [[comp1]]
-// CHECK-NEXT:   [[lowbit2:%[0-9]+]] = OpCompositeExtract %uint [[low3]] 1
-// CHECK-NEXT:   [[highbit2:%[0-9]+]] = OpCompositeExtract %uint [[high3]] 1
-// CHECK-NEXT:   [[comp2:%[0-9]+]] = OpCompositeConstruct %v2uint [[lowbit2]] [[highbit2]]
-// CHECK-NEXT:      [[double2:%[0-9]+]] = OpBitcast %double [[comp2]]
-// CHECK-NEXT:   [[lowbit3:%[0-9]+]] = OpCompositeExtract %uint [[low3]] 2
-// CHECK-NEXT:   [[highbit3:%[0-9]+]] = OpCompositeExtract %uint [[high3]] 2
-// CHECK-NEXT:   [[comp3:%[0-9]+]] = OpCompositeConstruct %v2uint [[lowbit3]] [[highbit3]]
-// CHECK-NEXT:      [[double3:%[0-9]+]] = OpBitcast %double [[comp3]]
+// CHECK-NEXT:  [[elem1:%[0-9]+]] = OpVectorShuffle %v2uint [[low3]] [[high3]] 0 3
+// CHECK-NEXT:      [[double1:%[0-9]+]] = OpBitcast %double [[elem1]]
+// CHECK-NEXT:  [[elem2:%[0-9]+]] = OpVectorShuffle %v2uint [[low3]] [[high3]] 1 4
+// CHECK-NEXT:      [[double2:%[0-9]+]] = OpBitcast %double [[elem2]]
+// CHECK-NEXT:  [[elem3:%[0-9]+]] = OpVectorShuffle %v2uint [[low3]] [[high3]] 2 5
+// CHECK-NEXT:      [[double3:%[0-9]+]] = OpBitcast %double [[elem3]]
 // CHECK-NEXT:   {{%[0-9]+}} = OpCompositeConstruct %v3double [[double1]] [[double2]] [[double3]]
   uint3 low3, high3;
   double3 d = asdouble(low3, high3);
+
+// CHECK:         [[low4:%[0-9]+]] = OpLoad %v4uint %low4
+// CHECK-NEXT:   [[high4:%[0-9]+]] = OpLoad %v4uint %high4
+// CHECK-NEXT:  [[elem1:%[0-9]+]] = OpVectorShuffle %v2uint [[low4]] [[high4]] 0 4
+// CHECK-NEXT:      [[double1:%[0-9]+]] = OpBitcast %double [[elem1]]
+// CHECK-NEXT:  [[elem2:%[0-9]+]] = OpVectorShuffle %v2uint [[low4]] [[high4]] 1 5
+// CHECK-NEXT:      [[double2:%[0-9]+]] = OpBitcast %double [[elem2]]
+// CHECK-NEXT:  [[elem3:%[0-9]+]] = OpVectorShuffle %v2uint [[low4]] [[high4]] 2 6
+// CHECK-NEXT:      [[double3:%[0-9]+]] = OpBitcast %double [[elem3]]
+// CHECK-NEXT:  [[elem4:%[0-9]+]] = OpVectorShuffle %v2uint [[low4]] [[high4]] 3 7
+// CHECK-NEXT:      [[double4:%[0-9]+]] = OpBitcast %double [[elem4]]
+// CHECK-NEXT:   {{%[0-9]+}} = OpCompositeConstruct %v4double [[double1]] [[double2]] [[double3]] [[double4]]
+  uint4 low4, high4;
+  double4 e = asdouble(low4, high4);
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7699.

Previously, only `asdouble(uint, uint)` and `asdouble(uint2, uint2)` were supported. 

The fix is to manually extract each component and compose a  vector of doubles. 

Verified [asdouble.32.test](https://github.com/llvm/offload-test-suite/blob/main/test/Feature/HLSLLib/asdouble.32.test) is passing.