### PR TITLE
Omit reserved DXIL ops enum; catch reserved in validator

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -2342,18 +2342,6 @@ ID  Name                                                  Description
 223 TextureGatherRaw                                      Gather raw elements from 4 texels with no type conversions (SRV type is constrained)
 224 SampleCmpLevel                                        samples a texture and compares a single component against the specified comparison value
 225 TextureStoreSample                                    stores texel data at specified sample index
-226 Reserved_0x000000E2                                   reserved
-227 Reserved_0x000000E3                                   reserved
-228 Reserved_0x000000E4                                   reserved
-229 Reserved_0x000000E5                                   reserved
-230 Reserved_0x000000E6                                   reserved
-231 Reserved_0x000000E7                                   reserved
-232 Reserved_0x000000E8                                   reserved
-233 Reserved_0x000000E9                                   reserved
-234 Reserved_0x000000EA                                   reserved
-235 Reserved_0x000000EB                                   reserved
-236 Reserved_0x000000EC                                   reserved
-237 Reserved_0x000000ED                                   reserved
 238 AllocateNodeOutputRecords                             returns a handle for the output records
 239 GetNodeRecordPtr                                      retrieve node input/output record pointer in address space 6
 240 IncrementOutputCount                                  Select the next logical output count for an EmptyNodeOutput for the whole group or per thread.
@@ -2375,9 +2363,6 @@ ID  Name                                                  Description
 256 StartVertexLocation                                   returns the BaseVertexLocation from DrawIndexedInstanced or StartVertexLocation from DrawInstanced
 257 StartInstanceLocation                                 returns the StartInstanceLocation from Draw*Instanced
 258 AllocateRayQuery2                                     allocates space for RayQuery and return handle
-259 Reserved_0x00000103                                   reserved
-260 Reserved_0x00000104                                   reserved
-261 Reserved_0x00000105                                   reserved
 262 HitObject_TraceRay                                    Analogous to TraceRay but without invoking CH/MS and returns the intermediate state as a HitObject
 263 HitObject_FromRayQuery                                Creates a new HitObject representing a committed hit from a RayQuery
 264 HitObject_FromRayQueryWithAttrs                       Creates a new HitObject representing a committed hit from a RayQuery and committed attributes
@@ -2406,19 +2391,6 @@ ID  Name                                                  Description
 287 HitObject_SetShaderTableIndex                         Returns a HitObject with updated shader table index
 288 HitObject_LoadLocalRootTableConstant                  Returns the root table constant for this HitObject and offset
 289 HitObject_Attributes                                  Returns the attributes set for this HitObject
-290 Reserved_0x00000122                                   reserved
-291 Reserved_0x00000123                                   reserved
-292 Reserved_0x00000124                                   reserved
-293 Reserved_0x00000125                                   reserved
-294 Reserved_0x00000126                                   reserved
-295 Reserved_0x00000127                                   reserved
-296 Reserved_0x00000128                                   reserved
-297 Reserved_0x00000129                                   reserved
-298 Reserved_0x0000012A                                   reserved
-299 Reserved_0x0000012B                                   reserved
-300 Reserved_0x0000012C                                   reserved
-301 Reserved_0x0000012D                                   reserved
-302 Reserved_0x0000012E                                   reserved
 303 RawBufferVectorLoad                                   reads from a raw buffer and structured buffer
 304 RawBufferVectorStore                                  writes to a RWByteAddressBuffer or RWStructuredBuffer
 305 MatVecMul                                             Multiplies a MxK dimension matrix and a K sized input vector
@@ -3095,9 +3067,6 @@ ID         Name                                     Description
 2147483675 LinAlgMatrixAccumulateToDescriptor       accumulates a matrix to a RWByteAddressBuffer
 2147483676 LinAlgMatrixAccumulateToMemory           accumulates a matrix to groupshared memory
 2147483677 LinAlgMatrixOuterProduct                 Outer products an M sized vector and a N sized vector producing an MxN matrix
-2147483678 Reserved_0x8000001E                      reserved
-2147483679 Reserved_0x8000001F                      reserved
-2147483680 Reserved_0x80000020                      reserved
 2147483681 DebugBreak                               triggers a breakpoint if a debugger is attached
 2147483682 IsDebuggerPresent                        returns true if a debugger is attached
 ========== ======================================== ===================================================================================================================

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -523,11 +523,6 @@ namespace ExperimentalOps {
 static const OpCodeTableID TableID = OpCodeTableID::ExperimentalOps;
 // Enumeration for ExperimentalOps DXIL operations
 enum class OpCode : unsigned {
-  //
-  Reserved_0x8000001E = 30, // reserved
-  Reserved_0x8000001F = 31, // reserved
-  Reserved_0x80000020 = 32, // reserved
-
   // Debugging
   DebugBreak = 33,        // triggers a breakpoint if a debugger is attached
   IsDebuggerPresent = 34, // returns true if a debugger is attached
@@ -603,6 +598,9 @@ enum class OpCode : unsigned {
   HitObject_TriangleObjectPosition =
       10, // returns triangle vertices in object space as <9 x float>
 
+  // Reserved values:
+  // 30, 31, 32
+
   NumOpCodes = 35, // exclusive last value of enumeration
 };
 } // namespace ExperimentalOps
@@ -618,36 +616,6 @@ static const unsigned NumOpCodeTables = 2;
 // OPCODE-ENUM:BEGIN
 // Enumeration for CoreOps DXIL operations
 enum class OpCode : unsigned {
-  //
-  Reserved_0x000000E2 = 226, // reserved
-  Reserved_0x000000E3 = 227, // reserved
-  Reserved_0x000000E4 = 228, // reserved
-  Reserved_0x000000E5 = 229, // reserved
-  Reserved_0x000000E6 = 230, // reserved
-  Reserved_0x000000E7 = 231, // reserved
-  Reserved_0x000000E8 = 232, // reserved
-  Reserved_0x000000E9 = 233, // reserved
-  Reserved_0x000000EA = 234, // reserved
-  Reserved_0x000000EB = 235, // reserved
-  Reserved_0x000000EC = 236, // reserved
-  Reserved_0x000000ED = 237, // reserved
-  Reserved_0x00000103 = 259, // reserved
-  Reserved_0x00000104 = 260, // reserved
-  Reserved_0x00000105 = 261, // reserved
-  Reserved_0x00000122 = 290, // reserved
-  Reserved_0x00000123 = 291, // reserved
-  Reserved_0x00000124 = 292, // reserved
-  Reserved_0x00000125 = 293, // reserved
-  Reserved_0x00000126 = 294, // reserved
-  Reserved_0x00000127 = 295, // reserved
-  Reserved_0x00000128 = 296, // reserved
-  Reserved_0x00000129 = 297, // reserved
-  Reserved_0x0000012A = 298, // reserved
-  Reserved_0x0000012B = 299, // reserved
-  Reserved_0x0000012C = 300, // reserved
-  Reserved_0x0000012D = 301, // reserved
-  Reserved_0x0000012E = 302, // reserved
-
   // Amplification shader instructions
   DispatchMesh = 173, // Amplification shader intrinsic DispatchMesh
 
@@ -1201,6 +1169,10 @@ enum class OpCode : unsigned {
   OutputComplete =
       241, // indicates all outputs for a given records are complete
 
+  // Reserved values:
+  // 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 259, 260, 261,
+  // 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302
+
   NumOpCodes_Dxil_1_0 = 137,
   NumOpCodes_Dxil_1_1 = 139,
   NumOpCodes_Dxil_1_2 = 141,
@@ -1351,12 +1323,6 @@ enum class OpCode : unsigned {
       ExperimentalOps,
       LinAlgMatrixOuterProduct), // Outer products an M sized vector and a N
                                  // sized vector producing an MxN matrix
-  // Reserved_0x8000001E = 0x8000001E, 2147483678U, -2147483618
-  EXP_OPCODE(ExperimentalOps, Reserved_0x8000001E), // reserved
-  // Reserved_0x8000001F = 0x8000001F, 2147483679U, -2147483617
-  EXP_OPCODE(ExperimentalOps, Reserved_0x8000001F), // reserved
-  // Reserved_0x80000020 = 0x80000020, 2147483680U, -2147483616
-  EXP_OPCODE(ExperimentalOps, Reserved_0x80000020), // reserved
   // DebugBreak = 0x80000021, 2147483681U, -2147483615
   EXP_OPCODE(ExperimentalOps,
              DebugBreak), // triggers a breakpoint if a debugger is attached

--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -276,6 +276,7 @@ public:
                            unsigned *OptTableIndex = nullptr);
   static bool IsValidOpCode(unsigned EncodedOpCode);
   static bool IsValidOpCode(OpCode EncodedOpCode);
+  static bool IsReservedOpCode(unsigned EncodedOpCode);
 
 private:
   // Static properties.

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -35,6 +35,10 @@ using OCC = OP::OpCodeClass;
 //
 //  OP class const-static data and related static methods.
 //
+static const OP::OpCodeProperty ReservedOpCodeProps = {
+    OC::Invalid, "Reserved", OCC::Reserved, "reserved", Attribute::None, 0,
+    {},          {}};
+
 /* <py>
 import hctdb_instrhelp
 </py> */
@@ -1995,104 +1999,19 @@ static const OP::OpCodeProperty CoreOps_OpCodeProps[] = {
      Attribute::None,
      1,
      {{0x63}},
-     {{0x0}}}, // Overloads: hfwi
-
-    {OC::Reserved_0x000000E2,
-     "Reserved_0x000000E2",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E3,
-     "Reserved_0x000000E3",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E4,
-     "Reserved_0x000000E4",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E5,
-     "Reserved_0x000000E5",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E6,
-     "Reserved_0x000000E6",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E7,
-     "Reserved_0x000000E7",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E8,
-     "Reserved_0x000000E8",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000E9,
-     "Reserved_0x000000E9",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000EA,
-     "Reserved_0x000000EA",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000EB,
-     "Reserved_0x000000EB",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000EC,
-     "Reserved_0x000000EC",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x000000ED,
-     "Reserved_0x000000ED",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     {{0x0}}},           // Overloads: hfwi
+    ReservedOpCodeProps, // Reserved: 0x000000E2
+    ReservedOpCodeProps, // Reserved: 0x000000E3
+    ReservedOpCodeProps, // Reserved: 0x000000E4
+    ReservedOpCodeProps, // Reserved: 0x000000E5
+    ReservedOpCodeProps, // Reserved: 0x000000E6
+    ReservedOpCodeProps, // Reserved: 0x000000E7
+    ReservedOpCodeProps, // Reserved: 0x000000E8
+    ReservedOpCodeProps, // Reserved: 0x000000E9
+    ReservedOpCodeProps, // Reserved: 0x000000EA
+    ReservedOpCodeProps, // Reserved: 0x000000EB
+    ReservedOpCodeProps, // Reserved: 0x000000EC
+    ReservedOpCodeProps, // Reserved: 0x000000ED
 
     // Create/Annotate Node Handles
     {OC::AllocateNodeOutputRecords,
@@ -2278,32 +2197,10 @@ static const OP::OpCodeProperty CoreOps_OpCodeProps[] = {
      Attribute::None,
      0,
      {},
-     {}}, // Overloads: v
-
-    {OC::Reserved_0x00000103,
-     "Reserved_0x00000103",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000104,
-     "Reserved_0x00000104",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000105,
-     "Reserved_0x00000105",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     {}},                // Overloads: v
+    ReservedOpCodeProps, // Reserved: 0x00000103
+    ReservedOpCodeProps, // Reserved: 0x00000104
+    ReservedOpCodeProps, // Reserved: 0x00000105
 
     // Shader Execution Reordering
     {OC::HitObject_TraceRay,
@@ -2529,112 +2426,20 @@ static const OP::OpCodeProperty CoreOps_OpCodeProps[] = {
      Attribute::ArgMemOnly,
      1,
      {{0x100}},
-     {{0x0}}}, // Overloads: u
-
-    {OC::Reserved_0x00000122,
-     "Reserved_0x00000122",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000123,
-     "Reserved_0x00000123",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000124,
-     "Reserved_0x00000124",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000125,
-     "Reserved_0x00000125",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000126,
-     "Reserved_0x00000126",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000127,
-     "Reserved_0x00000127",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000128,
-     "Reserved_0x00000128",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x00000129,
-     "Reserved_0x00000129",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x0000012A,
-     "Reserved_0x0000012A",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x0000012B,
-     "Reserved_0x0000012B",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x0000012C,
-     "Reserved_0x0000012C",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x0000012D,
-     "Reserved_0x0000012D",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x0000012E,
-     "Reserved_0x0000012E",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     {{0x0}}},           // Overloads: u
+    ReservedOpCodeProps, // Reserved: 0x00000122
+    ReservedOpCodeProps, // Reserved: 0x00000123
+    ReservedOpCodeProps, // Reserved: 0x00000124
+    ReservedOpCodeProps, // Reserved: 0x00000125
+    ReservedOpCodeProps, // Reserved: 0x00000126
+    ReservedOpCodeProps, // Reserved: 0x00000127
+    ReservedOpCodeProps, // Reserved: 0x00000128
+    ReservedOpCodeProps, // Reserved: 0x00000129
+    ReservedOpCodeProps, // Reserved: 0x0000012A
+    ReservedOpCodeProps, // Reserved: 0x0000012B
+    ReservedOpCodeProps, // Reserved: 0x0000012C
+    ReservedOpCodeProps, // Reserved: 0x0000012D
+    ReservedOpCodeProps, // Reserved: 0x0000012E
 
     // Resources
     {OC::RawBufferVectorLoad,
@@ -2977,31 +2782,9 @@ static const OP::OpCodeProperty ExperimentalOps_OpCodeProps[] = {
      3,
      {{0x200}, {0x400}, {0x400}},
      {{0x0}, {0x63}, {0x63}}}, // Overloads: o,<hfwi,<hfwi
-
-    {OC::Reserved_0x8000001E,
-     "Reserved_0x8000001E",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x8000001F,
-     "Reserved_0x8000001F",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
-    {OC::Reserved_0x80000020,
-     "Reserved_0x80000020",
-     OCC::Reserved,
-     "reserved",
-     Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+    ReservedOpCodeProps,       // Reserved: 0x8000001E
+    ReservedOpCodeProps,       // Reserved: 0x8000001F
+    ReservedOpCodeProps,       // Reserved: 0x80000020
 
     // Debugging
     {OC::DebugBreak,
@@ -3071,14 +2854,15 @@ bool OP::DecodeOpCode(unsigned EncodedOpCode, OP::OpCodeTableID &TableID,
   unsigned TableIndex = GetOpCodeTableIndex(TID);
   if (TableIndex >= DXIL::NumOpCodeTables)
     return false;
+  OP::OpCodeTable &Table = OP::g_OpCodeTables[TableIndex];
   unsigned Op = (EncodedOpCode & 0xFFFF);
-  if (Op >= OP::g_OpCodeTables[TableIndex].Count)
+  if (Op >= Table.Count)
     return false;
   TableID = (OP::OpCodeTableID)TID;
   OpIndex = Op;
   if (OptTableIndex)
     *OptTableIndex = TableIndex;
-  return true;
+  return Table.Table[Op].opCode != OP::OpCode::Invalid;
 }
 bool OP::DecodeOpCode(OpCode EncodedOpCode, OP::OpCodeTableID &TableID,
                       unsigned &OpIndex, unsigned *OptTableIndex) {
@@ -3093,6 +2877,19 @@ bool OP::IsValidOpCode(unsigned EncodedOpCode) {
 }
 bool OP::IsValidOpCode(OP::OpCode EncodedOpCode) {
   return IsValidOpCode((unsigned)EncodedOpCode);
+}
+bool OP::IsReservedOpCode(unsigned EncodedOpCode) {
+  if (EncodedOpCode == (unsigned)OP::OpCode::Invalid)
+    return false;
+  OP::OpCodeTableID TID = (OP::OpCodeTableID)(EncodedOpCode >> 16);
+  unsigned TableIndex = GetOpCodeTableIndex(TID);
+  if (TableIndex >= DXIL::NumOpCodeTables)
+    return false;
+  OP::OpCodeTable &Table = OP::g_OpCodeTables[TableIndex];
+  unsigned Op = (EncodedOpCode & 0xFFFF);
+  if (Op >= Table.Count)
+    return false;
+  return Table.Table[Op].opCodeClass == OP::OpCodeClass::Reserved;
 }
 const OP::OpCodeProperty &OP::GetOpCodeProps(unsigned OriginalOpCode) {
   OP::OpCodeTableID TID = OP::OpCodeTableID::CoreOps;
@@ -3297,6 +3094,9 @@ bool OP::CheckOpCodeTable() {
     const OP::OpCodeTable &Table = OP::g_OpCodeTables[TableIndex];
     for (unsigned OpIndex = 0; OpIndex < Table.Count; OpIndex++) {
       const OP::OpCodeProperty &Prop = Table.Table[OpIndex];
+      // Skip reserved opcodes, which must never be used.
+      if ((unsigned)Prop.opCode == (unsigned)OP::OpCode::Invalid)
+        continue;
       OP::OpCodeTableID DecodedTID;
       unsigned DecodedOpIndex;
       unsigned DecodedTableIndex;
@@ -5960,56 +5760,6 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     break;
 
-    //
-  case OpCode::Reserved_0x000000E2:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E3:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E4:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E5:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E6:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E7:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E8:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000E9:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000EA:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000EB:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000EC:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x000000ED:
-    A(pV);
-    A(pI32);
-    break;
-
     // Create/Annotate Node Handles
   case OpCode::AllocateNodeOutputRecords:
     A(pNodeRecordHandle);
@@ -6166,20 +5916,6 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     A(pI32);
     A(pI32);
-    A(pI32);
-    break;
-
-    //
-  case OpCode::Reserved_0x00000103:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000104:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000105:
-    A(pV);
     A(pI32);
     break;
 
@@ -6361,60 +6097,6 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     A(pHit);
     A(udt);
-    break;
-
-    //
-  case OpCode::Reserved_0x00000122:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000123:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000124:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000125:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000126:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000127:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000128:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x00000129:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x0000012A:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x0000012B:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x0000012C:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x0000012D:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x0000012E:
-    A(pV);
-    A(pI32);
     break;
 
     // Resources
@@ -6711,20 +6393,6 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(EXT(2));
     break;
 
-    //
-  case OpCode::Reserved_0x8000001E:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x8000001F:
-    A(pV);
-    A(pI32);
-    break;
-  case OpCode::Reserved_0x80000020:
-    A(pV);
-    A(pI32);
-    break;
-
     // Debugging
   case OpCode::DebugBreak:
     A(pV);
@@ -6981,18 +6649,6 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::AnnotateHandle:
   case OpCode::CreateHandleFromBinding:
   case OpCode::CreateHandleFromHeap:
-  case OpCode::Reserved_0x000000E2:
-  case OpCode::Reserved_0x000000E3:
-  case OpCode::Reserved_0x000000E4:
-  case OpCode::Reserved_0x000000E5:
-  case OpCode::Reserved_0x000000E6:
-  case OpCode::Reserved_0x000000E7:
-  case OpCode::Reserved_0x000000E8:
-  case OpCode::Reserved_0x000000E9:
-  case OpCode::Reserved_0x000000EA:
-  case OpCode::Reserved_0x000000EB:
-  case OpCode::Reserved_0x000000EC:
-  case OpCode::Reserved_0x000000ED:
   case OpCode::AllocateNodeOutputRecords:
   case OpCode::IncrementOutputCount:
   case OpCode::OutputComplete:
@@ -7009,36 +6665,17 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::NodeOutputIsValid:
   case OpCode::GetRemainingRecursionLevels:
   case OpCode::AllocateRayQuery2:
-  case OpCode::Reserved_0x00000103:
-  case OpCode::Reserved_0x00000104:
-  case OpCode::Reserved_0x00000105:
   case OpCode::HitObject_FromRayQuery:
   case OpCode::HitObject_MakeMiss:
   case OpCode::HitObject_MakeNop:
   case OpCode::MaybeReorderThread:
   case OpCode::HitObject_SetShaderTableIndex:
   case OpCode::HitObject_LoadLocalRootTableConstant:
-  case OpCode::Reserved_0x00000122:
-  case OpCode::Reserved_0x00000123:
-  case OpCode::Reserved_0x00000124:
-  case OpCode::Reserved_0x00000125:
-  case OpCode::Reserved_0x00000126:
-  case OpCode::Reserved_0x00000127:
-  case OpCode::Reserved_0x00000128:
-  case OpCode::Reserved_0x00000129:
-  case OpCode::Reserved_0x0000012A:
-  case OpCode::Reserved_0x0000012B:
-  case OpCode::Reserved_0x0000012C:
-  case OpCode::Reserved_0x0000012D:
-  case OpCode::Reserved_0x0000012E:
   case OpCode::ExperimentalNop:
   case OpCode::GetGroupWaveIndex:
   case OpCode::GetGroupWaveCount:
   case OpCode::ClusterID:
   case OpCode::LinAlgMatrixQueryAccumulatorLayout:
-  case OpCode::Reserved_0x8000001E:
-  case OpCode::Reserved_0x8000001F:
-  case OpCode::Reserved_0x80000020:
   case OpCode::DebugBreak:
   case OpCode::IsDebuggerPresent:
     return Type::getVoidTy(Ctx);

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -3305,10 +3305,13 @@ static void ValidateFunctionBody(Function *F, ValidationContext &ValCtx) {
           OP::OpCodeTableID TableID;
           unsigned OpIndex;
           if (!OP::DecodeOpCode(Opcode, TableID, OpIndex)) {
+            std::string OpCodeStr = std::to_string(Opcode);
+            if (OP::IsReservedOpCode(Opcode))
+              OpCodeStr += " (reserved opcode)";
             ValCtx.EmitInstrFormatError(
                 &I, ValidationRule::InstrIllegalDXILOpCode,
                 {std::to_string((unsigned)DXIL::OpCode::NumOpCodes),
-                 std::to_string(Opcode)});
+                 OpCodeStr});
             continue;
           }
           if (TableID != OP::OpCodeTableID::CoreOps &&

--- a/tools/clang/test/LitDXILValidation/reservedDXILOp.ll
+++ b/tools/clang/test/LitDXILValidation/reservedDXILOp.ll
@@ -1,0 +1,39 @@
+; REQUIRES: dxil-1-10
+; RUN: not %dxv %s 2>&1 | FileCheck %s
+
+; Make sure that using a reserved DXIL opcode produces an appropriate error.
+
+; 302 is currently reserved. If it is ever assigned to a valid DXIL op,
+; this test should be updated to use a different reserved opcode.
+; See "Reserved values:" comment in main DXIL::OpCode definition in
+; DxilConstants.h for reserved opcodes.
+
+; CHECK: error: DXILOpCode must be [0..{{[0-9]+}}] or a supported experimental opcode. 302 (reserved opcode) specified.
+; CHECK: note: at 'call void @dx.op.reserved(i32 302)' in block '#0' of function 'main'.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @main() {
+  call void @dx.op.reserved(i32 302)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @dx.op.reserved(i32) #0
+
+attributes #0 = { nounwind}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.resources = !{!3}
+!dx.entryPoints = !{!4}
+
+!0 = !{!"hand-crafted"}
+!1 = !{i32 1, i32 10}
+!2 = !{!"vs", i32 6, i32 10}
+!3 = !{null, null, null, null}
+!4 = !{void ()* @main, !"main", !5, !3, null}
+!5 = !{null, null, null}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -71,6 +71,8 @@ class db_dxil_enum_value(object):
         self.name = name  # Name (identifier)
         self.doc = doc  # Documentation string
         self.category = None
+        # reserved: whether value reserved and excluded from enum definition
+        self.reserved = False
 
 
 class db_dxil_enum(object):
@@ -423,6 +425,15 @@ class db_dxil_op_table(object):
     def __iter__(self):
         return iter(self.ops)
 
+    def get_dxil_ops(self, include_reserved=False):
+        "Get all DXIL operations; optionally include_reserved."
+        if include_reserved:
+            return iter(self.ops)
+        for i in self.ops:
+            if i.is_reserved:
+                continue
+            yield i
+
     def set_op_count_for_version(self, major, minor):
         op_count = len(self.ops)
         self.op_enum.dxil_version_info[(major, minor)] = op_count
@@ -458,18 +469,14 @@ class db_dxil_op_table(object):
 
     def add_dxil_op_reserved(self):
         "Reserve a DXIL opcode for future use; returns the reserved op."
-        opcode = self._next_id()
-        # Give the reserved opcode a unique, stable name.  This allows ops to be
-        # replaced with reserved without changing any other reserved op names.
-        name = f"Reserved_0x{opcode:08X}"
         # The return value is parameter 0, insert the opcode as 1.
         op_params = [db_dxil_param(0, "v", "", "reserved"), self.opcode_param]
         i = db_dxil_inst(
-            name,
+            "Reserved",
             llvm_id=self.call_instr.llvm_id,
             llvm_name=self.call_instr.llvm_name,
-            dxil_op=name,
-            dxil_opid=opcode,
+            dxil_op="Reserved",
+            dxil_opid=self._next_id(),
             dxil_table=self.name,
             doc="reserved",
             ops=op_params,
@@ -530,18 +537,22 @@ class db_dxil(object):
         for i in self._llvm_insts:
             yield i
 
-    def get_dxil_ops(self):
-        "Get all DXIL operations."
+    def get_dxil_ops(self, include_reserved=False):
+        "Get all DXIL operations; optionally include_reserved."
         for table in self.op_tables:
             for i in table:
+                if not include_reserved and i.is_reserved:
+                    continue
                 yield i
 
-    def get_all_insts(self):
-        "Get all instructions, including LLVM and DXIL operations."
+    def get_all_insts(self, include_reserved=False):
+        "Get all LLVM instructions and DXIL operations; optionally include_reserved."
         for i in self._llvm_insts:
             yield i
         for table in self.op_tables:
             for i in table:
+                if not include_reserved and i.is_reserved:
+                    continue
                 yield i
 
     def get_insts_by_names(self, *names):
@@ -602,8 +613,9 @@ class db_dxil(object):
             for i in table:
                 v = table.op_enum.add_value(i.dxil_op_index(), i.dxil_op, i.doc)
                 v.category = i.category
+                v.reserved = i.is_reserved
                 class_dict[i.dxil_class] = i.category
-                if table != self.core_table:
+                if table != self.core_table and not i.is_reserved:
                     # // <op> = 0x<hex id>, <id>U, <signed i32 id>
                     # Signed id is useful for comparing with IR opcodes, which
                     # are printed as signed i32 values.
@@ -9348,6 +9360,8 @@ class db_dxil(object):
         )
 
     def add_inst(self, i):
+        if i.is_reserved:
+            return i
         if i.name != "UDiv":
             # These should not overlap, but UDiv is a known collision.
             assert i.name not in self.name_idx, f"Duplicate instruction name: {i.name}"

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -426,10 +426,10 @@ class db_enumhelp_gen:
         print("// %s" % e.doc)
         print("enum class %s : unsigned {" % e.name)
         hide_val = kwargs.get("hide_val", False)
-        sorted_values = e.values
+        sorted_values = filter(lambda v: not v.reserved, e.values)
         if kwargs.get("sort_val", True):
             sorted_values = sorted(
-                e.values,
+                sorted_values,
                 key=lambda v: ("" if v.category == None else v.category) + "." + v.name,
             )
         last_category = None
@@ -447,6 +447,12 @@ class db_enumhelp_gen:
             if v.doc:
                 line_format += " // {doc}"
             print(line_format.format(name=v.name, value=v.value, doc=v.doc))
+        # Print unnamed reserved values separately.
+        reserved_values = list(filter(lambda v: v.reserved, e.values))
+        if len(reserved_values) > 0:
+            print("")
+            print("  // Reserved values:")
+            print("  // " + ", ".join([str(v.value) for v in reserved_values]))
         if e.last_value_name:
             lastName = e.last_value_name
             versioned = [
@@ -462,7 +468,7 @@ class db_enumhelp_gen:
                 "  "
                 + lastName
                 + " = "
-                + str(len(sorted_values))
+                + str(len(e.values))
                 + ", // exclusive last value of enumeration"
             )
         if e.postfix_lines:
@@ -551,11 +557,13 @@ class db_oload_gen:
             "{" + ",".join(["{0x%x}" % m for m in oloads]) + "}"
         )
         for i in table:
+            if i.is_reserved:
+                print(f"ReservedOpCodeProps, // Reserved: 0x{i.dxil_opid:08X}")
+                continue
             if last_category != i.category:
                 if last_category != None:
                     print("")
-                if not i.is_reserved:
-                    print(f"  // {i.category}")
+                print(f"  // {i.category}")
                 last_category = i.category
             scalar_masks = []
             vector_masks = []
@@ -1430,7 +1438,7 @@ def get_opcodes_rst():
 
 def get_opcodes_rst_for_table(table):
     "Create an rst table of opcodes for given opcode table"
-    instrs = [i for i in table]
+    instrs = [i for i in table.get_dxil_ops()]
     rows = []
     rows.append(["ID", "Name", "Description"])
     for i in instrs:


### PR DESCRIPTION
This change excludes reserved ops from DXIL::OpCode enum, so they don't need a unique name. They should never be referenced, so this makes using them impossible. The reserved values will be listed in a comment at the end of the enum, before NumOpCodes.

Also fixed the validator to catch and reject reserved opcodes.

Since the OpCodeProperty table entries corresponding to their opcode must still be occupied due to the way ops are looked up by indexing the table, there's a new single ReservedOpCodeProps value, with opcode set to OpCode::Invalid, supplied for each reserved slot. This way the slot is occupied (reserved), but not valid for use.

For instance, for a reserved opcode, now:
- DecodeOpCode returns false (for invalid)
- IsValidOpCode returns false
- IsOverloadLegal returns false
- getOpCode on instruction returns OpCode::Invalid
- GetDxilOpFuncCallInst on instruction returns OpCode::Invalid
- new IsReservedOpCode returns true

Added a validation test. Previously, it would have incorrectly accepted the reserved opcode as valid.

Fixes #8144