### PR TITLE
[SPIR-V] Fix Mesh Shader debug info source locations

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8340,9 +8340,9 @@ SpirvInstruction *SpirvEmitter::tryToAssignToMSOutAttrsOrIndices(
   }
 
   if (isMSOutAttribute) {
-    assignToMSOutAttribute(varDecl, rhs, indices);
+    assignToMSOutAttribute(varDecl, rhs, indices, lhs->getLocStart());
   } else if (isMSOutIndices) {
-    assignToMSOutIndices(varDecl, rhs, indices);
+    assignToMSOutIndices(varDecl, rhs, indices, lhs->getLocStart());
   } else {
     assert(isMSOutAttributeBlock);
     QualType type = varDecl->getType();
@@ -8357,7 +8357,7 @@ SpirvInstruction *SpirvEmitter::tryToAssignToMSOutAttrsOrIndices(
       SpirvInstruction *subValue = spvBuilder.createCompositeExtract(
           fieldType, rhs, {getNumBaseClasses(type) + field->getFieldIndex()},
           lhs->getLocStart());
-      assignToMSOutAttribute(field, subValue, indices);
+      assignToMSOutAttribute(field, subValue, indices, lhs->getLocStart());
     }
   }
 
@@ -8369,7 +8369,8 @@ SpirvInstruction *SpirvEmitter::tryToAssignToMSOutAttrsOrIndices(
 
 void SpirvEmitter::assignToMSOutAttribute(
     const DeclaratorDecl *decl, SpirvInstruction *value,
-    const llvm::SmallVector<SpirvInstruction *, 4> &indices) {
+    const llvm::SmallVector<SpirvInstruction *, 4> &indices,
+    SourceLocation loc) {
   assert(spvContext.isMS() && !indices.empty());
 
   // Extract attribute index and vecComponent (if any).
@@ -8381,7 +8382,6 @@ void SpirvEmitter::assignToMSOutAttribute(
 
   auto semanticInfo = declIdMapper.getStageVarSemantic(decl);
   assert(semanticInfo.isValid());
-  const auto loc = decl->getLocation();
   // Special handle writes to clip/cull distance attributes.
   if (declIdMapper.glPerVertex.tryToAccess(
           hlsl::DXIL::SigPointKind::MSOut, semanticInfo.semantic->GetKind(),
@@ -8409,7 +8409,8 @@ void SpirvEmitter::assignToMSOutAttribute(
 
 void SpirvEmitter::assignToMSOutIndices(
     const DeclaratorDecl *decl, SpirvInstruction *value,
-    const llvm::SmallVector<SpirvInstruction *, 4> &indices) {
+    const llvm::SmallVector<SpirvInstruction *, 4> &indices,
+    SourceLocation loc) {
   assert(spvContext.isMS() && !indices.empty());
 
   bool extMesh = featureManager.isExtensionEnabled(Extension::EXT_mesh_shader);
@@ -8437,7 +8438,6 @@ void SpirvEmitter::assignToMSOutIndices(
     }
   }
 
-  const auto loc = decl->getLocation();
   if (numVertices == 1) {
     // for "point" output topology.
     assert(numValues == 1);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -370,12 +370,14 @@ private:
   /// Emit instructions for assigning to the given mesh out attribute.
   void assignToMSOutAttribute(
       const DeclaratorDecl *decl, SpirvInstruction *value,
-      const llvm::SmallVector<SpirvInstruction *, 4> &indices);
+      const llvm::SmallVector<SpirvInstruction *, 4> &indices,
+      SourceLocation loc);
 
   /// Emit instructions for assigning to the given mesh out indices object.
   void
   assignToMSOutIndices(const DeclaratorDecl *decl, SpirvInstruction *value,
-                       const llvm::SmallVector<SpirvInstruction *, 4> &indices);
+                       const llvm::SmallVector<SpirvInstruction *, 4> &indices,
+                       SourceLocation loc);
 
   /// Processes each vector within the given matrix by calling actOnEachVector.
   /// matrixVal should be the loaded value of the matrix. actOnEachVector takes

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.mesh.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -Zi -O0 -T ms_6_5 %s -spirv | FileCheck %s
+
+// CHECK: OpStore %62 %63
+// CHECK: OpLine %6 22 5
+// CHECK: OpLine %6 23 5
+// CHECK: OpLine %6 25 5
+// CHECK: OpLine %6 26 5
+// CHECK: OpLine %6 28 5
+// CHECK: OpLine %6 29 5
+
+struct MeshShaderOutput {
+    float4 position: SV_Position;
+    float3 color: COLOR0;
+};
+
+[outputtopology("triangle")]
+[numthreads(1, 1, 1)]
+void main(out indices uint3 triangleBox[1], out vertices MeshShaderOutput triangleVertex[3]) {
+    SetMeshOutputCounts(3, 1);
+    triangleBox[0] = uint3(0, 1, 1);
+
+    triangleVertex[0].position = float4(1, 0.5, 0.0, 1.0);
+    triangleVertex[0].color = float3(1, 0.0, 0.0);
+
+    triangleVertex[1].position = float4(1, 0.5, 0.0, 1.0);
+    triangleVertex[1].color = float3(1.0, 1.0, 0.0);
+    
+    triangleVertex[2].position = float4(1.0, -0.5, 0.0, 1.0);
+    triangleVertex[2].color = float3(1.0, 0.0, 1.0);
+}


### PR DESCRIPTION
dxc outputs incorrect line information for some mesh shader inputs, as shown in [this godbolt](https://godbolt.org/z/Tsqa7ed5a).  The final 6 OpStore instructions should be on lines 12-19 where the assignment occurs, but instead they are associated with lines 2 and 3 where the struct fields are declared. This is broken for all forms of debug info, not just NS.