### PR TITLE
Include <new> in Unicode.cpp

### DIFF
--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -18,6 +18,7 @@
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/WinIncludes.h"
 #include <assert.h>
+#include <new>
 #include <string>
 
 #ifndef _WIN32


### PR DESCRIPTION
Unicode.cpp references std::nothrow, but does not directly include new. We add the include to help with some internal tooling and compilation work flows.
