### PR TITLE
[SPIR-V] Wrap `vk::SampledTexture2D` type inside spirv ifdef.

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5048,7 +5048,9 @@ public:
       ResClass = DXIL::ResourceClass::UAV;
       return true;
     case AR_OBJECT_TEXTURE2D:
+#ifdef ENABLE_SPIRV_CODEGEN
     case AR_OBJECT_VK_SAMPLED_TEXTURE2D:
+#endif
       ResKind = DXIL::ResourceKind::Texture2D;
       ResClass = DXIL::ResourceClass::SRV;
       return true;


### PR DESCRIPTION
Bug introduced by https://github.com/microsoft/DirectXShaderCompiler/pull/8158