### PR TITLE
Set latest release to SM6.9

### DIFF
--- a/include/dxc/DXIL/DxilShaderModel.h
+++ b/include/dxc/DXIL/DxilShaderModel.h
@@ -41,7 +41,7 @@ public:
   // clang-format on
   // VALRULE-TEXT:BEGIN
   static const unsigned kHighestReleasedMajor = 6;
-  static const unsigned kHighestReleasedMinor = 8;
+  static const unsigned kHighestReleasedMinor = 9;
   // VALRULE-TEXT:END
 
   static const unsigned kOfflineMinor = 0xF;

--- a/tools/clang/test/LitDXILValidation/invalid-experimental-dxil-6-10-op-on-6-9.ll
+++ b/tools/clang/test/LitDXILValidation/invalid-experimental-dxil-6-10-op-on-6-9.ll
@@ -3,7 +3,7 @@
 target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 
-; CHECK: Function: main: error: Opcode ExperimentalNop not valid in shader model cs_6_9.
+; CHECK: Function: main: error: Use of experimental DXILOpCode requires an experimental shader model.
 ; CHECK-NEXT: note: at 'call void @dx.op.nop(i32 -2147483648)' in block '#0' of function 'main'.
 ; CHECK-NEXT: Function: main: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
 ; CHECK-NEXT: Function: main: error: Function uses features incompatible with the shader model.

--- a/utils/version/latest-release.json
+++ b/utils/version/latest-release.json
@@ -1,8 +1,8 @@
 {
   "version": {
     "major": "1",
-    "minor": "8",
-    "rev": "2505"
+    "minor": "9",
+    "rev": "2601"
   },
-  "sha": "0fd79eba6bb23f50ec21a7a7daeee3614bebe12b"
+  "sha": "b06a58d960fb0c9313cda10d17cc984a610b880f"
 }


### PR DESCRIPTION
The latest release information needs to be updated in order for SM6.9 shaders to use real hashes instead of preview hashes.