### PR TITLE
[SPIR-V] Allow function parameters to be decorated with inline spir-v

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1056,7 +1056,8 @@ SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
 
 SpirvFunctionParameter *
 DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
-                                  uint32_t dbgArgNumber) {
+                                  uint32_t dbgArgNumber,
+                                  bool decorateIntrinsicAttrs) {
   const auto type = getTypeOrFnRetType(param);
   const auto loc = param->getLocation();
   const auto range = param->getSourceRange();
@@ -1070,6 +1071,9 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
 
   if (isConstantTextureBuffer(type))
     fnParamInstr->setLayoutRule(spirvOptions.cBufferLayoutRule);
+
+  if (decorateIntrinsicAttrs && param->hasAttrs())
+    decorateWithIntrinsicAttrs(param, fnParamInstr);
 
   assert(astDecls[param].instr == nullptr);
   registerVariableForDecl(param, fnParamInstr);
@@ -5021,18 +5025,17 @@ bool DeclResultIdMapper::tryToCreateConstantVar(const ValueDecl *decl) {
 }
 
 void DeclResultIdMapper::decorateWithIntrinsicAttrs(
-    const NamedDecl *decl, SpirvVariable *varInst,
+    const NamedDecl *decl, SpirvInstruction *targetInst,
     llvm::function_ref<void(VKDecorateExtAttr *)> extraFunctionForDecoAttr) {
   if (!decl->hasAttrs())
     return;
 
-  // TODO: Handle member field in a struct and function parameter.
   for (auto &attr : decl->getAttrs()) {
     if (auto decoAttr = dyn_cast<VKDecorateExtAttr>(attr)) {
       spvBuilder.decorateWithLiterals(
-          varInst, decoAttr->getDecorate(),
+          targetInst, decoAttr->getDecorate(),
           {decoAttr->literals_begin(), decoAttr->literals_end()},
-          varInst->getSourceLocation());
+          targetInst->getSourceLocation());
       extraFunctionForDecoAttr(decoAttr);
       continue;
     }
@@ -5041,15 +5044,15 @@ void DeclResultIdMapper::decorateWithIntrinsicAttrs(
       for (Expr *arg : decoAttr->arguments()) {
         args.push_back(theEmitter.doExpr(arg));
       }
-      spvBuilder.decorateWithIds(varInst, decoAttr->getDecorate(), args,
-                                 varInst->getSourceLocation());
+      spvBuilder.decorateWithIds(targetInst, decoAttr->getDecorate(), args,
+                                 targetInst->getSourceLocation());
       continue;
     }
     if (auto decoAttr = dyn_cast<VKDecorateStringExtAttr>(attr)) {
       llvm::SmallVector<llvm::StringRef, 2> args(decoAttr->arguments_begin(),
                                                  decoAttr->arguments_end());
-      spvBuilder.decorateWithStrings(varInst, decoAttr->getDecorate(), args,
-                                     varInst->getSourceLocation());
+      spvBuilder.decorateWithStrings(targetInst, decoAttr->getDecorate(), args,
+                                     targetInst->getSourceLocation());
       continue;
     }
   }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -271,7 +271,8 @@ public:
   /// parameter must have "1", not "0", which is what Clang generates for
   /// LLVM debug metadata.
   SpirvFunctionParameter *createFnParam(const ParmVarDecl *param,
-                                        uint32_t dbgArgNumber = 0);
+                                        uint32_t dbgArgNumber = 0,
+                                        bool decorateIntrinsicAttrs = true);
 
   /// \brief Creates the counter variable associated with the given param.
   /// This is meant to be used for forward-declared functions and this objects
@@ -577,7 +578,7 @@ public:
   /// Decorate with spirv intrinsic attributes with lamda function variable
   /// check
   void decorateWithIntrinsicAttrs(
-      const NamedDecl *decl, SpirvVariable *varInst,
+      const NamedDecl *decl, SpirvInstruction *targetInst,
       llvm::function_ref<void(VKDecorateExtAttr *)> extraFunctionForDecoAttr =
           [](VKDecorateExtAttr *) {});
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1704,8 +1704,8 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
   for (uint32_t i = 0; i < decl->getNumParams(); ++i) {
     const ParmVarDecl *paramDecl = decl->getParamDecl(i);
     QualType paramType = paramDecl->getType();
-    auto *param =
-        declIdMapper.createFnParam(paramDecl, i + 1 + isNonStaticMemberFn);
+    auto *param = declIdMapper.createFnParam(
+        paramDecl, i + 1 + isNonStaticMemberFn, !isEntry);
     if (isEntry) {
       handleNodePayloadArrayType(paramDecl, param);
     }

--- a/tools/clang/test/CodeGenSPIRV/inline-spirv/spv.intrinsicDecorate.function-parameter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/inline-spirv/spv.intrinsicDecorate.function-parameter.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl -Vd -spirv -fcgl %s -spirv | FileCheck %s
+
+void SimpleAdd([[vk::ext_decorate(/* spv::DecorationAliased */ 20)]] inout float a,
+               [[vk::ext_decorate(/* spv::DecorationAliased */ 20)]] inout float b) {
+  a += 1.0;
+  b += 2.0;
+}
+
+// CHECK: OpDecorate %x Aliased
+// CHECK: OpDecorate %a Aliased
+// CHECK: OpDecorate %b Aliased
+// CHECK: %SimpleAdd = OpFunction %void None {{%[a-zA-Z0-9_]+}}
+// CHECK-NEXT: %a = OpFunctionParameter %_ptr_Function_float
+// CHECK-NEXT: %b = OpFunctionParameter %_ptr_Function_float
+
+float4 main() : SV_Target {
+  [[vk::ext_decorate(/*spv::DecorationAliased*/20)]] float x = 43.0;
+  SimpleAdd(x, x);
+  return float4(x, x, x, x);
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/8103