### PR TITLE
[SPIR-V] Fix void on extented inst sets

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1346,7 +1346,7 @@ SpirvInstruction *SpirvBuilder::createSpirvIntrInstExt(
   SpirvExtInstImport *set =
       (instSet.size() == 0) ? nullptr : getExtInstSet(instSet);
 
-  if (retType != QualType() && retType->isVoidType()) {
+  if (!set && retType != QualType() && retType->isVoidType()) {
     retType = QualType();
   }
 

--- a/tools/clang/test/CodeGenSPIRV/inline-spirv/spv.intrinsicInstruction.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/inline-spirv/spv.intrinsicInstruction.hlsl
@@ -1,8 +1,12 @@
 // RUN: %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv | FileCheck %s
 
 // CHECK: OpCapability ShaderClockKHR
-// CHECK: {{%[0-9]+}} = OpExtInstImport "GLSL.std.450"
-// CHECK: {{%[0-9]+}} = OpExtInstImport "SPV_AMD_shader_trinary_minmax"
+
+// CHECK: OpExtension "SPV_KHR_non_semantic_info"
+
+// CHECK-DAG:   [[glsl_set:%[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG:  [[debug_set:%[0-9]+]] = OpExtInstImport "NonSemantic.DebugBreak"
+// CHECK-DAG: [[minmax_set:%[0-9]+]] = OpExtInstImport "SPV_AMD_shader_trinary_minmax"
 
 struct SInstanceData {
   float4x3 VisualToWorld;
@@ -25,15 +29,22 @@ float4 spv_sin(float4 v);
 [[vk::ext_instruction(/* FMin3AMD */ 1, "SPV_AMD_shader_trinary_minmax")]]
 float FMin3AMD(float x, float y, float z);
 
+[[vk::ext_extension("SPV_KHR_non_semantic_info")]]
+[[vk::ext_instruction(1, "NonSemantic.DebugBreak")]]
+void debugBreak();
+
 float4 main(const VS_INPUT v) : SV_Position {
 	SInstanceData	I = v.InstanceData;
   uint64_t clock;
-// CHECK: {{%[0-9]+}} = OpExtInst %v4float {{%[0-9]+}} Sin {{%[0-9]+}}
+// CHECK: {{%[0-9]+}} = OpExtInst %v4float [[glsl_set]] Sin {{%[0-9]+}}
   I.Output = spv_sin(v.InstanceData.Output);
 // CHECK: {{%[0-9]+}} = OpReadClockKHR %ulong %uint_1
   clock = ReadClock(vk::DeviceScope);
-// CHECK: {{%[0-9]+}} = OpExtInst %float {{%[0-9]+}} FMin3AMD {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
+// CHECK: {{%[0-9]+}} = OpExtInst %float [[minmax_set]] FMin3AMD {{%[0-9]+}} {{%[0-9]+}} {{%[0-9]+}}
   I.Output.w = FMin3AMD(I.Output.z, I.Output.y, I.Output.z);
+
+  debugBreak();
+// CHECK: {{.*}} = OpExtInst %void [[debug_set]] 1
 
   return I.Output;
 }


### PR DESCRIPTION
Inline SPIR-V on normal instructions had a condition to avoid emitting a result type on instruction with a void return type. This is because instructions like `OpStore` have a void return type, but in SPIR-V have no result id.

OpExtInst when defining void instruction (like debugBreak()) always have a result id, even with a void result type. This commits fixes the condition to reflect this.

Fixes #8012