### PR TITLE
Execution Tests: 64 bit raw buffer loads should be sm 63

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -1632,7 +1632,7 @@
       <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' Flags='RAW' NumElements="60" Format="R32_TYPELESS" />
       <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="1" StructureByteStride="240" />
     </DescriptorHeap>
-    <Shader Name="CS" Target="cs_6_2">
+    <Shader Name="CS" Target="cs_6_3">
       <![CDATA[// Shader source code will be set at runtime]]>
     </Shader>
   </ShaderOp>>


### PR DESCRIPTION
This PR addresses a bug where ComputeRawBufferLdStI* tests were targeting SM6.2 when they should be targeting 6.3.
Resolves #7747 