### PR TITLE
[SM6.10][NFC] DXIL Ops Allow 4 type overloads

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -158,7 +158,7 @@ const unsigned kVecResRetStatusIndex = 1;
 
 /* <py::lines('OLOAD_DIMS-TEXT')>hctdb_instrhelp.get_max_oload_dims()</py>*/
 // OLOAD_DIMS-TEXT:BEGIN
-const unsigned kDxilMaxOloadDims = 3;
+const unsigned kDxilMaxOloadDims = 4;
 // OLOAD_DIMS-TEXT:END
 
 enum class ComponentType : uint32_t {

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -59,7 +59,7 @@ dxil_scalar_oload_chars = "hfd18wil"
 
 # Maximum number of overload dimensions supported through the extended overload
 # in DXIL instructions.
-dxil_max_overload_dims = 3
+dxil_max_overload_dims = 4
 
 
 class db_dxil_enum_value(object):

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -646,6 +646,7 @@ class db_oload_gen:
             "$x0": "EXT(0);",
             "$x1": "EXT(1);",
             "$x2": "EXT(2);",
+            "$x3": "EXT(3);",
         }
         last_category = None
         for i in self.db.get_dxil_ops():


### PR DESCRIPTION
The LinAlg spec requires certain new DXIL opcodes to have 4 type overloads. This NFC change updates the infrastructure to support that