### PR TITLE
Execution Tests: HLK  - Update for two HLK requirements for SM6.9. Core and double.

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1796,8 +1796,8 @@ using namespace LongVector;
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
-      "Kits.Specification",                                                    \
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")          \
+        "Kits.Specification",                                                  \
+        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")        \
     END_TEST_METHOD_PROPERTIES()                                               \
     runTest<DataType, OpType::Op>();                                           \
   }
@@ -1806,8 +1806,8 @@ using namespace LongVector;
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
-      "Kits.Specification",                                                    \
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")          \
+        "Kits.Specification",                                                  \
+        "Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")        \
     END_TEST_METHOD_PROPERTIES()                                               \
     runWaveOpTest<DataType, OpType::Op>();                                     \
   }
@@ -1816,8 +1816,8 @@ using namespace LongVector;
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
-      "Kits.Specification",                                                    \
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")          \
+        "Kits.Specification",                                                  \
+        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")        \
     END_TEST_METHOD_PROPERTIES()                                               \
     runWaveOpTest<DataType, OpType::Op>();                                     \
   }


### PR DESCRIPTION
This PR updates the tests to recognize an additional HLK requirement for SM6.9 double support as it remains optional for 6.9. 16-bit types, 64-bit integers, and wave ops are required for SM 6.9 so they are implied via the core requirement.

Also removes the priority '2' set on the wave op tests. P2 tests are skipped in our automation. These tests were originally being skipped as WARP did not yet support wave ops with long vectors.

Partially implements #7608 . The rest of the implementation will be handled in OS code.