### PR TITLE
[NFC] Execution Tests: Cleanup IsNormal and IsNormalHalf in xml

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml
@@ -320,47 +320,6 @@
                 <Value>0</Value>
             </Parameter>
         </Row>
-	<Row Name="IsNormal">
-            <Parameter Name="Validation.Type">Epsilon</Parameter>
-            <Parameter Name="Validation.Tolerance">0</Parameter>
-            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
-                float input;
-                float output;
-            };
-            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
-            [numthreads(8,8,1)]
-            void main(uint GI : SV_GroupIndex) {
-                SUnaryFPOp l = g_buf[GI];
-                if (isnormal(l.input))
-                    l.output = 1;
-                else
-                    l.output = 0;
-                g_buf[GI] = l;
-            };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
-            <Parameter Name="Validation.Input1">
-                <Value>NaN</Value>
-                <Value>-Inf</Value>
-                <Value>-denorm</Value>
-                <Value>-0</Value>
-                <Value>0</Value>
-                <Value>denorm</Value>
-                <Value>Inf</Value>
-                <Value>1.0</Value>
-                <Value>-1.0</Value>
-            </Parameter>
-            <Parameter Name="Validation.Expected1">
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>1</Value>
-                <Value>1</Value>
-            </Parameter>
-        </Row>
         <Row Name="Exp">
             <Parameter Name="Validation.Type">Relative</Parameter>
             <Parameter Name="Validation.Tolerance">21</Parameter>
@@ -1358,48 +1317,6 @@
                 <Value>1</Value>
                 <Value>0</Value>
                 <Value>0</Value>
-            </Parameter>
-            <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
-        </Row>
-	<Row Name="IsNormalHalf">
-            <Parameter Name="Validation.Type">Epsilon</Parameter>
-            <Parameter Name="Validation.Tolerance">0</Parameter>
-            <Parameter Name="ShaderOp.Text"> struct SUnaryFPOp {
-                float16_t input;
-                float16_t output;
-            };
-            RWStructuredBuffer&lt;SUnaryFPOp&gt; g_buf : register(u0);
-            [numthreads(8,8,1)]
-            void main(uint GI : SV_GroupIndex) {
-                SUnaryFPOp l = g_buf[GI];
-                if (isnormal(l.input))
-                    l.output = 1;
-                else
-                    l.output = 0;
-                g_buf[GI] = l;
-            };</Parameter>
-            <Parameter Name="ShaderOp.Target">cs_6_9</Parameter>
-            <Parameter Name="Validation.Input1">
-                <Value>NaN</Value>
-                <Value>-Inf</Value>
-                <Value>-denorm</Value>
-                <Value>-0</Value>
-                <Value>0</Value>
-                <Value>denorm</Value>
-                <Value>Inf</Value>
-                <Value>1.0</Value>
-                <Value>-1.0</Value>
-            </Parameter>
-            <Parameter Name="Validation.Expected1">
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-                <Value>1</Value>
-                <Value>1</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-enable-16bit-types</Parameter>
         </Row>


### PR DESCRIPTION
Remove unused test information in ShaderOpArithTable.xml.
Resolves #8136 