### PR TITLE
[SM6.10] Generate LinAlg DXIL overload name

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -164,6 +164,8 @@ bool IsHLSLObjectType(llvm::Type *Ty);
 bool IsHLSLRayQueryType(llvm::Type *Ty);
 llvm::Type *GetHLSLHitObjectType(llvm::Module *M);
 bool IsHLSLHitObjectType(llvm::Type *Ty);
+bool IsHLSLLinAlgMatrixType(llvm::Type *Ty);
+llvm::StringRef GetHLSLLinAlgMatrixTypeMangling(llvm::StructType *Ty);
 bool IsHLSLResourceDescType(llvm::Type *Ty);
 bool IsResourceSingleComponent(llvm::Type *Ty);
 uint8_t GetResourceComponentCount(llvm::Type *Ty);

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -13,6 +13,7 @@
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilUtil.h"
 #include "dxc/Support/Global.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -3174,6 +3175,9 @@ StringRef OP::GetTypeName(Type *Ty, SmallVectorImpl<char> &Storage) {
     return ST->getStructName();
   } else if (TypeSlot == TS_Object) {
     StructType *ST = cast<StructType>(Ty);
+    if (dxilutil::IsHLSLLinAlgMatrixType(Ty))
+      return (Twine("m") + Twine(dxilutil::GetHLSLLinAlgMatrixTypeMangling(ST)))
+          .toStringRef(Storage);
     return ST->getStructName();
   } else if (TypeSlot == TS_Vector) {
     VectorType *VecTy = cast<VectorType>(Ty);

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -18,9 +18,11 @@
 #include "dxc/Support/Global.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
@@ -577,6 +579,9 @@ bool IsHLSLObjectType(llvm::Type *Ty) {
 
     if (IsHLSLHitObjectType(Ty))
       return true;
+
+    if (IsHLSLLinAlgMatrixType(Ty))
+      return true;
   }
   return false;
 }
@@ -610,6 +615,19 @@ bool IsHLSLHitObjectType(llvm::Type *Ty) {
   if (!ST->hasName())
     return false;
   return ST->getName() == "dx.types.HitObject";
+}
+
+bool IsHLSLLinAlgMatrixType(llvm::Type *Ty) {
+  llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty);
+  if (!ST)
+    return false;
+  if (!ST->hasName())
+    return false;
+  return ST->getName().startswith("dx.types.LinAlgMatrix");
+}
+
+StringRef GetHLSLLinAlgMatrixTypeMangling(llvm::StructType *Ty) {
+  return Ty->getStructName().substr(sizeof("dx.types.LinAlgMatrix") - 1);
 }
 
 bool IsHLSLResourceDescType(llvm::Type *Ty) {


### PR DESCRIPTION
This change updates the infrastructure to generate overload names for the LinAlgMatrix type

When lowering a function that takes a LinAlgMatrix a unique name must be injected into the type for each unique matrix type to differentiate it from other calls to the same function. Per the spec, for LinAlgMatrix the mapping should be `dx.types.LinAlgMatrix<mangling>`  -> `m<mangling>`

Ex:
`dx.types.LinAlgMatrixC10M16N16U0S1`  -> `mC10M16N16U0S1`