### PR TITLE
Fix stale ODR-use state before lexed inline methods

### DIFF
--- a/tools/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/tools/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -521,6 +521,7 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
   // Parse the method body. Function body parsing code is similar enough
   // to be re-used for method bodies as well.
   ParseScope FnScope(this, Scope::FnScope|Scope::DeclScope);
+  Actions.CleanupVarDeclMarking();
   Actions.ActOnStartOfFunctionDef(getCurScope(), LM.D);
 
   if (Tok.is(tok::kw_try)) {

--- a/tools/clang/test/CodeGenSPIRV/ex40-lexed-inline-method-odr-use-crash.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/ex40-lexed-inline-method-odr-use-crash.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -HV 2021 -spirv -T cs_6_8 -E main -O0 -fspv-target-env=vulkan1.3 %s -Fo %t.spv
+
+struct Bindings {
+  const static uint Mask = 0;
+};
+
+const static uint SessionDSIndex = 0;
+[[vk::binding(Bindings::Mask, SessionDSIndex)]] RWTexture2DArray<float> gMask;
+
+struct Trigger {
+  void accumulate() {}
+};
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {}


### PR DESCRIPTION
## Summary

This clears stale delayed ODR-use bookkeeping before starting a lexed inline method body.

It also adds a small SPIR-V regression test for the same parser path.

## Root cause

The missing cleanup is in [`ParseLexedMethodDef`](https://github.com/microsoft/DirectXShaderCompiler/commit/6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437), which was introduced in [6ee4074a4](https://github.com/microsoft/DirectXShaderCompiler/commit/6ee4074a4b43fa23bf5ad27e4f6cafc6b835e437).

That path enters `ActOnStartOfFunctionDef(...)` without first calling `CleanupVarDeclMarking()`.

HLSL constant-expression references inside declarations such as `[[vk::binding(Bindings::Mask, SessionDSIndex)]]` can leave entries in `MaybeODRUseExprs`.

When the next lexed inline method is parsed, `ActOnFinishFunctionBody(...)` trips the debug invariant:

`Leftover expressions for odr-use checking`

## Impact

This crashes assert-enabled DXC builds on valid HLSL.

Public release-like builds usually compile the same source because assertions are off, so the bug is masked rather than absent.

## Repros

- Original immutable input from `NSC -P`: [godbolt.org/z/81nsEja1v](https://godbolt.org/z/81nsEja1v)
- New minimized repro now checked into `tools/clang/test/CodeGenSPIRV/ex40-lexed-inline-method-odr-use-crash.hlsl`: [godbolt.org/z/3zfraP9bf](https://godbolt.org/z/3zfraP9bf)

Both CE links use the public `dxc_trunk` build, so they compile there because that build does not expose the local debug assert path.
