### PR TITLE
Execution Tests: Prevent sinking in long vector derivative hlk

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -4477,7 +4477,7 @@ void MSMain(uint GID : SV_GroupIndex,
 
           // Prevents the above derivative call from being sunk into the if
           // condition below. DXC Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/8001
-          WaveReadLaneAt(Result, 3);
+          Result = WaveReadLaneAt(Result, 3);
 
           // For coarse derivatives, all lanes in the quad get the same result.
           // But for fine derivatives, each lane gets a different result. To


### PR DESCRIPTION
This PR adds a workaround to the hlk long vector derivative tests to prevent sinking of the derivative call into the conditional. This is a known bug in DXC that will not be fixed for 6.9 release. 
DXC bug tracked via issue #8001 
