### PR TITLE
[SM6.10] Restrict Wave and ThreadGroup scope matrix ops to compute stage

### DIFF
--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -3980,7 +3980,7 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
       (2147483671 <= op && op <= 2147483672) || op == 2147483676) {
     major = 6;
     minor = 10;
-    mask = SFLAG(Compute) | SFLAG(Mesh) | SFLAG(Amplification);
+    mask = SFLAG(Compute);
     return;
   }
   // Instructions: GetGroupWaveIndex=2147483649, GetGroupWaveCount=2147483650

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-as.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-as.ll
@@ -1,7 +1,22 @@
 ; REQUIRES: dxil-1-10
-; RUN: %dxv %s 2>&1 | FileCheck %s
+; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Validation succeeded.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixMultiply not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixAccumulate not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixLength not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgFillMatrix not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixGetElement not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixSetElement not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model as_6_10.
+; CHECK: Function:  mainAS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK: Function:  mainAS: error: Function uses features incompatible with the shader stage (as) of the entry function.
+; CHECK: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ms.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ms.ll
@@ -1,7 +1,22 @@
 ; REQUIRES: dxil-1-10
-; RUN: %dxv %s 2>&1 | FileCheck %s
+; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Validation succeeded.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixMultiply not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixLength not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgFillMatrix not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixGetElement not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixSetElement not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ms_6_10.
+; CHECK: Function:  mainMeS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK: Function:  mainMeS: error: Function uses features incompatible with the shader stage (ms) of the entry function.
+; CHECK: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1181,8 +1181,6 @@ class db_dxil(object):
             i.shader_model = experimental_sm
             i.shader_stages = (
                 "compute",
-                "mesh",
-                "amplification",
             )
 
         for i in insts("DebugBreak", "IsDebuggerPresent"):


### PR DESCRIPTION
Spec recently updated in https://github.com/microsoft/hlsl-specs/pull/841.