### PR TITLE
[SPIR-V] Create ResourceHeap when directly returned

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2926,6 +2926,17 @@ void SpirvEmitter::doReturnStmt(const ReturnStmt *stmt) {
   bool returnsVoid = curFunction->getReturnType().getTypePtr()->isVoidType();
   if (!returnsVoid) {
     assert(retVal);
+    const Expr *srcExpr = retVal->IgnoreParenCasts();
+    if (isDescriptorHeap(srcExpr)) {
+      const Expr *base = nullptr;
+      getDescriptorHeapOperands(srcExpr, &base, /* index= */ nullptr);
+      const Expr *parentExpr = cast<CastExpr>(parentMap->getParent(srcExpr));
+      QualType resourceType = parentExpr->getType();
+      const auto *declRefExpr = dyn_cast<DeclRefExpr>(base->IgnoreCasts());
+      auto *decl = cast<VarDecl>(declRefExpr->getDecl());
+      declIdMapper.createResourceHeap(decl, resourceType);
+    }
+
     // Update counter variable associated with function returns
     tryToAssignCounterVar(curFunction, retVal);
 

--- a/tools/clang/test/CodeGenSPIRV/sm6_6.descriptorheap.return.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6_6.descriptorheap.return.counter.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -T cs_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+RWStructuredBuffer<uint> GetBindlessResource_UIntBuffer() {
+     return  ResourceDescriptorHeap[0];
+}
+
+[numthreads(1, 1, 1)]
+void main() {
+// CHECK-DAG: OpDecorate %ResourceDescriptorHeap DescriptorSet 0
+// CHECK-DAG: OpDecorate %ResourceDescriptorHeap Binding 0
+// CHECK-DAG: OpDecorate %counter_var_ResourceDescriptorHeap DescriptorSet 0
+// CHECK-DAG: OpDecorate %counter_var_ResourceDescriptorHeap Binding 1
+  RWStructuredBuffer<uint> a = GetBindlessResource_UIntBuffer();
+
+  a.IncrementCounter();
+}


### PR DESCRIPTION
Currently, HLSL of the form "return  ResourceDescriptorHeap[0];" will break compilation, if this is the first reference to ResourceDescriptorHeap encountered by the SpirvEmitter.  Please see the enclosed testcase, at [https://godbolt.org/z/3aWcq5roa](https://godbolt.org/z/3aWcq5roa)


