### PR TITLE
[SPIR-V] Add parent map when handling var init

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -14740,11 +14740,13 @@ bool SpirvEmitter::emitEntryFunctionWrapperForRayTracing(
     const auto varInfo =
         declIdMapper.getDeclEvalInfo(varDecl, varDecl->getLocation());
     if (const auto *init = varDecl->getInit()) {
+      parentMap = std::make_unique<ParentMap>(const_cast<Expr *>(init));
       storeValue(varInfo, loadIfGLValue(init), varDecl->getType(),
                  init->getLocStart());
 
       // Update counter variable associated with global variables
       tryToAssignCounterVar(varDecl, init);
+      parentMap.reset(nullptr);
     }
     // If not explicitly initialized, initialize with their zero values if not
     // resource objects

--- a/tools/clang/test/CodeGenSPIRV/sm6_6.descriptorheap.global.lib.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6_6.descriptorheap.global.lib.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T lib_6_8 -fspv-target-env=vulkan1.3 -Od -spirv %s | FileCheck %s
+
+// CHECK-DAG:                                          OpCapability RuntimeDescriptorArray
+// CHECK-DAG:                                          OpExtension "SPV_EXT_descriptor_indexing"
+
+// CHECK-DAG:            [[uint_00:%[_a-zA-Z0-9]+]] = OpConstantComposite %v2uint %uint_0 %uint_0
+// CHECK-DAG:          [[float_0000:%[_a-zA-Z0-9]+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+// CHECK-DAG:             [[image_t:%[_a-zA-Z0-9]+]] = OpTypeImage %float 2D 2 0 0 2 Rgba32f
+// CHECK-DAG:       [[ptr_u_image_t:%[_a-zA-Z0-9]+]] = OpTypePointer UniformConstant [[image_t]]
+// CHECK-DAG:          [[ra_image_t:%[_a-zA-Z0-9]+]] = OpTypeRuntimeArray [[image_t]]
+// CHECK-DAG:    [[ptr_u_ra_image_t:%[_a-zA-Z0-9]+]] = OpTypePointer UniformConstant [[ra_image_t]]
+
+// CHECK-DAG: OpDecorate %ResourceDescriptorHeap DescriptorSet 0
+// CHECK-DAG: OpDecorate %ResourceDescriptorHeap Binding 0
+
+// CHECK: %ResourceDescriptorHeap = OpVariable [[ptr_u_ra_image_t]] UniformConstant
+
+// CHECK: [[ptr:%[_a-zA-Z0-9]+]] = OpAccessChain [[ptr_u_image_t]] %ResourceDescriptorHeap %uint_0
+// CHECK: [[img:%[_a-zA-Z0-9]+]] = OpLoad %type_2d_image [[ptr]]
+// CHECK: OpImageWrite [[img]] [[uint_00]] [[float_0000]] None
+
+static RWTexture2D<float4> OutputTexture = ResourceDescriptorHeap[0];
+
+[shader("raygeneration")]
+void RayGenMain() {
+  OutputTexture[uint2(0, 0)] = float4(0, 0, 0, 0);
+}


### PR DESCRIPTION
ResourceHeap resource type is not know looking at the type, but at the context around it (we need to look how the variable is assigned).
This means we need a parent map.

When the heap is used in a function, the parentMap is set to the function scope, so everything is fine. But when a static variable is set, we are in the global scope, and the parent should be the current variable declaration.

Fixes #8220