### PR TITLE
Execution Tests: change warning to error

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -85,7 +85,7 @@ static bool createDevice(
 ) {
   if (*D3DDevice)
     LogErrorFmt(L"createDevice called with non-null *D3DDevice - "
-                  L"this will likely leak the previous device");
+                L"this will likely leak the previous device");
   if (TestModel > D3D_HIGHEST_SHADER_MODEL) {
     const UINT Minor = (UINT)TestModel & 0x0f;
     LogCommentFmt(L"Installed SDK does not support "


### PR DESCRIPTION
Previously, this was a warning while we convinced ourselves that an error wouldn't break anything.

Fixes #7958