### PR TITLE
Remove non-standard nothrow specializations

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -570,24 +570,4 @@ namespace llvm {
   template <> struct isPodLike<StringRef> { static const bool value = true; };
 }
 
-// HLSL Change Starts
-// StringRef provides an operator string; that trips up the std::pair noexcept specification,
-// which (a) enables the moves constructor (because conversion is allowed), but (b)
-// misclassifies the the construction as nothrow.
-namespace std {
-  template<>
-  struct is_nothrow_constructible <std::string, llvm::StringRef>
-    : std::false_type {
-  };
-  template<>
-  struct is_nothrow_constructible <std::string, llvm::StringRef &>
-    : std::false_type {
-  };
-  template<>
-  struct is_nothrow_constructible <std::string, const llvm::StringRef &>
-    : std::false_type {
-  };
-}
-// HLSL Change Ends
-
 #endif


### PR DESCRIPTION
Fix for #7098
The specialisations of `is_nothrow_constructible` in `StringRef.h` are non-standard and as seen in the issue fail with newer versions of libc++. 
Manage to compile on MacOS 26.4(clang-2100.0.123.102). The static checks in `DiagnosticIDs.cpp` remain though so if there is an issue the builds should show it.