### PR TITLE
[SM6.10][Bugfix] Fixed swapped parameter in linalg.h

### DIFF
--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -373,8 +373,8 @@ class Matrix {
                            void>::type
   MultiplyAccumulate(const Matrix<LHSTy, M, K, MatrixUse::A, Scope> MatrixA,
                      const Matrix<RHSTy, K, N, MatrixUse::B, Scope> MatrixB) {
-    __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(
-        __handle, __handle, MatrixA.__handle, MatrixB.__handle);
+    __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(__handle, MatrixA.__handle,
+                                                    MatrixB.__handle, __handle);
   }
 };
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
@@ -157,10 +157,10 @@ void main(uint ID : SV_GroupID)
 // Matrix::MultiplyAccumulate
 //
 // CHECK: %[[ACCUM4:.*]] = call %dx.types.LinAlgMatrixC9M4N4U2S1
-// CHECK-SAME: @dx.op.linAlgMatrixMultiplyAccumulate.mC9M4N4U2S1.mC9M4N4U2S1.mC9M4N4U0S1.mC9M4N4U1S1(i32 -2147483637,
-// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM3]],
+// CHECK-SAME: @dx.op.linAlgMatrixMultiplyAccumulate.mC9M4N4U2S1.mC9M4N4U0S1.mC9M4N4U1S1.mC9M4N4U2S1(i32 -2147483637,
 // CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U0S1 %[[MATA1]],
-// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U1S1 %[[MATB1_2]])
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U1S1 %[[MATB1_2]],
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM3]])
 // CHECK-SAME: ; LinAlgMatrixMultiplyAccumulate(matrixA,matrixB,matrixC)
   AccMat2.MultiplyAccumulate(MatA1, MatB1);
 


### PR DESCRIPTION
Fixes #8334 

The parameters into the builtin for MatrixMultiplyAccumulate were in the wrong order in the header. This fixes that