### PR TITLE
Cherry-Pick #7587: Address compiler warnings: Enable warning C4146 as a break

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -301,7 +301,6 @@ if( MSVC )
 
   set(msvc_warning_flags
     # Disabled warnings.
-    -wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
     -wd4180 # Suppress 'qualifier applied to function type has no meaning; ignored'
     -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
     -wd4258 # Suppress ''var' : definition from the for loop is ignored; the definition from the enclosing scope is used'

--- a/include/llvm/ADT/IntervalMap.h
+++ b/include/llvm/ADT/IntervalMap.h
@@ -320,7 +320,11 @@ public:
       return Count;
     } else {
       // We want to shrink, copy to sib.
-      unsigned Count = std::min(std::min(unsigned(-Add), Size), N - SSize);
+      // Count <= INT_MAX: Since Add is an int, unsigned(-Add) <= 2^31, so
+      // std::min result <= INT_MAX. Meaning its safe to store the result in an
+      // int to avoid the compiler warning for '-Count' if we were to use an
+      // unsigned value instead.
+      int Count = std::min(std::min(unsigned(-Add), Size), N - SSize);
       transferToLeftSib(Size, Sib, SSize, Count);
       return -Count;
     }

--- a/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1677,8 +1677,8 @@ LoopAccessInfo::LoopAccessInfo(Loop *L, ScalarEvolution *SE,
                                const ValueToValueMap &Strides)
     : PtrRtChecking(SE), DepChecker(SE, L), TheLoop(L), SE(SE), DL(DL),
       TLI(TLI), AA(AA), DT(DT), LI(LI), NumLoads(0), NumStores(0),
-      MaxSafeDepDistBytes(-1U), CanVecMem(false),
-      StoreToLoopInvariantAddress(false) {
+      MaxSafeDepDistBytes(std::numeric_limits<unsigned>::max()),
+      CanVecMem(false), StoreToLoopInvariantAddress(false) {
   if (canAnalyzeLoop())
     analyzeLoop(Strides);
 }

--- a/lib/Transforms/Scalar/LoadCombine.cpp
+++ b/lib/Transforms/Scalar/LoadCombine.cpp
@@ -186,7 +186,7 @@ bool LoadCombine::combineLoads(SmallVectorImpl<LoadPOPPair> &Loads) {
 
   // Find first load. This is where we put the new load.
   LoadPOPPair FirstLP;
-  FirstLP.InsertOrder = -1u;
+  FirstLP.InsertOrder = std::numeric_limits<unsigned>::max();
   for (const auto &L : Loads)
     if (L.InsertOrder < FirstLP.InsertOrder)
       FirstLP = L;

--- a/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4472,8 +4472,8 @@ LoopVectorizationCostModel::selectVectorizationFactor(bool OptForSize) {
 
   unsigned WidestType = getWidestType();
   unsigned WidestRegister = TTI.getRegisterBitWidth(true);
-  unsigned MaxSafeDepDist = -1U;
-  if (Legal->getMaxSafeDepDistBytes() != -1U)
+  unsigned MaxSafeDepDist = std::numeric_limits<unsigned>::max();
+  if (Legal->getMaxSafeDepDistBytes() != std::numeric_limits<unsigned>::max())
     MaxSafeDepDist = Legal->getMaxSafeDepDistBytes() * 8;
   WidestRegister = ((WidestRegister < MaxSafeDepDist) ?
                     WidestRegister : MaxSafeDepDist);
@@ -4638,7 +4638,7 @@ unsigned LoopVectorizationCostModel::selectInterleaveCount(bool OptForSize,
     return 1;
 
   // We used the distance for the interleave count.
-  if (Legal->getMaxSafeDepDistBytes() != -1U)
+  if (Legal->getMaxSafeDepDistBytes() != std::numeric_limits<unsigned>::max())
     return 1;
 
   // Do not interleave loops with a relatively small trip count.

--- a/tools/clang/lib/AST/SelectorLocationsKind.cpp
+++ b/tools/clang/lib/AST/SelectorLocationsKind.cpp
@@ -28,7 +28,7 @@ static SourceLocation getStandardSelLoc(unsigned Index,
     if (EndLoc.isInvalid())
       return SourceLocation();
     IdentifierInfo *II = Sel.getIdentifierInfoForSlot(0);
-    unsigned Len = II ? II->getLength() : 0;
+    int Len = II ? II->getLength() : 0;
     return EndLoc.getLocWithOffset(-Len);
   }
 
@@ -36,7 +36,7 @@ static SourceLocation getStandardSelLoc(unsigned Index,
   if (ArgLoc.isInvalid())
     return SourceLocation();
   IdentifierInfo *II = Sel.getIdentifierInfoForSlot(Index);
-  unsigned Len = /* selector id */ (II ? II->getLength() : 0) + /* ':' */ 1;
+  int Len = /* selector id */ (II ? II->getLength() : 0) + /* ':' */ 1;
   if (WithArgSpace)
     ++Len;
   return ArgLoc.getLocWithOffset(-Len);

--- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1090,7 +1090,7 @@ llvm::Value *ItaniumCXXABI::EmitTypeid(CodeGenFunction &CGF,
       CGF.GetVTablePtr(ThisPtr, StdTypeInfoPtrTy->getPointerTo());
 
   // Load the type info.
-  Value = CGF.Builder.CreateConstInBoundsGEP1_64(Value, -1ULL);
+  Value = CGF.Builder.CreateConstInBoundsGEP1_64(Value, -1LL);
   return CGF.Builder.CreateLoad(Value);
 }
 

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -11,7 +11,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 // We need to keep & fix these warnings to integrate smoothly with HLK
-#pragma warning(error : 4100 4146 4242 4244 4267 4701 4389 4018)
+#pragma warning(error : 4100 4242 4244 4267 4701 4389 4018)
 
 // *** THIS FILE CANNOT TAKE ANY LLVM DEPENDENCIES  *** //
 

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
@@ -10,7 +10,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 // We need to keep & fix these warnings to integrate smoothly with HLK
-#pragma warning(error : 4100 4146 4242 4244 4267 4701 4389)
+#pragma warning(error : 4100 4242 4244 4267 4701 4389)
 
 #include "d3dx12.h"
 #include <atlbase.h>

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.h
@@ -26,7 +26,7 @@
 #include <vector>
 
 // We need to keep & fix these warnings to integrate smoothly with HLK
-#pragma warning(error : 4100 4146 4242 4244 4267 4701 4389)
+#pragma warning(error : 4100 4242 4244 4267 4701 4389)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Forward declarations.

--- a/unittests/ADT/APIntTest.cpp
+++ b/unittests/ADT/APIntTest.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "gtest/gtest.h"
 #include <array>
+#include <limits>
 #include <ostream>
 
 using namespace llvm;
@@ -753,7 +754,7 @@ TEST(APIntTest, StringDeath) {
 #endif
 
 TEST(APIntTest, mul_clear) {
-  APInt ValA(65, -1ULL);
+  APInt ValA(65, std::numeric_limits<uint64_t>::max());
   APInt ValB(65, 4);
   APInt ValC(65, 0);
   ValC = ValA * ValB;

--- a/unittests/ADT/BitVectorTest.cpp
+++ b/unittests/ADT/BitVectorTest.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "gtest/gtest.h"
+#include <limits>
 
 using namespace llvm;
 
@@ -73,7 +74,8 @@ TYPED_TEST(BitVectorTest, TrivialOperation) {
   Vec.resize(33, true);
   Vec.resize(57, false);
   unsigned Count = 0;
-  for (unsigned i = Vec.find_first(); i != -1u; i = Vec.find_next(i)) {
+  for (unsigned i = Vec.find_first(); i != std::numeric_limits<unsigned>::max();
+       i = Vec.find_next(i)) {
     ++Count;
     EXPECT_TRUE(Vec[i]);
     EXPECT_TRUE(Vec.test(i));
@@ -103,7 +105,8 @@ TYPED_TEST(BitVectorTest, TrivialOperation) {
   Vec.resize(91, true);
   Vec.resize(130, false);
   Count = 0;
-  for (unsigned i = Vec.find_first(); i != -1u; i = Vec.find_next(i)) {
+  for (unsigned i = Vec.find_first(); i != std::numeric_limits<unsigned>::max();
+       i = Vec.find_next(i)) {
     ++Count;
     EXPECT_TRUE(Vec[i]);
     EXPECT_TRUE(Vec.test(i));

--- a/unittests/Support/DataExtractorTest.cpp
+++ b/unittests/Support/DataExtractorTest.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "llvm/Support/DataExtractor.h"
+#include "gtest/gtest.h"
+#include <limits>
 using namespace llvm;
 
 namespace {
@@ -20,7 +21,8 @@ const char bigleb128data[] = "\xAA\xA9\xFF\xAA\xFF\xAA\xFF\x4A";
 
 TEST(DataExtractorTest, OffsetOverflow) {
   DataExtractor DE(StringRef(numberData, sizeof(numberData)-1), false, 8);
-  EXPECT_FALSE(DE.isValidOffsetForDataOfSize(-2U, 5));
+  EXPECT_FALSE(DE.isValidOffsetForDataOfSize(
+      std::numeric_limits<uint32_t>::max() - 1, 5));
 }
 
 TEST(DataExtractorTest, UnsignedNumbers) {


### PR DESCRIPTION
Cherry-pick of PR #7587 into release-1.8.2505.

**Original PR:** https://github.com/microsoft/DirectXShaderCompiler/pull/7587
**Original Commit:** 94abfe972ad839185965f670329bcf33cd7bccbd

**Note:** This PR promotes C4146 to an error. The other C4146 fix PRs (#7551, #7556, #7559, #7562, #7567, #7574) should be merged first.

Assisted by GitHub Copilot.