### PR TITLE
Execution Tests: Split long vector tests into classes based on hlk requirement

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -2745,8 +2745,9 @@ public:
       "Kits.TestName",
       "D3D12 - Shader Model 6.9 - Vectorized DXIL - Double Precision Tests")
   TEST_CLASS_PROPERTY("Kits.TestId", "3a7a9687-6d99-469d-9951-795c2fcbe94d")
-  TEST_CLASS_PROPERTY("Kits.Description",
-                      "Validates required SM 6.9 vectorized DXIL operations")
+  TEST_CLASS_PROPERTY(
+      "Kits.Description",
+      "Validates required double precision SM 6.9 vectorized DXIL operations")
   TEST_METHOD_PROPERTY(
       "Kits.Specification",
       "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")


### PR DESCRIPTION
This PR splits the long vector HLK execution tests into two taef subclasses. The reasoning for this is that the HLK infrastructure creates test 'jobs' based off of a the Kits.TestId GUID. By splitting into two sub classes we're able to have one 'job' that runs the core requirement tests and another that runs the tests dependent on double precision support in addition to SM6.9 support.

Verified by manually loading the test dll onto a dev HLK server and running the tool to update the HLK job database.