### PR TITLE
[SPIR-V] Add sampler & resource heaps for textures

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -429,6 +429,17 @@ def Wno_vk_emulated_features : Joined<["-"], "Wno-vk-emulated-features">, Group<
   HelpText<"Do not emit warnings for emulated features resulting from no direct mapping">;
 def fspv_print_all: Flag<["-"], "fspv-print-all">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Print the SPIR-V module before each pass and after the last one. Useful for debugging SPIR-V legalization and optimization passes.">;
+def fspv_use_emulated_heap
+    : Flag<["-"], "fspv-use-emulated-heap">,
+      Group<spirv_Group>,
+      Flags<[CoreOption, DriverOption]>,
+      HelpText<
+          "Use emulated descriptor heap using descriptor indexing (default).">;
+def fspv_use_descriptor_heap
+    : Flag<["-"], "fspv-use-descriptor-heap">,
+      Group<spirv_Group>,
+      Flags<[CoreOption, DriverOption]>,
+      HelpText<"Use SPV_EXT_descriptor_heap for HLSL descriptor heaps.">;
 def Oconfig : CommaJoined<["-"], "Oconfig=">, Group<spirv_Group>, Flags<[CoreOption]>,
   HelpText<"Specify a comma-separated list of SPIRV-Tools passes to customize optimization configuration (see http://khr.io/hlsl2spirv#optimization)">;
 def fspv_preserve_bindings : Flag<["-"], "fspv-preserve-bindings">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -72,6 +72,7 @@ struct SpirvCodeGenOptions {
   bool enableMaximalReconvergence = false;
   bool useVulkanMemoryModel = false;
   bool useUnknownImageFormat = false;
+  bool useDescriptorHeap = false;
   bool IEEEStrict = false;
   /// Maximum length in words for the OpString literal containing the shader
   /// source for DebugSource and DebugSourceContinued. If the source code length

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1139,6 +1139,9 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.useUnknownImageFormat =
       Args.hasFlag(OPT_fspv_use_unknown_image_format, OPT_INVALID, false);
 
+  opts.SpirvOptions.useDescriptorHeap = Args.hasFlag(
+      OPT_fspv_use_descriptor_heap, OPT_fspv_use_emulated_heap, false);
+
   if (!handleVkShiftArgs(Args, OPT_fvk_b_shift, "b", &opts.SpirvOptions.bShift,
                          errors) ||
       !handleVkShiftArgs(Args, OPT_fvk_t_shift, "t", &opts.SpirvOptions.tShift,
@@ -1295,6 +1298,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_fix_func_call_arguments, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_print_all, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fspv_use_emulated_heap, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fspv_use_descriptor_heap, OPT_INVALID, false) ||
       Args.hasFlag(OPT_Wno_vk_ignored_features, OPT_INVALID, false) ||
       Args.hasFlag(OPT_Wno_vk_emulated_features, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_auto_shift_bindings, OPT_INVALID, false) ||

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -66,6 +66,8 @@ enum class Extension {
   KHR_float_controls,
   NV_shader_subgroup_partitioned,
   KHR_quad_control,
+  EXT_descriptor_heap,
+  KHR_untyped_pointers,
   Unknown,
 };
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -274,6 +274,12 @@ public:
                                                   SpirvInstruction *sample,
                                                   SourceLocation);
 
+  /// \brief Creates an OpUntypedImageTexelPointerEXT SPIR-V instruction with
+  /// the given parameters.
+  SpirvUntypedImageTexelPointerEXT *createUntypedImageTexelPointerEXT(
+      QualType resultType, SpirvInstruction *image,
+      SpirvInstruction *coordinate, SpirvInstruction *sample, SourceLocation);
+
   /// \brief Creates an OpConverPtrToU SPIR-V instruction with the given
   /// parameters.
   SpirvConvertPtrToU *createConvertPtrToU(SpirvInstruction *ptr, QualType type);
@@ -281,6 +287,12 @@ public:
   /// \brief Creates an OpConverUToPtr SPIR-V instruction with the given
   /// parameters.
   SpirvConvertUToPtr *createConvertUToPtr(SpirvInstruction *val, QualType type);
+
+  /// \brief Creates an OpBufferPointerEXT SPIR-V instruction with the given
+  /// parameters.
+  SpirvBufferPointerEXT *createBufferPointerEXT(const SpirvType *resultType,
+                                                SpirvInstruction *buffer,
+                                                SourceLocation);
 
   /// \brief Creates SPIR-V instructions for sampling the given image.
   ///
@@ -630,8 +642,7 @@ public:
   /// support a single entry point per module for now.
   inline void addEntryPoint(spv::ExecutionModel em, SpirvFunction *target,
                             llvm::StringRef targetName,
-                            llvm::ArrayRef<SpirvVariable *> interfaces);
-
+                            llvm::ArrayRef<SpirvInstruction *> interfaces);
   /// \brief Sets the shader model version, source file name, and source file
   /// content. Returns the SpirvString instruction of the file name.
   inline SpirvString *setDebugSource(uint32_t major, uint32_t minor,
@@ -707,6 +718,18 @@ public:
                llvm::StringRef name = "",
                llvm::Optional<SpirvInstruction *> init = llvm::None,
                SourceLocation loc = {});
+
+  /// \brief Adds an untyped module variable.
+  SpirvUntypedVariableKHR *createUntypedVariableKHR(
+      const SpirvType *valueType, spv::StorageClass storageClass,
+      SourceLocation loc = {}, llvm::StringRef name = "heap");
+
+  /// \brief Creates an OpUntypedAccessChainKHR instruction.
+  SpirvUntypedAccessChainKHR *
+  createUntypedAccessChainKHR(const SpirvType *resultType,
+                              const SpirvType *baseType, SpirvInstruction *base,
+                              llvm::ArrayRef<SpirvInstruction *> indexes,
+                              SourceLocation loc);
 
   /// \brief Decorates the given target with the given location.
   void decorateLocation(SpirvInstruction *target, uint32_t location);
@@ -974,13 +997,12 @@ void SpirvBuilder::setMemoryModel(spv::AddressingModel addrModel,
   mod->setMemoryModel(new (context) SpirvMemoryModel(addrModel, memModel));
 }
 
-void SpirvBuilder::addEntryPoint(spv::ExecutionModel em, SpirvFunction *target,
-                                 llvm::StringRef targetName,
-                                 llvm::ArrayRef<SpirvVariable *> interfaces) {
+void SpirvBuilder::addEntryPoint(
+    spv::ExecutionModel em, SpirvFunction *target, llvm::StringRef targetName,
+    llvm::ArrayRef<SpirvInstruction *> interfaces) {
   mod->addEntryPoint(new (context) SpirvEntryPoint(
       target->getSourceLocation(), em, target, targetName, interfaces));
 }
-
 SpirvString *
 SpirvBuilder::setDebugSource(uint32_t major, uint32_t minor,
                              const std::vector<llvm::StringRef> &fileNames,

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -288,12 +288,6 @@ public:
   /// parameters.
   SpirvConvertUToPtr *createConvertUToPtr(SpirvInstruction *val, QualType type);
 
-  /// \brief Creates an OpBufferPointerEXT SPIR-V instruction with the given
-  /// parameters.
-  SpirvBufferPointerEXT *createBufferPointerEXT(const SpirvType *resultType,
-                                                SpirvInstruction *buffer,
-                                                SourceLocation);
-
   /// \brief Creates SPIR-V instructions for sampling the given image.
   ///
   /// If compareVal is given a non-zero value, *Dref* variants of OpImageSample*
@@ -720,9 +714,10 @@ public:
                SourceLocation loc = {});
 
   /// \brief Adds an untyped module variable.
-  SpirvUntypedVariableKHR *createUntypedVariableKHR(
-      const SpirvType *valueType, spv::StorageClass storageClass,
-      SourceLocation loc = {}, llvm::StringRef name = "heap");
+  SpirvUntypedVariableKHR *
+  createUntypedVariableKHR(const SpirvType *valueType,
+                           spv::StorageClass storageClass, llvm::StringRef name,
+                           SourceLocation loc = {});
 
   /// \brief Creates an OpUntypedAccessChainKHR instruction.
   SpirvUntypedAccessChainKHR *

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -636,7 +636,7 @@ public:
   /// support a single entry point per module for now.
   inline void addEntryPoint(spv::ExecutionModel em, SpirvFunction *target,
                             llvm::StringRef targetName,
-                            llvm::ArrayRef<SpirvInstruction *> interfaces);
+                            llvm::ArrayRef<SpirvVariableLike *> interfaces);
   /// \brief Sets the shader model version, source file name, and source file
   /// content. Returns the SpirvString instruction of the file name.
   inline SpirvString *setDebugSource(uint32_t major, uint32_t minor,
@@ -994,7 +994,7 @@ void SpirvBuilder::setMemoryModel(spv::AddressingModel addrModel,
 
 void SpirvBuilder::addEntryPoint(
     spv::ExecutionModel em, SpirvFunction *target, llvm::StringRef targetName,
-    llvm::ArrayRef<SpirvInstruction *> interfaces) {
+    llvm::ArrayRef<SpirvVariableLike *> interfaces) {
   mod->addEntryPoint(new (context) SpirvEntryPoint(
       target->getSourceLocation(), em, target, targetName, interfaces));
 }

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -297,6 +297,8 @@ public:
   const SpirvPointerType *getPointerType(const SpirvType *pointee,
                                          spv::StorageClass);
 
+  const UntypedPointerKHRType *getUntypedPointerKHRType(spv::StorageClass sc);
+
   FunctionType *getFunctionType(const SpirvType *ret,
                                 llvm::ArrayRef<const SpirvType *> param);
 
@@ -531,6 +533,9 @@ private:
   llvm::SmallVector<const HybridStructType *, 8> hybridStructTypes;
   llvm::DenseMap<const SpirvType *, SCToPtrTyMap> pointerTypes;
   llvm::SmallVector<const HybridPointerType *, 8> hybridPointerTypes;
+  llvm::DenseMap<spv::StorageClass, const UntypedPointerKHRType *,
+                 StorageClassDenseMapInfo>
+      untypedPointerKHRTypes;
   llvm::MapVector<QualType, const ForwardPointerType *> forwardPointerTypes;
   llvm::MapVector<QualType, const SpirvPointerType *> forwardReferences;
   llvm::DenseSet<FunctionType *, FunctionTypeMapInfo> functionTypes;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -48,19 +48,20 @@ public:
     // "Metadata" kinds
     // In the order of logical layout
 
-    IK_Capability,      // OpCapability
-    IK_Extension,       // OpExtension
-    IK_ExtInstImport,   // OpExtInstImport
-    IK_MemoryModel,     // OpMemoryModel
-    IK_EntryPoint,      // OpEntryPoint
-    IK_ExecutionMode,   // OpExecutionMode
-    IK_ExecutionModeId, // OpExecutionModeId
-    IK_String,          // OpString (debug)
-    IK_Source,          // OpSource (debug)
-    IK_ModuleProcessed, // OpModuleProcessed (debug)
-    IK_Decoration,      // Op*Decorate
-    IK_Type,            // OpType*
-    IK_Variable,        // OpVariable
+    IK_Capability,         // OpCapability
+    IK_Extension,          // OpExtension
+    IK_ExtInstImport,      // OpExtInstImport
+    IK_MemoryModel,        // OpMemoryModel
+    IK_EntryPoint,         // OpEntryPoint
+    IK_ExecutionMode,      // OpExecutionMode
+    IK_ExecutionModeId,    // OpExecutionModeId
+    IK_String,             // OpString (debug)
+    IK_Source,             // OpSource (debug)
+    IK_ModuleProcessed,    // OpModuleProcessed (debug)
+    IK_Decoration,         // Op*Decorate
+    IK_Type,               // OpType*
+    IK_Variable,           // OpVariable
+    IK_UntypedVariableKHR, // OpUntypedVariableKHR
 
     // Different kind of constants. Order matters.
     IK_ConstantBoolean,
@@ -73,6 +74,7 @@ public:
     // Pointer <-> uint conversions.
     IK_ConvertPtrToU,
     IK_ConvertUToPtr,
+    IK_BufferPointerEXT, // OpBufferPointerEXT
 
     // OpUndef
     IK_Undef,
@@ -101,6 +103,7 @@ public:
     // In alphabetical order
 
     IK_AccessChain,              // OpAccessChain
+    IK_UntypedAccessChainKHR,    // OpUntypedAccessChainKHR
     IK_ArrayLength,              // OpArrayLength
     IK_Atomic,                   // OpAtomic*
     IK_Barrier,                  // Op*Barrier
@@ -123,23 +126,24 @@ public:
 
     IK_GroupNonUniformOp, // Group non-uniform operations
 
-    IK_ImageOp,                   // OpImage*
-    IK_ImageQuery,                // OpImageQuery*
-    IK_ImageSparseTexelsResident, // OpImageSparseTexelsResident
-    IK_ImageTexelPointer,         // OpImageTexelPointer
-    IK_Load,                      // OpLoad
-    IK_RayQueryOpKHR,             // KHR rayquery ops
-    IK_RayTracingOpNV,            // NV raytracing ops
-    IK_ReadClock,                 // OpReadClock
-    IK_SampledImage,              // OpSampledImage
-    IK_Select,                    // OpSelect
-    IK_SpecConstantBinaryOp,      // SpecConstant binary operations
-    IK_SpecConstantUnaryOp,       // SpecConstant unary operations
-    IK_Store,                     // OpStore
-    IK_UnaryOp,                   // Unary operations
-    IK_NullaryOp,                 // Nullary operations
-    IK_VectorShuffle,             // OpVectorShuffle
-    IK_SpirvIntrinsicInstruction, // Spirv Intrinsic Instructions
+    IK_ImageOp,                     // OpImage*
+    IK_ImageQuery,                  // OpImageQuery*
+    IK_ImageSparseTexelsResident,   // OpImageSparseTexelsResident
+    IK_ImageTexelPointer,           // OpImageTexelPointer
+    IK_UntypedImageTexelPointerEXT, // OpUntypedImageTexelPointerEXT
+    IK_Load,                        // OpLoad
+    IK_RayQueryOpKHR,               // KHR rayquery ops
+    IK_RayTracingOpNV,              // NV raytracing ops
+    IK_ReadClock,                   // OpReadClock
+    IK_SampledImage,                // OpSampledImage
+    IK_Select,                      // OpSelect
+    IK_SpecConstantBinaryOp,        // SpecConstant binary operations
+    IK_SpecConstantUnaryOp,         // SpecConstant unary operations
+    IK_Store,                       // OpStore
+    IK_UnaryOp,                     // Unary operations
+    IK_NullaryOp,                   // Nullary operations
+    IK_VectorShuffle,               // OpVectorShuffle
+    IK_SpirvIntrinsicInstruction,   // Spirv Intrinsic Instructions
 
     // For DebugInfo instructions defined in
     // OpenCL.DebugInfo.100 and NonSemantic.Shader.DebugInfo.100
@@ -387,7 +391,7 @@ class SpirvEntryPoint : public SpirvInstruction {
 public:
   SpirvEntryPoint(SourceLocation loc, spv::ExecutionModel executionModel,
                   SpirvFunction *entryPoint, llvm::StringRef nameStr,
-                  llvm::ArrayRef<SpirvVariable *> iface);
+                  llvm::ArrayRef<SpirvInstruction *> iface);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvEntryPoint)
 
@@ -401,13 +405,15 @@ public:
   spv::ExecutionModel getExecModel() const { return execModel; }
   SpirvFunction *getEntryPoint() const { return entryPoint; }
   llvm::StringRef getEntryPointName() const { return name; }
-  llvm::ArrayRef<SpirvVariable *> getInterface() const { return interfaceVec; }
+  llvm::ArrayRef<SpirvInstruction *> getInterface() const {
+    return interfaceVec;
+  }
 
 private:
   spv::ExecutionModel execModel;
   SpirvFunction *entryPoint;
   std::string name;
-  llvm::SmallVector<SpirvVariable *, 8> interfaceVec;
+  llvm::SmallVector<SpirvInstruction *, 8> interfaceVec;
 };
 
 class SpirvExecutionModeBase : public SpirvInstruction {
@@ -638,6 +644,52 @@ private:
   int32_t descriptorSet;
   int32_t binding;
   std::string hlslUserType;
+};
+
+/// \brief OpUntypedVariableKHR instruction
+class SpirvUntypedVariableKHR : public SpirvInstruction {
+public:
+  SpirvUntypedVariableKHR(QualType resultType, SourceLocation loc,
+                          spv::StorageClass sc);
+
+  SpirvUntypedVariableKHR(const SpirvType *spvType, SourceLocation loc,
+                          spv::StorageClass sc);
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvUntypedVariableKHR)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_UntypedVariableKHR;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+};
+
+/// \brief Untyped Access Chain instruction representation
+/// (OpUntypedAccessChainKHR)
+class SpirvUntypedAccessChainKHR : public SpirvInstruction {
+public:
+  SpirvUntypedAccessChainKHR(const SpirvType *resultType, SourceLocation loc,
+                             const SpirvType *baseType, SpirvInstruction *base,
+                             llvm::ArrayRef<SpirvInstruction *> indexVec);
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvUntypedAccessChainKHR)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_UntypedAccessChainKHR;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+
+  SpirvInstruction *getBase() const { return base; }
+  const SpirvType *getBaseType() const { return baseType; };
+  llvm::ArrayRef<SpirvInstruction *> getIndices() const { return indices; }
+
+private:
+  const SpirvType *baseType;
+  SpirvInstruction *base;
+  llvm::SmallVector<SpirvInstruction *, 4> indices;
 };
 
 class SpirvFunctionParameter : public SpirvInstruction {
@@ -1542,6 +1594,26 @@ private:
   SpirvInstruction *val;
 };
 
+class SpirvBufferPointerEXT : public SpirvInstruction {
+public:
+  SpirvBufferPointerEXT(const SpirvType *resultType, SourceLocation loc,
+                        SpirvInstruction *buffer);
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvBufferPointerEXT)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_BufferPointerEXT;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+
+  SpirvInstruction *getBuffer() const { return buffer; }
+
+private:
+  SpirvInstruction *buffer;
+};
+
 class SpirvUndef : public SpirvInstruction {
 public:
   SpirvUndef(QualType type);
@@ -1995,6 +2067,32 @@ public:
       bool inEntryFunctionWrapper) override {
     coordinate = remapOp(coordinate);
   }
+
+private:
+  SpirvInstruction *image;
+  SpirvInstruction *coordinate;
+  SpirvInstruction *sample;
+};
+
+class SpirvUntypedImageTexelPointerEXT : public SpirvInstruction {
+public:
+  SpirvUntypedImageTexelPointerEXT(QualType resultType, SourceLocation loc,
+                                   SpirvInstruction *image,
+                                   SpirvInstruction *coordinate,
+                                   SpirvInstruction *sample);
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvUntypedImageTexelPointerEXT)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_UntypedImageTexelPointerEXT;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+
+  SpirvInstruction *getImage() const { return image; }
+  SpirvInstruction *getCoordinate() const { return coordinate; }
+  SpirvInstruction *getSample() const { return sample; }
 
 private:
   SpirvInstruction *image;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -297,6 +297,14 @@ protected:
   bool isRasterizerOrdered_;
 };
 
+/// \brief class wrapping OpVariable and OpUntypedVariableKHR
+class SpirvVariableLike : public SpirvInstruction {
+
+protected:
+  SpirvVariableLike(Kind kind, spv::Op opcode, QualType astResultType,
+                    SourceLocation loc, SourceRange range = {});
+};
+
 /// \brief OpCapability instruction
 class SpirvCapability : public SpirvInstruction {
 public:
@@ -391,7 +399,7 @@ class SpirvEntryPoint : public SpirvInstruction {
 public:
   SpirvEntryPoint(SourceLocation loc, spv::ExecutionModel executionModel,
                   SpirvFunction *entryPoint, llvm::StringRef nameStr,
-                  llvm::ArrayRef<SpirvInstruction *> iface);
+                  llvm::ArrayRef<SpirvVariableLike *> iface);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvEntryPoint)
 
@@ -405,7 +413,7 @@ public:
   spv::ExecutionModel getExecModel() const { return execModel; }
   SpirvFunction *getEntryPoint() const { return entryPoint; }
   llvm::StringRef getEntryPointName() const { return name; }
-  llvm::ArrayRef<SpirvInstruction *> getInterface() const {
+  llvm::ArrayRef<SpirvVariableLike *> getInterface() const {
     return interfaceVec;
   }
 
@@ -413,7 +421,7 @@ private:
   spv::ExecutionModel execModel;
   SpirvFunction *entryPoint;
   std::string name;
-  llvm::SmallVector<SpirvInstruction *, 8> interfaceVec;
+  llvm::SmallVector<SpirvVariableLike *, 8> interfaceVec;
 };
 
 class SpirvExecutionModeBase : public SpirvInstruction {
@@ -611,7 +619,7 @@ private:
 };
 
 /// \brief OpVariable instruction
-class SpirvVariable : public SpirvInstruction {
+class SpirvVariable : public SpirvVariableLike {
 public:
   SpirvVariable(QualType resultType, SourceLocation loc, spv::StorageClass sc,
                 bool isPrecise, bool isNointerp,
@@ -647,7 +655,7 @@ private:
 };
 
 /// \brief OpUntypedVariableKHR instruction
-class SpirvUntypedVariableKHR : public SpirvInstruction {
+class SpirvUntypedVariableKHR : public SpirvVariableLike {
 public:
   SpirvUntypedVariableKHR(QualType resultType, SourceLocation loc,
                           spv::StorageClass sc);

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1594,26 +1594,6 @@ private:
   SpirvInstruction *val;
 };
 
-class SpirvBufferPointerEXT : public SpirvInstruction {
-public:
-  SpirvBufferPointerEXT(const SpirvType *resultType, SourceLocation loc,
-                        SpirvInstruction *buffer);
-
-  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvBufferPointerEXT)
-
-  // For LLVM-style RTTI
-  static bool classof(const SpirvInstruction *inst) {
-    return inst->getKind() == IK_BufferPointerEXT;
-  }
-
-  bool invokeVisitor(Visitor *v) override;
-
-  SpirvInstruction *getBuffer() const { return buffer; }
-
-private:
-  SpirvInstruction *buffer;
-};
-
 class SpirvUndef : public SpirvInstruction {
 public:
   SpirvUndef(QualType type);

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -137,11 +137,11 @@ public:
   SpirvExtInstImport *getExtInstSet(llvm::StringRef name);
 
   // Adds a variable to the module.
-  void addVariable(SpirvVariable *);
+  void addVariable(SpirvInstruction *);
 
   // Adds a variable to the module immediately before `pos`.
   // If `pos` is not found, `var` is added at the end of the variable list.
-  void addVariable(SpirvVariable *var, SpirvInstruction *pos);
+  void addVariable(SpirvInstruction *var, SpirvInstruction *pos);
 
   // Adds a decoration to the module.
   void addDecoration(SpirvDecoration *);
@@ -172,7 +172,7 @@ public:
   // Adds the given OpModuleProcessed to the module.
   void addModuleProcessed(SpirvModuleProcessed *);
 
-  llvm::ArrayRef<SpirvVariable *> getVariables() const { return variables; }
+  llvm::ArrayRef<SpirvInstruction *> getVariables() const { return variables; }
 
   llvm::ArrayRef<SpirvEntryPoint *> getEntryPoints() const {
     return entryPoints;
@@ -217,7 +217,7 @@ private:
 
   std::vector<SpirvConstant *> constants;
   std::vector<SpirvUndef *> undefs;
-  std::vector<SpirvVariable *> variables;
+  std::vector<SpirvInstruction *> variables;
   // A vector of functions in the module in the order that they should be
   // emitted. The order starts with the entry-point function followed by a
   // depth-first discovery of functions reachable from the entry-point function.

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -137,11 +137,11 @@ public:
   SpirvExtInstImport *getExtInstSet(llvm::StringRef name);
 
   // Adds a variable to the module.
-  void addVariable(SpirvInstruction *);
+  void addVariable(SpirvVariableLike *);
 
   // Adds a variable to the module immediately before `pos`.
   // If `pos` is not found, `var` is added at the end of the variable list.
-  void addVariable(SpirvInstruction *var, SpirvInstruction *pos);
+  void addVariable(SpirvVariableLike *var, SpirvInstruction *pos);
 
   // Adds a decoration to the module.
   void addDecoration(SpirvDecoration *);
@@ -172,7 +172,7 @@ public:
   // Adds the given OpModuleProcessed to the module.
   void addModuleProcessed(SpirvModuleProcessed *);
 
-  llvm::ArrayRef<SpirvInstruction *> getVariables() const { return variables; }
+  llvm::ArrayRef<SpirvVariableLike *> getVariables() const { return variables; }
 
   llvm::ArrayRef<SpirvEntryPoint *> getEntryPoints() const {
     return entryPoints;
@@ -217,7 +217,7 @@ private:
 
   std::vector<SpirvConstant *> constants;
   std::vector<SpirvUndef *> undefs;
-  std::vector<SpirvInstruction *> variables;
+  std::vector<SpirvVariableLike *> variables;
   // A vector of functions in the module in the order that they should be
   // emitted. The order starts with the entry-point function followed by a
   // depth-first discovery of functions reachable from the entry-point function.

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -59,6 +59,8 @@ public:
     TK_AccelerationStructureNV,
     TK_RayQueryKHR,
     TK_SpirvIntrinsicType,
+    TK_BufferEXT,
+    TK_UntypedPointerKHR,
     // Order matters: all the following are hybrid types
     TK_HybridStruct,
     TK_HybridPointer,
@@ -387,6 +389,45 @@ private:
   // If this structure is a uniform buffer shader-interface, it will be
   // decorated with 'Block'.
   StructInterfaceType interfaceType;
+};
+
+class BufferEXTType : public SpirvType {
+public:
+  BufferEXTType(spv::StorageClass sc)
+      : SpirvType(TK_BufferEXT, "type.buffer.ext"), storageClass(sc) {}
+
+  static bool classof(const SpirvType *t) {
+    return t->getKind() == TK_BufferEXT;
+  }
+
+  bool operator==(const BufferEXTType &that) const {
+    return storageClass == that.storageClass;
+  }
+
+  spv::StorageClass getStorageClass() const { return storageClass; }
+
+private:
+  spv::StorageClass storageClass;
+};
+
+class UntypedPointerKHRType : public SpirvType {
+public:
+  UntypedPointerKHRType(spv::StorageClass sc)
+      : SpirvType(TK_UntypedPointerKHR, "type.untyped.pointer"),
+        storageClass(sc) {}
+
+  static bool classof(const SpirvType *t) {
+    return t->getKind() == TK_UntypedPointerKHR;
+  }
+
+  bool operator==(const UntypedPointerKHRType &that) const {
+    return storageClass == that.storageClass;
+  }
+
+  spv::StorageClass getStorageClass() const { return storageClass; }
+
+private:
+  spv::StorageClass storageClass;
 };
 
 /// Represents a SPIR-V pointer type.

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -100,7 +100,6 @@ public:
   DEFINE_VISIT_METHOD(SpirvConstantNull)
   DEFINE_VISIT_METHOD(SpirvConvertPtrToU)
   DEFINE_VISIT_METHOD(SpirvConvertUToPtr)
-  DEFINE_VISIT_METHOD(SpirvBufferPointerEXT)
   DEFINE_VISIT_METHOD(SpirvUndef)
   DEFINE_VISIT_METHOD(SpirvCompositeConstruct)
   DEFINE_VISIT_METHOD(SpirvCompositeExtract)

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -67,6 +67,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvModuleProcessed)
   DEFINE_VISIT_METHOD(SpirvDecoration)
   DEFINE_VISIT_METHOD(SpirvVariable)
+  DEFINE_VISIT_METHOD(SpirvUntypedVariableKHR)
 
   DEFINE_VISIT_METHOD(SpirvFunctionParameter)
   DEFINE_VISIT_METHOD(SpirvLoopMerge)
@@ -80,6 +81,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvUnreachable)
 
   DEFINE_VISIT_METHOD(SpirvAccessChain)
+  DEFINE_VISIT_METHOD(SpirvUntypedAccessChainKHR)
   DEFINE_VISIT_METHOD(SpirvAtomic)
   DEFINE_VISIT_METHOD(SpirvBarrier)
   DEFINE_VISIT_METHOD(SpirvIsNodePayloadValid)
@@ -98,6 +100,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvConstantNull)
   DEFINE_VISIT_METHOD(SpirvConvertPtrToU)
   DEFINE_VISIT_METHOD(SpirvConvertUToPtr)
+  DEFINE_VISIT_METHOD(SpirvBufferPointerEXT)
   DEFINE_VISIT_METHOD(SpirvUndef)
   DEFINE_VISIT_METHOD(SpirvCompositeConstruct)
   DEFINE_VISIT_METHOD(SpirvCompositeExtract)
@@ -111,6 +114,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvImageQuery)
   DEFINE_VISIT_METHOD(SpirvImageSparseTexelsResident)
   DEFINE_VISIT_METHOD(SpirvImageTexelPointer)
+  DEFINE_VISIT_METHOD(SpirvUntypedImageTexelPointerEXT)
   DEFINE_VISIT_METHOD(SpirvLoad)
   DEFINE_VISIT_METHOD(SpirvCopyObject)
   DEFINE_VISIT_METHOD(SpirvSampledImage)

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -954,6 +954,12 @@ bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
   addExtensionAndCapabilitiesIfEnabled(Extension::KHR_quad_control,
                                        {spv::Capability::QuadControlKHR});
 
+  if (spvOptions.useDescriptorHeap) {
+    addExtension(Extension::EXT_descriptor_heap, "DescriptorHeap", {});
+    addExtension(Extension::KHR_untyped_pointers, "DescriptorHeap", {});
+    addCapability(spv::Capability::DescriptorHeapEXT);
+  }
+
   return true;
 }
 

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -419,6 +419,13 @@ SpirvDebugType *DebugTypeVisitor::lowerToDebugType(const SpirvType *spirvType) {
         spvContext.getDebugTypeFunction(spirvType, flags, returnType, params);
     break;
   }
+  case SpirvType::TK_BufferEXT:
+  case SpirvType::TK_UntypedPointerKHR: {
+    // There is no standard debug type for opaque buffer/pointers yet.
+    // For now, lower it as an empty composite type or ignore.
+    debugType = lowerToDebugTypeComposite(spirvType);
+    break;
+  }
   case SpirvType::TK_AccelerationStructureNV: {
     debugType = lowerToDebugTypeComposite(spirvType);
     break;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1202,7 +1202,7 @@ DeclResultIdMapper::createResourceDescriptorHeap(const VarDecl *var) {
     }
     HeapVar = SamplerHeapVar;
   } else
-    assert(0 && "Unsupported heap type");
+    llvm_unreachable("Unsupported heap type. FIXME");
 
   // Decorate with BuiltIn
   astDecls[var] = createDeclSpirvInfo(HeapVar);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1174,46 +1174,55 @@ DeclResultIdMapper::createFileVar(const VarDecl *var,
 }
 
 SpirvInstruction *
-DeclResultIdMapper::createResourceHeap(const VarDecl *var,
-                                       QualType ResourceType) {
-  if (spirvOptions.useDescriptorHeap) {
-    SpirvUntypedVariableKHR *HeapVar = nullptr;
+DeclResultIdMapper::createResourceDescriptorHeap(const VarDecl *var) {
+  SpirvUntypedVariableKHR *HeapVar = nullptr;
 
-    if (isResourceDescriptorHeap(var)) {
-      if (!ResourceHeapVar) {
-        const auto loc = var->getLocation();
-        const auto *type = spvContext.getUntypedPointerKHRType(
-            spv::StorageClass::UniformConstant);
-        ResourceHeapVar = spvBuilder.createUntypedVariableKHR(
-            type, spv::StorageClass::UniformConstant, loc, "resource_heap");
-        spvBuilder.decorateWithLiterals(
-            ResourceHeapVar, static_cast<uint32_t>(spv::Decoration::BuiltIn),
-            {static_cast<uint32_t>(spv::BuiltIn::ResourceHeapEXT)}, loc);
-      }
-      HeapVar = ResourceHeapVar;
-    } else if (isSamplerDescriptorHeap(var)) {
-      if (!SamplerHeapVar) {
-        const auto loc = var->getLocation();
-        const auto *type = spvContext.getUntypedPointerKHRType(
-            spv::StorageClass::UniformConstant);
-        SamplerHeapVar = spvBuilder.createUntypedVariableKHR(
-            type, spv::StorageClass::UniformConstant, loc, "sampler_heap");
-        spvBuilder.decorateWithLiterals(
-            SamplerHeapVar, static_cast<uint32_t>(spv::Decoration::BuiltIn),
-            {static_cast<uint32_t>(spv::BuiltIn::SamplerHeapEXT)}, loc);
-      }
-      HeapVar = SamplerHeapVar;
-    } else
-      assert(0 && "Unsupported heap type");
+  if (isResourceDescriptorHeap(var)) {
+    if (!ResourceHeapVar) {
+      const auto loc = var->getLocation();
+      const auto *type = spvContext.getUntypedPointerKHRType(
+          spv::StorageClass::UniformConstant);
+      ResourceHeapVar = spvBuilder.createUntypedVariableKHR(
+          type, spv::StorageClass::UniformConstant, "resource_heap", loc);
+      spvBuilder.decorateWithLiterals(
+          ResourceHeapVar, static_cast<uint32_t>(spv::Decoration::BuiltIn),
+          {static_cast<uint32_t>(spv::BuiltIn::ResourceHeapEXT)}, loc);
+    }
+    HeapVar = ResourceHeapVar;
+  } else if (isSamplerDescriptorHeap(var)) {
+    if (!SamplerHeapVar) {
+      const auto loc = var->getLocation();
+      const auto *type = spvContext.getUntypedPointerKHRType(
+          spv::StorageClass::UniformConstant);
+      SamplerHeapVar = spvBuilder.createUntypedVariableKHR(
+          type, spv::StorageClass::UniformConstant, "sampler_heap", loc);
+      spvBuilder.decorateWithLiterals(
+          SamplerHeapVar, static_cast<uint32_t>(spv::Decoration::BuiltIn),
+          {static_cast<uint32_t>(spv::BuiltIn::SamplerHeapEXT)}, loc);
+    }
+    HeapVar = SamplerHeapVar;
+  } else
+    assert(0 && "Unsupported heap type");
 
-    // Decorate with BuiltIn
-    astDecls[var] = createDeclSpirvInfo(HeapVar);
-    return HeapVar;
-  }
+  // Decorate with BuiltIn
+  astDecls[var] = createDeclSpirvInfo(HeapVar);
+  return HeapVar;
+}
 
+SpirvInstruction *
+DeclResultIdMapper::createEmulatedDescriptorHeap(const VarDecl *var,
+                                                 QualType resourceType) {
   QualType ResourceArrayType = astContext.getIncompleteArrayType(
-      ResourceType, clang::ArrayType::Normal, 0);
+      resourceType, clang::ArrayType::Normal, 0);
   return createExternVar(var, ResourceArrayType);
+}
+
+SpirvInstruction *
+DeclResultIdMapper::createResourceHeap(const VarDecl *var,
+                                       QualType resourceType) {
+  if (spirvOptions.useDescriptorHeap)
+    return createResourceDescriptorHeap(var);
+  return createEmulatedDescriptorHeap(var, resourceType);
 }
 
 SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
@@ -3933,13 +3942,15 @@ bool DeclResultIdMapper::createPayloadStageVars(
     if (featureManager.isExtensionEnabled(Extension::EXT_mesh_shader)) {
       for (SpirvInstruction *moduleInst :
            spvBuilder.getModule()->getVariables()) {
-        if (auto *moduleVar = dyn_cast<SpirvVariable>(moduleInst)) {
-          if (moduleVar->getAstResultType() == type) {
-            moduleVar->setStorageClass(
-                spv::StorageClass::TaskPayloadWorkgroupEXT);
-            varInstr = moduleVar;
-          }
-        }
+        auto *moduleVar = dyn_cast<SpirvVariable>(moduleInst);
+        if (!moduleVar)
+          continue;
+
+        if (moduleVar->getAstResultType() != type)
+          continue;
+
+        moduleVar->setStorageClass(spv::StorageClass::TaskPayloadWorkgroupEXT);
+        varInstr = moduleVar;
       }
     }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1173,7 +1173,7 @@ DeclResultIdMapper::createFileVar(const VarDecl *var,
   return varInstr;
 }
 
-SpirvInstruction *
+SpirvVariableLike *
 DeclResultIdMapper::createResourceDescriptorHeap(const VarDecl *var) {
   SpirvUntypedVariableKHR *HeapVar = nullptr;
 
@@ -1209,7 +1209,7 @@ DeclResultIdMapper::createResourceDescriptorHeap(const VarDecl *var) {
   return HeapVar;
 }
 
-SpirvInstruction *
+SpirvVariableLike *
 DeclResultIdMapper::createEmulatedDescriptorHeap(const VarDecl *var,
                                                  QualType resourceType) {
   QualType ResourceArrayType = astContext.getIncompleteArrayType(
@@ -1217,7 +1217,7 @@ DeclResultIdMapper::createEmulatedDescriptorHeap(const VarDecl *var,
   return createExternVar(var, ResourceArrayType);
 }
 
-SpirvInstruction *
+SpirvVariableLike *
 DeclResultIdMapper::createResourceHeap(const VarDecl *var,
                                        QualType resourceType) {
   if (spirvOptions.useDescriptorHeap)
@@ -1999,9 +1999,9 @@ void DeclResultIdMapper::createFieldCounterVars(
   }
 }
 
-std::vector<SpirvInstruction *>
+std::vector<SpirvVariableLike *>
 DeclResultIdMapper::collectStageVars(SpirvFunction *entryPoint) const {
-  std::vector<SpirvInstruction *> vars;
+  std::vector<SpirvVariableLike *> vars;
 
   for (auto var : glPerVertex.getStageInVars())
     vars.push_back(var);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1173,8 +1173,44 @@ DeclResultIdMapper::createFileVar(const VarDecl *var,
   return varInstr;
 }
 
-SpirvVariable *DeclResultIdMapper::createResourceHeap(const VarDecl *var,
-                                                      QualType ResourceType) {
+SpirvInstruction *
+DeclResultIdMapper::createResourceHeap(const VarDecl *var,
+                                       QualType ResourceType) {
+  if (spirvOptions.useDescriptorHeap) {
+    SpirvUntypedVariableKHR *HeapVar = nullptr;
+
+    if (isResourceDescriptorHeap(var)) {
+      if (!ResourceHeapVar) {
+        const auto loc = var->getLocation();
+        const auto *type = spvContext.getUntypedPointerKHRType(
+            spv::StorageClass::UniformConstant);
+        ResourceHeapVar = spvBuilder.createUntypedVariableKHR(
+            type, spv::StorageClass::UniformConstant, loc, "resource_heap");
+        spvBuilder.decorateWithLiterals(
+            ResourceHeapVar, static_cast<uint32_t>(spv::Decoration::BuiltIn),
+            {static_cast<uint32_t>(spv::BuiltIn::ResourceHeapEXT)}, loc);
+      }
+      HeapVar = ResourceHeapVar;
+    } else if (isSamplerDescriptorHeap(var)) {
+      if (!SamplerHeapVar) {
+        const auto loc = var->getLocation();
+        const auto *type = spvContext.getUntypedPointerKHRType(
+            spv::StorageClass::UniformConstant);
+        SamplerHeapVar = spvBuilder.createUntypedVariableKHR(
+            type, spv::StorageClass::UniformConstant, loc, "sampler_heap");
+        spvBuilder.decorateWithLiterals(
+            SamplerHeapVar, static_cast<uint32_t>(spv::Decoration::BuiltIn),
+            {static_cast<uint32_t>(spv::BuiltIn::SamplerHeapEXT)}, loc);
+      }
+      HeapVar = SamplerHeapVar;
+    } else
+      assert(0 && "Unsupported heap type");
+
+    // Decorate with BuiltIn
+    astDecls[var] = createDeclSpirvInfo(HeapVar);
+    return HeapVar;
+  }
+
   QualType ResourceArrayType = astContext.getIncompleteArrayType(
       ResourceType, clang::ArrayType::Normal, 0);
   return createExternVar(var, ResourceArrayType);
@@ -1954,9 +1990,9 @@ void DeclResultIdMapper::createFieldCounterVars(
   }
 }
 
-std::vector<SpirvVariable *>
+std::vector<SpirvInstruction *>
 DeclResultIdMapper::collectStageVars(SpirvFunction *entryPoint) const {
-  std::vector<SpirvVariable *> vars;
+  std::vector<SpirvInstruction *> vars;
 
   for (auto var : glPerVertex.getStageInVars())
     vars.push_back(var);
@@ -3895,11 +3931,14 @@ bool DeclResultIdMapper::createPayloadStageVars(
     // DispatchMesh. In this case, change the storage class from Workgroup to
     // TaskPayloadWorkgroupEXT.
     if (featureManager.isExtensionEnabled(Extension::EXT_mesh_shader)) {
-      for (SpirvVariable *moduleVar : spvBuilder.getModule()->getVariables()) {
-        if (moduleVar->getAstResultType() == type) {
-          moduleVar->setStorageClass(
-              spv::StorageClass::TaskPayloadWorkgroupEXT);
-          varInstr = moduleVar;
+      for (SpirvInstruction *moduleInst :
+           spvBuilder.getModule()->getVariables()) {
+        if (auto *moduleVar = dyn_cast<SpirvVariable>(moduleInst)) {
+          if (moduleVar->getAstResultType() == type) {
+            moduleVar->setStorageClass(
+                spv::StorageClass::TaskPayloadWorkgroupEXT);
+            varInstr = moduleVar;
+          }
         }
       }
     }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -1006,6 +1006,14 @@ private:
   /// all of them should be associated with the same variable.
   void registerVariableForDecl(const VarDecl *var, DeclSpirvInfo spirvInfo);
 
+  /// Creates a global variable for resource heaps using VK_EXT_descriptor_heap.
+  SpirvInstruction *createResourceDescriptorHeap(const VarDecl *var);
+
+  /// Creates a global variable for resource heaps containing elements of type
+  /// |type| (emulated descriptor heaps).
+  SpirvInstruction *createEmulatedDescriptorHeap(const VarDecl *var,
+                                                 QualType resourceType);
+
 private:
   SpirvBuilder &spvBuilder;
   SpirvEmitter &theEmitter;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -291,7 +291,7 @@ public:
 
   /// Creates a global variable for resource heaps containing elements of type
   /// |type|.
-  SpirvInstruction *createResourceHeap(const VarDecl *var, QualType type);
+  SpirvVariableLike *createResourceHeap(const VarDecl *var, QualType type);
 
   /// \brief Creates an external-visible variable and returns its instruction.
   SpirvVariable *createExternVar(const VarDecl *var);
@@ -510,7 +510,7 @@ public:
 
   /// \brief Returns all defined stage (builtin/input/ouput) variables for the
   /// entry point function entryPoint in this mapper.
-  std::vector<SpirvInstruction *>
+  std::vector<SpirvVariableLike *>
   collectStageVars(SpirvFunction *entryPoint) const;
 
   /// \brief Writes out the contents in the function parameter for the GS
@@ -1007,12 +1007,12 @@ private:
   void registerVariableForDecl(const VarDecl *var, DeclSpirvInfo spirvInfo);
 
   /// Creates a global variable for resource heaps using VK_EXT_descriptor_heap.
-  SpirvInstruction *createResourceDescriptorHeap(const VarDecl *var);
+  SpirvVariableLike *createResourceDescriptorHeap(const VarDecl *var);
 
   /// Creates a global variable for resource heaps containing elements of type
   /// |type| (emulated descriptor heaps).
-  SpirvInstruction *createEmulatedDescriptorHeap(const VarDecl *var,
-                                                 QualType resourceType);
+  SpirvVariableLike *createEmulatedDescriptorHeap(const VarDecl *var,
+                                                  QualType resourceType);
 
 private:
   SpirvBuilder &spvBuilder;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -291,7 +291,7 @@ public:
 
   /// Creates a global variable for resource heaps containing elements of type
   /// |type|.
-  SpirvVariable *createResourceHeap(const VarDecl *var, QualType type);
+  SpirvInstruction *createResourceHeap(const VarDecl *var, QualType type);
 
   /// \brief Creates an external-visible variable and returns its instruction.
   SpirvVariable *createExternVar(const VarDecl *var);
@@ -510,7 +510,7 @@ public:
 
   /// \brief Returns all defined stage (builtin/input/ouput) variables for the
   /// entry point function entryPoint in this mapper.
-  std::vector<SpirvVariable *>
+  std::vector<SpirvInstruction *>
   collectStageVars(SpirvFunction *entryPoint) const;
 
   /// \brief Writes out the contents in the function parameter for the GS
@@ -1050,6 +1050,10 @@ private:
 
   /// Vector of all defined resource variables.
   llvm::SmallVector<ResourceVar, 8> resourceVars;
+
+  SpirvUntypedVariableKHR *ResourceHeapVar = nullptr;
+  SpirvUntypedVariableKHR *SamplerHeapVar = nullptr;
+
   /// Mapping from {RW|Append|Consume}StructuredBuffers to their
   /// counter variables' (instr-ptr, is-alias-or-not) pairs
   ///

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -816,17 +816,6 @@ bool EmitVisitor::visit(SpirvUntypedAccessChainKHR *inst) {
   return true;
 }
 
-bool EmitVisitor::visit(SpirvBufferPointerEXT *inst) {
-  initInstruction(inst);
-  curInst.push_back(inst->getResultTypeId());
-  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
-  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getBuffer()));
-  finalizeInstruction(&mainBinary);
-  emitDebugNameForInstruction(getOrAssignResultId<SpirvInstruction>(inst),
-                              inst->getDebugName());
-  return true;
-}
-
 bool EmitVisitor::visit(SpirvUntypedImageTexelPointerEXT *inst) {
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -789,6 +789,58 @@ bool EmitVisitor::visit(SpirvVariable *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvUntypedVariableKHR *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(static_cast<uint32_t>(inst->getStorageClass()));
+  finalizeInstruction(inst->getStorageClass() == spv::StorageClass::Function
+                          ? &mainBinary
+                          : &globalVarsBinary);
+  emitDebugNameForInstruction(getOrAssignResultId<SpirvInstruction>(inst),
+                              inst->getDebugName());
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvUntypedAccessChainKHR *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(typeHandler.emitType(inst->getBaseType()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getBase()));
+  for (const auto index : inst->getIndices())
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(index));
+  finalizeInstruction(&mainBinary);
+  emitDebugNameForInstruction(getOrAssignResultId<SpirvInstruction>(inst),
+                              inst->getDebugName());
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvBufferPointerEXT *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getBuffer()));
+  finalizeInstruction(&mainBinary);
+  emitDebugNameForInstruction(getOrAssignResultId<SpirvInstruction>(inst),
+                              inst->getDebugName());
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvUntypedImageTexelPointerEXT *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getImage()));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getCoordinate()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSample()));
+  finalizeInstruction(&mainBinary);
+  emitDebugNameForInstruction(getOrAssignResultId<SpirvInstruction>(inst),
+                              inst->getDebugName());
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvFunctionParameter *inst) {
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());
@@ -2593,6 +2645,22 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
     curTypeInst.push_back(imageType->isMSImage() ? 1 : 0);
     curTypeInst.push_back(static_cast<uint32_t>(imageType->withSampler()));
     curTypeInst.push_back(static_cast<uint32_t>(imageType->getImageFormat()));
+    finalizeTypeInstruction();
+  }
+  // UntypedPointerKHR types
+  else if (const auto *untypedPtrType = dyn_cast<UntypedPointerKHRType>(type)) {
+    initTypeInstruction(spv::Op::OpTypeUntypedPointerKHR);
+    curTypeInst.push_back(id);
+    curTypeInst.push_back(
+        static_cast<uint32_t>(untypedPtrType->getStorageClass()));
+    finalizeTypeInstruction();
+  }
+  // BufferEXT types
+  else if (const auto *bufferExtType = dyn_cast<BufferEXTType>(type)) {
+    initTypeInstruction(spv::Op::OpTypeBufferEXT);
+    curTypeInst.push_back(id);
+    curTypeInst.push_back(
+        static_cast<uint32_t>(bufferExtType->getStorageClass()));
     finalizeTypeInstruction();
   }
   // Sampler types

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -245,7 +245,6 @@ public:
   bool visit(SpirvVariable *) override;
   bool visit(SpirvUntypedVariableKHR *) override;
   bool visit(SpirvUntypedAccessChainKHR *) override;
-  bool visit(SpirvBufferPointerEXT *) override;
   bool visit(SpirvUntypedImageTexelPointerEXT *) override;
   bool visit(SpirvFunctionParameter *) override;
   bool visit(SpirvLoopMerge *) override;

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -243,6 +243,10 @@ public:
   bool visit(SpirvModuleProcessed *) override;
   bool visit(SpirvDecoration *) override;
   bool visit(SpirvVariable *) override;
+  bool visit(SpirvUntypedVariableKHR *) override;
+  bool visit(SpirvUntypedAccessChainKHR *) override;
+  bool visit(SpirvBufferPointerEXT *) override;
+  bool visit(SpirvUntypedImageTexelPointerEXT *) override;
   bool visit(SpirvFunctionParameter *) override;
   bool visit(SpirvLoopMerge *) override;
   bool visit(SpirvSelectionMerge *) override;

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -228,6 +228,8 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
       .Case("SPV_NV_shader_subgroup_partitioned",
             Extension::NV_shader_subgroup_partitioned)
       .Case("SPV_KHR_quad_control", Extension::KHR_quad_control)
+      .Case("SPV_EXT_descriptor_heap", Extension::EXT_descriptor_heap)
+      .Case("SPV_KHR_untyped_pointers", Extension::KHR_untyped_pointers)
       .Default(Extension::Unknown);
 }
 
@@ -303,6 +305,10 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_NV_shader_subgroup_partitioned";
   case Extension::KHR_quad_control:
     return "SPV_KHR_quad_control";
+  case Extension::EXT_descriptor_heap:
+    return "SPV_EXT_descriptor_heap";
+  case Extension::KHR_untyped_pointers:
+    return "SPV_KHR_untyped_pointers";
   default:
     break;
   }

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -333,7 +333,8 @@ const SpirvType *LowerTypeVisitor::lowerType(const SpirvType *type,
   else if (isa<VoidType>(type) || isa<ScalarType>(type) ||
            isa<MatrixType>(type) || isa<ImageType>(type) ||
            isa<SamplerType>(type) || isa<SampledImageType>(type) ||
-           isa<FunctionType>(type) || isa<StructType>(type)) {
+           isa<FunctionType>(type) || isa<StructType>(type) ||
+           isa<BufferEXTType>(type) || isa<UntypedPointerKHRType>(type)) {
     return type;
   }
   // Vectors could contain a hybrid type

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -531,6 +531,19 @@ SpirvImageTexelPointer *SpirvBuilder::createImageTexelPointer(
   return instruction;
 }
 
+SpirvUntypedImageTexelPointerEXT *
+SpirvBuilder::createUntypedImageTexelPointerEXT(QualType resultType,
+                                                SpirvInstruction *image,
+                                                SpirvInstruction *coordinate,
+                                                SpirvInstruction *sample,
+                                                SourceLocation loc) {
+  assert(insertPoint && "null insert point");
+  auto *instruction = new (context) SpirvUntypedImageTexelPointerEXT(
+      resultType, loc, image, coordinate, sample);
+  insertPoint->addInstruction(instruction);
+  return instruction;
+}
+
 SpirvConvertPtrToU *SpirvBuilder::createConvertPtrToU(SpirvInstruction *ptr,
                                                       QualType type) {
   auto *instruction = new (context) SpirvConvertPtrToU(ptr, type);
@@ -543,6 +556,16 @@ SpirvConvertUToPtr *SpirvBuilder::createConvertUToPtr(SpirvInstruction *val,
                                                       QualType type) {
   auto *instruction = new (context) SpirvConvertUToPtr(val, type);
   instruction->setRValue(false);
+  insertPoint->addInstruction(instruction);
+  return instruction;
+}
+
+SpirvBufferPointerEXT *SpirvBuilder::createBufferPointerEXT(
+    const SpirvType *resultType, SpirvInstruction *buffer, SourceLocation loc) {
+  assert(insertPoint && "null insert point");
+  auto *instruction =
+      new (context) SpirvBufferPointerEXT(resultType, loc, buffer);
+  instruction->setRValue(true);
   insertPoint->addInstruction(instruction);
   return instruction;
 }
@@ -1713,6 +1736,29 @@ SpirvVariable *SpirvBuilder::addModuleVar(
   var->setDebugName(name);
   mod->addVariable(var, pos);
   return var;
+}
+
+SpirvUntypedVariableKHR *SpirvBuilder::createUntypedVariableKHR(
+    const SpirvType *type, spv::StorageClass storageClass, SourceLocation loc,
+    llvm::StringRef name) {
+  assert(storageClass != spv::StorageClass::Function);
+  auto *var = new (context) SpirvUntypedVariableKHR(type, loc, storageClass);
+  mod->addVariable(var);
+  var->setDebugName(name);
+  return var;
+}
+
+SpirvUntypedAccessChainKHR *SpirvBuilder::createUntypedAccessChainKHR(
+    const SpirvType *resultType, const SpirvType *baseType,
+    SpirvInstruction *base, llvm::ArrayRef<SpirvInstruction *> indexes,
+    SourceLocation loc) {
+  assert(insertPoint && "null insert point");
+  auto *instruction = new (context)
+      SpirvUntypedAccessChainKHR(resultType, loc, baseType, base, indexes);
+  instruction->setStorageClass(base->getStorageClass());
+  instruction->setLayoutRule(base->getLayoutRule());
+  insertPoint->addInstruction(instruction);
+  return instruction;
 }
 
 void SpirvBuilder::decorateLocation(SpirvInstruction *target,

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -560,16 +560,6 @@ SpirvConvertUToPtr *SpirvBuilder::createConvertUToPtr(SpirvInstruction *val,
   return instruction;
 }
 
-SpirvBufferPointerEXT *SpirvBuilder::createBufferPointerEXT(
-    const SpirvType *resultType, SpirvInstruction *buffer, SourceLocation loc) {
-  assert(insertPoint && "null insert point");
-  auto *instruction =
-      new (context) SpirvBufferPointerEXT(resultType, loc, buffer);
-  instruction->setRValue(true);
-  insertPoint->addInstruction(instruction);
-  return instruction;
-}
-
 spv::ImageOperandsMask SpirvBuilder::composeImageOperandsMask(
     SpirvInstruction *bias, SpirvInstruction *lod,
     const std::pair<SpirvInstruction *, SpirvInstruction *> &grad,
@@ -1739,8 +1729,8 @@ SpirvVariable *SpirvBuilder::addModuleVar(
 }
 
 SpirvUntypedVariableKHR *SpirvBuilder::createUntypedVariableKHR(
-    const SpirvType *type, spv::StorageClass storageClass, SourceLocation loc,
-    llvm::StringRef name) {
+    const SpirvType *type, spv::StorageClass storageClass, llvm::StringRef name,
+    SourceLocation loc) {
   assert(storageClass != spv::StorageClass::Function);
   auto *var = new (context) SpirvUntypedVariableKHR(type, loc, storageClass);
   mod->addVariable(var);

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -337,6 +337,15 @@ const SpirvPointerType *SpirvContext::getPointerType(const SpirvType *pointee,
   return pointerTypes[pointee][sc] = new (this) SpirvPointerType(pointee, sc);
 }
 
+const UntypedPointerKHRType *
+SpirvContext::getUntypedPointerKHRType(spv::StorageClass sc) {
+  auto found = untypedPointerKHRTypes.find(sc);
+  if (found != untypedPointerKHRTypes.end()) {
+    return found->second;
+  }
+  return untypedPointerKHRTypes[sc] = new (this) UntypedPointerKHRType(sc);
+}
+
 const HybridPointerType *SpirvContext::getPointerType(QualType pointee,
                                                       spv::StorageClass sc) {
   const HybridPointerType *result = new (this) HybridPointerType(pointee, sc);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -696,15 +696,11 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
   }
 }
 
-std::vector<SpirvInstruction *>
+std::vector<SpirvVariableLike *>
 SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
   auto stageVars = declIdMapper.collectStageVars(entryPoint);
-  if (!featureManager.isTargetEnvVulkan1p1Spirv1p4OrAbove()) {
-    std::vector<SpirvInstruction *> ifaces;
-    for (auto *v : stageVars)
-      ifaces.push_back(v);
-    return ifaces;
-  }
+  if (!featureManager.isTargetEnvVulkan1p1Spirv1p4OrAbove())
+    return stageVars;
 
   // In SPIR-V 1.4 or above, we must include global variables in the 'Interface'
   // operands of OpEntryPoint. SpirvModule keeps all global variables, but some
@@ -712,8 +708,8 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
   // declIdMapper keeps the mapping between variables with Input or Output
   // storage class and their storage class, we have to rely on
   // declIdMapper.collectStageVars() to collect them.
-  llvm::SetVector<SpirvInstruction *> interfaces(stageVars.begin(),
-                                                 stageVars.end());
+  llvm::SetVector<SpirvVariableLike *> interfaces(stageVars.begin(),
+                                                  stageVars.end());
 
   for (auto *moduleVar : spvBuilder.getModule()->getVariables()) {
     if (moduleVar->getStorageClass() == spv::StorageClass::Input ||
@@ -733,7 +729,7 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
     }
     interfaces.insert(moduleVar);
   }
-  std::vector<SpirvInstruction *> interfacesInVector;
+  std::vector<SpirvVariableLike *> interfacesInVector;
   interfacesInVector.reserve(interfaces.size());
   for (auto *interface : interfaces) {
     interfacesInVector.push_back(interface);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -696,11 +696,15 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
   }
 }
 
-std::vector<SpirvVariable *>
+std::vector<SpirvInstruction *>
 SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
   auto stageVars = declIdMapper.collectStageVars(entryPoint);
-  if (!featureManager.isTargetEnvVulkan1p1Spirv1p4OrAbove())
-    return stageVars;
+  if (!featureManager.isTargetEnvVulkan1p1Spirv1p4OrAbove()) {
+    std::vector<SpirvInstruction *> ifaces;
+    for (auto *v : stageVars)
+      ifaces.push_back(v);
+    return ifaces;
+  }
 
   // In SPIR-V 1.4 or above, we must include global variables in the 'Interface'
   // operands of OpEntryPoint. SpirvModule keeps all global variables, but some
@@ -708,20 +712,28 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
   // declIdMapper keeps the mapping between variables with Input or Output
   // storage class and their storage class, we have to rely on
   // declIdMapper.collectStageVars() to collect them.
-  llvm::SetVector<SpirvVariable *> interfaces(stageVars.begin(),
-                                              stageVars.end());
+  llvm::SetVector<SpirvInstruction *> interfaces(stageVars.begin(),
+                                                 stageVars.end());
+
   for (auto *moduleVar : spvBuilder.getModule()->getVariables()) {
-    if (moduleVar->getStorageClass() != spv::StorageClass::Input &&
-        moduleVar->getStorageClass() != spv::StorageClass::Output) {
-      if (auto *varEntry =
-              declIdMapper.getRayTracingStageVarEntryFunction(moduleVar)) {
-        if (varEntry != entryPoint)
-          continue;
-      }
+    if (moduleVar->getStorageClass() == spv::StorageClass::Input ||
+        moduleVar->getStorageClass() == spv::StorageClass::Output)
+      continue;
+
+    auto *untypedVar = dyn_cast<SpirvUntypedVariableKHR>(moduleVar);
+    if (untypedVar) {
       interfaces.insert(moduleVar);
+      continue;
     }
+
+    if (auto *varEntry = declIdMapper.getRayTracingStageVarEntryFunction(
+            cast<SpirvVariable>(moduleVar))) {
+      if (varEntry != entryPoint)
+        continue;
+    }
+    interfaces.insert(moduleVar);
   }
-  std::vector<SpirvVariable *> interfacesInVector;
+  std::vector<SpirvInstruction *> interfacesInVector;
   interfacesInVector.reserve(interfaces.size());
   for (auto *interface : interfaces) {
     interfacesInVector.push_back(interface);
@@ -6646,6 +6658,33 @@ SpirvEmitter::doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr,
       auto *var = declIdMapper.createResourceHeap(decl, resourceType);
 
       auto *index = doExpr(indexExpr);
+
+      if (spirvOptions.useDescriptorHeap) {
+        emitWarning("SPV_EXT_descriptor_heap support is incomplete.",
+                    baseExpr->getExprLoc());
+        needsLegalization = true;
+
+        if (isAKindOfStructuredOrByteBuffer(resourceType)) {
+          emitError("UAV support not implemented with non-emulated heaps.",
+                    expr->getExprLoc());
+          return nullptr;
+        }
+
+        const auto *untypedType = spvContext.getUntypedPointerKHRType(
+            spv::StorageClass::UniformConstant);
+        LowerTypeVisitor lowerTypeVisitor(astContext, spvContext, spirvOptions,
+                                          spvBuilder);
+        const SpirvType *handleType =
+            lowerTypeVisitor.lowerType(resourceType, SpirvLayoutRule::Void,
+                                       llvm::None, baseExpr->getExprLoc());
+        const auto *arrayType =
+            spvContext.getRuntimeArrayType(handleType, llvm::None);
+        auto *untypedAccessChainPtr = spvBuilder.createUntypedAccessChainKHR(
+            untypedType, arrayType, var, index, baseExpr->getExprLoc());
+        return spvBuilder.createLoad(resourceType, untypedAccessChainPtr,
+                                     baseExpr->getExprLoc(), range);
+      }
+
       auto *accessChainPtr = spvBuilder.createAccessChain(
           resourceType, var, index, baseExpr->getExprLoc(), range);
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1320,7 +1320,7 @@ private:
 
   /// \brief Returns OpVariable to be used as 'Interface' operands of
   /// OpEntryPoint. entryPoint is the SpirvFunction for the OpEntryPoint.
-  std::vector<SpirvVariable *>
+  std::vector<SpirvInstruction *>
   getInterfacesForEntryPoint(SpirvFunction *entryPoint);
 
   /// \brief Emits OpBeginInvocationInterlockEXT and add the appropriate

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1320,7 +1320,7 @@ private:
 
   /// \brief Returns OpVariable to be used as 'Interface' operands of
   /// OpEntryPoint. entryPoint is the SpirvFunction for the OpEntryPoint.
-  std::vector<SpirvInstruction *>
+  std::vector<SpirvVariableLike *>
   getInterfacesForEntryPoint(SpirvFunction *entryPoint);
 
   /// \brief Emits OpBeginInvocationInterlockEXT and add the appropriate

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -38,6 +38,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSource)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvModuleProcessed)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDecoration)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvVariable)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUntypedVariableKHR)
 
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvFunctionParameter)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvLoopMerge)
@@ -50,6 +51,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSwitch)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUnreachable)
 
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvAccessChain)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUntypedAccessChainKHR)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvAtomic)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvBarrier)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvIsNodePayloadValid)
@@ -68,6 +70,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantString)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantNull)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConvertPtrToU)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConvertUToPtr)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvBufferPointerEXT)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUndef)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeConstruct)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeExtract)
@@ -81,6 +84,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvImageOp)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvImageQuery)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvImageSparseTexelsResident)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvImageTexelPointer)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUntypedImageTexelPointerEXT)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvLoad)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCopyObject)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSampledImage)
@@ -204,7 +208,7 @@ SpirvEntryPoint::SpirvEntryPoint(SourceLocation loc,
                                  spv::ExecutionModel executionModel,
                                  SpirvFunction *entryPointFn,
                                  llvm::StringRef nameStr,
-                                 llvm::ArrayRef<SpirvVariable *> iface)
+                                 llvm::ArrayRef<SpirvInstruction *> iface)
     : SpirvInstruction(IK_EntryPoint, spv::Op::OpEntryPoint, QualType(), loc),
       execModel(executionModel), entryPoint(entryPointFn), name(nameStr),
       interfaceVec(iface.begin(), iface.end()) {}
@@ -325,6 +329,33 @@ SpirvVariable::SpirvVariable(const SpirvType *spvType, SourceLocation loc,
   setStorageClass(sc);
   setPrecise(precise);
   setNoninterpolated(isNointerp);
+}
+
+SpirvUntypedVariableKHR::SpirvUntypedVariableKHR(QualType resultType,
+                                                 SourceLocation loc,
+                                                 spv::StorageClass sc)
+    : SpirvInstruction(IK_UntypedVariableKHR, spv::Op::OpUntypedVariableKHR,
+                       resultType, loc) {
+  setStorageClass(sc);
+}
+
+SpirvUntypedVariableKHR::SpirvUntypedVariableKHR(const SpirvType *spvType,
+                                                 SourceLocation loc,
+                                                 spv::StorageClass sc)
+    : SpirvInstruction(IK_UntypedVariableKHR, spv::Op::OpUntypedVariableKHR,
+                       QualType(), loc) {
+  setResultType(spvType);
+  setStorageClass(sc);
+}
+
+SpirvUntypedAccessChainKHR::SpirvUntypedAccessChainKHR(
+    const SpirvType *resultType, SourceLocation loc, const SpirvType *baseType,
+    SpirvInstruction *baseInst, llvm::ArrayRef<SpirvInstruction *> indexVec)
+    : SpirvInstruction(IK_UntypedAccessChainKHR,
+                       spv::Op::OpUntypedAccessChainKHR, QualType(), loc),
+      baseType(baseType), base(baseInst),
+      indices(indexVec.begin(), indexVec.end()) {
+  setResultType(resultType);
 }
 
 SpirvFunctionParameter::SpirvFunctionParameter(QualType resultType,
@@ -705,6 +736,15 @@ bool SpirvConvertUToPtr::operator==(const SpirvConvertUToPtr &that) const {
          astResultType == that.astResultType && val == that.val;
 }
 
+SpirvBufferPointerEXT::SpirvBufferPointerEXT(const SpirvType *resultType,
+                                             SourceLocation loc,
+                                             SpirvInstruction *bufferInst)
+    : SpirvInstruction(IK_BufferPointerEXT, spv::Op::OpBufferPointerEXT,
+                       QualType(), loc),
+      buffer(bufferInst) {
+  setResultType(resultType);
+}
+
 SpirvUndef::SpirvUndef(QualType type)
     : SpirvInstruction(IK_Undef, spv::Op::OpUndef, type,
                        /*SourceLocation*/ {}) {}
@@ -930,6 +970,13 @@ SpirvImageTexelPointer::SpirvImageTexelPointer(QualType resultType,
                                                SpirvInstruction *sampleInst)
     : SpirvInstruction(IK_ImageTexelPointer, spv::Op::OpImageTexelPointer,
                        resultType, loc),
+      image(imageInst), coordinate(coordinateInst), sample(sampleInst) {}
+
+SpirvUntypedImageTexelPointerEXT::SpirvUntypedImageTexelPointerEXT(
+    QualType resultType, SourceLocation loc, SpirvInstruction *imageInst,
+    SpirvInstruction *coordinateInst, SpirvInstruction *sampleInst)
+    : SpirvInstruction(IK_UntypedImageTexelPointerEXT,
+                       spv::Op::OpUntypedImageTexelPointerEXT, resultType, loc),
       image(imageInst), coordinate(coordinateInst), sample(sampleInst) {}
 
 SpirvLoad::SpirvLoad(QualType resultType, SourceLocation loc,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -207,7 +207,7 @@ SpirvEntryPoint::SpirvEntryPoint(SourceLocation loc,
                                  spv::ExecutionModel executionModel,
                                  SpirvFunction *entryPointFn,
                                  llvm::StringRef nameStr,
-                                 llvm::ArrayRef<SpirvInstruction *> iface)
+                                 llvm::ArrayRef<SpirvVariableLike *> iface)
     : SpirvInstruction(IK_EntryPoint, spv::Op::OpEntryPoint, QualType(), loc),
       execModel(executionModel), entryPoint(entryPointFn), name(nameStr),
       interfaceVec(iface.begin(), iface.end()) {}
@@ -310,7 +310,7 @@ bool SpirvDecoration::operator==(const SpirvDecoration &that) const {
 SpirvVariable::SpirvVariable(QualType resultType, SourceLocation loc,
                              spv::StorageClass sc, bool precise,
                              bool isNointerp, SpirvInstruction *initializerInst)
-    : SpirvInstruction(IK_Variable, spv::Op::OpVariable, resultType, loc),
+    : SpirvVariableLike(IK_Variable, spv::Op::OpVariable, resultType, loc),
       initializer(initializerInst), descriptorSet(-1), binding(-1),
       hlslUserType("") {
   setStorageClass(sc);
@@ -321,7 +321,7 @@ SpirvVariable::SpirvVariable(QualType resultType, SourceLocation loc,
 SpirvVariable::SpirvVariable(const SpirvType *spvType, SourceLocation loc,
                              spv::StorageClass sc, bool precise,
                              bool isNointerp, SpirvInstruction *initializerInst)
-    : SpirvInstruction(IK_Variable, spv::Op::OpVariable, QualType(), loc),
+    : SpirvVariableLike(IK_Variable, spv::Op::OpVariable, QualType(), loc),
       initializer(initializerInst), descriptorSet(-1), binding(-1),
       hlslUserType("") {
   setResultType(spvType);
@@ -333,19 +333,24 @@ SpirvVariable::SpirvVariable(const SpirvType *spvType, SourceLocation loc,
 SpirvUntypedVariableKHR::SpirvUntypedVariableKHR(QualType resultType,
                                                  SourceLocation loc,
                                                  spv::StorageClass sc)
-    : SpirvInstruction(IK_UntypedVariableKHR, spv::Op::OpUntypedVariableKHR,
-                       resultType, loc) {
+    : SpirvVariableLike(IK_UntypedVariableKHR, spv::Op::OpUntypedVariableKHR,
+                        resultType, loc) {
   setStorageClass(sc);
 }
 
 SpirvUntypedVariableKHR::SpirvUntypedVariableKHR(const SpirvType *spvType,
                                                  SourceLocation loc,
                                                  spv::StorageClass sc)
-    : SpirvInstruction(IK_UntypedVariableKHR, spv::Op::OpUntypedVariableKHR,
-                       QualType(), loc) {
+    : SpirvVariableLike(IK_UntypedVariableKHR, spv::Op::OpUntypedVariableKHR,
+                        QualType(), loc) {
   setResultType(spvType);
   setStorageClass(sc);
 }
+
+SpirvVariableLike::SpirvVariableLike(Kind kind, spv::Op opcode,
+                                     QualType astResultType, SourceLocation loc,
+                                     SourceRange range)
+    : SpirvInstruction(kind, opcode, astResultType, loc, range) {}
 
 SpirvUntypedAccessChainKHR::SpirvUntypedAccessChainKHR(
     const SpirvType *resultType, SourceLocation loc, const SpirvType *baseType,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -70,7 +70,6 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantString)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantNull)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConvertPtrToU)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConvertUToPtr)
-DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvBufferPointerEXT)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUndef)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeConstruct)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeExtract)
@@ -734,15 +733,6 @@ SpirvConvertUToPtr::SpirvConvertUToPtr(SpirvInstruction *val, QualType type,
 bool SpirvConvertUToPtr::operator==(const SpirvConvertUToPtr &that) const {
   return opcode == that.opcode && resultType == that.resultType &&
          astResultType == that.astResultType && val == that.val;
-}
-
-SpirvBufferPointerEXT::SpirvBufferPointerEXT(const SpirvType *resultType,
-                                             SourceLocation loc,
-                                             SpirvInstruction *bufferInst)
-    : SpirvInstruction(IK_BufferPointerEXT, spv::Op::OpBufferPointerEXT,
-                       QualType(), loc),
-      buffer(bufferInst) {
-  setResultType(resultType);
 }
 
 SpirvUndef::SpirvUndef(QualType type)

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -336,12 +336,12 @@ SpirvExtInstImport *SpirvModule::getExtInstSet(llvm::StringRef name) {
   return nullptr;
 }
 
-void SpirvModule::addVariable(SpirvVariable *var) {
+void SpirvModule::addVariable(SpirvInstruction *var) {
   assert(var && "cannot add null variable to the module");
   variables.push_back(var);
 }
 
-void SpirvModule::addVariable(SpirvVariable *var, SpirvInstruction *pos) {
+void SpirvModule::addVariable(SpirvInstruction *var, SpirvInstruction *pos) {
   assert(var && "cannot add null variable to the module");
   auto location = std::find(variables.begin(), variables.end(), pos);
   variables.insert(location, var);

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -336,12 +336,12 @@ SpirvExtInstImport *SpirvModule::getExtInstSet(llvm::StringRef name) {
   return nullptr;
 }
 
-void SpirvModule::addVariable(SpirvInstruction *var) {
+void SpirvModule::addVariable(SpirvVariableLike *var) {
   assert(var && "cannot add null variable to the module");
   variables.push_back(var);
 }
 
-void SpirvModule::addVariable(SpirvInstruction *var, SpirvInstruction *pos) {
+void SpirvModule::addVariable(SpirvVariableLike *var, SpirvInstruction *pos) {
   assert(var && "cannot add null variable to the module");
   auto location = std::find(variables.begin(), variables.end(), pos);
   variables.insert(location, var);

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -89,9 +89,13 @@ bool SpirvType::isSubpassInputMS(const SpirvType *type) {
 
 bool SpirvType::isResourceType(const SpirvType *type) {
   if (isa<ImageType>(type) || isa<SamplerType>(type) ||
-      isa<AccelerationStructureTypeNV>(type) || isa<BufferEXTType>(type) ||
-      isa<UntypedPointerKHRType>(type))
+      isa<AccelerationStructureTypeNV>(type))
     return true;
+
+  if (auto *UTP = dyn_cast<UntypedPointerKHRType>(type))
+    return UTP->getStorageClass() == spv::StorageClass::UniformConstant
+        || UTP->getStorageClass() == spv::StorageClass::Uniform
+        || UTP->getStorageClass() == spv::StorageClass::StorageBuffer;
 
   if (const auto *structType = dyn_cast<StructType>(type))
     return structType->getInterfaceType() !=

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -93,9 +93,9 @@ bool SpirvType::isResourceType(const SpirvType *type) {
     return true;
 
   if (auto *UTP = dyn_cast<UntypedPointerKHRType>(type))
-    return UTP->getStorageClass() == spv::StorageClass::UniformConstant
-        || UTP->getStorageClass() == spv::StorageClass::Uniform
-        || UTP->getStorageClass() == spv::StorageClass::StorageBuffer;
+    return UTP->getStorageClass() == spv::StorageClass::UniformConstant ||
+           UTP->getStorageClass() == spv::StorageClass::Uniform ||
+           UTP->getStorageClass() == spv::StorageClass::StorageBuffer;
 
   if (const auto *structType = dyn_cast<StructType>(type))
     return structType->getInterfaceType() !=

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -89,7 +89,8 @@ bool SpirvType::isSubpassInputMS(const SpirvType *type) {
 
 bool SpirvType::isResourceType(const SpirvType *type) {
   if (isa<ImageType>(type) || isa<SamplerType>(type) ||
-      isa<AccelerationStructureTypeNV>(type))
+      isa<AccelerationStructureTypeNV>(type) || isa<BufferEXTType>(type) ||
+      isa<UntypedPointerKHRType>(type))
     return true;
 
   if (const auto *structType = dyn_cast<StructType>(type))

--- a/tools/clang/test/CodeGenSPIRV/resource-heap-ext-texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/resource-heap-ext-texture.hlsl
@@ -1,0 +1,59 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-use-descriptor-heap -spirv %s | FileCheck %s
+
+// CHECK: OpCapability DescriptorHeapEXT
+// CHECK: OpExtension "SPV_EXT_descriptor_heap"
+
+// CHECK-DAG: OpDecorate %[[ResourceHeap:[a-zA-Z0-9_]+]] BuiltIn ResourceHeapEXT
+// CHECK-DAG: OpDecorate %[[SamplerHeap:[a-zA-Z0-9_]+]] BuiltIn SamplerHeapEXT
+
+// CHECK-DAG: %[[UntypedPtrType:[a-zA-Z0-9_]+]] = OpTypeUntypedPointerKHR Uniform
+// CHECK-DAG: %[[Tex2DType:[a-zA-Z0-9_]+]] = OpTypeImage %float 2D 2 0 0 1 Unknown
+// CHECK-DAG: %[[RWTex2DType:[a-zA-Z0-9_]+]] = OpTypeImage %float 2D 2 0 0 2 Rgba32f
+// CHECK-DAG: %[[BufferType:[a-zA-Z0-9_]+]] = OpTypeImage %float Buffer 2 0 0 1 Rgba32f
+// CHECK-DAG: %[[RWBufferType:[a-zA-Z0-9_]+]] = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
+// CHECK-DAG: %[[SamplerType:[a-zA-Z0-9_]+]] = OpTypeSampler
+
+// CHECK-DAG: %[[RA_Tex2DType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[Tex2DType]]
+// CHECK-DAG: %[[RA_RWTex2DType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[RWTex2DType]]
+// CHECK-DAG: %[[RA_BufferType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[BufferType]]
+// CHECK-DAG: %[[RA_RWBufferType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[RWBufferType]]
+// CHECK-DAG: %[[RA_SamplerType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[SamplerType]]
+
+// CHECK: %[[ResourceHeap]] = OpUntypedVariableKHR %[[UntypedPtrType]] Uniform
+// CHECK: %[[SamplerHeap]]  = OpUntypedVariableKHR %[[UntypedPtrType]] Uniform
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+    Texture2D<float4> myTex = ResourceDescriptorHeap[0];
+    // CHECK: %[[TexIndex:[a-zA-Z0-9_]+]] = OpUntypedAccessChainKHR %[[UntypedPtrType]] %[[RA_Tex2DType]] %[[ResourceHeap]] %uint_0
+    // CHECK: %[[TexHandle:[a-zA-Z0-9_]+]] = OpLoad %[[Tex2DType]] %[[TexIndex]]
+
+    RWTexture2D<float4> myRWTex = ResourceDescriptorHeap[1];
+    // CHECK: %[[RWTexIndex:[a-zA-Z0-9_]+]] = OpUntypedAccessChainKHR %[[UntypedPtrType]] %[[RA_RWTex2DType]] %[[ResourceHeap]] %uint_1
+    // CHECK: %[[RWTexHandle:[a-zA-Z0-9_]+]] = OpLoad %[[RWTex2DType]] %[[RWTexIndex]]
+
+    Buffer<float4> myBuf = ResourceDescriptorHeap[2];
+    // CHECK: %[[BufIndex:[a-zA-Z0-9_]+]] = OpUntypedAccessChainKHR %[[UntypedPtrType]] %[[RA_BufferType]] %[[ResourceHeap]] %uint_2
+    // CHECK: %[[BufHandle:[a-zA-Z0-9_]+]] = OpLoad %[[BufferType]] %[[BufIndex]]
+
+    RWBuffer<float4> myRWBuf = ResourceDescriptorHeap[3];
+    // CHECK: %[[RWBufIndex:[a-zA-Z0-9_]+]] = OpUntypedAccessChainKHR %[[UntypedPtrType]] %[[RA_RWBufferType]] %[[ResourceHeap]] %uint_3
+    // CHECK: %[[RWBufHandle:[a-zA-Z0-9_]+]] = OpLoad %[[RWBufferType]] %[[RWBufIndex]]
+
+    SamplerState mySamp = SamplerDescriptorHeap[0];
+    // CHECK: %[[SampIndex:[a-zA-Z0-9_]+]] = OpUntypedAccessChainKHR %[[UntypedPtrType]] %[[RA_SamplerType]] %[[SamplerHeap]] %uint_0
+    // CHECK: %[[SampHandle:[a-zA-Z0-9_]+]] = OpLoad %[[SamplerType]] %[[SampIndex]]
+
+    // CHECK: %[[SampledImage:[a-zA-Z0-9_]+]] = OpSampledImage %{{.*}} %[[TexHandle]] %[[SampHandle]]
+    // CHECK: %[[TexResult:[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod %v4float %[[SampledImage]]
+    float4 texVal = myTex.SampleLevel(mySamp, float2(0, 0), 0);
+
+    // CHECK: %[[BufResult:[a-zA-Z0-9_]+]] = OpImageFetch %v4float %[[BufHandle]]
+    float4 bufVal = myBuf.Load(tid.x);
+
+    // CHECK: OpImageWrite %[[RWTexHandle]]
+    myRWTex[tid.xy] = texVal;
+
+    // CHECK: OpImageWrite %[[RWBufHandle]]
+    myRWBuf[tid.x] = bufVal;
+}

--- a/tools/clang/test/CodeGenSPIRV/resource-heap-ext-texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/resource-heap-ext-texture.hlsl
@@ -6,7 +6,7 @@
 // CHECK-DAG: OpDecorate %[[ResourceHeap:[a-zA-Z0-9_]+]] BuiltIn ResourceHeapEXT
 // CHECK-DAG: OpDecorate %[[SamplerHeap:[a-zA-Z0-9_]+]] BuiltIn SamplerHeapEXT
 
-// CHECK-DAG: %[[UntypedPtrType:[a-zA-Z0-9_]+]] = OpTypeUntypedPointerKHR Uniform
+// CHECK-DAG: %[[UntypedPtrType:[a-zA-Z0-9_]+]] = OpTypeUntypedPointerKHR UniformConstant
 // CHECK-DAG: %[[Tex2DType:[a-zA-Z0-9_]+]] = OpTypeImage %float 2D 2 0 0 1 Unknown
 // CHECK-DAG: %[[RWTex2DType:[a-zA-Z0-9_]+]] = OpTypeImage %float 2D 2 0 0 2 Rgba32f
 // CHECK-DAG: %[[BufferType:[a-zA-Z0-9_]+]] = OpTypeImage %float Buffer 2 0 0 1 Rgba32f

--- a/tools/clang/test/CodeGenSPIRV/resource-heap-ext-texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/resource-heap-ext-texture.hlsl
@@ -19,8 +19,8 @@
 // CHECK-DAG: %[[RA_RWBufferType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[RWBufferType]]
 // CHECK-DAG: %[[RA_SamplerType:[a-zA-Z0-9_]+]] = OpTypeRuntimeArray %[[SamplerType]]
 
-// CHECK: %[[ResourceHeap]] = OpUntypedVariableKHR %[[UntypedPtrType]] Uniform
-// CHECK: %[[SamplerHeap]]  = OpUntypedVariableKHR %[[UntypedPtrType]] Uniform
+// CHECK: %[[ResourceHeap]] = OpUntypedVariableKHR %[[UntypedPtrType]] UniformConstant
+// CHECK: %[[SamplerHeap]]  = OpUntypedVariableKHR %[[UntypedPtrType]] UniformConstant
 
 [numthreads(1, 1, 1)]
 void main(uint3 tid : SV_DispatchThreadID) {


### PR DESCRIPTION
Resource & Sampler heaps are already implemented in DXC, but rely on an emulated heap. A new VK/SPV extension bring actual descriptor heaps. This is the first step toward a complete support.

This commits focuses on Texture/Sampler/Buffer resources, which are all backed by OpTypeImage/OpTypeSampler. This path is a bit simpler as we have no ArrayStride, nor OpAccessChain legalization issues: the whole image handle loading is handled in DXC, and the rest follows the normal path.

Next step is to implement RWStructuredBuffer/StructuredBuffer support, with counters and chain legalization.

Related to #8243