### PR TITLE
[SPIR-V][NFC] Remove useless function

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1838,7 +1838,7 @@ SpirvFunction *DeclResultIdMapper::getOrRegisterFn(const FunctionDecl *fn) {
   return spirvFunction;
 }
 
-const CounterIdAliasPair *DeclResultIdMapper::getCounterIdAliasPair(
+const CounterIdAliasPair *DeclResultIdMapper::getOrCreateCounterIdAliasPair(
     const DeclaratorDecl *decl, const llvm::SmallVector<uint32_t, 4> *indices) {
   if (!decl)
     return nullptr;
@@ -1864,24 +1864,6 @@ const CounterIdAliasPair *DeclResultIdMapper::getCounterIdAliasPair(
       return &counter->second;
   }
 
-  return nullptr;
-}
-
-const CounterIdAliasPair *
-DeclResultIdMapper::createOrGetCounterIdAliasPair(const DeclaratorDecl *decl) {
-  auto counterPair = getCounterIdAliasPair(decl);
-  if (counterPair)
-    return counterPair;
-  if (!decl)
-    return nullptr;
-  // If deferred RWStructuredBuffer, try creating the counter now
-  auto declInstr = declRWSBuffers[decl];
-  if (declInstr) {
-    createCounterVar(decl, declInstr, /*isAlias*/ false);
-    auto counter = counterVars.find(decl);
-    assert(counter != counterVars.end() && "counter not found");
-    return &counter->second;
-  }
   return nullptr;
 }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -492,17 +492,11 @@ public:
   /// \brief Returns the associated counter's (instr-ptr, is-alias-or-not)
   /// pair for the given {RW|Append|Consume}StructuredBuffer variable.
   /// If indices is not nullptr, walks trhough the fields of the decl, expected
-  /// to be of struct type, using the indices to find the field. Returns nullptr
-  /// if the given decl has no associated counter variable created.
-  const CounterIdAliasPair *getCounterIdAliasPair(
+  /// to be of struct type, using the indices to find the field.
+  /// Creates counter for RW buffer if not already created.
+  const CounterIdAliasPair *getOrCreateCounterIdAliasPair(
       const DeclaratorDecl *decl,
       const llvm::SmallVector<uint32_t, 4> *indices = nullptr);
-
-  /// \brief Returns the associated counter's (instr-ptr, is-alias-or-not)
-  /// pair for the given {RW|Append|Consume}StructuredBuffer variable. Creates
-  /// counter for RW buffer if not already created.
-  const CounterIdAliasPair *
-  createOrGetCounterIdAliasPair(const DeclaratorDecl *decl);
 
   /// \brief Returns all the associated counters for the given decl. The decl is
   /// expected to be a struct containing alias RW/Append/Consume structured

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -5105,7 +5105,7 @@ bool SpirvEmitter::tryToAssignCounterVar(const DeclaratorDecl *dstDecl,
 
   // Handle AssocCounter#1 (see CounterVarFields comment)
   if (const auto *dstPair =
-          declIdMapper.createOrGetCounterIdAliasPair(dstDecl)) {
+          declIdMapper.getOrCreateCounterIdAliasPair(dstDecl)) {
     auto *srcCounter = getFinalACSBufferCounterInstruction(srcExpr);
     if (!srcCounter) {
       emitFatalError("cannot find the associated counter variable",
@@ -5213,13 +5213,13 @@ const CounterIdAliasPair *
 SpirvEmitter::getFinalACSBufferCounter(const Expr *expr) {
   // AssocCounter#1: referencing some stand-alone variable
   if (const auto *decl = getReferencedDef(expr))
-    return declIdMapper.createOrGetCounterIdAliasPair(decl);
+    return declIdMapper.getOrCreateCounterIdAliasPair(decl);
 
   const Expr *expr_withoutcasts = expr->IgnoreParenCasts();
   if (isResourceDescriptorHeap(expr_withoutcasts->getType())) {
     const Expr *base = nullptr;
     getDescriptorHeapOperands(expr_withoutcasts, &base, /* index= */ nullptr);
-    return declIdMapper.createOrGetCounterIdAliasPair(getReferencedDef(base));
+    return declIdMapper.getOrCreateCounterIdAliasPair(getReferencedDef(base));
   }
 
   // AssocCounter#2: referencing some non-struct field
@@ -5230,7 +5230,7 @@ SpirvEmitter::getFinalACSBufferCounter(const Expr *expr) {
       (base && isa<CXXThisExpr>(base))
           ? getOrCreateDeclForMethodObject(cast<CXXMethodDecl>(curFunction))
           : getReferencedDef(base);
-  return declIdMapper.getCounterIdAliasPair(decl, &rawIndices);
+  return declIdMapper.getOrCreateCounterIdAliasPair(decl, &rawIndices);
 }
 
 const CounterVarFields *SpirvEmitter::getIntermediateACSBufferCounter(


### PR DESCRIPTION
The removed function was getting or creating a counter. But the called function (called *get* counter) was also creating the counter with the same pattern if no counter was found. This essentially meant the parent create code was dead code.