### PR TITLE
Update checkout from target branch to main

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: microsoft/DirectXShaderCompiler
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
             utils/git/requirements_formatting.txt
             utils/git/code-format-helper.py
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: microsoft/DirectXShaderCompiler
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
             utils/git/requirements_formatting.txt
             utils/git/code-format-helper.py


### PR DESCRIPTION
This PR changes clang-format-checker.yml so that the main branch is checked out when fetching formatting tools, not the target branch of the PR.