### PR TITLE
[SPIR-V] Support sizeof(vk::BufferPointer)

### DIFF
--- a/tools/clang/lib/AST/ASTContext.cpp
+++ b/tools/clang/lib/AST/ASTContext.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExternalASTSource.h"
+#include "clang/AST/HlslTypes.h" // HLSL Change
 #include "clang/AST/Mangle.h"
 #include "clang/AST/MangleNumberingContext.h"
 #include "clang/AST/RecordLayout.h"
@@ -38,8 +39,8 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/Capacity.h"
 #include "llvm/Support/MathExtras.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/MathExtras.h" // HLSL Change
+#include "llvm/Support/raw_ostream.h"
 #include <map>
 
 using namespace clang;
@@ -1804,6 +1805,17 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
 
     const RecordType *RT = cast<RecordType>(TT);
     const RecordDecl *RD = RT->getDecl();
+    // HLSL Change Begins
+#ifdef ENABLE_SPIRV_CODEGEN
+    if (hlsl::IsVKBufferPointerType(QualType(T, 0))) {
+      TypeInfo Info = getTypeInfo(UnsignedLongLongTy);
+      Width = Info.Width;
+      Align = Info.Align;
+      AlignIsRequired = Info.AlignIsRequired;
+      break;
+    }
+#endif
+    // HLSL Change Ends
     const ASTRecordLayout &Layout = getASTRecordLayout(RD);
     Width = toBits(Layout.getSize());
     Align = toBits(Layout.getAlignment());

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -11,8 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/AST/OperationKinds.h"
-#include "clang/Sema/SemaInternal.h"
 #include "TreeTransform.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
@@ -25,6 +23,8 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExprObjC.h"
+#include "clang/AST/HlslTypes.h" // HLSL Change
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/PartialDiagnostic.h"
@@ -42,9 +42,10 @@
 #include "clang/Sema/Scope.h"
 #include "clang/Sema/ScopeInfo.h"
 #include "clang/Sema/SemaFixItUtils.h"
+#include "clang/Sema/SemaHLSL.h" // HLSL Change
+#include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
 #include "llvm/Support/ConvertUTF.h"
-#include "clang/Sema/SemaHLSL.h" // HLSL Change
 using namespace clang;
 using namespace sema;
 
@@ -3819,6 +3820,13 @@ bool Sema::CheckHLSLUnaryExprOrTypeTraitOperand(QualType ExprType,
     Diag(Loc, diag::err_hlsl_sizeof_literal) << ExprType;
     return true;
   }
+
+  // vk::BufferPointer is allowed in sizeof
+#ifdef ENABLE_SPIRV_CODEGEN
+  if (hlsl::IsVKBufferPointerType(ExprType)) {
+    return false;
+  }
+#endif
 
   if (!hlsl::IsHLSLNumericOrAggregateOfNumericType(ExprType)) {
     Diag(Loc, diag::err_hlsl_sizeof_nonnumeric) << ExprType;

--- a/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.sizeof.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.sizeof.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T cs_6_0 -E main -fcgl %s -spirv | FileCheck %s
+
+struct S {
+    float a;
+};
+
+[numthreads(1, 1, 1)]
+void main() {
+    vk::BufferPointer<S> p = vk::BufferPointer<S>(0);
+    // CHECK: %uint_8 = OpConstant %uint 8
+    // CHECK: OpStore %size %uint_8
+    uint size = sizeof(p);
+}


### PR DESCRIPTION
This commit enables sizeof operator support for vk::BufferPointer types.
It updates SemaExpr to allow vk::BufferPointer in sizeof expressions,
and modifies ASTContext to correctly report the size and alignment of
vk::BufferPointer as equivalent to uint64_t.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7998
