### PR TITLE
[SM6.10][Bugfix] Update Matrix::Cast definition to switch matrix sizes on transpose

### DIFF
--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -194,6 +194,16 @@ template <ComponentEnum DstTy, ComponentEnum SrcTy, int SrcN> struct DstN {
       ComponentTypeTraits<DstTy>::ElementsPerScalar;
 };
 
+template <SIZE_TYPE MVal, SIZE_TYPE NVal, bool Transposed> struct DimMN {
+  static const SIZE_TYPE M = MVal;
+  static const SIZE_TYPE N = NVal;
+};
+
+template <SIZE_TYPE MVal, SIZE_TYPE NVal> struct DimMN<MVal, NVal, true> {
+  static const SIZE_TYPE M = NVal;
+  static const SIZE_TYPE N = MVal;
+};
+
 } // namespace __detail
 
 template <ComponentEnum ElementType, uint DimA> struct VectorRef {
@@ -242,8 +252,11 @@ class Matrix {
 
   template <ComponentEnum NewCompTy, MatrixUseEnum NewUse = Use,
             bool Transpose = false>
-  Matrix<NewCompTy, M, N, NewUse, Scope> Cast() {
-    Matrix<NewCompTy, M, N, NewUse, Scope> Result;
+  Matrix<NewCompTy, __detail::DimMN<M, N, Transpose>::M,
+         __detail::DimMN<M, N, Transpose>::N, NewUse, Scope>
+  Cast() {
+    Matrix<NewCompTy, __detail::DimMN<M, N, Transpose>::M,
+           __detail::DimMN<M, N, Transpose>::N, NewUse, Scope> Result;
     __builtin_LinAlg_CopyConvertMatrix(Result.__handle, __handle, Transpose);
     return Result;
   }

--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -256,7 +256,8 @@ class Matrix {
          __detail::DimMN<M, N, Transpose>::N, NewUse, Scope>
   Cast() {
     Matrix<NewCompTy, __detail::DimMN<M, N, Transpose>::M,
-           __detail::DimMN<M, N, Transpose>::N, NewUse, Scope> Result;
+           __detail::DimMN<M, N, Transpose>::N, NewUse, Scope>
+        Result;
     __builtin_LinAlg_CopyConvertMatrix(Result.__handle, __handle, Transpose);
     return Result;
   }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
@@ -6,10 +6,14 @@ using namespace dx::linalg;
 
 using MatrixATy = Matrix<ComponentType::F32, 4, 4, MatrixUse::A, MatrixScope::Wave>;
 using MatrixBTy = Matrix<ComponentType::F32, 4, 4, MatrixUse::B, MatrixScope::Wave>;
-using MatrixBTyInt = Matrix<ComponentType::I32, 4, 4, MatrixUse::B, MatrixScope::Wave>;
 using MatrixAccumTy = Matrix<ComponentType::F32, 4, 4, MatrixUse::Accumulator, MatrixScope::Wave>;
 using TSMatrixATy = Matrix<ComponentType::F32, 4, 4, MatrixUse::A, MatrixScope::Thread>;
 using TSMatrixAccumTy = Matrix<ComponentType::F32, 4, 4, MatrixUse::Accumulator, MatrixScope::Thread>;
+
+using Matrix48TyFloat = Matrix<ComponentType::F32, 4, 8, MatrixUse::A, MatrixScope::Wave>;
+using Matrix48TyInt = Matrix<ComponentType::I32, 4, 8, MatrixUse::A, MatrixScope::Wave>;
+using Matrix84TyInt = Matrix<ComponentType::I32, 8, 4, MatrixUse::A, MatrixScope::Wave>;
+
 
 ByteAddressBuffer BAB : register(t0);
 RWByteAddressBuffer RWBAB : register(u0);
@@ -34,16 +38,19 @@ void main(uint ID : SV_GroupID)
 
 // Matrix::Cast
 //
-// CHECK: call %dx.types.LinAlgMatrixC4M4N4U1S1 @dx.op.linAlgCopyConvertMatrix.mC4M4N4U1S1.mC9M4N4U0S1(
-// CHECK-SAME: i32 -2147483635, %dx.types.LinAlgMatrixC9M4N4U0S1 %[[MATA1]], i1 false)
-// CHECK-SAME: ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
-  MatrixBTyInt MatBInt1 = MatA1.Cast<ComponentType::I32, MatrixUse::B>();
+// CHECK: %[[MAT48F:.*]] = call %dx.types.LinAlgMatrixC9M4N8U0S1 @dx.op.linAlgFillMatrix.mC9M4N8U0S1.f32(
+// CHECK-SAME: i32 -2147483636, float 3.000000e+00)  ; LinAlgFillMatrix(value)
 
-// CHECK: call %dx.types.LinAlgMatrixC4M4N4U1S1 @dx.op.linAlgCopyConvertMatrix.mC4M4N4U1S1.mC9M4N4U1S1(
-// CHECK-SAME: i32 -2147483635, %dx.types.LinAlgMatrixC9M4N4U1S1 %[[MATB1]], i1 true)
+// CHECK: call %dx.types.LinAlgMatrixC4M4N8U0S1 @dx.op.linAlgCopyConvertMatrix.mC4M4N8U0S1.mC9M4N8U0S1(
+// CHECK-SAME: i32 -2147483635, %dx.types.LinAlgMatrixC9M4N8U0S1 %[[MAT48F]], i1 false)
 // CHECK-SAME: ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
-  MatrixBTyInt MatBInt2;
-  MatBInt2 = MatB1.Cast<ComponentType::I32, MatrixUse::B, true>();
+  Matrix48TyFloat Mat48F = Matrix48TyFloat::Splat(3.0f);
+  Matrix48TyInt Mat48I = Mat48F.Cast<ComponentType::I32>();
+
+// CHECK: call %dx.types.LinAlgMatrixC4M8N4U0S1 @dx.op.linAlgCopyConvertMatrix.mC4M8N4U0S1.mC9M4N8U0S1(
+// CHECK-SAME: i32 -2147483635, %dx.types.LinAlgMatrixC9M4N8U0S1 %[[MAT48F]], i1 true)
+// CHECK-SAME: ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
+  Matrix84TyInt Mat84I = Mat48F.Cast<ComponentType::I32, MatrixUse::A, true>();
 
 // Matrix::Load from ByteAddressBuffer
 //


### PR DESCRIPTION
Spec updated in https://github.com/microsoft/hlsl-specs/pull/842