### PR TITLE
Cherry-Pick #7889: Explicitly install g++-9 on linux images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,11 @@ stages:
       condition: eq(variables['image'], variables['linux'])
 
     - bash: |
+        sudo apt-get install g++-9 -y
+      displayName: 'Installing g++-9'
+      condition: and(eq(variables['CXX'], 'g++-9'), eq(variables['image'], variables['linux']))
+
+    - bash: |
         brew update
         brew install ninja
         ulimit -Sn 1024


### PR DESCRIPTION
Cherry-pick of PR #7889 into release-1.8.2505.

**Original PR:** https://github.com/microsoft/DirectXShaderCompiler/pull/7889
**Original Commit:** b1cf2cad8f19f2ce733bd108e63485b33fbd4774

Fixes Linux CI build failure where g++-9 is no longer pre-installed on the Ubuntu pipeline images.

Assisted by GitHub Copilot.