### PR TITLE
[SPIR-V][NFC] Add const to many FeatureManager fns

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -92,7 +92,7 @@ public:
   const char *getExtensionName(Extension symbol);
 
   /// Returns true if the given extension is a KHR extension.
-  bool isKHRExtension(llvm::StringRef name);
+  bool isKHRExtension(llvm::StringRef name) const;
 
   /// Returns the names of all known extensions as a string.
   std::string getKnownExtensions(const char *delimiter, const char *prefix = "",
@@ -110,33 +110,33 @@ public:
 
   /// Returns true if the given extension is not part of the core of the target
   /// environment.
-  bool isExtensionRequiredForTargetEnv(Extension);
+  bool isExtensionRequiredForTargetEnv(Extension) const;
 
   /// Returns true if the given extension is set in allowedExtensions
-  bool isExtensionEnabled(Extension);
+  bool isExtensionEnabled(Extension) const;
 
   /// Returns true if the target environment is Vulkan 1.1 or above.
   /// Returns false otherwise.
-  bool isTargetEnvVulkan1p1OrAbove();
+  bool isTargetEnvVulkan1p1OrAbove() const;
 
   /// Returns true if the target environment is SPIR-V 1.4 or above.
   /// Returns false otherwise.
-  bool isTargetEnvSpirv1p4OrAbove();
+  bool isTargetEnvSpirv1p4OrAbove() const;
 
   /// Returns true if the target environment is Vulkan 1.1 with SPIR-V 1.4 or
   /// above. Returns false otherwise.
-  bool isTargetEnvVulkan1p1Spirv1p4OrAbove();
+  bool isTargetEnvVulkan1p1Spirv1p4OrAbove() const;
 
   /// Returns true if the target environment is Vulkan 1.2 or above.
   /// Returns false otherwise.
-  bool isTargetEnvVulkan1p2OrAbove();
+  bool isTargetEnvVulkan1p2OrAbove() const;
 
   /// Returns true if the target environment is Vulkan 1.3 or above.
   /// Returns false otherwise.
-  bool isTargetEnvVulkan1p3OrAbove();
+  bool isTargetEnvVulkan1p3OrAbove() const;
 
   /// Return true if the target environment is a Vulkan environment.
-  bool isTargetEnvVulkan();
+  bool isTargetEnvVulkan() const;
 
   /// Returns the spv_target_env matching the input string if possible.
   /// This functions matches the spv_target_env with the command-line version

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -309,7 +309,7 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
   return "<unknown extension>";
 }
 
-bool FeatureManager::isKHRExtension(llvm::StringRef name) {
+bool FeatureManager::isKHRExtension(llvm::StringRef name) const {
   return name.startswith_lower("spv_khr_");
 }
 
@@ -332,7 +332,7 @@ std::string FeatureManager::getKnownExtensions(const char *delimiter,
   return oss.str();
 }
 
-bool FeatureManager::isExtensionRequiredForTargetEnv(Extension ext) {
+bool FeatureManager::isExtensionRequiredForTargetEnv(Extension ext) const {
   bool required = true;
   if (targetEnv >= SPV_ENV_VULKAN_1_3) {
     // The following extensions are incorporated into Vulkan 1.3 or above, and
@@ -367,7 +367,7 @@ bool FeatureManager::isExtensionRequiredForTargetEnv(Extension ext) {
   return required;
 }
 
-bool FeatureManager::isExtensionEnabled(Extension ext) {
+bool FeatureManager::isExtensionEnabled(Extension ext) const {
   bool allowed = false;
   if (ext != Extension::Unknown &&
       allowedExtensions.test(static_cast<unsigned>(ext)))
@@ -399,27 +399,27 @@ bool FeatureManager::enabledByDefault(Extension ext) {
   }
 }
 
-bool FeatureManager::isTargetEnvVulkan1p1OrAbove() {
+bool FeatureManager::isTargetEnvVulkan1p1OrAbove() const {
   return targetEnv >= SPV_ENV_VULKAN_1_1;
 }
 
-bool FeatureManager::isTargetEnvSpirv1p4OrAbove() {
+bool FeatureManager::isTargetEnvSpirv1p4OrAbove() const {
   return targetEnv >= SPV_ENV_UNIVERSAL_1_4;
 }
 
-bool FeatureManager::isTargetEnvVulkan1p1Spirv1p4OrAbove() {
+bool FeatureManager::isTargetEnvVulkan1p1Spirv1p4OrAbove() const {
   return targetEnv >= SPV_ENV_VULKAN_1_1_SPIRV_1_4;
 }
 
-bool FeatureManager::isTargetEnvVulkan1p2OrAbove() {
+bool FeatureManager::isTargetEnvVulkan1p2OrAbove() const {
   return targetEnv >= SPV_ENV_VULKAN_1_2;
 }
 
-bool FeatureManager::isTargetEnvVulkan1p3OrAbove() {
+bool FeatureManager::isTargetEnvVulkan1p3OrAbove() const {
   return targetEnv >= SPV_ENV_VULKAN_1_3;
 }
 
-bool FeatureManager::isTargetEnvVulkan() {
+bool FeatureManager::isTargetEnvVulkan() const {
   // This assert ensure that this list will be updated, if necessary, when
   // a new target environment is added.
   static_assert(SPV_ENV_VULKAN_1_4 + 1 == SPV_ENV_MAX);


### PR DESCRIPTION
Many feature manager functions are const getters, and should be marked as such allowing using FeatureManager as const ref.