### PR TITLE
[SM6.10] LinAlg: Fix thread-scope InterlockedAccumulate params

### DIFF
--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -406,11 +406,9 @@ class Matrix<ComponentTy, M, N, Use, MatrixScope::Thread> {
   template <MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
-  InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
-                        MatrixLayoutEnum Layout,
-                        uint Align = sizeof(ElementType)) {
-    __builtin_LinAlg_MatrixAccumulateToDescriptor(__handle, Res, StartOffset,
-                                                  Stride, Layout, Align);
+  InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset) {
+    __builtin_LinAlg_MatrixAccumulateToDescriptor(
+        __handle, Res, StartOffset, 0, MatrixLayout::OuterProductOptimal, 0);
   }
 };
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
@@ -175,12 +175,12 @@ void main(uint ID : SV_GroupID)
 //
 // CHECK: %[[TSACCUM:.*]] = call %dx.types.LinAlgMatrixC9M4N4U2S0 @dx.op.linAlgMatrixOuterProduct.mC9M4N4U2S0.v4f32.v4f32
 // CHECK: call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC9M4N4U2S0(i32 -2147483621,
-// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S0 %[[TSACCUM]], %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 4)
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S0 %[[TSACCUM]], %dx.types.Handle %{{[0-9]+}}, i32 0, i32 0, i32 4, i32 0)
 // CHECK-SAME: ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
   vector<float, 4> vec1 = 1.0f;
   vector<float, 4> vec2 = 2.0f;
   TSMatrixAccumTy TSMatAccum = OuterProduct<ComponentType::F32>(vec1, vec2);
-  TSMatAccum.InterlockedAccumulate(RWBAB, 0, 16, MatrixLayoutEnum::ColMajor);
+  TSMatAccum.InterlockedAccumulate(RWBAB, 0);
 
 // CHECK: call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
   MatrixUseEnum layout = AccumulatorLayout();


### PR DESCRIPTION
The thread-scope overload wasn't supposed to have Stride and Layout, since the Layout must be OuterProductOptimal for thread scope.

Additionally, Align is device-dependent for OuterProductOptimal, so there's no point supplying it from HLSL or DXIL.

This change removes these three parameters from this function in the HLSL Header, supplying 0 for Stride, MatrixLayout::OuterProductOptimal for Layout, and 0 for Align to the builtin operation which will pass these values along to the DXIL operation.

Fixes #8360