### PR TITLE
Add missing ENABLE_SPIRV_CODEGEN guards

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4996,9 +4996,11 @@ public:
     case AR_OBJECT_LEGACY_EFFECT: // used for all legacy effect object types
 
     case AR_OBJECT_TEXTURE1D:
-    case AR_OBJECT_VK_SAMPLED_TEXTURE1D:
     case AR_OBJECT_TEXTURE1D_ARRAY:
+#ifdef ENABLE_SPIRV_CODEGEN
+    case AR_OBJECT_VK_SAMPLED_TEXTURE1D:
     case AR_OBJECT_VK_SAMPLED_TEXTURE1D_ARRAY:
+#endif
     case AR_OBJECT_TEXTURE2D:
     case AR_OBJECT_TEXTURE2D_ARRAY:
     case AR_OBJECT_TEXTURE3D:
@@ -11725,9 +11727,11 @@ void hlsl::DiagnoseRegisterType(clang::Sema *self, clang::SourceLocation loc,
     break;
 
   case AR_OBJECT_TEXTURE1D:
-  case AR_OBJECT_VK_SAMPLED_TEXTURE1D:
   case AR_OBJECT_TEXTURE1D_ARRAY:
+#ifdef ENABLE_SPIRV_CODEGEN
+  case AR_OBJECT_VK_SAMPLED_TEXTURE1D:
   case AR_OBJECT_VK_SAMPLED_TEXTURE1D_ARRAY:
+#endif
   case AR_OBJECT_TEXTURE2D:
   case AR_OBJECT_TEXTURE2D_ARRAY:
   case AR_OBJECT_TEXTURE3D:


### PR DESCRIPTION
The AR_OBJECT_VK_* enums are only available when ENABLE_SPIRV_CODEGEN is defined.