### PR TITLE
[SM6.10] Add Convert function to linalg.h

### DIFF
--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -183,6 +183,12 @@ __MATRIX_SCALAR_COMPONENT_MAPPING(ComponentType::I64, int64_t)
 __MATRIX_SCALAR_COMPONENT_MAPPING(ComponentType::U64, uint64_t)
 __MATRIX_SCALAR_COMPONENT_MAPPING(ComponentType::F64, double)
 
+template <ComponentEnum DstTy, ComponentEnum SrcTy, int SrcN> struct DstN {
+  static const int Value =
+      (SrcN * ComponentTypeTraits<SrcTy>::ElementsPerScalar) /
+      ComponentTypeTraits<DstTy>::ElementsPerScalar;
+};
+
 } // namespace __detail
 
 template <ComponentEnum ElementType, uint DimA> struct VectorRef {
@@ -201,6 +207,17 @@ template <ComponentEnum DT, typename T, int N>
 InterpretedVector<T, N, DT> MakeInterpretedVector(vector<T, N> Vec) {
   InterpretedVector<T, N, DT> IV = {Vec};
   return IV;
+}
+
+template <ComponentEnum DestTy, ComponentEnum OriginTy, typename T, int N>
+InterpretedVector<typename __detail::ComponentTypeTraits<DestTy>::Type,
+                  __detail::DstN<DestTy, OriginTy, N>::Value, DestTy>
+Convert(vector<T, N> Vec) {
+  vector<typename __detail::ComponentTypeTraits<DestTy>::Type,
+         __detail::DstN<DestTy, OriginTy, N>::Value>
+      Result;
+  __builtin_LinAlg_Convert(Result, Vec, OriginTy, DestTy);
+  return MakeInterpretedVector<DestTy>(Result);
 }
 
 template <ComponentEnum ComponentTy, SIZE_TYPE M, SIZE_TYPE N,

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/vectors.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/vectors.hlsl
@@ -63,4 +63,9 @@ void main(uint ID : SV_GroupID) {
   // CHECK-SAME: @dx.op.linAlgMatrixOuterProduct.mC8M8N8U2S0.v8f16.v8f16(i32 -2147483619,
   // CHECK-SAME: <8 x half> %[[VEC5]], <8 x half> %[[VEC6]])  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   MatrixAccumTy AccumMatrix = OuterProduct<ComponentType::F16>(vec5, vec6);
+
+  // CHECK: %[[CONV_VEC:.*]] = call <8 x float> @dx.op.linAlgConvert.v8f32.v8f16(i32 -2147483618,
+  // CHECK-SAME: <8 x half> %[[VEC6]], i32 8, i32 9)  ; LinAlgConvert(inputVector,inputInterpretation,outputInterpretation)
+  InterpretedVector<float, 8, ComponentType::F32> convertedVec;
+  convertedVec = Convert<ComponentType::F32, ComponentType::F16>(vec6);
 }


### PR DESCRIPTION
Adds `Convert` function to `linalg.h`. This function converts a vector to an `InterpretedVector` of a different component type. It has been added to the spec in https://github.com/microsoft/hlsl-specs/pull/819. It is implemented by calling a built-in function that was added in https://github.com/microsoft/DirectXShaderCompiler/pull/8308.