### PR TITLE
Revert "Bump pynacl from 1.5.0 to 1.6.2 in /utils/git"

### DIFF
--- a/utils/git/requirements_formatting.txt
+++ b/utils/git/requirements_formatting.txt
@@ -40,7 +40,7 @@ pygithub==1.59.1
     # via -r llvm/utils/git/requirements_formatting.txt.in
 pyjwt[crypto]==2.8.0
     # via pygithub
-pynacl==1.6.2
+pynacl==1.5.0
     # via pygithub
 requests==2.32.4
     # via pygithub


### PR DESCRIPTION
Reverts microsoft/DirectXShaderCompiler#8045

Looks like this is actually breaking the formatting checks.