### PR TITLE
NFC: exp DXIL prereq: abstract certain methods in populate_dxil_operations

### DIFF
--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1413,6 +1413,9 @@ class db_dxil(object):
         )
 
     def populate_dxil_operations(self):
+        add_dxil_op = self.add_dxil_op
+        reserve_dxil_op_range = self.reserve_dxil_op_range
+        set_op_count_for_version = self.set_op_count_for_version
         # $o in a parameter type means the overload type
         # $r in a parameter type means the resource type
         # $cb in a parameter type means cbuffer legacy load return type
@@ -1420,7 +1423,7 @@ class db_dxil(object):
         # overload types are a string of (v)oid, (h)alf, (f)loat, (d)ouble, (1)-bit, (8)-bit, (w)ord, (i)nt, (l)ong
         self.opcode_param = db_dxil_param(1, "i32", "opcode", "DXIL opcode")
         retvoid_param = db_dxil_param(0, "v", "", "no return value")
-        self.add_dxil_op(
+        add_dxil_op(
             "TempRegLoad",
             "TempRegLoad",
             "helper load operation",
@@ -1431,7 +1434,7 @@ class db_dxil(object):
                 db_dxil_param(2, "u32", "index", "linearized register index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "TempRegStore",
             "TempRegStore",
             "helper store operation",
@@ -1443,7 +1446,7 @@ class db_dxil(object):
                 db_dxil_param(3, "$o", "value", "value to store"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "MinPrecXRegLoad",
             "MinPrecXRegLoad",
             "helper load operation for minprecision",
@@ -1456,7 +1459,7 @@ class db_dxil(object):
                 db_dxil_param(4, "u8", "component", "component"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "MinPrecXRegStore",
             "MinPrecXRegStore",
             "helper store operation for minprecision",
@@ -1470,7 +1473,7 @@ class db_dxil(object):
                 db_dxil_param(5, "$o", "value", "value to store"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "LoadInput",
             "LoadInput",
             "loads the value from shader input",
@@ -1485,7 +1488,7 @@ class db_dxil(object):
             ],
             counters=("sig_ld",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "StoreOutput",
             "StoreOutput",
             "stores the value to shader output",
@@ -1515,7 +1518,7 @@ class db_dxil(object):
 
         # Unary float operations are regular.
         for i in "FAbs,Saturate".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Unary",
                 "returns the " + i,
@@ -1528,7 +1531,7 @@ class db_dxil(object):
                 counters=("floats",),
             )
         for i in "IsNaN,IsInf,IsFinite,IsNormal".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "IsSpecialFloat",
                 "returns the " + i,
@@ -1545,7 +1548,7 @@ class db_dxil(object):
         ) in "Cos,Sin,Tan,Acos,Asin,Atan,Hcos,Hsin,Htan,Exp,Frc,Log,Sqrt,Rsqrt,Round_ne,Round_ni,Round_pi,Round_z".split(
             ","
         ):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Unary",
                 "returns the " + i,
@@ -1560,7 +1563,7 @@ class db_dxil(object):
 
         # Unary int operations are regular.
         for i in "Bfrev".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Unary",
                 "returns the reverse bit pattern of the input value",
@@ -1573,7 +1576,7 @@ class db_dxil(object):
                 counters=("uints",),
             )
         for i in "Countbits,FirstbitLo".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "UnaryBits",
                 "returns the " + i,
@@ -1586,7 +1589,7 @@ class db_dxil(object):
                 counters=("uints",),
             )
         for i in "FirstbitHi,FirstbitSHi".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "UnaryBits",
                 "returns src != 0? (BitWidth-1 - " + i + ") : -1",
@@ -1601,7 +1604,7 @@ class db_dxil(object):
 
         # Binary float operations
         for i in "FMax,FMin".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Binary",
                 "returns the " + i + " of the input values",
@@ -1617,7 +1620,7 @@ class db_dxil(object):
 
         # Binary int operations
         for i in "IMax,IMin,UMax,UMin".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Binary",
                 "returns the " + i + " of the input values",
@@ -1633,7 +1636,7 @@ class db_dxil(object):
 
         # Binary int operations with two outputs
         for i in "IMul,UMul,UDiv".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "BinaryWithTwoOuts",
                 "returns the " + i + " of the input values",
@@ -1649,7 +1652,7 @@ class db_dxil(object):
 
         # Binary int operations with carry
         for i in "UAddc,USubb".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "BinaryWithCarryOrBorrow",
                 "returns the " + i + " of the input values",
@@ -1666,7 +1669,7 @@ class db_dxil(object):
             )
 
         # Tertiary float.
-        self.add_dxil_op(
+        add_dxil_op(
             "FMad",
             "Tertiary",
             "performs a fused multiply add (FMA) of the form a * b + c",
@@ -1681,7 +1684,7 @@ class db_dxil(object):
                 db_dxil_param(4, "$o", "c", "third value for FMA, the addend"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "Fma",
             "Tertiary",
             "performs a fused multiply add (FMA) of the form a * b + c",
@@ -1703,7 +1706,7 @@ class db_dxil(object):
 
         # Tertiary int.
         for i in "IMad,UMad".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Tertiary",
                 "performs an integral " + i,
@@ -1722,7 +1725,7 @@ class db_dxil(object):
                 counters=(UFI(i),),
             )
         for i in "Msad,Ibfe,Ubfe".split(","):
-            self.add_dxil_op(
+            add_dxil_op(
                 i,
                 "Tertiary",
                 "performs an integral " + i,
@@ -1742,7 +1745,7 @@ class db_dxil(object):
             )
 
         # Quaternary
-        self.add_dxil_op(
+        add_dxil_op(
             "Bfi",
             "Quaternary",
             "given a bit range from the LSB of a number, places that number of bits in another number at any offset",
@@ -1765,7 +1768,7 @@ class db_dxil(object):
         )
 
         # Dot
-        self.add_dxil_op(
+        add_dxil_op(
             "Dot2",
             "Dot2",
             "two-dimensional vector dot-product",
@@ -1786,7 +1789,7 @@ class db_dxil(object):
             ],
             counters=("floats",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "Dot3",
             "Dot3",
             "three-dimensional vector dot-product",
@@ -1811,7 +1814,7 @@ class db_dxil(object):
             ],
             counters=("floats",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "Dot4",
             "Dot4",
             "four-dimensional vector dot-product",
@@ -1844,7 +1847,7 @@ class db_dxil(object):
         )
 
         # Resources.
-        self.add_dxil_op(
+        add_dxil_op(
             "CreateHandle",
             "CreateHandle",
             "creates the handle to a resource",
@@ -1872,7 +1875,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "CBufferLoad",
             "CBufferLoad",
             "loads a value from a constant buffer resource",
@@ -1889,7 +1892,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "CBufferLoadLegacy",
             "CBufferLoadLegacy",
             "loads a value from a constant buffer resource",
@@ -1905,7 +1908,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "Sample",
             "Sample",
             "samples a texture",
@@ -1945,7 +1948,7 @@ class db_dxil(object):
             ],
             counters=("tex_norm",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleBias",
             "SampleBias",
             "samples a texture after applying the input bias to the mipmap level",
@@ -1986,7 +1989,7 @@ class db_dxil(object):
             ],
             counters=("tex_bias",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleLevel",
             "SampleLevel",
             "samples a texture using a mipmap-level offset",
@@ -2031,7 +2034,7 @@ class db_dxil(object):
             ],
             counters=("tex_norm",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleGrad",
             "SampleGrad",
             "samples a texture using a gradient to influence the way the sample location is calculated",
@@ -2107,7 +2110,7 @@ class db_dxil(object):
             ],
             counters=("tex_grad",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleCmp",
             "SampleCmp",
             "samples a texture and compares a single component against the specified comparison value",
@@ -2150,7 +2153,7 @@ class db_dxil(object):
             ],
             counters=("tex_cmp",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleCmpLevelZero",
             "SampleCmpLevelZero",
             "samples a texture and compares a single component against the specified comparison value",
@@ -2192,7 +2195,7 @@ class db_dxil(object):
             ],
             counters=("tex_cmp",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "TextureLoad",
             "TextureLoad",
             "reads texel data without any filtering or sampling",
@@ -2216,7 +2219,7 @@ class db_dxil(object):
             ],
             counters=("tex_load",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "TextureStore",
             "TextureStore",
             "reads texel data without any filtering or sampling",
@@ -2236,7 +2239,7 @@ class db_dxil(object):
             ],
             counters=("tex_store",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BufferLoad",
             "BufferLoad",
             "reads from a TypedBuffer",
@@ -2250,7 +2253,7 @@ class db_dxil(object):
             ],
             counters=("tex_load",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BufferStore",
             "BufferStore",
             "writes to a RWTypedBuffer",
@@ -2269,7 +2272,7 @@ class db_dxil(object):
             ],
             counters=("tex_store",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BufferUpdateCounter",
             "BufferUpdateCounter",
             "atomically increments/decrements the hidden 32-bit counter stored with a Count or Append UAV",
@@ -2287,7 +2290,7 @@ class db_dxil(object):
             ],
             counters=("atomic",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "CheckAccessFullyMapped",
             "CheckAccessFullyMapped",
             "determines whether all values from a Sample, Gather, or Load operation accessed mapped tiles in a tiled resource",
@@ -2308,7 +2311,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "GetDimensions",
             "GetDimensions",
             "gets texture size information",
@@ -2320,7 +2323,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "mipLevel", "mip level to query"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "TextureGather",
             "TextureGather",
             "gathers the four texels that would be used in a bi-linear filtering operation",
@@ -2357,7 +2360,7 @@ class db_dxil(object):
             ],
             counters=("tex_norm",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "TextureGatherCmp",
             "TextureGatherCmp",
             "same as TextureGather, except this instrution performs comparison on texels, similar to SampleCmp",
@@ -2396,7 +2399,7 @@ class db_dxil(object):
             counters=("tex_cmp",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "Texture2DMSGetSamplePosition",
             "Texture2DMSGetSamplePosition",
             "gets the position of the specified sample",
@@ -2408,7 +2411,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "index", "zero-based sample index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "RenderTargetGetSamplePosition",
             "RenderTargetGetSamplePosition",
             "gets the position of the specified sample",
@@ -2419,7 +2422,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "index", "zero-based sample index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "RenderTargetGetSampleCount",
             "RenderTargetGetSampleCount",
             "gets the number of samples for a render target",
@@ -2433,7 +2436,7 @@ class db_dxil(object):
         )
 
         # Atomics. Note that on TGSM, atomics are performed with LLVM instructions.
-        self.add_dxil_op(
+        add_dxil_op(
             "AtomicBinOp",
             "AtomicBinOp",
             "performs an atomic operation on two operands",
@@ -2457,7 +2460,7 @@ class db_dxil(object):
             ],
             counters=("atomic",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "AtomicCompareExchange",
             "AtomicCompareExchange",
             "atomic compare and exchange to memory",
@@ -2478,7 +2481,7 @@ class db_dxil(object):
         )
 
         # Synchronization.
-        self.add_dxil_op(
+        add_dxil_op(
             "Barrier",
             "Barrier",
             "inserts a memory barrier in the shader",
@@ -2498,7 +2501,7 @@ class db_dxil(object):
         )
 
         # Pixel shader
-        self.add_dxil_op(
+        add_dxil_op(
             "CalculateLOD",
             "CalculateLOD",
             "calculates the level of detail",
@@ -2519,7 +2522,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "Discard",
             "Discard",
             "discard the current pixel",
@@ -2532,7 +2535,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "DerivCoarseX",
             "Unary",
             "computes the rate of change of components per stamp",
@@ -2548,7 +2551,7 @@ class db_dxil(object):
                 db_dxil_param(2, "$o", "value", "input to rate of change"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "DerivCoarseY",
             "Unary",
             "computes the rate of change of components per stamp",
@@ -2564,7 +2567,7 @@ class db_dxil(object):
                 db_dxil_param(2, "$o", "value", "input to rate of change"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "DerivFineX",
             "Unary",
             "computes the rate of change of components per pixel",
@@ -2580,7 +2583,7 @@ class db_dxil(object):
                 db_dxil_param(2, "$o", "value", "input to rate of change"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "DerivFineY",
             "Unary",
             "computes the rate of change of components per pixel",
@@ -2596,7 +2599,7 @@ class db_dxil(object):
                 db_dxil_param(2, "$o", "value", "input to rate of change"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "EvalSnapped",
             "EvalSnapped",
             "evaluates an input attribute at pixel center with an offset",
@@ -2625,7 +2628,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "EvalSampleIndex",
             "EvalSampleIndex",
             "evaluates an input attribute at a sample location",
@@ -2643,7 +2646,7 @@ class db_dxil(object):
                 db_dxil_param(5, "i32", "sampleIndex", "sample location"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "EvalCentroid",
             "EvalCentroid",
             "evaluates an input attribute at pixel center",
@@ -2660,7 +2663,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleIndex",
             "SampleIndex",
             "returns the sample index in a sample-frequency pixel shader",
@@ -2668,7 +2671,7 @@ class db_dxil(object):
             "rn",
             [db_dxil_param(0, "i32", "", "result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "Coverage",
             "Coverage",
             "returns the coverage mask input in a pixel shader",
@@ -2676,7 +2679,7 @@ class db_dxil(object):
             "rn",
             [db_dxil_param(0, "i32", "", "result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "InnerCoverage",
             "InnerCoverage",
             "returns underestimated coverage input from conservative rasterization in a pixel shader",
@@ -2686,7 +2689,7 @@ class db_dxil(object):
         )
 
         # Compute shader.
-        self.add_dxil_op(
+        add_dxil_op(
             "ThreadId",
             "ThreadId",
             "reads the thread ID",
@@ -2697,7 +2700,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "component", "component to read (x,y,z)"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "GroupId",
             "GroupId",
             "reads the group ID (SV_GroupID)",
@@ -2708,7 +2711,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "component", "component to read"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "ThreadIdInGroup",
             "ThreadIdInGroup",
             "reads the thread ID within the group (SV_GroupThreadID)",
@@ -2719,7 +2722,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "component", "component to read (x,y,z)"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "FlattenedThreadIdInGroup",
             "FlattenedThreadIdInGroup",
             "provides a flattened index for a given thread within a given group (SV_GroupIndex)",
@@ -2729,7 +2732,7 @@ class db_dxil(object):
         )
 
         # Geometry shader
-        self.add_dxil_op(
+        add_dxil_op(
             "EmitStream",
             "EmitStream",
             "emits a vertex to a given stream",
@@ -2741,7 +2744,7 @@ class db_dxil(object):
             ],
             counters=("gs_emit",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "CutStream",
             "CutStream",
             "completes the current primitive topology at the specified stream",
@@ -2753,7 +2756,7 @@ class db_dxil(object):
             ],
             counters=("gs_cut",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "EmitThenCutStream",
             "EmitThenCutStream",
             "equivalent to an EmitStream followed by a CutStream",
@@ -2765,7 +2768,7 @@ class db_dxil(object):
             ],
             counters=("gs_emit", "gs_cut"),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "GSInstanceID",
             "GSInstanceID",
             "GSInstanceID",
@@ -2775,7 +2778,7 @@ class db_dxil(object):
         )
 
         # Double precision
-        self.add_dxil_op(
+        add_dxil_op(
             "MakeDouble",
             "MakeDouble",
             "creates a double value",
@@ -2787,7 +2790,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "hi", "high part of double"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "SplitDouble",
             "SplitDouble",
             "splits a double into low and high parts",
@@ -2800,7 +2803,7 @@ class db_dxil(object):
         )
 
         # Domain & Hull shader.
-        self.add_dxil_op(
+        add_dxil_op(
             "LoadOutputControlPoint",
             "LoadOutputControlPoint",
             "LoadOutputControlPoint",
@@ -2815,7 +2818,7 @@ class db_dxil(object):
             ],
             counters=("sig_ld",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "LoadPatchConstant",
             "LoadPatchConstant",
             "LoadPatchConstant",
@@ -2831,7 +2834,7 @@ class db_dxil(object):
         )
 
         # Domain shader.
-        self.add_dxil_op(
+        add_dxil_op(
             "DomainLocation",
             "DomainLocation",
             "DomainLocation",
@@ -2844,7 +2847,7 @@ class db_dxil(object):
         )
 
         # Hull shader.
-        self.add_dxil_op(
+        add_dxil_op(
             "StorePatchConstant",
             "StorePatchConstant",
             "StorePatchConstant",
@@ -2859,7 +2862,7 @@ class db_dxil(object):
             ],
             counters=("sig_st",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "OutputControlPointID",
             "OutputControlPointID",
             "OutputControlPointID",
@@ -2867,7 +2870,7 @@ class db_dxil(object):
             "rn",
             [db_dxil_param(0, "i32", "", "result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "PrimitiveID",
             "PrimitiveID",
             "PrimitiveID",
@@ -2876,7 +2879,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "CycleCounterLegacy",
             "CycleCounterLegacy",
             "CycleCounterLegacy",
@@ -2886,7 +2889,7 @@ class db_dxil(object):
         )
 
         # Add wave intrinsics.
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveIsFirstLane",
             "WaveIsFirstLane",
             "returns 1 for the first lane in the wave",
@@ -2894,7 +2897,7 @@ class db_dxil(object):
             "",
             [db_dxil_param(0, "i1", "", "operation result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveGetLaneIndex",
             "WaveGetLaneIndex",
             "returns the index of the current lane in the wave",
@@ -2902,7 +2905,7 @@ class db_dxil(object):
             "ro",
             [db_dxil_param(0, "i32", "", "operation result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveGetLaneCount",
             "WaveGetLaneCount",
             "returns the number of lanes in the wave",
@@ -2910,7 +2913,7 @@ class db_dxil(object):
             "rn",
             [db_dxil_param(0, "i32", "", "operation result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveAnyTrue",
             "WaveAnyTrue",
             "returns 1 if any of the lane evaluates the value to true",
@@ -2921,7 +2924,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i1", "cond", "condition to test"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveAllTrue",
             "WaveAllTrue",
             "returns 1 if all the lanes evaluate the value to true",
@@ -2932,7 +2935,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i1", "cond", "condition to test"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveActiveAllEqual",
             "WaveActiveAllEqual",
             "returns 1 if all the lanes have the same value",
@@ -2943,7 +2946,7 @@ class db_dxil(object):
                 db_dxil_param(2, "$o", "value", "value to compare"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveActiveBallot",
             "WaveActiveBallot",
             "returns a struct with a bit set for each lane where the condition is true",
@@ -2954,7 +2957,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i1", "cond", "condition to ballot on"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveReadLaneAt",
             "WaveReadLaneAt",
             "returns the value from the specified lane",
@@ -2966,7 +2969,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "lane", "lane index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveReadLaneFirst",
             "WaveReadLaneFirst",
             "returns the value from the first lane",
@@ -2977,7 +2980,7 @@ class db_dxil(object):
                 db_dxil_param(2, "$o", "value", "value to read"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveActiveOp",
             "WaveActiveOp",
             "returns the result the operation across waves",
@@ -3022,7 +3025,7 @@ class db_dxil(object):
                 (3, "Max", "maximum value"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveActiveBit",
             "WaveActiveBit",
             "returns the result of the operation across all lanes",
@@ -3050,7 +3053,7 @@ class db_dxil(object):
                 (2, "Xor", "bitwise xor of values"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WavePrefixOp",
             "WavePrefixOp",
             "returns the result of the operation on prior lanes",
@@ -3077,7 +3080,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "QuadReadLaneAt",
             "QuadReadLaneAt",
             "reads from a lane in the quad",
@@ -3112,7 +3115,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "QuadOp",
             "QuadOp",
             "returns the result of a quad-level operation",
@@ -3128,7 +3131,7 @@ class db_dxil(object):
         )
 
         # Add bitcasts
-        self.add_dxil_op(
+        add_dxil_op(
             "BitcastI16toF16",
             "BitcastI16toF16",
             "bitcast between different sizes",
@@ -3139,7 +3142,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i16", "value", "input value"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BitcastF16toI16",
             "BitcastF16toI16",
             "bitcast between different sizes",
@@ -3150,7 +3153,7 @@ class db_dxil(object):
                 db_dxil_param(2, "h", "value", "input value"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BitcastI32toF32",
             "BitcastI32toF32",
             "bitcast between different sizes",
@@ -3161,7 +3164,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "value", "input value"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BitcastF32toI32",
             "BitcastF32toI32",
             "bitcast between different sizes",
@@ -3172,7 +3175,7 @@ class db_dxil(object):
                 db_dxil_param(2, "f", "value", "input value"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BitcastI64toF64",
             "BitcastI64toF64",
             "bitcast between different sizes",
@@ -3183,7 +3186,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i64", "value", "input value"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BitcastF64toI64",
             "BitcastF64toI64",
             "bitcast between different sizes",
@@ -3195,7 +3198,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "LegacyF32ToF16",
             "LegacyF32ToF16",
             "legacy fuction to convert float (f32) to half (f16) (this is not related to min-precision)",
@@ -3209,7 +3212,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "LegacyF16ToF32",
             "LegacyF16ToF32",
             "legacy fuction to convert half (f16) to float (f32) (this is not related to min-precision)",
@@ -3221,7 +3224,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "LegacyDoubleToFloat",
             "LegacyDoubleToFloat",
             "legacy fuction to convert double to float",
@@ -3233,7 +3236,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "LegacyDoubleToSInt32",
             "LegacyDoubleToSInt32",
             "legacy fuction to convert double to int32",
@@ -3245,7 +3248,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "LegacyDoubleToUInt32",
             "LegacyDoubleToUInt32",
             "legacy fuction to convert double to uint32",
@@ -3257,7 +3260,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveAllBitCount",
             "WaveAllOp",
             "returns the count of bits set to 1 across the wave",
@@ -3271,7 +3274,7 @@ class db_dxil(object):
         # WavePrefixBitCount has different signature compare to WavePrefixOp, set its opclass to WavePrefixOp is not correct.
         # It works now because WavePrefixOp and WavePrefixBitCount don't interfere on overload types.
         # Keep it unchanged for back-compat.
-        self.add_dxil_op(
+        add_dxil_op(
             "WavePrefixBitCount",
             "WavePrefixOp",
             "returns the count of bits set to 1 on prior lanes",
@@ -3284,9 +3287,9 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.0 opcodes.
-        self.set_op_count_for_version(1, 0)
+        set_op_count_for_version(1, 0)
 
-        self.add_dxil_op(
+        add_dxil_op(
             "AttributeAtVertex",
             "AttributeAtVertex",
             "returns the values of the attributes at the vertex.",
@@ -3304,7 +3307,7 @@ class db_dxil(object):
                 db_dxil_param(5, "i8", "VertexID", "Vertex Index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "ViewID",
             "ViewID",
             "returns the view index",
@@ -3314,9 +3317,9 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.1 opcodes.
-        self.set_op_count_for_version(1, 1)
+        set_op_count_for_version(1, 1)
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RawBufferLoad",
             "RawBufferLoad",
             "reads from a raw buffer and structured buffer",
@@ -3349,7 +3352,7 @@ class db_dxil(object):
             counters=("tex_load",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RawBufferStore",
             "RawBufferStore",
             "writes to a RWByteAddressBuffer or RWStructuredBuffer",
@@ -3393,13 +3396,13 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.2 opcodes.
-        op_count = self.set_op_count_for_version(1, 2)
+        op_count = set_op_count_for_version(1, 2)
         assert op_count == 141, (
             "next operation index is %d rather than 141 and thus opcodes are broken"
             % op_count
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "InstanceID",
             "InstanceID",
             "The user-provided InstanceID on the bottom-level acceleration structure instance within the top-level structure",
@@ -3408,7 +3411,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "InstanceIndex",
             "InstanceIndex",
             "The autogenerated index of the current instance in the top-level structure",
@@ -3417,7 +3420,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitKind",
             "HitKind",
             "Returns the value passed as HitKind in ReportIntersection().  If intersection was reported by fixed-function triangle intersection, HitKind will be one of HIT_KIND_TRIANGLE_FRONT_FACE or HIT_KIND_TRIANGLE_BACK_FACE.",
@@ -3426,7 +3429,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayFlags",
             "RayFlags",
             "uint containing the current ray flags.",
@@ -3435,7 +3438,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "DispatchRaysIndex",
             "DispatchRaysIndex",
             "The current x and y location within the Width and Height",
@@ -3447,7 +3450,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "DispatchRaysDimensions",
             "DispatchRaysDimensions",
             "The Width and Height values from the D3D12_DISPATCH_RAYS_DESC structure provided to the originating DispatchRays() call.",
@@ -3459,7 +3462,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WorldRayOrigin",
             "WorldRayOrigin",
             "The world-space origin for the current ray.",
@@ -3471,7 +3474,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WorldRayDirection",
             "WorldRayDirection",
             "The world-space direction for the current ray.",
@@ -3483,7 +3486,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "ObjectRayOrigin",
             "ObjectRayOrigin",
             "Object-space origin for the current ray.",
@@ -3495,7 +3498,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "ObjectRayDirection",
             "ObjectRayDirection",
             "Object-space direction for the current ray.",
@@ -3507,7 +3510,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "ObjectToWorld",
             "ObjectToWorld",
             "Matrix for transforming from object-space to world-space.",
@@ -3520,7 +3523,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WorldToObject",
             "WorldToObject",
             "Matrix for transforming from world-space to object-space.",
@@ -3533,7 +3536,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayTMin",
             "RayTMin",
             "float representing the parametric starting point for the ray.",
@@ -3542,7 +3545,7 @@ class db_dxil(object):
             [db_dxil_param(0, "f", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayTCurrent",
             "RayTCurrent",
             "float representing the current parametric ending point for the ray",
@@ -3551,7 +3554,7 @@ class db_dxil(object):
             [db_dxil_param(0, "f", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "IgnoreHit",
             "IgnoreHit",
             "Used in an any hit shader to reject an intersection and terminate the shader",
@@ -3560,7 +3563,7 @@ class db_dxil(object):
             [db_dxil_param(0, "v", "", "")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "AcceptHitAndEndSearch",
             "AcceptHitAndEndSearch",
             "Used in an any hit shader to abort the ray query and the intersection shader (if any). The current hit is committed and execution passes to the closest hit shader with the closest hit recorded so far",
@@ -3569,7 +3572,7 @@ class db_dxil(object):
             [db_dxil_param(0, "v", "", "")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "TraceRay",
             "TraceRay",
             "initiates raytrace",
@@ -3625,7 +3628,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "ReportHit",
             "ReportHit",
             "returns true if hit was accepted",
@@ -3651,7 +3654,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "CallShader",
             "CallShader",
             "Call a shader in the callable shader table supplied through the DispatchRays() API",
@@ -3674,7 +3677,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "CreateHandleForLib",
             "CreateHandleForLib",
             "create resource handle from resource struct for library",
@@ -3687,7 +3690,7 @@ class db_dxil(object):
         )
 
         # Maps to PrimitiveIndex() intrinsics for raytracing (same meaning as PrimitiveID)
-        self.add_dxil_op(
+        add_dxil_op(
             "PrimitiveIndex",
             "PrimitiveIndex",
             "PrimitiveIndex for raytracing shaders",
@@ -3697,13 +3700,13 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.3 opcodes.
-        op_count = self.set_op_count_for_version(1, 3)
+        op_count = set_op_count_for_version(1, 3)
         assert op_count == 162, (
             "next operation index is %d rather than 162 and thus opcodes are broken"
             % op_count
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "Dot2AddHalf",
             "Dot2AddHalf",
             "2D half dot product with accumulate to float",
@@ -3722,7 +3725,7 @@ class db_dxil(object):
             counters=("floats",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "Dot4AddI8Packed",
             "Dot4AddPacked",
             "signed dot product of 4 x i8 vectors packed into i32, with accumulate to i32",
@@ -3737,7 +3740,7 @@ class db_dxil(object):
             counters=("ints",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "Dot4AddU8Packed",
             "Dot4AddPacked",
             "unsigned dot product of 4 x u8 vectors packed into i32, with accumulate to i32",
@@ -3753,13 +3756,13 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.4 opcodes.
-        op_count = self.set_op_count_for_version(1, 4)
+        op_count = set_op_count_for_version(1, 4)
         assert op_count == 165, (
             "next operation index is %d rather than 165 and thus opcodes are broken"
             % op_count
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveMatch",
             "WaveMatch",
             "returns the bitmask of active lanes that have the same value",
@@ -3771,7 +3774,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveMultiPrefixOp",
             "WaveMultiPrefixOp",
             "returns the result of the operation on groups of lanes identified by a bitmask",
@@ -3814,7 +3817,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "WaveMultiPrefixBitCount",
             "WaveMultiPrefixBitCount",
             "returns the count of bits set to 1 on groups of lanes identified by a bitmask",
@@ -3831,7 +3834,7 @@ class db_dxil(object):
         )
 
         # Mesh Shader
-        self.add_dxil_op(
+        add_dxil_op(
             "SetMeshOutputCounts",
             "SetMeshOutputCounts",
             "Mesh shader intrinsic SetMeshOutputCounts",
@@ -3843,7 +3846,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "numPrimitives", "number of output primitives"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "EmitIndices",
             "EmitIndices",
             "emit a primitive's vertex indices in a mesh shader",
@@ -3863,7 +3866,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "GetMeshPayload",
             "GetMeshPayload",
             "get the mesh payload which is from amplification shader",
@@ -3871,7 +3874,7 @@ class db_dxil(object):
             "ro",
             [db_dxil_param(0, "$o", "", "mesh payload result")],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "StoreVertexOutput",
             "StoreVertexOutput",
             "stores the value to mesh shader vertex output",
@@ -3889,7 +3892,7 @@ class db_dxil(object):
             ],
             counters=("sig_st",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "StorePrimitiveOutput",
             "StorePrimitiveOutput",
             "stores the value to mesh shader primitive output",
@@ -3909,7 +3912,7 @@ class db_dxil(object):
         )
 
         # Amplification Shader
-        self.add_dxil_op(
+        add_dxil_op(
             "DispatchMesh",
             "DispatchMesh",
             "Amplification shader intrinsic DispatchMesh",
@@ -3925,7 +3928,7 @@ class db_dxil(object):
         )
 
         # Sampler feedback
-        self.add_dxil_op(
+        add_dxil_op(
             "WriteSamplerFeedback",
             "WriteSamplerFeedback",
             "updates a feedback texture for a sampling operation",
@@ -3946,7 +3949,7 @@ class db_dxil(object):
             ],
             counters=("tex_store",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WriteSamplerFeedbackBias",
             "WriteSamplerFeedbackBias",
             "updates a feedback texture for a sampling operation with a bias on the mipmap level",
@@ -3968,7 +3971,7 @@ class db_dxil(object):
             ],
             counters=("tex_store",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WriteSamplerFeedbackLevel",
             "WriteSamplerFeedbackLevel",
             "updates a feedback texture for a sampling operation with a mipmap-level offset",
@@ -3989,7 +3992,7 @@ class db_dxil(object):
             ],
             counters=("tex_store",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "WriteSamplerFeedbackGrad",
             "WriteSamplerFeedbackGrad",
             "updates a feedback texture for a sampling operation with explicit gradients",
@@ -4045,7 +4048,7 @@ class db_dxil(object):
         )
 
         # RayQuery
-        self.add_dxil_op(
+        add_dxil_op(
             "AllocateRayQuery",
             "AllocateRayQuery",
             "allocates space for RayQuery and return handle",
@@ -4063,7 +4066,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_TraceRayInline",
             "RayQuery_TraceRayInline",
             "initializes RayQuery for raytrace",
@@ -4101,7 +4104,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_Proceed",
             "RayQuery_Proceed",
             "advances a ray query",
@@ -4113,7 +4116,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_Abort",
             "RayQuery_Abort",
             "aborts a ray query",
@@ -4125,7 +4128,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommitNonOpaqueTriangleHit",
             "RayQuery_CommitNonOpaqueTriangleHit",
             "commits a non opaque triangle hit",
@@ -4137,7 +4140,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommitProceduralPrimitiveHit",
             "RayQuery_CommitProceduralPrimitiveHit",
             "commits a procedural primitive hit",
@@ -4152,7 +4155,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedStatus",
             "RayQuery_StateScalar",
             "returns uint status (COMMITTED_STATUS) of the committed hit in a ray query",
@@ -4164,7 +4167,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateType",
             "RayQuery_StateScalar",
             "returns uint candidate type (CANDIDATE_TYPE) of the current hit candidate in a ray query, after Proceed() has returned true",
@@ -4176,7 +4179,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateObjectToWorld3x4",
             "RayQuery_StateMatrix",
             "returns matrix for transforming from object-space to world-space for a candidate hit.",
@@ -4190,7 +4193,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateWorldToObject3x4",
             "RayQuery_StateMatrix",
             "returns matrix for transforming from world-space to object-space for a candidate hit.",
@@ -4204,7 +4207,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedObjectToWorld3x4",
             "RayQuery_StateMatrix",
             "returns matrix for transforming from object-space to world-space for a Committed hit.",
@@ -4218,7 +4221,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedWorldToObject3x4",
             "RayQuery_StateMatrix",
             "returns matrix for transforming from world-space to object-space for a Committed hit.",
@@ -4232,7 +4235,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateProceduralPrimitiveNonOpaque",
             "RayQuery_StateScalar",
             "returns if current candidate procedural primitive is non opaque",
@@ -4244,7 +4247,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateTriangleFrontFace",
             "RayQuery_StateScalar",
             "returns if current candidate triangle is front facing",
@@ -4256,7 +4259,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedTriangleFrontFace",
             "RayQuery_StateScalar",
             "returns if current committed triangle is front facing",
@@ -4268,7 +4271,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateTriangleBarycentrics",
             "RayQuery_StateVector",
             "returns candidate triangle hit barycentrics",
@@ -4281,7 +4284,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedTriangleBarycentrics",
             "RayQuery_StateVector",
             "returns committed triangle hit barycentrics",
@@ -4294,7 +4297,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_RayFlags",
             "RayQuery_StateScalar",
             "returns ray flags",
@@ -4306,7 +4309,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_WorldRayOrigin",
             "RayQuery_StateVector",
             "returns world ray origin",
@@ -4319,7 +4322,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_WorldRayDirection",
             "RayQuery_StateVector",
             "returns world ray direction",
@@ -4332,7 +4335,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_RayTMin",
             "RayQuery_StateScalar",
             "returns float representing the parametric starting point for the ray.",
@@ -4344,7 +4347,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateTriangleRayT",
             "RayQuery_StateScalar",
             "returns float representing the parametric point on the ray for the current candidate triangle hit.",
@@ -4356,7 +4359,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedRayT",
             "RayQuery_StateScalar",
             "returns float representing the parametric point on the ray for the current committed hit.",
@@ -4368,7 +4371,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateInstanceIndex",
             "RayQuery_StateScalar",
             "returns candidate hit instance index",
@@ -4380,7 +4383,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateInstanceID",
             "RayQuery_StateScalar",
             "returns candidate hit instance ID",
@@ -4392,7 +4395,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateGeometryIndex",
             "RayQuery_StateScalar",
             "returns candidate hit geometry index",
@@ -4404,7 +4407,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidatePrimitiveIndex",
             "RayQuery_StateScalar",
             "returns candidate hit geometry index",
@@ -4416,7 +4419,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateObjectRayOrigin",
             "RayQuery_StateVector",
             "returns candidate hit object ray origin",
@@ -4429,7 +4432,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateObjectRayDirection",
             "RayQuery_StateVector",
             "returns candidate object ray direction",
@@ -4442,7 +4445,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedInstanceIndex",
             "RayQuery_StateScalar",
             "returns committed hit instance index",
@@ -4454,7 +4457,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedInstanceID",
             "RayQuery_StateScalar",
             "returns committed hit instance ID",
@@ -4466,7 +4469,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedGeometryIndex",
             "RayQuery_StateScalar",
             "returns committed hit geometry index",
@@ -4478,7 +4481,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedPrimitiveIndex",
             "RayQuery_StateScalar",
             "returns committed hit geometry index",
@@ -4490,7 +4493,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedObjectRayOrigin",
             "RayQuery_StateVector",
             "returns committed hit object ray origin",
@@ -4503,7 +4506,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedObjectRayDirection",
             "RayQuery_StateVector",
             "returns committed object ray direction",
@@ -4516,7 +4519,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "GeometryIndex",
             "GeometryIndex",
             "The autogenerated index of the current geometry in the bottom-level structure",
@@ -4525,7 +4528,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CandidateInstanceContributionToHitGroupIndex",
             "RayQuery_StateScalar",
             "returns candidate hit InstanceContributionToHitGroupIndex",
@@ -4537,7 +4540,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RayQuery_CommittedInstanceContributionToHitGroupIndex",
             "RayQuery_StateScalar",
             "returns committed hit InstanceContributionToHitGroupIndex",
@@ -4550,13 +4553,13 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.5 opcodes.
-        op_count = self.set_op_count_for_version(1, 5)
+        op_count = set_op_count_for_version(1, 5)
         assert op_count == 216, (
             "216 is expected next operation index but encountered %d and thus opcodes are broken"
             % op_count
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "AnnotateHandle",
             "AnnotateHandle",
             "annotate handle with resource properties",
@@ -4575,7 +4578,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "CreateHandleFromBinding",
             "CreateHandleFromBinding",
             "create resource handle from binding",
@@ -4597,7 +4600,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "CreateHandleFromHeap",
             "CreateHandleFromHeap",
             "create resource handle from heap",
@@ -4623,7 +4626,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "Unpack4x8",
             "Unpack4x8",
             "unpacks 4 8-bit signed or unsigned values into int32 or int16 vector",
@@ -4636,7 +4639,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "Pack4x8",
             "Pack4x8",
             "packs vector of 4 signed or unsigned values into a packed datatype, drops or clamps unused bits",
@@ -4652,7 +4655,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "IsHelperLane",
             "IsHelperLane",
             "returns true on helper lanes in pixel shaders",
@@ -4662,7 +4665,7 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.6 opcodes.
-        op_count = self.set_op_count_for_version(1, 6)
+        op_count = set_op_count_for_version(1, 6)
         assert op_count == 222, (
             "222 is expected next operation index but encountered %d and thus opcodes are broken"
             % op_count
@@ -4676,7 +4679,7 @@ class db_dxil(object):
                 (1, "All", "true if all conditions are true in this quad"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "QuadVote",
             "QuadVote",
             "compares boolean accross a quad",
@@ -4696,7 +4699,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "TextureGatherRaw",
             "TextureGatherRaw",
             "Gather raw elements from 4 texels with no type conversions (SRV type is constrained)",
@@ -4735,7 +4738,7 @@ class db_dxil(object):
             counters=("tex_norm",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleCmpLevel",
             "SampleCmpLevel",
             "samples a texture and compares a single component against the specified comparison value",
@@ -4782,7 +4785,7 @@ class db_dxil(object):
             counters=("tex_cmp",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "TextureStoreSample",
             "TextureStoreSample",
             "stores texel data at specified sample index",
@@ -4807,17 +4810,17 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.7 opcodes.
-        op_count = self.set_op_count_for_version(1, 7)
+        op_count = set_op_count_for_version(1, 7)
         assert op_count == 226, (
             "226 is expected next operation index but encountered %d and thus opcodes are broken"
             % op_count
         )
 
         # Reserved ops
-        self.reserve_dxil_op_range("Reserved", 12)
+        reserve_dxil_op_range("Reserved", 12)
 
         # Work Graph
-        self.add_dxil_op(
+        add_dxil_op(
             "AllocateNodeOutputRecords",
             "AllocateNodeOutputRecords",
             "returns a handle for the output records",
@@ -4831,7 +4834,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "GetNodeRecordPtr",
             "GetNodeRecordPtr",
             "retrieve node input/output record pointer in address space 6",
@@ -4845,7 +4848,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "arrayIndex", "array index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "IncrementOutputCount",
             "IncrementOutputCount",
             "Select the next logical output count for an EmptyNodeOutput for the whole group or per thread.",
@@ -4860,7 +4863,7 @@ class db_dxil(object):
                 db_dxil_param(4, "i1", "perThread", "perThread flag", is_const=True),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "OutputComplete",
             "OutputComplete",
             "indicates all outputs for a given records are complete",
@@ -4871,7 +4874,7 @@ class db_dxil(object):
                 db_dxil_param(2, "noderecordhandle", "output", "handle of record"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "GetInputRecordCount",
             "GetInputRecordCount",
             "returns the number of records that have been coalesced into the current thread group",
@@ -4882,7 +4885,7 @@ class db_dxil(object):
                 db_dxil_param(2, "noderecordhandle", "input", "handle of input record"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "FinishedCrossGroupSharing",
             "FinishedCrossGroupSharing",
             "returns true if the current thread group is the last to access the input",
@@ -4898,7 +4901,7 @@ class db_dxil(object):
                 db_dxil_param(2, "noderecordhandle", "input", "handle of input record"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BarrierByMemoryType",
             "BarrierByMemoryType",
             "Request a barrier for a set of memory types and/or thread group execution sync",
@@ -4915,7 +4918,7 @@ class db_dxil(object):
             ],
             counters=("barrier",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BarrierByMemoryHandle",
             "BarrierByMemoryHandle",
             "Request a barrier for just the memory used by the specified object",
@@ -4930,7 +4933,7 @@ class db_dxil(object):
             ],
             counters=("barrier",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "BarrierByNodeRecordHandle",
             "BarrierByNodeRecordHandle",
             "Request a barrier for just the memory used by the node record",
@@ -4945,7 +4948,7 @@ class db_dxil(object):
             ],
             counters=("barrier",),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "CreateNodeOutputHandle",
             "createNodeOutputHandle",
             "Creates a handle to a NodeOutput",
@@ -4956,7 +4959,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "MetadataIdx", "metadata index", is_const=True),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "IndexNodeHandle",
             "IndexNodeHandle",
             "returns the handle for the location in the output node array at the indicated index",
@@ -4973,7 +4976,7 @@ class db_dxil(object):
                 db_dxil_param(3, "i32", "ArrayIndex", "array index"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "AnnotateNodeHandle",
             "AnnotateNodeHandle",
             "annotate handle with node properties",
@@ -4991,7 +4994,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "CreateNodeInputRecordHandle",
             "CreateNodeInputRecordHandle",
             "create a handle for an InputRecord",
@@ -5002,7 +5005,7 @@ class db_dxil(object):
                 db_dxil_param(2, "i32", "MetadataIdx", "metadata index", is_const=True),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "AnnotateNodeRecordHandle",
             "AnnotateNodeRecordHandle",
             "annotate handle with node record properties",
@@ -5024,7 +5027,7 @@ class db_dxil(object):
                 ),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "NodeOutputIsValid",
             "NodeOutputIsValid",
             "returns true if the specified output node is present in the work graph",
@@ -5035,7 +5038,7 @@ class db_dxil(object):
                 db_dxil_param(2, "nodehandle", "output", "handle of output node"),
             ],
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "GetRemainingRecursionLevels",
             "GetRemainingRecursionLevels",
             "returns how many levels of recursion remain",
@@ -5045,7 +5048,7 @@ class db_dxil(object):
         )
 
         # Comparison Sampling
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleCmpGrad",
             "SampleCmpGrad",
             "samples a texture using a gradient and compares a single component against the specified comparison value",
@@ -5123,7 +5126,7 @@ class db_dxil(object):
             counters=("tex_cmp",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "SampleCmpBias",
             "SampleCmpBias",
             "samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value",
@@ -5166,7 +5169,7 @@ class db_dxil(object):
             counters=("tex_cmp",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "StartVertexLocation",
             "StartVertexLocation",
             "returns the BaseVertexLocation from DrawIndexedInstanced or StartVertexLocation from DrawInstanced",
@@ -5175,7 +5178,7 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "StartInstanceLocation",
             "StartInstanceLocation",
             "returns the StartInstanceLocation from Draw*Instanced",
@@ -5185,14 +5188,14 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.8 opcodes.
-        op_count = self.set_op_count_for_version(1, 8)
+        op_count = set_op_count_for_version(1, 8)
         assert op_count == 258, (
             "258 is expected next operation index but encountered %d and thus opcodes are broken"
             % op_count
         )
 
         # RayQuery
-        self.add_dxil_op(
+        add_dxil_op(
             "AllocateRayQuery2",
             "AllocateRayQuery2",
             "allocates space for RayQuery and return handle",
@@ -5218,10 +5221,10 @@ class db_dxil(object):
         )
 
         # Reserved block A
-        self.reserve_dxil_op_range("ReservedA", 3)
+        reserve_dxil_op_range("ReservedA", 3)
 
         # Shader Execution Reordering
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_TraceRay",
             "HitObject_TraceRay",
             "Analogous to TraceRay but without invoking CH/MS and returns the intermediate state as a HitObject",
@@ -5282,7 +5285,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_FromRayQuery",
             "HitObject_FromRayQuery",
             "Creates a new HitObject representing a committed hit from a RayQuery",
@@ -5296,7 +5299,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_FromRayQueryWithAttrs",
             "HitObject_FromRayQueryWithAttrs",
             "Creates a new HitObject representing a committed hit from a RayQuery and committed attributes",
@@ -5317,7 +5320,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_MakeMiss",
             "HitObject_MakeMiss",
             "Creates a new HitObject representing a miss",
@@ -5338,7 +5341,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_MakeNop",
             "HitObject_MakeNop",
             "Creates an empty nop HitObject",
@@ -5347,7 +5350,7 @@ class db_dxil(object):
             [db_dxil_param(0, "hit_object", "", "Empty nop HitObject")],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_Invoke",
             "HitObject_Invoke",
             "Represents the invocation of the CH/MS shader represented by the HitObject",
@@ -5365,7 +5368,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "MaybeReorderThread",
             "MaybeReorderThread",
             "Reorders the current thread",
@@ -5384,7 +5387,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_IsMiss",
             "HitObject_StateScalar",
             "Returns `true` if the HitObject represents a miss",
@@ -5396,7 +5399,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_IsHit",
             "HitObject_StateScalar",
             "Returns `true` if the HitObject is a NOP-HitObject",
@@ -5408,7 +5411,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_IsNop",
             "HitObject_StateScalar",
             "Returns `true` if the HitObject represents a nop",
@@ -5420,7 +5423,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_RayFlags",
             "HitObject_StateScalar",
             "Returns the ray flags set in the HitObject",
@@ -5432,7 +5435,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_RayTMin",
             "HitObject_StateScalar",
             "Returns the TMin value set in the HitObject",
@@ -5444,7 +5447,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_RayTCurrent",
             "HitObject_StateScalar",
             "Returns the current T value set in the HitObject",
@@ -5456,7 +5459,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_WorldRayOrigin",
             "HitObject_StateVector",
             "Returns the ray origin in world space",
@@ -5469,7 +5472,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_WorldRayDirection",
             "HitObject_StateVector",
             "Returns the ray direction in world space",
@@ -5482,7 +5485,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_ObjectRayOrigin",
             "HitObject_StateVector",
             "Returns the ray origin in object space",
@@ -5495,7 +5498,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_ObjectRayDirection",
             "HitObject_StateVector",
             "Returns the ray direction in object space",
@@ -5508,7 +5511,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_ObjectToWorld3x4",
             "HitObject_StateMatrix",
             "Returns the object to world space transformation matrix in 3x4 form",
@@ -5534,7 +5537,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_WorldToObject3x4",
             "HitObject_StateMatrix",
             "Returns the world to object space transformation matrix in 3x4 form",
@@ -5560,7 +5563,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_GeometryIndex",
             "HitObject_StateScalar",
             "Returns the geometry index committed on hit",
@@ -5572,7 +5575,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_InstanceIndex",
             "HitObject_StateScalar",
             "Returns the instance index committed on hit",
@@ -5584,7 +5587,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_InstanceID",
             "HitObject_StateScalar",
             "Returns the instance id committed on hit",
@@ -5596,7 +5599,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_PrimitiveIndex",
             "HitObject_StateScalar",
             "Returns the primitive index committed on hit",
@@ -5608,7 +5611,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_HitKind",
             "HitObject_StateScalar",
             "Returns the HitKind of the hit",
@@ -5620,7 +5623,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_ShaderTableIndex",
             "HitObject_StateScalar",
             "Returns the shader table index set for this HitObject",
@@ -5632,7 +5635,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_SetShaderTableIndex",
             "HitObject_SetShaderTableIndex",
             "Returns a HitObject with updated shader table index",
@@ -5647,7 +5650,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_LoadLocalRootTableConstant",
             "HitObject_LoadLocalRootTableConstant",
             "Returns the root table constant for this HitObject and offset",
@@ -5660,7 +5663,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "HitObject_Attributes",
             "HitObject_Attributes",
             "Returns the attributes set for this HitObject",
@@ -5675,13 +5678,13 @@ class db_dxil(object):
             ],
         )
 
-        self.reserve_dxil_op_range("ReservedB", 3, 28)
+        reserve_dxil_op_range("ReservedB", 3, 28)
 
         # Reserved block C
-        self.reserve_dxil_op_range("ReservedC", 10)
+        reserve_dxil_op_range("ReservedC", 10)
 
         # Long Vectors
-        self.add_dxil_op(
+        add_dxil_op(
             "RawBufferVectorLoad",
             "RawBufferVectorLoad",
             "reads from a raw buffer and structured buffer",
@@ -5713,7 +5716,7 @@ class db_dxil(object):
             counters=("tex_load",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "RawBufferVectorStore",
             "RawBufferVectorStore",
             "writes to a RWByteAddressBuffer or RWStructuredBuffer",
@@ -5746,7 +5749,7 @@ class db_dxil(object):
             counters=("tex_store",),
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "MatVecMul",
             "MatVecMul",
             "Multiplies a MxK dimension matrix and a K sized input vector",
@@ -5769,7 +5772,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "MatVecMulAdd",
             "MatVecMulAdd",
             "multiplies a MxK dimension matrix and a K sized input vector and adds an M-sized bias vector",
@@ -5797,7 +5800,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "OuterProductAccumulate",
             "OuterProductAccumulate",
             "Computes the outer product between column vectors and an MxN matrix is accumulated component-wise atomically (with device scope) in memory",
@@ -5821,7 +5824,7 @@ class db_dxil(object):
             ],
         )
 
-        self.add_dxil_op(
+        add_dxil_op(
             "VectorAccumulate",
             "VectorAccumulate",
             "Accumulates the components of a vector component-wise atomically (with device scope) to the corresponding elements of an array in memory",
@@ -5836,7 +5839,7 @@ class db_dxil(object):
         )
 
         # Long Vector Reduction
-        self.add_dxil_op(
+        add_dxil_op(
             "VectorReduceAnd",
             "VectorReduce",
             "Bitwise AND reduction of the vector returning a scalar",
@@ -5851,7 +5854,7 @@ class db_dxil(object):
                 "uints",
             ),
         )
-        self.add_dxil_op(
+        add_dxil_op(
             "VectorReduceOr",
             "VectorReduce",
             "Bitwise OR reduction of the vector returning a scalar",
@@ -5868,7 +5871,7 @@ class db_dxil(object):
         )
 
         # Long Vector Dot
-        self.add_dxil_op(
+        add_dxil_op(
             "FDot",
             "Dot",
             "computes the n-dimensional vector dot-product",
@@ -5883,7 +5886,7 @@ class db_dxil(object):
         )
 
         # End of DXIL 1.9 opcodes.
-        op_count = self.set_op_count_for_version(1, 9)
+        op_count = set_op_count_for_version(1, 9)
         assert op_count == 312, (
             "312 is expected next operation index but encountered %d and thus opcodes are broken"
             % op_count


### PR DESCRIPTION
Inside populate_dxil_operations, use local assigned add_dxil_op, reserve_dxil_op_range, and set_op_count_for_version for initial NFC change, which will minimize changes when moving to DXIL opcode tables.