### PR TITLE
Execution Tests: Clean up - Factor out createWARPDevice and createHardwareDevice

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -83,7 +83,7 @@ static void createWarpDevice(
         CreateDeviceFn,
     ID3D12Device **D3DDevice, bool SkipUnsupported) {
 
-   if (*D3DDevice)
+  if (*D3DDevice)
     LogWarningFmt(L"createDevice called with non-null *D3DDevice - "
                   L"this will likely leak the previous device");
   *D3DDevice = nullptr;
@@ -152,7 +152,7 @@ static void createHardwareDevice(
         CreateDeviceFn,
     ID3D12Device **D3DDevice) {
 
-   if (*D3DDevice)
+  if (*D3DDevice)
     LogWarningFmt(L"createDevice called with non-null *D3DDevice - "
                   L"this will likely leak the previous device");
   *D3DDevice = nullptr;


### PR DESCRIPTION
This PR just cleans up the createDevice function by factoring out the logic for creating a WARP device. And I also included a suggestion from co-pilot to add a small RAII wrapper for managing the lifetime of the Warp DLL.