### PR TITLE
[SM6.10][HLK][Bugfix] Remove using std from common header

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -47,8 +47,8 @@
 #include "dxc/Test/TestConfig.h"
 #endif
 
-using std::min;
 using std::max;
+using std::min;
 
 #ifndef HLSLDATAFILEPARAM
 #define HLSLDATAFILEPARAM L"HlslDataDir"

--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -47,7 +47,8 @@
 #include "dxc/Test/TestConfig.h"
 #endif
 
-using namespace std;
+using std::min;
+using std::max;
 
 #ifndef HLSLDATAFILEPARAM
 #define HLSLDATAFILEPARAM L"HlslDataDir"
@@ -121,12 +122,12 @@ static constexpr wchar_t wideWhitespaceChars[] = L" \t\r\n";
 
 inline std::string strltrim(const std::string &value) {
   size_t first = value.find_first_not_of(whitespaceChars);
-  return first == string::npos ? value : value.substr(first);
+  return first == std::string::npos ? value : value.substr(first);
 }
 
 inline std::string strrtrim(const std::string &value) {
   size_t last = value.find_last_not_of(whitespaceChars);
-  return last == string::npos ? value : value.substr(0, last + 1);
+  return last == std::string::npos ? value : value.substr(0, last + 1);
 }
 
 inline std::string strtrim(const std::string &value) {

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -9739,8 +9739,8 @@ TEST_F(ExecutionTest, PackUnpackTest) {
     return;
   }
 #else
-  string args = "-enable-16bit-types";
-  string target = "cs_6_6";
+  std::string args = "-enable-16bit-types";
+  std::string target = "cs_6_6";
 
   if (!createDevice(&pDevice, D3D_SHADER_MODEL_6_6)) {
     return;
@@ -10211,7 +10211,7 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
   st::ShaderOp *pShaderOp =
       ShaderOpSet->GetShaderOp("DynamicResourcesDynamicIndexing");
-  vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
+  std::vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
 
   bool Skipped = true;
 


### PR DESCRIPTION
`using namespace std;` is generally considered a bad practice so it should be removed anyways but this was causing downstream ambeguity errors so it needs to be fix.

Completely removing is was going to cause a bunch of min/max headaches so those were added in as more precise using statements.