### PR TITLE
[SPIR-V][vk::SampledTexture] #4. Add `.Load()` methods for `vk::SampledTexture2D` type.

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/vk.sampledtexture.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.sampledtexture.load.hlsl
@@ -1,0 +1,48 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+
+vk::SampledTexture2D<float4> tex2D_F4 : register(t1);
+
+// CHECK: OpCapability SparseResidency
+
+// CHECK: [[v2ic:%[0-9]+]] = OpConstantComposite %v2int %int_1 %int_2
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
+
+float4 main(int3 location: A) : SV_Target {
+    uint status;
+
+// CHECK:        [[loc:%[0-9]+]] = OpLoad %v3int %location
+// CHECK-NEXT: [[coord_0:%[0-9]+]] = OpVectorShuffle %v2int [[loc]] [[loc]] 0 1
+// CHECK-NEXT:   [[lod_0:%[0-9]+]] = OpCompositeExtract %int [[loc]] 2
+// CHECK-NEXT:    [[tex:%[0-9]+]] = OpLoad %type_sampled_image %tex2D_F4
+// CHECK-NEXT:    [[tex_img:%[0-9]+]] = OpImage %type_2d_image [[tex]]
+// CHECK-NEXT:       {{%[0-9]+}} = OpImageFetch %v4float [[tex_img]] [[coord_0]] Lod [[lod_0]]
+    float4 val1 = tex2D_F4.Load(location);
+
+// CHECK:        [[loc:%[0-9]+]] = OpLoad %v3int %location
+// CHECK-NEXT: [[coord_0:%[0-9]+]] = OpVectorShuffle %v2int [[loc]] [[loc]] 0 1
+// CHECK-NEXT:   [[lod_0:%[0-9]+]] = OpCompositeExtract %int [[loc]] 2
+// CHECK-NEXT:    [[tex:%[0-9]+]] = OpLoad %type_sampled_image %tex2D_F4
+// CHECK-NEXT:    [[tex_img:%[0-9]+]] = OpImage %type_2d_image [[tex]]
+// CHECK-NEXT:       {{%[0-9]+}} = OpImageFetch %v4float [[tex_img]] [[coord_0]] Lod|ConstOffset [[lod_0]] [[v2ic]]
+    float4 val2 = tex2D_F4.Load(location, int2(1, 2));
+
+/////////////////////////////////
+/// Using the Status argument ///
+/////////////////////////////////
+
+// CHECK:        [[loc:%[0-9]+]] = OpLoad %v3int %location
+// CHECK-NEXT: [[coord_0:%[0-9]+]] = OpVectorShuffle %v2int [[loc]] [[loc]] 0 1
+// CHECK-NEXT:   [[lod_0:%[0-9]+]] = OpCompositeExtract %int [[loc]] 2
+// CHECK-NEXT:    [[tex:%[0-9]+]] = OpLoad %type_sampled_image %tex2D_F4
+// CHECK-NEXT:    [[tex_img:%[0-9]+]] = OpImage %type_2d_image [[tex]]
+// CHECK-NEXT:[[structResult:%[0-9]+]] = OpImageSparseFetch %SparseResidencyStruct [[tex_img]] [[coord_0]] Lod|ConstOffset [[lod_0]] [[v2ic]]
+// CHECK-NEXT:      [[status:%[0-9]+]] = OpCompositeExtract %uint [[structResult]] 0
+// CHECK-NEXT:                        OpStore %status [[status]]
+// CHECK-NEXT:    [[v4result:%[0-9]+]] = OpCompositeExtract %v4float [[structResult]] 1
+// CHECK-NEXT:                        OpStore %val3 [[v4result]]
+    float4  val3 = tex2D_F4.Load(location, int2(1, 2), status);
+
+    return 1.0;
+}

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -1242,4 +1242,7 @@ namespace VkSampledTexture2DMethods {
     void [[]] GetDimensions(in uint x, out float_like width, out $type2 height, out $type2 levels) : resinfo;
     void [[]] GetDimensions(out uint_only width, out $type1 height) : resinfo_uint_o;
     void [[]] GetDimensions(out float_like width, out $type1 height) : resinfo_o;
+    $classT [[ro]] Load(in int<3> x) : tex2d_t_load;
+    $classT [[ro]] Load(in int<3> x, in int<2> o) : tex2d_t_load_o;
+    $classT [[]] Load(in int<3> x, in int<2> o, out uint_only status) : tex2d_t_load_o_s;
 } namespace


### PR DESCRIPTION
Part of https://github.com/microsoft/DirectXShaderCompiler/issues/7979

Implement `Load()` methods for `vk::SampledTexture2D`:
```hlsl
ParamType Load(int3 location, [], [ParamType offset], [uint status]);
```
Please see the last commit.