### PR TITLE
[Release SM 6.9] Cherry-Pick Execution Tests: Long Vectors fix-up HLK feature reference

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -2729,9 +2729,9 @@ public:
 #define HLK_TEST_DOUBLE(Op, DataType)                                          \
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
-    TEST_METHOD_PROPERTY(                                                      \
-        "Kits.Specification",                                                  \
-        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optional")                                                             \
+    TEST_METHOD_PROPERTY("Kits.Specification",                                 \
+                         "Device.Graphics.D3D12.DXILCore.ShaderModel69."       \
+                         "DoublePrecision.Optional")                           \
     END_TEST_METHOD_PROPERTIES()                                               \
     runTest<DataType, OpType::Op>();                                           \
   }
@@ -2739,9 +2739,9 @@ public:
 #define HLK_WAVEOP_TEST_DOUBLE(Op, DataType)                                   \
   TEST_METHOD(Op##_##DataType) {                                               \
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
-    TEST_METHOD_PROPERTY(                                                      \
-        "Kits.Specification",                                                  \
-        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optional")                                                             \
+    TEST_METHOD_PROPERTY("Kits.Specification",                                 \
+                         "Device.Graphics.D3D12.DXILCore.ShaderModel69."       \
+                         "DoublePrecision.Optional")                           \
     END_TEST_METHOD_PROPERTIES()                                               \
     runWaveOpTest<DataType, OpType::Op>();                                     \
   }

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -2758,7 +2758,7 @@ public:
       "Validates required double precision SM 6.9 vectorized DXIL operations")
   TEST_METHOD_PROPERTY(
       "Kits.Specification",
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optinal")
+      "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optional")
   TEST_METHOD_PROPERTY(L"Priority", L"0")
   END_TEST_CLASS()
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -2731,7 +2731,7 @@ public:
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
         "Kits.Specification",                                                  \
-        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")        \
+        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optional")                                                             \
     END_TEST_METHOD_PROPERTIES()                                               \
     runTest<DataType, OpType::Op>();                                           \
   }
@@ -2741,7 +2741,7 @@ public:
     BEGIN_TEST_METHOD_PROPERTIES()                                             \
     TEST_METHOD_PROPERTY(                                                      \
         "Kits.Specification",                                                  \
-        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")        \
+        "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optional")                                                             \
     END_TEST_METHOD_PROPERTIES()                                               \
     runWaveOpTest<DataType, OpType::Op>();                                     \
   }
@@ -2758,7 +2758,7 @@ public:
       "Validates required double precision SM 6.9 vectorized DXIL operations")
   TEST_METHOD_PROPERTY(
       "Kits.Specification",
-      "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision")
+      "Device.Graphics.D3D12.DXILCore.ShaderModel69.DoublePrecision.Optinal")
   TEST_METHOD_PROPERTY(L"Priority", L"0")
   END_TEST_CLASS()
 


### PR DESCRIPTION
Cherry-pick PR (#8353)

Assisted by gh copilot.

Depends on: #8369, #8370, #8371

SHA [f86cda3](https://github.com/microsoft/DirectXShaderCompiler/commit/f86cda3f65084a6e42e4223dcee136254d59793d)