### PR TITLE
Verify code format changes come from the github-actions bot

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -82,7 +82,7 @@ jobs:
             --end-rev $END_REV \
             --changed-files "$CHANGED_FILES"
   apply_diff:
-    if: ${{ github.event_name == 'issue_comment' && endsWith(github.event.comment.body, '- [x] Check this box to apply formatting changes to this branch.') }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.comment.user.login == 'github-actions[bot]' && endsWith(github.event.comment.body, '- [x] Check this box to apply formatting changes to this branch.') }}
     runs-on: ubuntu-latest
     env:
       TMP_DIFF_FILE: /tmp/diff.patch

--- a/utils/git/code-format-save-diff.py
+++ b/utils/git/code-format-save-diff.py
@@ -24,6 +24,9 @@ CRLF = '\r\n'
 CR = '\r'
 
 
+COMMENT_TAG = "<!--LLVM CODE FORMAT COMMENT:"
+
+
 def get_diff_from_comment(comment: IssueComment.IssueComment) -> str:
     diff_pat = re.compile(r"``````````diff(?P<DIFF>.+)``````````", re.DOTALL)
     m = re.search(diff_pat, comment.body)
@@ -49,6 +52,18 @@ def apply_patches(args: argparse.Namespace) -> None:
     comment = pr.get_issue_comment(args.comment_id)
     if comment is None:
         raise Exception(f"Comment {args.comment_id} does not exist")
+
+    if comment.user.login != "github-actions[bot]":
+        raise Exception(
+            f"Comment {args.comment_id} was not created by the expected bot "
+            f"(author: {comment.user.login})"
+        )
+
+    if COMMENT_TAG not in comment.body:
+        raise Exception(
+            f"Comment {args.comment_id} does not contain the expected "
+            f"format comment tag"
+        )
 
     # get the diff from the comment
     diff = get_diff_from_comment(comment)


### PR DESCRIPTION
The change makes it so that code format changes are only applied if the comment was updated by the github-actions identity.