### PR TITLE
[SPIR-V] Remove unnecessary cases for `SampledTexture` that are breaking builds

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11724,10 +11724,6 @@ void hlsl::DiagnoseRegisterType(clang::Sema *self, clang::SourceLocation loc,
 
   case AR_OBJECT_TEXTURE1D:
   case AR_OBJECT_TEXTURE1D_ARRAY:
-#ifdef ENABLE_SPIRV_CODEGEN
-  case AR_OBJECT_VK_SAMPLED_TEXTURE1D:
-  case AR_OBJECT_VK_SAMPLED_TEXTURE1D_ARRAY:
-#endif
   case AR_OBJECT_TEXTURE2D:
   case AR_OBJECT_TEXTURE2D_ARRAY:
   case AR_OBJECT_TEXTURE3D:

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4996,9 +4996,7 @@ public:
     case AR_OBJECT_LEGACY_EFFECT: // used for all legacy effect object types
 
     case AR_OBJECT_TEXTURE1D:
-    case AR_OBJECT_VK_SAMPLED_TEXTURE1D:
     case AR_OBJECT_TEXTURE1D_ARRAY:
-    case AR_OBJECT_VK_SAMPLED_TEXTURE1D_ARRAY:
     case AR_OBJECT_TEXTURE2D:
     case AR_OBJECT_TEXTURE2D_ARRAY:
     case AR_OBJECT_TEXTURE3D:


### PR DESCRIPTION
Part of #7979

These cases aren't needed and should be removed. (previously was failing builds because they weren't wrapped around `#ifdef`)

`GetBasicKindType` maps `ArBasicKind` values to Clang QualType objects. SampledTexture wrappers are not introduced through that mapping table, so it shouldn't be added here (it's a no-op for SampledTexture types). 