### PR TITLE
[SM6.10] Add HLSL MatrixRef type and lower CreateMatrix intrinsic

### DIFF
--- a/include/dxc/dxcapi.internal.h
+++ b/include/dxc/dxcapi.internal.h
@@ -130,15 +130,17 @@ enum LEGAL_INTRINSIC_COMPTYPES {
   LICOMPTYPE_HIT_OBJECT = 51,
   LICOMPTYPE_RAY_QUERY = 52,
 
-  LICOMPTYPE_LINALG = 53, // f32, partial-precision-f32, f16,
+  LICOMPTYPE_MATRIX_REF = 53,
+
+  LICOMPTYPE_LINALG = 54, // f32, partial-precision-f32, f16,
                           // i32, i16, u32, u16,
                           // int8_4packed, uint8_4packed
 
 #ifdef ENABLE_SPIRV_CODEGEN
-  LICOMPTYPE_VK_BUFFER_POINTER = 54,
-  LICOMPTYPE_COUNT = 55
+  LICOMPTYPE_VK_BUFFER_POINTER = 55,
+  LICOMPTYPE_COUNT = 56
 #else
-  LICOMPTYPE_COUNT = 54
+  LICOMPTYPE_COUNT = 55
 #endif
 };
 

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -6792,6 +6792,22 @@ Value *TranslateVectorAccumulate(CallInst *CI, IntrinsicOp IOP,
                             {OpArg, InputVector, MatrixBuffer, MatrixOffset});
 }
 
+Value *TranslateLinAlgCreateMatrix(CallInst *CI, IntrinsicOp IOP,
+                                   OP::OpCode OpCode,
+                                   HLOperationLowerHelper &Helper,
+                                   HLObjectOperationLowerHelper *ObjHelper,
+                                   bool &Translated) {
+  hlsl::OP *HlslOP = &Helper.hlslOP;
+  IRBuilder<> Builder(CI);
+  Value *MatrixRefPtr = CI->getArgOperand(1);
+  Value *MatrixRef = TrivialDxilOperation(
+      OpCode, {nullptr}, Type::getVoidTy(CI->getContext()), CI, HlslOP);
+  Builder.CreateStore(MatrixRef, MatrixRefPtr);
+  DXASSERT(
+      CI->use_empty(),
+      "Default ctor return type is a Clang artifact. Value must not be used");
+  return nullptr;
+}
 } // namespace
 
 // Lower table.
@@ -7539,8 +7555,8 @@ constexpr IntrinsicLower gLowerTable[] = {
 
     {IntrinsicOp::IOP___builtin_LinAlg_CopyConvertMatrix, EmptyLower,
      DXIL::OpCode::CopyConvertMatrix},
-    {IntrinsicOp::IOP___builtin_LinAlg_CreateMatrix, EmptyLower,
-     DXIL::OpCode::CreateMatrix},
+    {IntrinsicOp::IOP___builtin_LinAlg_CreateMatrix,
+     TranslateLinAlgCreateMatrix, DXIL::OpCode::CreateMatrix},
     {IntrinsicOp::IOP___builtin_LinAlg_FillMatrix, EmptyLower,
      DXIL::OpCode::FillMatrix},
     {IntrinsicOp::IOP___builtin_LinAlg_MatrixGetCoordinate, EmptyLower,

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -393,6 +393,7 @@ DeclareConstantBufferViewType(clang::ASTContext &context,
                               clang::InheritableAttr *Attr);
 clang::CXXRecordDecl *DeclareRayQueryType(clang::ASTContext &context);
 clang::CXXRecordDecl *DeclareHitObjectType(clang::NamespaceDecl &NSDecl);
+clang::CXXRecordDecl *DeclareMatrixRefType(clang::ASTContext &Context);
 clang::CXXRecordDecl *DeclareResourceType(clang::ASTContext &context,
                                           bool bSampler);
 
@@ -480,7 +481,7 @@ bool IsHLSLDynamicResourceType(clang::QualType type);
 bool IsHLSLDynamicSamplerType(clang::QualType type);
 bool IsHLSLNodeType(clang::QualType type);
 bool IsHLSLHitObjectType(clang::QualType type);
-
+bool IsHLSLMatrixRefType(clang::QualType type);
 bool IsHLSLObjectWithImplicitMemberAccess(clang::QualType type);
 bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);
 bool IsHLSLRWNodeInputRecordType(clang::QualType type);

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1190,6 +1190,14 @@ def HLSLHitObject : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+// HLSL MatrixRef Attribute
+
+def HLSLMatrixRef : InheritableAttr {
+  let Spellings = []; // No spellings!
+  let Subjects = SubjectList<[CXXRecord]>;
+  let Documentation = [Undocumented];
+}
+
 // HLSL Parameter Attributes
 
 def HLSLMaxRecords : InheritableAttr {

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -1306,6 +1306,33 @@ CXXRecordDecl *hlsl::DeclareHitObjectType(NamespaceDecl &NSDecl) {
   return RecordDecl;
 }
 
+CXXRecordDecl *hlsl::DeclareMatrixRefType(ASTContext &Context) {
+  // MatrixRef { ... }
+  BuiltinTypeDeclBuilder TypeDeclBuilder(Context.getTranslationUnitDecl(),
+                                         "__builtin_LinAlg_MatrixRef");
+
+  TypeDeclBuilder.startDefinition();
+
+  // Add handle to mark as HLSL object.
+  TypeDeclBuilder.addField("h", GetHLSLObjectHandleType(Context));
+  CXXRecordDecl *RecordDecl = TypeDeclBuilder.getRecordDecl();
+
+  // Add AvailabilityAttribute for SM6.10+
+  VersionTuple VT610 = VersionTuple(6, 10);
+  AvailabilityAttr *AAttr = AvailabilityAttr::CreateImplicit(
+      Context, &Context.Idents.get(""), clang::VersionTuple(6, 10),
+      clang::VersionTuple(), clang::VersionTuple(), false, "");
+  RecordDecl->addAttr(AAttr);
+
+  // Add the implicit HLSLMatrixRefAttr attribute to unambiguously recognize the
+  // builtin MatrixRef type.
+  RecordDecl->addAttr(HLSLMatrixRefAttr::CreateImplicit(Context));
+  RecordDecl->setImplicit(true);
+
+  // Add to namespace
+  return RecordDecl;
+}
+
 CXXRecordDecl *hlsl::DeclareResourceType(ASTContext &context, bool bSampler) {
   // struct ResourceDescriptor { uint8 desc; }
   StringRef Name = bSampler ? ".Sampler" : ".Resource";

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -528,6 +528,10 @@ bool IsHLSLHitObjectType(QualType type) {
   return nullptr != getAttr<HLSLHitObjectAttr>(type);
 }
 
+bool IsHLSLMatrixRefType(QualType type) {
+  return nullptr != getAttr<HLSLMatrixRefAttr>(type);
+}
+
 DXIL::NodeIOKind GetNodeIOType(clang::QualType type) {
   if (const HLSLNodeObjectAttr *Attr = getAttr<HLSLNodeObjectAttr>(type))
     return Attr->getNodeIOType();

--- a/tools/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -369,6 +369,8 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
                  .getTypePtr();
       } else if (hlsl::IsHLSLHitObjectType(T)) // HLSL Change
         return hlsl::dxilutil::GetHLSLHitObjectType(&TheModule);
+      else if (hlsl::IsHLSLMatrixRefType(T)) // HLSL Change
+        return hlsl::dxilutil::GetHLSLMatrixRefType(&TheModule);
       else
         return ConvertRecordDeclType(RT->getDecl());
     }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -253,6 +253,9 @@ enum ArBasicKind {
   // Shader Execution Reordering
   AR_OBJECT_HIT_OBJECT,
 
+  // Linear Algebra
+  AR_OBJECT_MATRIX_REF,
+
   AR_BASIC_MAXIMUM_COUNT
 };
 
@@ -606,6 +609,9 @@ const UINT g_uBasicKindProps[] = {
 
     // Shader Execution Reordering
     LICOMPTYPE_HIT_OBJECT, // AR_OBJECT_HIT_OBJECT,
+
+    // Linear Algebra
+    LICOMPTYPE_MATRIX_REF, // AR_OBJECT_MATRIX_REF,
 
     // AR_BASIC_MAXIMUM_COUNT
 };
@@ -1247,6 +1253,10 @@ static const ArBasicKind g_AnyOutputRecordCT[] = {
 static const ArBasicKind g_DxHitObjectCT[] = {AR_OBJECT_HIT_OBJECT,
                                               AR_BASIC_UNKNOWN};
 
+// Linear Algebra
+static const ArBasicKind g_MatrixRefCT[] = {AR_OBJECT_MATRIX_REF,
+                                            AR_BASIC_UNKNOWN};
+
 #ifdef ENABLE_SPIRV_CODEGEN
 static const ArBasicKind g_VKBufferPointerCT[] = {AR_OBJECT_VK_BUFFER_POINTER,
                                                   AR_BASIC_UNKNOWN};
@@ -1308,6 +1318,7 @@ const ArBasicKind *g_LegalIntrinsicCompTypes[] = {
     g_ThreadNodeOutputRecordsCT, // LICOMPTYPE_THREAD_NODE_OUTPUT_RECORDS
     g_DxHitObjectCT,             // LICOMPTYPE_HIT_OBJECT
     g_RayQueryCT,                // LICOMPTYPE_RAY_QUERY
+    g_MatrixRefCT,               // LICOMPTYPE_MATRIX_REF
     g_LinAlgCT,                  // LICOMPTYPE_LINALG
 #ifdef ENABLE_SPIRV_CODEGEN
     g_VKBufferPointerCT, // LICOMPTYPE_VK_BUFFER_POINTER
@@ -1404,7 +1415,10 @@ static const ArBasicKind g_ArBasicKindsAsTypes[] = {
     AR_OBJECT_THREAD_NODE_OUTPUT_RECORDS, AR_OBJECT_GROUP_NODE_OUTPUT_RECORDS,
 
     // Shader Execution Reordering
-    AR_OBJECT_HIT_OBJECT};
+    AR_OBJECT_HIT_OBJECT,
+
+    // Linear Algebra
+    AR_OBJECT_MATRIX_REF};
 
 // Count of template arguments for basic kind of objects that look like
 // templates (one or more type arguments).
@@ -1524,6 +1538,9 @@ static const uint8_t g_ArBasicKindsTemplateCount[] = {
 
     // Shader Execution Reordering
     0, // AR_OBJECT_HIT_OBJECT,
+
+    // Linear Algebra
+    0, // AR_OBJECT_MATRIX_REF,
 };
 
 C_ASSERT(_countof(g_ArBasicKindsAsTypes) ==
@@ -1674,6 +1691,9 @@ static const SubscriptOperatorRecord g_ArBasicKindsSubscripts[] = {
 
     // Shader Execution Reordering
     {0, MipsFalse, SampleFalse}, // AR_OBJECT_HIT_OBJECT,
+
+    // Linear Algebra
+    {0, MipsFalse, SampleFalse}, // AR_OBJECT_MATRIX_REF
 };
 
 C_ASSERT(_countof(g_ArBasicKindsAsTypes) == _countof(g_ArBasicKindsSubscripts));
@@ -1841,6 +1861,9 @@ static const char *g_ArBasicTypeNames[] = {
 
     // Shader Execution Reordering
     "HitObject",
+
+    // Linear Algebra
+    "__builtin_LinAlg_MatrixRef",
 };
 
 C_ASSERT(_countof(g_ArBasicTypeNames) == AR_BASIC_MAXIMUM_COUNT);
@@ -3605,6 +3628,9 @@ private:
       case LICOMPTYPE_HIT_OBJECT:
         paramTypes.push_back(GetBasicKindType(AR_OBJECT_HIT_OBJECT));
         break;
+      case LICOMPTYPE_MATRIX_REF:
+        paramTypes.push_back(GetBasicKindType(AR_OBJECT_MATRIX_REF));
+        break;
 #ifdef ENABLE_SPIRV_CODEGEN
       case LICOMPTYPE_VK_BUFFER_POINTER: {
         const ArBasicKind *match =
@@ -3864,6 +3890,8 @@ private:
         // Declare 'HitObject' in '::dx' extension namespace.
         DXASSERT(m_dxNSDecl, "namespace ::dx must be declared in SM6.9+");
         recordDecl = DeclareHitObjectType(*m_dxNSDecl);
+      } else if (kind == AR_OBJECT_MATRIX_REF) {
+        recordDecl = DeclareMatrixRefType(*m_context);
       } else if (kind == AR_OBJECT_HEAP_RESOURCE) {
         recordDecl = DeclareResourceType(*m_context, /*bSampler*/ false);
         if (SM->IsSM66Plus()) {
@@ -4860,6 +4888,7 @@ public:
     case AR_OBJECT_ACCELERATION_STRUCT:
     case AR_OBJECT_RAY_DESC:
     case AR_OBJECT_HIT_OBJECT:
+    case AR_OBJECT_MATRIX_REF:
     case AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES:
     case AR_OBJECT_RWTEXTURE2DMS:
     case AR_OBJECT_RWTEXTURE2DMS_ARRAY:

--- a/tools/clang/test/SemaHLSL/hlsl/objects/MatrixRef/matrixref_in_buffer.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/MatrixRef/matrixref_in_buffer.hlsl
@@ -1,0 +1,5 @@
+// REQUIRES dxil-1-10
+// RUN: %dxc -T lib_6_10 %s -verify
+
+// expected-error@+1{{object '__builtin_LinAlg_MatrixRef' is not allowed in builtin template parameters}}
+RWStructuredBuffer<__builtin_LinAlg_MatrixRef> InvalidBuffer;

--- a/tools/clang/test/SemaHLSL/hlsl/objects/MatrixRef/matrixref_make.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/MatrixRef/matrixref_make.hlsl
@@ -1,0 +1,23 @@
+// REQUIRES: dxil-1-10
+// RUN: %dxc -T cs_6_10 -E main %s -ast-dump-implicit | FileCheck %s --check-prefix AST
+// RUN: %dxc -T cs_6_10 -E main %s | FileCheck %s --check-prefix DXIL
+
+// AST: |-CXXRecordDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> implicit referenced class __builtin_LinAlg_MatrixRef definition
+// AST-NEXT: | |-FinalAttr {{[^ ]+}} <<invalid sloc>> Implicit final
+// AST-NEXT: | |-AvailabilityAttr {{[^ ]+}} <<invalid sloc>> Implicit  6.10 0 0 ""
+// AST-NEXT: | |-HLSLMatrixRefAttr {{[^ ]+}} <<invalid sloc>> Implicit
+// AST-NEXT: | |-FieldDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
+// -- Constructor intentionally not here --
+// AST-NEXT: | `-CXXDestructorDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> implicit referenced ~__builtin_LinAlg_MatrixRef 'void () noexcept' inline
+
+
+// AST: `-FunctionDecl {{[^ ]+}} <<invalid sloc>> <invalid sloc> implicit used __builtin_LinAlg_CreateMatrix '__builtin_LinAlg_MatrixRef ()' extern
+// AST-NEXT: |-HLSLIntrinsicAttr {{[^ ]+}} <<invalid sloc>> Implicit "op" "" 406
+// AST-NEXT: |-AvailabilityAttr {{[^ ]+}} <<invalid sloc>> Implicit  6.10 0 0 ""
+
+// DXIL-LABEL: define void @main()
+[numthreads(4,1,1)]
+void main() {
+  // DXIL: call %dx.types.MatrixRef @dx.op.createMatrix(i32 -2147483637)  ; CreateMatrix()
+  __builtin_LinAlg_MatrixRef mat = __builtin_LinAlg_CreateMatrix();
+}

--- a/tools/clang/test/SemaHLSL/hlsl/objects/MatrixRef/matrixref_unavailable_pre_sm610.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/MatrixRef/matrixref_unavailable_pre_sm610.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T cs_6_9 -E main %s -verify
+
+[numthreads(4,1,1)]
+void main() {
+  // expected-error@+2{{intrinsic __builtin_LinAlg_CreateMatrix potentially used by ''main'' requires shader model 6.10 or greater}}
+  // expected-error@+1{{potential misuse of built-in type '__builtin_LinAlg_MatrixRef' in shader model cs_6_9; introduced in shader model 6.10}}
+  __builtin_LinAlg_MatrixRef mat = __builtin_LinAlg_CreateMatrix();
+}

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -397,34 +397,32 @@ void [[min_sm=6.10]] __builtin_VectorAccumulate(in LinAlg<c> InputVector, in RWB
 
 // LinAlg intrinsics
 
-// TODO: Update return type for CreateMatrix to MatrixRef
-// TODO: Replace all int MatrixRef with MatrixRef type
 // TODO: Replace all int GroupSharedMem with groupshared memory
-void [[min_sm=6.10]] __builtin_LinAlg_CreateMatrix();
-void [[min_sm=6.10]] __builtin_LinAlg_FillMatrix(int MatrixRef, numeric value);
-void [[min_sm=6.10]] __builtin_LinAlg_CopyConvertMatrix(int MatrixRefDest, int MatrixRefSrc, bool transpose);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixLoadFromDescriptor(int MatrixRef, resource buf, int32_only offset, int32_only stride, int32_only layout);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixLoadFromMemory(int MatrixRef, int GroupSharedMem, int32_only offset, int32_only stride, int32_only layout);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixLength(int MatrixRef);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixGetCoordinate(int MatrixRef, int32_only threadLocalIndex);
-numeric [[min_sm=6.10]] __builtin_LinAlg_MatrixGetElement(int MatrixRef, int32_only threadLocalIndex);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixSetElement(int MatrixRef, int32_only threadLocalIndex, numeric value);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixStoreToDescriptor(int MatrixRef, resource buf, int32_only offset, int32_only stride, int32_only layout);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixStoreToMemory(int MatrixRef, int GroupSharedMem, int32_only offset, int32_only stride, int32_only layout);
-int32_only [[min_sm=6.10]] __builtin_LinAlg_MatrixQueryAccumulatorLayout();
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixMatrixMultiply(int MatrixRefA, int MatrixRefB, int MatrixRefC);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(int MatrixRefA, int MatrixRefB, int MatrixRefC);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixAccumulate(int MatrixRefRHS, int MatrixRefLHS);
+MatrixRef [[min_sm=6.10]] __builtin_LinAlg_CreateMatrix();
+void [[min_sm=6.10]] __builtin_LinAlg_FillMatrix(in MatrixRef matrix, in numeric value);
+void [[min_sm=6.10]] __builtin_LinAlg_CopyConvertMatrix(in MatrixRef destination, in MatrixRef source, in bool transpose);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixLoadFromDescriptor(in MatrixRef matrix, in resource buf, in uint offset, in uint stride, in uint layout);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixLoadFromMemory(in MatrixRef matrix, in int GroupSharedMem, in uint offset, in uint stride, in uint layout);
+uint [[min_sm=6.10]] __builtin_LinAlg_MatrixLength(in MatrixRef matrix);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixGetCoordinate(in MatrixRef matrix, in uint threadLocalIndex);
+numeric [[min_sm=6.10]] __builtin_LinAlg_MatrixGetElement(in MatrixRef matrix, in uint threadLocalIndex);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixSetElement(in MatrixRef matrix, in uint threadLocalIndex, in numeric value);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixStoreToDescriptor(in MatrixRef matrix, in resource buf, in uint offset, in uint stride, in uint layout);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixStoreToMemory(in MatrixRef matrix, in int GroupSharedMem, in uint offset, in uint stride, in uint layout);
+uint [[min_sm=6.10]] __builtin_LinAlg_MatrixQueryAccumulatorLayout();
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixMatrixMultiply(in MatrixRef matrixA, in MatrixRef matrixB, in MatrixRef matrixC);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(in MatrixRef matrixA, in MatrixRef matrixB, in MatrixRef matrixC);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixAccumulate(in MatrixRef matrixRHS, in MatrixRef matrixLHS);
 
 // TODO: Fix vector types
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixVectorMultiply(int MatrixRef);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixVectorMultiplyAdd(int MatrixRef);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixVectorMultiply(in MatrixRef matrix);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixVectorMultiplyAdd(in MatrixRef matrix);
 
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixAccumulateToDescriptor(int MatrixRef, resource buf, int32_only offset, int32_only stride, int32_only layout);
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixAccumulateToMemory(int MatrixRef, int GroupSharedMem, int32_only offset, int32_only stride, int32_only layout);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixAccumulateToDescriptor(in MatrixRef matrix, in resource buf, in uint offset, in uint stride, in uint layout);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixAccumulateToMemory(in MatrixRef matrix, in int GroupSharedMem, in uint offset, in uint stride, in uint layout);
 
 // TODO: Fix vector types
-void [[min_sm=6.10]] __builtin_LinAlg_MatrixOuterProduct(int MatrixRef);
+void [[min_sm=6.10]] __builtin_LinAlg_MatrixOuterProduct(in MatrixRef matrix);
 
 } namespace
 

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -9537,6 +9537,7 @@ class db_hlsl(object):
             "GroupNodeOutputRecords": "LICOMPTYPE_GROUP_NODE_OUTPUT_RECORDS",
             "ThreadNodeOutputRecords": "LICOMPTYPE_THREAD_NODE_OUTPUT_RECORDS",
             "DxHitObject": "LICOMPTYPE_HIT_OBJECT",
+            "MatrixRef": "LICOMPTYPE_MATRIX_REF",
             "VkBufferPointer": "LICOMPTYPE_VK_BUFFER_POINTER",
             "RayQuery": "LICOMPTYPE_RAY_QUERY",
             "LinAlg": "LICOMPTYPE_LINALG",
@@ -9600,7 +9601,7 @@ class db_hlsl(object):
             sampler\w* | string |
             (?:RW)?(?:Texture\w*|ByteAddressBuffer) |
             acceleration_struct | ray_desc | RayQuery | DxHitObject |
-            Node\w* | RWNode\w* | EmptyNode\w* |
+            MatrixRef | Node\w* | RWNode\w* | EmptyNode\w* |
             AnyNodeOutput\w* | NodeOutputRecord\w* | GroupShared\w* |
             VkBufferPointer
             $)""",


### PR DESCRIPTION
- Adds the `__builtin_LinAlg_MatrixRef` type to HLSL
- implements the first stage of `__builtin_LinAlg_CreateMatrix` which currently returns an unannotated MatrixRef.
- updates HLSL intrinsics to operate over `__builtin_LinAlg_MatrixRef`
- Adds the appropriate tests


Notes:
- Annotation is intentionally ignored in this change and will be managed seperately
- The PR couldn't be split further because __builtin_LinAlg_CreateMatrix was needed for any effective test of `__builtin_LinAlg_MatrixRef`