### PR TITLE
Ensure DXC generators use the repository’s own .clang-format during codegen

### DIFF
--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -13,6 +13,16 @@ if (NOT CLANG_FORMAT_EXE)
   endif ()
 endif ()
 
+# If an upstream folder contains a .clang-format, incorrect formatting may be
+# applied which causes the build to fail. Create a copy in the build dir
+# to ensure the right formatting is applied.
+get_filename_component(HLSL_SRC_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+get_filename_component(HLSL_BIN_ROOT "${CMAKE_CURRENT_BINARY_DIR}/../.." ABSOLUTE)
+if (EXISTS "${HLSL_SRC_ROOT}/.clang-format")
+  file(MAKE_DIRECTORY "${HLSL_BIN_ROOT}")
+  file(CREATE_LINK "${HLSL_SRC_ROOT}/.clang-format" "${HLSL_BIN_ROOT}/.clang-format" COPY_ON_ERROR)
+endif()
+
 if (WIN32 AND NOT DEFINED HLSL_AUTOCRLF)
   find_program(git_executable NAMES git git.exe git.cmd)
   execute_process(COMMAND ${git_executable} config --get core.autocrlf


### PR DESCRIPTION
clang-format can pick a parent directory’s config when formatting generated files, leading to mismatches with checked-in headers and failing compare steps. This change ensures the repository’s .clang-format is used consistently.

Generated files are written under the build tree, which may not contain a .clang-format. clang-format searches upward and can apply an unrelated config, causing byte-level diffs and verification failures.

In cmake/modules/HCT.cmake, we mirror the repository’s .clang-format into the DXC build root so clang-format’s upward search finds the intended config.

