### PR TITLE
[NFC] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ tools/polly
 docs/_build
 # TAEF crash logs.
 WexLogFileOutput/*
+# .cache directory - used by clangd
+.cache
 
 #==============================================================================#
 # Files created in tree by the Go bindings.


### PR DESCRIPTION
Adds .cache directory to .gitignore. It is used by clangd.