### PR TITLE
Fixing long vectors tests to use wide chars for text

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -261,7 +261,7 @@ template <typename T> const std::vector<T> &getInputSet(InputSet InputSet) {
   default:                                                                     \
     break;                                                                     \
     }                                                                          \
-    VERIFY_FAIL(L"Missing input set");                                          \
+    VERIFY_FAIL(L"Missing input set");                                         \
     std::abort();                                                              \
     }
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1809,8 +1809,8 @@ using namespace LongVector;
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
-        L"Kits.Specification",                                                  \
-        L"Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")        \
+        L"Kits.Specification",                                                 \
+        L"Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")       \
     END_TEST_METHOD_PROPERTIES()                                               \
     runTest<DataType, OpType::Op>();                                           \
   }
@@ -1819,8 +1819,8 @@ using namespace LongVector;
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
-        L"Kits.Specification",                                                  \
-        L"Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")        \
+        L"Kits.Specification",                                                 \
+        L"Device.Graphics.D3D12.DXILCore.ShaderModel69.CoreRequirement")       \
     END_TEST_METHOD_PROPERTIES()                                               \
     runWaveOpTest<DataType, OpType::Op>();                                     \
   }
@@ -1829,8 +1829,8 @@ using namespace LongVector;
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
-        L"Kits.Specification",                                                  \
-        L"Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")        \
+        L"Kits.Specification",                                                 \
+        L"Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")       \
     END_TEST_METHOD_PROPERTIES()                                               \
     runWaveOpTest<DataType, OpType::Op>();                                     \
   }
@@ -1838,8 +1838,9 @@ using namespace LongVector;
 class DxilConf_SM69_Vectorized {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM69_Vectorized)
-  TEST_CLASS_PROPERTY(L"Kits.TestName",
-                      L"D3D12 - Shader Model 6.9 - Vectorized DXIL - Core Tests")
+  TEST_CLASS_PROPERTY(
+      L"Kits.TestName",
+      L"D3D12 - Shader Model 6.9 - Vectorized DXIL - Core Tests")
   TEST_CLASS_PROPERTY(L"Kits.TestId", L"81db1ff8-5bc5-48a1-8d7b-600fc600a677")
   TEST_CLASS_PROPERTY(L"Kits.Description",
                       L"Validates required SM 6.9 vectorized DXIL operations")


### PR DESCRIPTION
I'm not sure if this is related to using a newer VC++ compiler (VS 2022 - 14.44.35207), but I got a compile failure locally without this fix. Looking at the other uses of these macros, I believe this the intended usage in any case.