### PR TITLE
[HLK] Modify Wave match test logic to support modifications in different lanes and vector position

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1616,7 +1616,6 @@ template <typename T> struct Op<OpType::WaveMatch, T, 1> : StrictValidation {};
 
 static void WriteExpectedValueForLane(UINT *Dest, const UINT LaneID,
                                       const std::bitset<128> &ExpectedValue) {
-  // We need the mask to always be 32 bits, this calculation assurers that.
   std::bitset<128> Lo32Mask;
   Lo32Mask.set();
   Lo32Mask >>= 128 - 32;

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -4423,9 +4423,6 @@ void MSMain(uint GID : SV_GroupIndex,
                 Vector[LaneIndex] = (TYPE) 1;
             }
 
-            // Making sure all lanes finish updating their vectors.
-            AllMemoryBarrierWithGroupSync();
-
             uint4 Result = WaveMatch(Vector);
             uint Index = WaveGetLaneIndex();
 


### PR DESCRIPTION
This patch modifies the Wave Match test to test modifications in different lanes and vector
indexes. This is achieved by forcing lanes `0`, `WAVE_SIZE/2` and `WAVE_SIZE -1`, to modify 
the vector at indexes `0`, `WAVE_SIZE/2` or `WAVE_SIZE -1`, respectively.