### PR TITLE
NFC: exp DXIL prereq: Improve hctdb enums and _idx maps

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1414,17 +1414,6 @@ enum class OpCodeClass : unsigned {
   NodeOutputIsValid,
   OutputComplete,
 
-  NumOpClasses_Dxil_1_0 = 93,
-  NumOpClasses_Dxil_1_1 = 95,
-  NumOpClasses_Dxil_1_2 = 97,
-  NumOpClasses_Dxil_1_3 = 118,
-  NumOpClasses_Dxil_1_4 = 120,
-  NumOpClasses_Dxil_1_5 = 143,
-  NumOpClasses_Dxil_1_6 = 149,
-  NumOpClasses_Dxil_1_7 = 153,
-  NumOpClasses_Dxil_1_8 = 174,
-  NumOpClasses_Dxil_1_9 = 196,
-
   NumOpClasses = 196 // exclusive last value of enumeration
 };
 // OPCODECLASS-ENUM:END

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -423,8 +423,6 @@ class db_enumhelp_gen:
 
     def __init__(self, db):
         self.db = db
-        # Some enums should get a last enum marker.
-        self.lastEnumNames = {"OpCode": "NumOpCodes", "OpCodeClass": "NumOpClasses"}
 
     def print_enum(self, e, **kwargs):
         print("// %s" % e.doc)
@@ -451,12 +449,11 @@ class db_enumhelp_gen:
             if v.doc:
                 line_format += " // {doc}"
             print(line_format.format(name=v.name, value=v.value, doc=v.doc))
-        if e.name in self.lastEnumNames:
-            lastName = self.lastEnumNames[e.name]
+        if e.last_value_name:
+            lastName = e.last_value_name
             versioned = [
-                "%s_Dxil_%d_%d = %d," % (lastName, major, minor, info[lastName])
-                for (major, minor), info in sorted(self.db.dxil_version_info.items())
-                if lastName in info
+                "%s_Dxil_%d_%d = %d," % (lastName, major, minor, count)
+                for (major, minor), count in sorted(e.dxil_version_info.items())
             ]
             if versioned:
                 print("")


### PR DESCRIPTION
db_dxil_enum_value constructor arg order made consistent with db_dxil_enum constructor's valNameDocTuples arg.

Move dxil_version_info into enum, as it tracks version markers for that enum. Removed version tracking for OpCodeClass because it didn't make sense and wasn't really usable (not stable, internal compiler enum). This causes a change in DxilConstants.h which removes these unused enum values.

db_dxil_enum.add_value to construct, add, and return new enum value.

Removed build_indices, adding to *_idx maps in add_enum_type and new add_inst now used by add_dxil_op and related functions. They show up in the index immediately, without having to call build_indices() to update multiple times during initialization.