### PR TITLE
Add missing REQUIRES: spirv to vk.sampledtexture.struct.error.hlsl

### DIFF
--- a/tools/clang/test/SemaHLSL/vk.sampledtexture.struct.error.hlsl
+++ b/tools/clang/test/SemaHLSL/vk.sampledtexture.struct.error.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv
 // RUN: %dxc -T ps_6_0 -E main %s -spirv -fcgl -verify
 
 struct Struct { float f; };


### PR DESCRIPTION
Test uses `-spirv` but lacks the `REQUIRES: spirv` annotation, so it runs and fails under `-DENABLE_SPIRV_CODEGEN=OFF`.

Co-authored-by: copilot
