### PR TITLE
Fix lib_6_x bug blocking CI

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
+++ b/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
@@ -759,6 +759,15 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
       }
     }
 
+    // lib_6_x is an offline linking target, which allows exported functions to
+    // perform actions that would otherwise be disallowed, as long as these
+    // actions are either inlined into entry points where they are allowed, or
+    // eliminated by the time the final library is linked to a runtime supported
+    // shader model. Therefore, skip reachable call diagnostics for non-entry
+    // points.
+    if (EntrySK == DXIL::ShaderKind::Library && IsTargetProfileLib6x(*self))
+      continue;
+
     // Visit all visited functions in call graph to collect illegal intrinsic
     // calls.
     HLSLReachableDiagnoseVisitor Visitor(


### PR DESCRIPTION
https://github.com/microsoft/DirectXShaderCompiler/pull/8202 and https://github.com/microsoft/DirectXShaderCompiler/pull/8233 collided post merge to reveal a long standing bug with `-lib_6_x` that is currently breaking CI on main.

This change fixes that bug by skipping reachable call diagnostics in the case that they are allowed to be transiently invalid. The comment in the PR is a bit more verbose on the details and I'll avoid reposting it here.