### PR TITLE
[SM6.10][specs/769] Update DXIL Op Defs

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3076,7 +3076,7 @@ ID         Name                                     Description
 2147483656 RayQuery_CandidateTriangleObjectPosition returns candidate triangle vertices in object space as <9 x float>
 2147483657 RayQuery_CommittedTriangleObjectPosition returns committed triangle vertices in object space as <9 x float>
 2147483658 HitObject_TriangleObjectPosition         returns triangle vertices in object space as <9 x float>
-2147483659 CreateMatrix                             creates a handle to a Matrix
+2147483659 ReservedD0                               reserved
 2147483660 FillMatrix                               fills a matrix with a scalar value
 2147483661 CopyConvertMatrix                        Converts and copies the element and use type of the source matrix to the destination matrix with optional transpose
 2147483662 MatrixLoadFromDescriptor                 fills a matrix with data from a [RW]ByteAddressBuffer
@@ -3094,10 +3094,10 @@ ID         Name                                     Description
 2147483674 MatrixVecMulAdd                          Multiplies a MxK dimension matrix and a K sized input vector then adds a M sized bias vector
 2147483675 MatrixAccumulateToDescriptor             accumulates a matrix to a RWByteAddressBuffer
 2147483676 MatrixAccumulateToMemory                 accumulates a matrix to groupshared memory
-2147483677 MatrixOuterProduct                       Outer products an M sized vector and a K sized vector producing an MxK matrix
-2147483678 LinAlgMatrixReserved0                    reserved
-2147483679 LinAlgMatrixReserved1                    reserved
-2147483680 LinAlgMatrixReserved2                    reserved
+2147483677 MatrixOuterProduct                       Outer products an M sized vector and a N sized vector producing an MxN matrix
+2147483678 ReservedD1                               reserved
+2147483679 ReservedD2                               reserved
+2147483680 ReservedD3                               reserved
 2147483681 DebugBreak                               triggers a breakpoint if a debugger is attached
 2147483682 IsDebuggerPresent                        returns true if a debugger is attached
 ========== ======================================== ===================================================================================================================

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -524,9 +524,10 @@ static const OpCodeTableID TableID = OpCodeTableID::ExperimentalOps;
 // Enumeration for ExperimentalOps DXIL operations
 enum class OpCode : unsigned {
   //
-  LinAlgMatrixReserved0 = 30, // reserved
-  LinAlgMatrixReserved1 = 31, // reserved
-  LinAlgMatrixReserved2 = 32, // reserved
+  ReservedD0 = 11, // reserved
+  ReservedD1 = 30, // reserved
+  ReservedD2 = 31, // reserved
+  ReservedD3 = 32, // reserved
 
   // Debugging
   DebugBreak = 33,        // triggers a breakpoint if a debugger is attached
@@ -548,7 +549,6 @@ enum class OpCode : unsigned {
   CopyConvertMatrix =
       13, // Converts and copies the element and use type of the source matrix
           // to the destination matrix with optional transpose
-  CreateMatrix = 11,     // creates a handle to a Matrix
   FillMatrix = 12,       // fills a matrix with a scalar value
   MatrixAccumulate = 24, // accumulate A or B matrix into Accumulator matrix
                          // following LHS += RHS
@@ -568,8 +568,8 @@ enum class OpCode : unsigned {
       15, // fills a matrix with data from a groupshared array
   MatrixMulOp =
       23, // applies a multiplication op to matrix C using A and B as parameters
-  MatrixOuterProduct = 29, // Outer products an M sized vector and a K sized
-                           // vector producing an MxK matrix
+  MatrixOuterProduct = 29, // Outer products an M sized vector and a N sized
+                           // vector producing an MxN matrix
   MatrixQueryAccumulatorLayout = 22, // returns comptime 0 when accumulator
                                      // matrix are A layout, 1 when B layout
   MatrixSetElement = 19, // sets the element of the matrix corresponding to the
@@ -1258,8 +1258,8 @@ enum class OpCode : unsigned {
   EXP_OPCODE(ExperimentalOps,
              HitObject_TriangleObjectPosition), // returns triangle vertices in
                                                 // object space as <9 x float>
-  // CreateMatrix = 0x8000000B, 2147483659U, -2147483637
-  EXP_OPCODE(ExperimentalOps, CreateMatrix), // creates a handle to a Matrix
+  // ReservedD0 = 0x8000000B, 2147483659U, -2147483637
+  EXP_OPCODE(ExperimentalOps, ReservedD0), // reserved
   // FillMatrix = 0x8000000C, 2147483660U, -2147483636
   EXP_OPCODE(ExperimentalOps, FillMatrix), // fills a matrix with a scalar value
   // CopyConvertMatrix = 0x8000000D, 2147483661U, -2147483635
@@ -1332,14 +1332,14 @@ enum class OpCode : unsigned {
       MatrixAccumulateToMemory), // accumulates a matrix to groupshared memory
   // MatrixOuterProduct = 0x8000001D, 2147483677U, -2147483619
   EXP_OPCODE(ExperimentalOps,
-             MatrixOuterProduct), // Outer products an M sized vector and a K
-                                  // sized vector producing an MxK matrix
-  // LinAlgMatrixReserved0 = 0x8000001E, 2147483678U, -2147483618
-  EXP_OPCODE(ExperimentalOps, LinAlgMatrixReserved0), // reserved
-  // LinAlgMatrixReserved1 = 0x8000001F, 2147483679U, -2147483617
-  EXP_OPCODE(ExperimentalOps, LinAlgMatrixReserved1), // reserved
-  // LinAlgMatrixReserved2 = 0x80000020, 2147483680U, -2147483616
-  EXP_OPCODE(ExperimentalOps, LinAlgMatrixReserved2), // reserved
+             MatrixOuterProduct), // Outer products an M sized vector and a N
+                                  // sized vector producing an MxN matrix
+  // ReservedD1 = 0x8000001E, 2147483678U, -2147483618
+  EXP_OPCODE(ExperimentalOps, ReservedD1), // reserved
+  // ReservedD2 = 0x8000001F, 2147483679U, -2147483617
+  EXP_OPCODE(ExperimentalOps, ReservedD2), // reserved
+  // ReservedD3 = 0x80000020, 2147483680U, -2147483616
+  EXP_OPCODE(ExperimentalOps, ReservedD3), // reserved
   // DebugBreak = 0x80000021, 2147483681U, -2147483615
   EXP_OPCODE(ExperimentalOps,
              DebugBreak), // triggers a breakpoint if a debugger is attached
@@ -1506,7 +1506,6 @@ enum class OpCodeClass : unsigned {
 
   // Linear Algebra Operations
   CopyConvertMatrix,
-  CreateMatrix,
   FillMatrix,
   MatVecMul,
   MatVecMulAdd,
@@ -1714,7 +1713,7 @@ enum class OpCodeClass : unsigned {
   NodeOutputIsValid,
   OutputComplete,
 
-  NumOpClasses = 225, // exclusive last value of enumeration
+  NumOpClasses = 224, // exclusive last value of enumeration
 };
 // OPCODECLASS-ENUM:END
 

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -10500,26 +10500,6 @@ struct DxilInst_HitObject_TriangleObjectPosition {
   void set_hitObject(llvm::Value *val) { Instr->setOperand(1, val); }
 };
 
-/// This instruction creates a handle to a Matrix
-struct DxilInst_CreateMatrix {
-  llvm::Instruction *Instr;
-  // Construction and identification
-  DxilInst_CreateMatrix(llvm::Instruction *pInstr) : Instr(pInstr) {}
-  operator bool() const {
-    return hlsl::OP::IsDxilOpFuncCallInst(Instr,
-                                          hlsl::OP::OpCode::CreateMatrix);
-  }
-  // Validation support
-  bool isAllowed() const { return true; }
-  bool isArgumentListValid() const {
-    if (1 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
-      return false;
-    return true;
-  }
-  // Metadata
-  bool requiresUniformInputs() const { return false; }
-};
-
 /// This instruction fills a matrix with a scalar value
 struct DxilInst_FillMatrix {
   llvm::Instruction *Instr;
@@ -10531,7 +10511,7 @@ struct DxilInst_FillMatrix {
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (3 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+    if (2 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
       return false;
     return true;
   }
@@ -10539,14 +10519,11 @@ struct DxilInst_FillMatrix {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
-    arg_value = 2,
+    arg_value = 1,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_value() const { return Instr->getOperand(2); }
-  void set_value(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_value() const { return Instr->getOperand(1); }
+  void set_value(llvm::Value *val) { Instr->setOperand(1, val); }
 };
 
 /// This instruction Converts and copies the element and use type of the source
@@ -10562,7 +10539,7 @@ struct DxilInst_CopyConvertMatrix {
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (4 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+    if (3 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
       return false;
     return true;
   }
@@ -10570,17 +10547,14 @@ struct DxilInst_CopyConvertMatrix {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_destMatrixRef = 1,
-    arg_srcMatrixRef = 2,
-    arg_transpose = 3,
+    arg_srcMatrix = 1,
+    arg_transpose = 2,
   };
   // Accessors
-  llvm::Value *get_destMatrixRef() const { return Instr->getOperand(1); }
-  void set_destMatrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_srcMatrixRef() const { return Instr->getOperand(2); }
-  void set_srcMatrixRef(llvm::Value *val) { Instr->setOperand(2, val); }
-  llvm::Value *get_transpose() const { return Instr->getOperand(3); }
-  void set_transpose(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_srcMatrix() const { return Instr->getOperand(1); }
+  void set_srcMatrix(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_transpose() const { return Instr->getOperand(2); }
+  void set_transpose(llvm::Value *val) { Instr->setOperand(2, val); }
 };
 
 /// This instruction fills a matrix with data from a [RW]ByteAddressBuffer
@@ -10596,7 +10570,7 @@ struct DxilInst_MatrixLoadFromDescriptor {
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (6 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+    if (5 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
       return false;
     return true;
   }
@@ -10604,23 +10578,20 @@ struct DxilInst_MatrixLoadFromDescriptor {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
-    arg_handle = 2,
-    arg_offset = 3,
-    arg_stride = 4,
-    arg_layout = 5,
+    arg_handle = 1,
+    arg_offset = 2,
+    arg_stride = 3,
+    arg_layout = 4,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_handle() const { return Instr->getOperand(2); }
-  void set_handle(llvm::Value *val) { Instr->setOperand(2, val); }
-  llvm::Value *get_offset() const { return Instr->getOperand(3); }
-  void set_offset(llvm::Value *val) { Instr->setOperand(3, val); }
-  llvm::Value *get_stride() const { return Instr->getOperand(4); }
-  void set_stride(llvm::Value *val) { Instr->setOperand(4, val); }
-  llvm::Value *get_layout() const { return Instr->getOperand(5); }
-  void set_layout(llvm::Value *val) { Instr->setOperand(5, val); }
+  llvm::Value *get_handle() const { return Instr->getOperand(1); }
+  void set_handle(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_offset() const { return Instr->getOperand(2); }
+  void set_offset(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_stride() const { return Instr->getOperand(3); }
+  void set_stride(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_layout() const { return Instr->getOperand(4); }
+  void set_layout(llvm::Value *val) { Instr->setOperand(4, val); }
 };
 
 /// This instruction fills a matrix with data from a groupshared array
@@ -10635,7 +10606,7 @@ struct DxilInst_MatrixLoadFromMemory {
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (6 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+    if (5 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
       return false;
     return true;
   }
@@ -10643,23 +10614,20 @@ struct DxilInst_MatrixLoadFromMemory {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
-    arg_groupsharedArr = 2,
-    arg_offset = 3,
-    arg_stride = 4,
-    arg_layout = 5,
+    arg_groupsharedArr = 1,
+    arg_offset = 2,
+    arg_stride = 3,
+    arg_layout = 4,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_groupsharedArr() const { return Instr->getOperand(2); }
-  void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(2, val); }
-  llvm::Value *get_offset() const { return Instr->getOperand(3); }
-  void set_offset(llvm::Value *val) { Instr->setOperand(3, val); }
-  llvm::Value *get_stride() const { return Instr->getOperand(4); }
-  void set_stride(llvm::Value *val) { Instr->setOperand(4, val); }
-  llvm::Value *get_layout() const { return Instr->getOperand(5); }
-  void set_layout(llvm::Value *val) { Instr->setOperand(5, val); }
+  llvm::Value *get_groupsharedArr() const { return Instr->getOperand(1); }
+  void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_offset() const { return Instr->getOperand(2); }
+  void set_offset(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_stride() const { return Instr->getOperand(3); }
+  void set_stride(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_layout() const { return Instr->getOperand(4); }
+  void set_layout(llvm::Value *val) { Instr->setOperand(4, val); }
 };
 
 /// This instruction returns the number of elements stored in thread-local
@@ -10683,11 +10651,11 @@ struct DxilInst_MatrixLength {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
 };
 
 /// This instruction returns a two element vector containing the column and row
@@ -10711,12 +10679,12 @@ struct DxilInst_MatrixGetCoordinate {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_threadLocalIndex = 2,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_threadLocalIndex() const { return Instr->getOperand(2); }
   void set_threadLocalIndex(llvm::Value *val) { Instr->setOperand(2, val); }
 };
@@ -10742,12 +10710,12 @@ struct DxilInst_MatrixGetElement {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_threadLocalIndex = 2,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_threadLocalIndex() const { return Instr->getOperand(2); }
   void set_threadLocalIndex(llvm::Value *val) { Instr->setOperand(2, val); }
 };
@@ -10773,13 +10741,13 @@ struct DxilInst_MatrixSetElement {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_threadLocalIndex = 2,
     arg_value = 3,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_threadLocalIndex() const { return Instr->getOperand(2); }
   void set_threadLocalIndex(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_value() const { return Instr->getOperand(3); }
@@ -10806,15 +10774,15 @@ struct DxilInst_MatrixStoreToDescriptor {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_handle = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_handle() const { return Instr->getOperand(2); }
   void set_handle(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -10845,15 +10813,15 @@ struct DxilInst_MatrixStoreToMemory {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_groupsharedArr = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_groupsharedArr() const { return Instr->getOperand(2); }
   void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -10898,7 +10866,7 @@ struct DxilInst_MatrixMulOp {
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (4 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+    if (3 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
       return false;
     return true;
   }
@@ -10906,17 +10874,14 @@ struct DxilInst_MatrixMulOp {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRefA = 1,
-    arg_matrixRefB = 2,
-    arg_matrixRefC = 3,
+    arg_matrixA = 1,
+    arg_matrixB = 2,
   };
   // Accessors
-  llvm::Value *get_matrixRefA() const { return Instr->getOperand(1); }
-  void set_matrixRefA(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_matrixRefB() const { return Instr->getOperand(2); }
-  void set_matrixRefB(llvm::Value *val) { Instr->setOperand(2, val); }
-  llvm::Value *get_matrixRefC() const { return Instr->getOperand(3); }
-  void set_matrixRefC(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_matrixA() const { return Instr->getOperand(1); }
+  void set_matrixA(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixB() const { return Instr->getOperand(2); }
+  void set_matrixB(llvm::Value *val) { Instr->setOperand(2, val); }
 };
 
 /// This instruction accumulate A or B matrix into Accumulator matrix following
@@ -10940,14 +10905,14 @@ struct DxilInst_MatrixAccumulate {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRefRHS = 1,
-    arg_matrixRefLHS = 2,
+    arg_matrixLHS = 1,
+    arg_matrixRHS = 2,
   };
   // Accessors
-  llvm::Value *get_matrixRefRHS() const { return Instr->getOperand(1); }
-  void set_matrixRefRHS(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_matrixRefLHS() const { return Instr->getOperand(2); }
-  void set_matrixRefLHS(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_matrixLHS() const { return Instr->getOperand(1); }
+  void set_matrixLHS(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrixRHS() const { return Instr->getOperand(2); }
+  void set_matrixRHS(llvm::Value *val) { Instr->setOperand(2, val); }
 };
 
 /// This instruction Multiplies a MxK dimension matrix and a K sized input
@@ -10971,13 +10936,13 @@ struct DxilInst_MatrixVecMul {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_inputVector = 2,
     arg_interpretation = 3,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_inputVector() const { return Instr->getOperand(2); }
   void set_inputVector(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_interpretation() const { return Instr->getOperand(3); }
@@ -11005,15 +10970,15 @@ struct DxilInst_MatrixVecMulAdd {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_inputVector = 2,
     arg_inputInterpretation = 3,
     arg_biasVector = 4,
     arg_biasInterpretation = 5,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_inputVector() const { return Instr->getOperand(2); }
   void set_inputVector(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_inputInterpretation() const { return Instr->getOperand(3); }
@@ -11045,15 +11010,15 @@ struct DxilInst_MatrixAccumulateToDescriptor {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_handle = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_handle() const { return Instr->getOperand(2); }
   void set_handle(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -11085,15 +11050,15 @@ struct DxilInst_MatrixAccumulateToMemory {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
+    arg_matrix = 1,
     arg_groupsharedArr = 2,
     arg_offset = 3,
     arg_stride = 4,
     arg_layout = 5,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_matrix() const { return Instr->getOperand(1); }
+  void set_matrix(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_groupsharedArr() const { return Instr->getOperand(2); }
   void set_groupsharedArr(llvm::Value *val) { Instr->setOperand(2, val); }
   llvm::Value *get_offset() const { return Instr->getOperand(3); }
@@ -11104,8 +11069,8 @@ struct DxilInst_MatrixAccumulateToMemory {
   void set_layout(llvm::Value *val) { Instr->setOperand(5, val); }
 };
 
-/// This instruction Outer products an M sized vector and a K sized vector
-/// producing an MxK matrix
+/// This instruction Outer products an M sized vector and a N sized vector
+/// producing an MxN matrix
 struct DxilInst_MatrixOuterProduct {
   llvm::Instruction *Instr;
   // Construction and identification
@@ -11117,7 +11082,7 @@ struct DxilInst_MatrixOuterProduct {
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (4 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+    if (3 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
       return false;
     return true;
   }
@@ -11125,17 +11090,14 @@ struct DxilInst_MatrixOuterProduct {
   bool requiresUniformInputs() const { return false; }
   // Operand indexes
   enum OperandIdx {
-    arg_matrixRef = 1,
-    arg_vectorA = 2,
-    arg_vectorB = 3,
+    arg_vectorA = 1,
+    arg_vectorB = 2,
   };
   // Accessors
-  llvm::Value *get_matrixRef() const { return Instr->getOperand(1); }
-  void set_matrixRef(llvm::Value *val) { Instr->setOperand(1, val); }
-  llvm::Value *get_vectorA() const { return Instr->getOperand(2); }
-  void set_vectorA(llvm::Value *val) { Instr->setOperand(2, val); }
-  llvm::Value *get_vectorB() const { return Instr->getOperand(3); }
-  void set_vectorB(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_vectorA() const { return Instr->getOperand(1); }
+  void set_vectorA(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_vectorB() const { return Instr->getOperand(2); }
+  void set_vectorB(llvm::Value *val) { Instr->setOperand(2, val); }
 };
 
 /// This instruction triggers a breakpoint if a debugger is attached

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -2823,95 +2823,96 @@ static const OP::OpCodeProperty ExperimentalOps_OpCodeProps[] = {
      {{0x2}},
      {{0x0}}}, // Overloads: f
 
-    // Linear Algebra Operations
-    {OC::CreateMatrix,
-     "CreateMatrix",
-     OCC::CreateMatrix,
-     "createMatrix",
+    {OC::ReservedD0,
+     "ReservedD0",
+     OCC::Reserved,
+     "reserved",
      Attribute::None,
      0,
      {},
      {}}, // Overloads: v
+
+    // Linear Algebra Operations
     {OC::FillMatrix,
      "FillMatrix",
      OCC::FillMatrix,
      "fillMatrix",
      Attribute::None,
-     1,
-     {{0x63}},
-     {{0x0}}}, // Overloads: hfwi
+     2,
+     {{0x200}, {0x63}},
+     {{0x0}, {0x0}}}, // Overloads: o,hfwi
     {OC::CopyConvertMatrix,
      "CopyConvertMatrix",
      OCC::CopyConvertMatrix,
      "copyConvertMatrix",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     2,
+     {{0x200}, {0x200}},
+     {{0x0}, {0x0}}}, // Overloads: o,o
     {OC::MatrixLoadFromDescriptor,
      "MatrixLoadFromDescriptor",
      OCC::MatrixLoadFromDescriptor,
      "matrixLoadFromDescriptor",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     1,
+     {{0x200}},
+     {{0x0}}}, // Overloads: o
     {OC::MatrixLoadFromMemory,
      "MatrixLoadFromMemory",
      OCC::MatrixLoadFromMemory,
      "matrixLoadFromMemory",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     2,
+     {{0x200}, {0x63}},
+     {{0x0}, {0x0}}}, // Overloads: o,hfwi
     {OC::MatrixLength,
      "MatrixLength",
      OCC::MatrixLength,
      "matrixLength",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     1,
+     {{0x200}},
+     {{0x0}}}, // Overloads: o
     {OC::MatrixGetCoordinate,
      "MatrixGetCoordinate",
      OCC::MatrixGetCoordinate,
      "matrixGetCoordinate",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     1,
+     {{0x200}},
+     {{0x0}}}, // Overloads: o
     {OC::MatrixGetElement,
      "MatrixGetElement",
      OCC::MatrixGetElement,
      "matrixGetElement",
      Attribute::None,
-     1,
-     {{0x63}},
-     {{0x0}}}, // Overloads: hfwi
+     2,
+     {{0x63}, {0x200}},
+     {{0x0}, {0x0}}}, // Overloads: hfwi,o
     {OC::MatrixSetElement,
      "MatrixSetElement",
      OCC::MatrixSetElement,
      "matrixSetElement",
      Attribute::None,
-     1,
-     {{0x63}},
-     {{0x0}}}, // Overloads: hfwi
+     3,
+     {{0x200}, {0x200}, {0x63}},
+     {{0x0}, {0x0}, {0x0}}}, // Overloads: o,o,hfwi
     {OC::MatrixStoreToDescriptor,
      "MatrixStoreToDescriptor",
      OCC::MatrixStoreToDescriptor,
      "matrixStoreToDescriptor",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     1,
+     {{0x200}},
+     {{0x0}}}, // Overloads: o
     {OC::MatrixStoreToMemory,
      "MatrixStoreToMemory",
      OCC::MatrixStoreToMemory,
      "matrixStoreToMemory",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     2,
+     {{0x200}, {0x63}},
+     {{0x0}, {0x0}}}, // Overloads: o,hfwi
     {OC::MatrixQueryAccumulatorLayout,
      "MatrixQueryAccumulatorLayout",
      OCC::MatrixQueryAccumulatorLayout,
@@ -2925,76 +2926,76 @@ static const OP::OpCodeProperty ExperimentalOps_OpCodeProps[] = {
      OCC::MatrixMulOp,
      "matrixMulOp",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     3,
+     {{0x200}, {0x200}, {0x200}},
+     {{0x0}, {0x0}, {0x0}}}, // Overloads: o,o,o
     {OC::MatrixAccumulate,
      "MatrixAccumulate",
      OCC::MatrixAccumulate,
      "matrixAccumulate",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     3,
+     {{0x200}, {0x200}, {0x200}},
+     {{0x0}, {0x0}, {0x0}}}, // Overloads: o,o,o
     {OC::MatrixVecMul,
      "MatrixVecMul",
      OCC::MatrixVecMul,
      "matrixVecMul",
      Attribute::None,
-     2,
-     {{0x400}, {0x400}},
-     {{0x63}, {0x63}}}, // Overloads: <hfwi,<hfwi
+     3,
+     {{0x400}, {0x200}, {0x400}},
+     {{0x63}, {0x0}, {0x63}}}, // Overloads: <hfwi,o,<hfwi
     {OC::MatrixVecMulAdd,
      "MatrixVecMulAdd",
      OCC::MatrixVecMulAdd,
      "matrixVecMulAdd",
      Attribute::None,
-     2,
-     {{0x400}, {0x400}},
-     {{0x63}, {0x63}}}, // Overloads: <hfwi,<hfwi
+     4,
+     {{0x400}, {0x200}, {0x400}, {0x400}},
+     {{0x63}, {0x0}, {0x63}, {0x63}}}, // Overloads: <hfwi,o,<hfwi,<hfwi
     {OC::MatrixAccumulateToDescriptor,
      "MatrixAccumulateToDescriptor",
      OCC::MatrixAccumulateToDescriptor,
      "matrixAccumulateToDescriptor",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     1,
+     {{0x200}},
+     {{0x0}}}, // Overloads: o
     {OC::MatrixAccumulateToMemory,
      "MatrixAccumulateToMemory",
      OCC::MatrixAccumulateToMemory,
      "matrixAccumulateToMemory",
      Attribute::None,
-     0,
-     {},
-     {}}, // Overloads: v
+     2,
+     {{0x200}, {0x63}},
+     {{0x0}, {0x0}}}, // Overloads: o,hfwi
     {OC::MatrixOuterProduct,
      "MatrixOuterProduct",
      OCC::MatrixOuterProduct,
      "matrixOuterProduct",
      Attribute::None,
-     2,
-     {{0x400}, {0x400}},
-     {{0x63}, {0x63}}}, // Overloads: <hfwi,<hfwi
+     3,
+     {{0x200}, {0x400}, {0x400}},
+     {{0x0}, {0x63}, {0x63}}}, // Overloads: o,<hfwi,<hfwi
 
-    {OC::LinAlgMatrixReserved0,
-     "LinAlgMatrixReserved0",
+    {OC::ReservedD1,
+     "ReservedD1",
      OCC::Reserved,
      "reserved",
      Attribute::None,
      0,
      {},
      {}}, // Overloads: v
-    {OC::LinAlgMatrixReserved1,
-     "LinAlgMatrixReserved1",
+    {OC::ReservedD2,
+     "ReservedD2",
      OCC::Reserved,
      "reserved",
      Attribute::None,
      0,
      {},
      {}}, // Overloads: v
-    {OC::LinAlgMatrixReserved2,
-     "LinAlgMatrixReserved2",
+    {OC::ReservedD3,
+     "ReservedD3",
      OCC::Reserved,
      "reserved",
      Attribute::None,
@@ -3934,17 +3935,16 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
   // RayQuery_CommittedClusterID=2147483653,
   // RayQuery_CandidateTriangleObjectPosition=2147483656,
   // RayQuery_CommittedTriangleObjectPosition=2147483657,
-  // CreateMatrix=2147483659, MatrixLoadFromDescriptor=2147483662,
+  // MatrixLoadFromDescriptor=2147483662,
   // MatrixQueryAccumulatorLayout=2147483670, MatrixVecMul=2147483673,
   // MatrixVecMulAdd=2147483674, MatrixAccumulateToDescriptor=2147483675,
   // MatrixOuterProduct=2147483677, DebugBreak=2147483681,
   // IsDebuggerPresent=2147483682
   if ((305 <= op && op <= 308) || op == 2147483648 ||
       (2147483652 <= op && op <= 2147483653) ||
-      (2147483656 <= op && op <= 2147483657) || op == 2147483659 ||
-      op == 2147483662 || op == 2147483670 ||
-      (2147483673 <= op && op <= 2147483675) || op == 2147483677 ||
-      (2147483681 <= op && op <= 2147483682)) {
+      (2147483656 <= op && op <= 2147483657) || op == 2147483662 ||
+      op == 2147483670 || (2147483673 <= op && op <= 2147483675) ||
+      op == 2147483677 || (2147483681 <= op && op <= 2147483682)) {
     major = 6;
     minor = 10;
     return;
@@ -6554,27 +6554,26 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pHit);
     break;
 
-    // Linear Algebra Operations
-  case OpCode::CreateMatrix:
-    A(pI32);
-    A(pI32);
-    break;
-  case OpCode::FillMatrix:
+    //
+  case OpCode::ReservedD0:
     A(pV);
     A(pI32);
+    break;
+
+    // Linear Algebra Operations
+  case OpCode::FillMatrix:
+    EXT(0);
     A(pI32);
-    A(pETy);
+    EXT(1);
     break;
   case OpCode::CopyConvertMatrix:
-    A(pV);
+    EXT(0);
     A(pI32);
-    A(pI32);
-    A(pI32);
+    EXT(1);
     A(pI1);
     break;
   case OpCode::MatrixLoadFromDescriptor:
-    A(pV);
-    A(pI32);
+    A(pETy);
     A(pI32);
     A(pRes);
     A(pI32);
@@ -6582,10 +6581,9 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     break;
   case OpCode::MatrixLoadFromMemory:
-    A(pV);
+    EXT(0);
     A(pI32);
-    A(pI32);
-    A(pI32);
+    EXT(1);
     A(pI32);
     A(pI32);
     A(pI32);
@@ -6593,31 +6591,31 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixLength:
     A(pI32);
     A(pI32);
-    A(pI32);
+    A(pETy);
     break;
   case OpCode::MatrixGetCoordinate:
+    VEC4(pETy);
     A(pI32);
-    A(pI32);
-    A(pI32);
+    A(pETy);
     A(pI32);
     break;
   case OpCode::MatrixGetElement:
-    A(pETy);
+    EXT(0);
     A(pI32);
-    A(pI32);
+    EXT(1);
     A(pI32);
     break;
   case OpCode::MatrixSetElement:
-    A(pV);
+    EXT(0);
     A(pI32);
+    EXT(1);
     A(pI32);
-    A(pI32);
-    A(pETy);
+    EXT(2);
     break;
   case OpCode::MatrixStoreToDescriptor:
     A(pV);
     A(pI32);
-    A(pI32);
+    A(pETy);
     A(pRes);
     A(pI32);
     A(pI32);
@@ -6626,8 +6624,8 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixStoreToMemory:
     A(pV);
     A(pI32);
-    A(pI32);
-    A(pI32);
+    EXT(0);
+    EXT(1);
     A(pI32);
     A(pI32);
     A(pI32);
@@ -6637,38 +6635,37 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     break;
   case OpCode::MatrixMulOp:
-    A(pV);
+    EXT(0);
     A(pI32);
-    A(pI32);
-    A(pI32);
-    A(pI32);
+    EXT(1);
+    EXT(2);
     break;
   case OpCode::MatrixAccumulate:
-    A(pV);
+    EXT(0);
     A(pI32);
-    A(pI32);
-    A(pI32);
+    EXT(1);
+    EXT(2);
     break;
   case OpCode::MatrixVecMul:
     EXT(0);
     A(pI32);
-    A(pI32);
     EXT(1);
+    EXT(2);
     A(pI32);
     break;
   case OpCode::MatrixVecMulAdd:
     EXT(0);
     A(pI32);
-    A(pI32);
     EXT(1);
+    EXT(2);
     A(pI32);
-    A(pI32);
+    EXT(3);
     A(pI32);
     break;
   case OpCode::MatrixAccumulateToDescriptor:
     A(pV);
     A(pI32);
-    A(pI32);
+    A(pETy);
     A(pRes);
     A(pI32);
     A(pI32);
@@ -6677,30 +6674,29 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   case OpCode::MatrixAccumulateToMemory:
     A(pV);
     A(pI32);
-    A(pI32);
-    A(pI32);
+    EXT(0);
+    EXT(1);
     A(pI32);
     A(pI32);
     A(pI32);
     break;
   case OpCode::MatrixOuterProduct:
-    A(pV);
-    A(pI32);
-    A(pI32);
     EXT(0);
+    A(pI32);
     EXT(1);
+    EXT(2);
     break;
 
     //
-  case OpCode::LinAlgMatrixReserved0:
+  case OpCode::ReservedD1:
     A(pV);
     A(pI32);
     break;
-  case OpCode::LinAlgMatrixReserved1:
+  case OpCode::ReservedD2:
     A(pV);
     A(pI32);
     break;
-  case OpCode::LinAlgMatrixReserved2:
+  case OpCode::ReservedD3:
     A(pV);
     A(pI32);
     break;
@@ -6853,7 +6849,6 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::Pack4x8:
   case OpCode::HitObject_Invoke:
   case OpCode::HitObject_Attributes:
-  case OpCode::FillMatrix:
     if (FT->getNumParams() <= 2)
       return nullptr;
     return FT->getParamType(2);
@@ -6891,6 +6886,9 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::VectorReduceAnd:
   case OpCode::VectorReduceOr:
   case OpCode::FDot:
+  case OpCode::MatrixLength:
+  case OpCode::MatrixStoreToDescriptor:
+  case OpCode::MatrixAccumulateToDescriptor:
     if (FT->getNumParams() <= 1)
       return nullptr;
     return FT->getParamType(1);
@@ -6902,7 +6900,6 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::CalculateLOD:
   case OpCode::ReportHit:
   case OpCode::HitObject_FromRayQueryWithAttrs:
-  case OpCode::MatrixSetElement:
     if (FT->getNumParams() <= 3)
       return nullptr;
     return FT->getParamType(3);
@@ -7013,22 +7010,11 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::GetGroupWaveIndex:
   case OpCode::GetGroupWaveCount:
   case OpCode::ClusterID:
-  case OpCode::CreateMatrix:
-  case OpCode::CopyConvertMatrix:
-  case OpCode::MatrixLoadFromDescriptor:
-  case OpCode::MatrixLoadFromMemory:
-  case OpCode::MatrixLength:
-  case OpCode::MatrixGetCoordinate:
-  case OpCode::MatrixStoreToDescriptor:
-  case OpCode::MatrixStoreToMemory:
+  case OpCode::ReservedD0:
   case OpCode::MatrixQueryAccumulatorLayout:
-  case OpCode::MatrixMulOp:
-  case OpCode::MatrixAccumulate:
-  case OpCode::MatrixAccumulateToDescriptor:
-  case OpCode::MatrixAccumulateToMemory:
-  case OpCode::LinAlgMatrixReserved0:
-  case OpCode::LinAlgMatrixReserved1:
-  case OpCode::LinAlgMatrixReserved2:
+  case OpCode::ReservedD1:
+  case OpCode::ReservedD2:
+  case OpCode::ReservedD3:
   case OpCode::DebugBreak:
   case OpCode::IsDebuggerPresent:
     return Type::getVoidTy(Ctx);
@@ -7051,7 +7037,8 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::SampleCmpLevel:
   case OpCode::SampleCmpGrad:
   case OpCode::SampleCmpBias:
-  case OpCode::RawBufferVectorLoad: {
+  case OpCode::RawBufferVectorLoad:
+  case OpCode::MatrixGetCoordinate: {
     StructType *ST = cast<StructType>(Ty);
     return ST->getElementType(0);
   }
@@ -7063,29 +7050,44 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
     return cast<VectorType>(Ty)->getElementType();
   case OpCode::MatVecMul:
   case OpCode::MatVecMulAdd:
+  case OpCode::FillMatrix:
+  case OpCode::CopyConvertMatrix:
+  case OpCode::MatrixLoadFromMemory:
+  case OpCode::MatrixGetElement:
     if (FT->getNumParams() < 2)
       return nullptr;
     return llvm::StructType::get(Ctx,
                                  {FT->getReturnType(), FT->getParamType(1)});
 
   case OpCode::OuterProductAccumulate:
+  case OpCode::MatrixStoreToMemory:
+  case OpCode::MatrixAccumulateToMemory:
     if (FT->getNumParams() < 3)
       return nullptr;
     return llvm::StructType::get(Ctx,
                                  {FT->getParamType(1), FT->getParamType(2)});
 
-  case OpCode::MatrixVecMul:
-  case OpCode::MatrixVecMulAdd:
-    if (FT->getNumParams() < 3)
-      return nullptr;
-    return llvm::StructType::get(Ctx,
-                                 {FT->getReturnType(), FT->getParamType(2)});
-
-  case OpCode::MatrixOuterProduct:
+  case OpCode::MatrixSetElement:
     if (FT->getNumParams() < 4)
       return nullptr;
+    return llvm::StructType::get(
+        Ctx, {FT->getReturnType(), FT->getParamType(1), FT->getParamType(3)});
+
+  case OpCode::MatrixMulOp:
+  case OpCode::MatrixAccumulate:
+  case OpCode::MatrixVecMul:
+  case OpCode::MatrixOuterProduct:
+    if (FT->getNumParams() < 3)
+      return nullptr;
+    return llvm::StructType::get(
+        Ctx, {FT->getReturnType(), FT->getParamType(1), FT->getParamType(2)});
+
+  case OpCode::MatrixVecMulAdd:
+    if (FT->getNumParams() < 5)
+      return nullptr;
     return llvm::StructType::get(Ctx,
-                                 {FT->getParamType(2), FT->getParamType(3)});
+                                 {FT->getReturnType(), FT->getParamType(1),
+                                  FT->getParamType(2), FT->getParamType(4)});
 
   // OPCODE-OLOAD-TYPES:END
   default:


### PR DESCRIPTION
https://github.com/microsoft/hlsl-specs/pull/769 updated the signatures for the linalg DXIL ops. Update the implementation to reflect that


- removes create matrix dxil op
- renames the reserved ops to match the rest of the reserved ops
- Update the ops to they return a matrix instead of accepting it as a parameter
- updates the matrix type from i32 to object


`utils/hct/hctdb.py` is the interesting changes, everything else is generated code