### PR TITLE
[Release SM 6.9] Cherry-Pick : Execution Tests: Split long vector tests into classes based on hlk requirement#8134

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -2756,7 +2756,7 @@ public:
   TEST_CLASS_SETUP(setupClass) {
     const bool result = TestClassCommon::setupClass();
 #ifndef _HLK_CONF
-    if (result && !doesDeviceSupportDouble(D3DDevice)) {
+    if (result) {
       WEX::Logging::Log::Comment(
           L"Skipping test as device does not support double precision.");
       WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);


### PR DESCRIPTION
Cherry-Pick : [Execution Tests: Split long vector tests into classes based on hlk requirement#8134](https://github.com/microsoft/DirectXShaderCompiler/pull/8134)

Cherry-picked from [main@da2d4a33913b178ef74e571bbbf35ca3aac34d57](https://github.com/microsoft/DirectXShaderCompiler/commit/da2d4a33913b178ef74e571bbbf35ca3aac34d57)