### PR TITLE
Revert "[SM6.10] Add dx.types.MatrixRef to DXIL"

### DIFF
--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -10539,12 +10539,12 @@ struct DxilInst_FillMatrix {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_value = 2,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_value() const { return Instr->getOperand(2); }
   void set_value(llvm::Value *val) { Instr->setOperand(2, val); }
 };
@@ -10570,15 +10570,15 @@ struct DxilInst_CopyConvertMatrix {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_destination = 1,
-    arg_source = 2,
+    arg_destMatrixRef = 1,
+    arg_srcMatrixRef = 2,
     arg_transpose = 3,
   };
   // Accessors
-  llvm::Value *get_destination() const { return Instr->getOperand(1); }
-  void set_destination(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_source() const { return Instr->getOperand(2); }
-  void set_source(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_destMatrixRef() const { return Instr->getOperand(1); }
+  void set_destMatrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_srcMatrixRef() const { return Instr->getOperand(2); }
+  void set_srcMatrixRef(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_transpose() const { return Instr->getOperand(3); }
   void set_transpose(llvm::Value *val) { Instr->setOperand(3, val); }
 };
@@ -10604,15 +10604,15 @@ struct DxilInst_MatrixLoadFromDescriptor {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_handle = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_handle() const { return Instr->getOperand(2); }
   void set_handle(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -10643,15 +10643,15 @@ struct DxilInst_MatrixLoadFromMemory {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_groupsharedArr = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_groupsharedArr() const { return Instr->getOperand(2); }
   void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -10683,11 +10683,11 @@ struct DxilInst_MatrixLength {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
 };
 
 /// This instruction returns a two element vector containing the column and row
@@ -10711,12 +10711,12 @@ struct DxilInst_MatrixGetCoordinate {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_threadLocalIndex = 2,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_threadLocalIndex() const { return Instr->getOperand(2); }
   void set_threadLocalIndex(llvm::Value *val) { Instr->setOperand(2, val); }
 };
@@ -10742,12 +10742,12 @@ struct DxilInst_MatrixGetElement {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_threadLocalIndex = 2,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_threadLocalIndex() const { return Instr->getOperand(2); }
   void set_threadLocalIndex(llvm::Value *val) { Instr->setOperand(2, val); }
 };
@@ -10773,13 +10773,13 @@ struct DxilInst_MatrixSetElement {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_threadLocalIndex = 2,
     arg_value = 3,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_threadLocalIndex() const { return Instr->getOperand(2); }
   void set_threadLocalIndex(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_value() const { return Instr->getOperand(3); }
@@ -10806,15 +10806,15 @@ struct DxilInst_MatrixStoreToDescriptor {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_handle = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_handle() const { return Instr->getOperand(2); }
   void set_handle(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -10845,15 +10845,15 @@ struct DxilInst_MatrixStoreToMemory {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_groupsharedArr = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_groupsharedArr() const { return Instr->getOperand(2); }
   void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -10906,17 +10906,17 @@ struct DxilInst_MatrixMulOp {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixA = 1,
-    arg_matrixB = 2,
-    arg_matrixC = 3,
+    arg_matrixRefA = 1,
+    arg_matrixRefB = 2,
+    arg_matrixRefC = 3,
   };
   // Accessors
-  llvm::Value *get_matrixA() const { return Instr->getOperand(1); }
-  void set_matrixA(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_matrixB() const { return Instr->getOperand(2); }
-  void set_matrixB(llvm::Value *val) { Instr->setOperand(2, val); }
-  llvm::Value *get_matrixC() const { return Instr->getOperand(3); }
-  void set_matrixC(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_matrixRefA() const { return Instr->getOperand(1); }
+  void set_matrixRefA(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRefB() const { return Instr->getOperand(2); }
+  void set_matrixRefB(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_matrixRefC() const { return Instr->getOperand(3); }
+  void set_matrixRefC(llvm::Value *val) { Instr->setOperand(3, val); }
 };
 
 /// This instruction accumulate A or B matrix into Accumulator matrix following
@@ -10940,14 +10940,14 @@ struct DxilInst_MatrixAccumulate {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRHS = 1,
-    arg_matrixLHS = 2,
+    arg_matrixRefRHS = 1,
+    arg_matrixRefLHS = 2,
   };
   // Accessors
-  llvm::Value *get_matrixRHS() const { return Instr->getOperand(1); }
-  void set_matrixRHS(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_matrixLHS() const { return Instr->getOperand(2); }
-  void set_matrixLHS(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_matrixRefRHS() const { return Instr->getOperand(1); }
+  void set_matrixRefRHS(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRefLHS() const { return Instr->getOperand(2); }
+  void set_matrixRefLHS(llvm::Value *val) { Instr->setOperand(2, val); }
 };
 
 /// This instruction Multiplies a MxK dimension matrix and a K sized input
@@ -10971,13 +10971,13 @@ struct DxilInst_MatrixVecMul {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_inputVector = 2,
     arg_interpretation = 3,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_inputVector() const { return Instr->getOperand(2); }
   void set_inputVector(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_interpretation() const { return Instr->getOperand(3); }
@@ -11005,15 +11005,15 @@ struct DxilInst_MatrixVecMulAdd {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_inputVector = 2,
     arg_inputInterpretation = 3,
     arg_biasVector = 4,
     arg_biasInterpretation = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_inputVector() const { return Instr->getOperand(2); }
   void set_inputVector(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_inputInterpretation() const { return Instr->getOperand(3); }
@@ -11045,15 +11045,15 @@ struct DxilInst_MatrixAccumulateToDescriptor {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_handle = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_handle() const { return Instr->getOperand(2); }
   void set_handle(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -11085,15 +11085,15 @@ struct DxilInst_MatrixAccumulateToMemory {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_groupsharedArr = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_groupsharedArr() const { return Instr->getOperand(2); }
   void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -11125,13 +11125,13 @@ struct DxilInst_MatrixOuterProduct {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrix = 1,
+    arg_matrixRef = 1,
     arg_vectorA = 2,
     arg_vectorB = 3,
   };
   // Accessors
-  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
-  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
+  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_vectorA() const { return Instr->getOperand(2); }
   void set_vectorA(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_vectorB() const { return Instr->getOperand(3); }

--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -84,7 +84,6 @@ public:
   llvm::LLVMContext &GetCtx() { return m_Ctx; }
   llvm::Module *GetModule() { return m_pModule; }
   llvm::Type *GetHandleType() const;
-  llvm::Type *GetMatrixRefType() const;
   llvm::Type *GetHitObjectType() const;
   llvm::Type *GetNodeHandleType() const;
   llvm::Type *GetNodeRecordHandleType() const;
@@ -191,7 +190,6 @@ private:
   llvm::Type *m_pSplitDoubleType;
   llvm::Type *m_pFourI32Type;
   llvm::Type *m_pFourI16Type;
-  llvm::Type *m_pMatrixRefType;
 
   DXIL::LowPrecisionMode m_LowPrecisionMode;
 

--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -164,8 +164,6 @@ bool IsHLSLObjectType(llvm::Type *Ty);
 bool IsHLSLRayQueryType(llvm::Type *Ty);
 llvm::Type *GetHLSLHitObjectType(llvm::Module *M);
 bool IsHLSLHitObjectType(llvm::Type *Ty);
-llvm::Type *GetHLSLMatrixRefType(llvm::Module *M);
-bool IsHLSLMatrixRefType(llvm::Type *Ty);
 bool IsHLSLResourceDescType(llvm::Type *Ty);
 bool IsResourceSingleComponent(llvm::Type *Ty);
 uint8_t GetResourceComponentCount(llvm::Type *Ty);

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -4118,9 +4118,6 @@ OP::OP(LLVMContext &Ctx, Module *pModule)
                            Type::getInt16Ty(m_Ctx)}; // HiHi, HiLo, LoHi, LoLo
   m_pFourI16Type =
       GetOrCreateStructType(m_Ctx, FourI16Types, "dx.types.fouri16", pModule);
-
-  m_pMatrixRefType = GetOrCreateStructType(m_Ctx, Type::getInt8PtrTy(m_Ctx),
-                                           "dx.types.MatrixRef", pModule);
 }
 
 void OP::RefreshCache() {
@@ -4231,7 +4228,6 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   Type *pETy = pOverloadType;
   Type *pRes = GetHandleType();
   Type *pNodeHandle = GetNodeHandleType();
-  Type *pMatrixRef = GetMatrixRefType();
   Type *pNodeRecordHandle = GetNodeRecordHandleType();
   Type *pDim = GetDimensionsType();
   Type *pPos = GetSamplePosType();
@@ -6530,26 +6526,26 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
 
     // Linear Algebra Operations
   case OpCode::CreateMatrix:
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     break;
   case OpCode::FillMatrix:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pETy);
     break;
   case OpCode::CopyConvertMatrix:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
-    A(pMatrixRef);
+    A(pI32);
+    A(pI32);
     A(pI1);
     break;
   case OpCode::MatrixLoadFromDescriptor:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pRes);
     A(pI32);
     A(pI32);
@@ -6558,7 +6554,7 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixLoadFromMemory:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     A(pI32);
     A(pI32);
@@ -6567,31 +6563,31 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixLength:
     A(pI32);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     break;
   case OpCode::MatrixGetCoordinate:
     A(pI32);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     break;
   case OpCode::MatrixGetElement:
     A(pETy);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     break;
   case OpCode::MatrixSetElement:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     A(pETy);
     break;
   case OpCode::MatrixStoreToDescriptor:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pRes);
     A(pI32);
     A(pI32);
@@ -6600,7 +6596,7 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixStoreToMemory:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     A(pI32);
     A(pI32);
@@ -6613,27 +6609,27 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixMulOp:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
-    A(pMatrixRef);
-    A(pMatrixRef);
+    A(pI32);
+    A(pI32);
+    A(pI32);
     break;
   case OpCode::MatrixAccumulate:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
-    A(pMatrixRef);
+    A(pI32);
+    A(pI32);
     break;
   case OpCode::MatrixVecMul:
     EXT(0);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     EXT(1);
     A(pI32);
     break;
   case OpCode::MatrixVecMulAdd:
     EXT(0);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     EXT(1);
     A(pI32);
     A(pI32);
@@ -6642,7 +6638,7 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixAccumulateToDescriptor:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pRes);
     A(pI32);
     A(pI32);
@@ -6651,7 +6647,7 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixAccumulateToMemory:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     A(pI32);
     A(pI32);
     A(pI32);
@@ -6660,7 +6656,7 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixOuterProduct:
     A(pV);
     A(pI32);
-    A(pMatrixRef);
+    A(pI32);
     EXT(0);
     EXT(1);
     break;
@@ -7058,8 +7054,6 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
 Type *OP::GetHandleType() const { return m_pHandleType; }
 
 Type *OP::GetNodeHandleType() const { return m_pNodeHandleType; }
-
-Type *OP::GetMatrixRefType() const { return m_pMatrixRefType; }
 
 Type *OP::GetHitObjectType() const { return m_pHitObjectType; }
 

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -577,9 +577,6 @@ bool IsHLSLObjectType(llvm::Type *Ty) {
 
     if (IsHLSLHitObjectType(Ty))
       return true;
-
-    if (IsHLSLMatrixRefType(Ty))
-      return true;
   }
   return false;
 }
@@ -613,24 +610,6 @@ bool IsHLSLHitObjectType(llvm::Type *Ty) {
   if (!ST->hasName())
     return false;
   return ST->getName() == "dx.types.HitObject";
-}
-
-llvm::Type *GetHLSLMatrixRefType(llvm::Module *M) {
-  using namespace llvm;
-  StructType *MatrixRefTy = M->getTypeByName("dx.types.MatrixRef");
-  if (!MatrixRefTy)
-    MatrixRefTy = StructType::create({Type::getInt8PtrTy(M->getContext(), 0)},
-                                     "dx.types.MatrixRef", false);
-  return MatrixRefTy;
-}
-
-bool IsHLSLMatrixRefType(llvm::Type *Ty) {
-  llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty);
-  if (!ST)
-    return false;
-  if (!ST->hasName())
-    return false;
-  return ST->getName() == "dx.types.MatrixRef";
 }
 
 bool IsHLSLResourceDescType(llvm::Type *Ty) {

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -6321,7 +6321,9 @@ class db_dxil(object):
             "v",
             "",
             [
-                db_dxil_param(0, "matrixref", "", "operation result"),
+                db_dxil_param(
+                    0, "i32", "", "operation result"
+                ),  # TODO: %dx.types.MatrixRef
             ],
         )
 
@@ -6333,7 +6335,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be filled"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be filled"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(3, "$o", "value", "value to fill matrix with"),
             ],
         )
@@ -6346,8 +6350,12 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "destination", "matrix to be filled"),
-                db_dxil_param(3, "matrixref", "source", "matrix to fill matrix with"),
+                db_dxil_param(
+                    2, "i32", "destMatrixRef", "matrix to be filled"
+                ),  # TODO: %dx.types.MatrixRef
+                db_dxil_param(
+                    3, "i32", "srcMatrixRef", "matrix to fill matrix with"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(4, "i1", "transpose", "should the matrix be transposed"),
             ],
         )
@@ -6360,7 +6368,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be filled"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be filled"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(
                     3, "res", "handle", "byte address buffer to fill matrix with"
                 ),
@@ -6383,7 +6393,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be filled"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be filled"
+                ),  # TODO: %dx.types.MatrixRef
                 # TODO: [Ty] * addrspace(4),   ; groupshared T[M * N]
                 db_dxil_param(
                     3, "i32", "groupsharedArr", "groupshared array to fill matrix with"
@@ -6407,7 +6419,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "i32", "", "operation result"),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be examined"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be examined"
+                ),  # TODO: %dx.types.MatrixRef
             ],
         )
 
@@ -6419,7 +6433,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "i32", "", "operation result"),  # TODO: <2 x i32>
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be examined"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be examined"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(
                     3, "i32", "threadLocalIndex", "thread-local index to be examined"
                 ),
@@ -6434,7 +6450,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "$o", "", "operation result"),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be examined"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be examined"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(
                     3, "i32", "threadLocalIndex", "thread-local index to be examined"
                 ),
@@ -6449,7 +6467,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be examined"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be examined"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(
                     3, "i32", "threadLocalIndex", "thread-local index to be examined"
                 ),
@@ -6465,7 +6485,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be stored"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be stored"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(3, "res", "handle", "byte address buffer to store into"),
                 db_dxil_param(4, "i32", "offset", "starting offset in the buffer"),
                 db_dxil_param(
@@ -6486,7 +6508,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be stored"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be stored"
+                ),  # TODO: %dx.types.MatrixRef
                 # TODO: [Ty] * addrspace(4),   ; groupshared T[M * N]
                 db_dxil_param(
                     3, "i32", "groupsharedArr", "groupshared array to store into"
@@ -6521,9 +6545,15 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrixA", "matrix A"),
-                db_dxil_param(3, "matrixref", "matrixB", "matrix B"),
-                db_dxil_param(4, "matrixref", "matrixC", "matrix C"),
+                db_dxil_param(
+                    2, "i32", "matrixRefA", "matrix A"
+                ),  # TODO: %dx.types.MatrixRef
+                db_dxil_param(
+                    3, "i32", "matrixRefB", "matrix B"
+                ),  # TODO: %dx.types.MatrixRef
+                db_dxil_param(
+                    4, "i32", "matrixRefC", "matrix C"
+                ),  # TODO: %dx.types.MatrixRef
             ],
         )
 
@@ -6535,8 +6565,12 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrixRHS", "A or B matrix"),
-                db_dxil_param(3, "matrixref", "matrixLHS", "Accumulator matrix"),
+                db_dxil_param(
+                    2, "i32", "matrixRefRHS", "A or B matrix"
+                ),  # TODO: %dx.types.MatrixRef
+                db_dxil_param(
+                    3, "i32", "matrixRefLHS", "Accumulator matrix"
+                ),  # TODO: %dx.types.MatrixRef
             ],
         )
 
@@ -6548,7 +6582,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "$x0", "", "operation result"),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to multiply"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to multiply"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(3, "$x1", "inputVector", "K dim vector to multiply"),
                 db_dxil_param(4, "i32", "interpretation", "vector interpretation type"),
             ],
@@ -6562,7 +6598,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "$x0", "", "operation result"),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to multiply"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to multiply"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(3, "$x1", "inputVector", "K dim vector to multiply"),
                 db_dxil_param(
                     4, "i32", "inputInterpretation", "input vector interpretation type"
@@ -6583,7 +6621,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be accumulated"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be accumulated"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(
                     3, "res", "handle", "byte address buffer to accumulated into"
                 ),
@@ -6606,7 +6646,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to be accumulated"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to be accumulated"
+                ),  # TODO: %dx.types.MatrixRef
                 # TODO: [Ty] * addrspace(4),   ; groupshared T[M * N]
                 db_dxil_param(
                     3, "i32", "groupsharedArr", "groupshared array to accumulate into"
@@ -6630,7 +6672,9 @@ class db_dxil(object):
             "",
             [
                 db_dxil_param(0, "v", "", ""),
-                db_dxil_param(2, "matrixref", "matrix", "matrix to fill"),
+                db_dxil_param(
+                    2, "i32", "matrixRef", "matrix to fill"
+                ),  # TODO: %dx.types.MatrixRef
                 db_dxil_param(3, "$x0", "vectorA", "M dim vector"),
                 db_dxil_param(4, "$x1", "vectorB", "K dim vector"),
             ],

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -641,7 +641,6 @@ class db_oload_gen:
             "nodeproperty": "A(nodeProperty);",
             "noderecordproperty": "A(nodeRecordProperty);",
             "hit_object": "A(pHit);",
-            "matrixref": "A(pMatrixRef);",
             # Extended overload slots, extend as needed:
             "$x0": "EXT(0);",
             "$x1": "EXT(1);",


### PR DESCRIPTION
Reverts microsoft/DirectXShaderCompiler#8027

the `dx.types.MatrixRef` type is no longer part of the spec and any fix forward attempts just became essentially reverts so instead I'm just putting up a clear revert PR.