### PR TITLE
Execution Tests: Update datasets for rhs values for shift operations

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectorTestData.h
+++ b/tools/clang/unittests/HLSLExec/LongVectorTestData.h
@@ -298,7 +298,7 @@ BEGIN_INPUT_SETS(int32_t)
 INPUT_SET(InputSet::Default1, -6, 1, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -6, -3, -2, 9, 3, 1, -3, -7, 2);
 INPUT_SET(InputSet::Default3, -5, 6, 3, 2, -9, -3, -1, 3, 7, -2);
-INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 29, 30, 31);
+INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
 INPUT_SET(InputSet::Zero, 0);
 INPUT_SET(InputSet::NoZero, 1);
 INPUT_SET(InputSet::Bitwise, std::numeric_limits<int32_t>::min(), -1, 0, 1, 3,
@@ -314,7 +314,7 @@ BEGIN_INPUT_SETS(int64_t)
 INPUT_SET(InputSet::Default1, -6, 11, 7, 3, 8, 4, -3, 8, 8, -2);
 INPUT_SET(InputSet::Default2, 5, -1337, -3, -2, 9, 3, 1, -3, 501, 2);
 INPUT_SET(InputSet::Default3, -5, 1337, 3, 2, -9, -3, -1, 3, -501, -2);
-INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 61, 62, 63);
+INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
 INPUT_SET(InputSet::Zero, 0);
 INPUT_SET(InputSet::NoZero, 1);
 INPUT_SET(InputSet::Bitwise, std::numeric_limits<int64_t>::min(), -1, 0, 1, 3,
@@ -345,7 +345,7 @@ INPUT_SET(InputSet::Default1, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
 INPUT_SET(InputSet::Zero, 0);
-INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 29, 30, 31);
+INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 30, 31, 32);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x55555555, 0xAAAAAAAA, 0x80000000,
           127, std::numeric_limits<uint32_t>::max());
 INPUT_SET(InputSet::SelectCond, 0, 1);
@@ -359,7 +359,7 @@ INPUT_SET(InputSet::Default1, 1, 2, 3, 4, 5, 0, 7, 1000, 9, 10);
 INPUT_SET(InputSet::Default2, 1, 2, 1337, 4, 5, 6, 7, 8, 9, 10);
 INPUT_SET(InputSet::Default3, 10, 20, 1338, 40, 50, 60, 70, 80, 90, 11);
 INPUT_SET(InputSet::Zero, 0);
-INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 61, 62, 63);
+INPUT_SET(InputSet::BitShiftRhs, 1, 6, 3, 0, 9, 3, 62, 63, 64);
 INPUT_SET(InputSet::Bitwise, 0, 1, 3, 6, 9, 0x5555555555555555,
           0xAAAAAAAAAAAAAAAA, 0x8000000000000000, 127,
           std::numeric_limits<uint64_t>::max());


### PR DESCRIPTION
Assisted by gh copilot.

Fix BitShiftRhs test input sets to avoid shift amounts >= bit width, which is undefined behavior in C++ and can cause test failures as expected values are computed via C++.