### PR TITLE
[SM 6.10][LinAlg] Fixes float truncation and coordinate calculation in LinAlg exec tests

### DIFF
--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -505,7 +505,7 @@ static void runSplatStore(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << "-DFILL_VALUE=" << FillValue;
+  ExtraDefs << std::showpoint << "-DFILL_VALUE=" << FillValue;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -624,7 +624,7 @@ static const char ElementAccessShader[] = R"(
   // flatten the 2D index into a 1D index then scale by element size
   // Always store row-major and work it out in the test runner
   uint coordToByteOffset(uint2 coord) {
-    return (coord.y * M_DIM + coord.x) * ELEM_SIZE;
+    return (coord.x * N_DIM + coord.y) * ELEM_SIZE;
   }
 
   [WaveSize(4, 64)]
@@ -935,6 +935,7 @@ static void runMatMatMul(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  ExtraDefs << std::showpoint;
   ExtraDefs << " -DK_DIM=" << K;
   ExtraDefs << " -DA_FILL=" << AFill;
   ExtraDefs << " -DB_FILL=" << BFill;
@@ -1017,6 +1018,7 @@ static void runMatMatMulAccum(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  ExtraDefs << std::showpoint;
   ExtraDefs << " -DK_DIM=" << K;
   ExtraDefs << " -DA_FILL=" << AFill;
   ExtraDefs << " -DB_FILL=" << BFill;
@@ -1094,6 +1096,7 @@ static void runMatAccum(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  ExtraDefs << std::showpoint;
   ExtraDefs << " -DLHS_FILL=" << LHSFill;
   ExtraDefs << " -DRHS_FILL=" << RHSFill;
 
@@ -1551,6 +1554,7 @@ static void runStoreMemory(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  ExtraDefs << std::showpoint;
   ExtraDefs << " -DOFFSET=" << 0;
   ExtraDefs << " -DFILL_VALUE=" << FillValue;
 
@@ -1631,6 +1635,7 @@ static void runAccumulateMemory(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  ExtraDefs << std::showpoint;
   ExtraDefs << " -DOFFSET=" << 0;
   ExtraDefs << " -DFILL_VALUE=" << FillValue;
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -28,6 +28,10 @@
 #include <optional>
 #include <sstream>
 #include <string>
+
+#define STREAM_FLOAT(stream, name, value) \
+  stream << std::showpoint << " -D" << name << "=" << value << "F" \
+         << std::noshowpoint
 #include <variant>
 #include <vector>
 
@@ -505,7 +509,7 @@ static void runSplatStore(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint << "-DFILL_VALUE=" << FillValue << "F";
+  STREAM_FLOAT(ExtraDefs, "FILL_VALUE", FillValue);
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -935,10 +939,9 @@ static void runMatMatMul(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint;
   ExtraDefs << " -DK_DIM=" << K;
-  ExtraDefs << " -DA_FILL=" << AFill << "F";
-  ExtraDefs << " -DB_FILL=" << BFill << "F";
+  STREAM_FLOAT(ExtraDefs, "A_FILL", AFill);
+  STREAM_FLOAT(ExtraDefs, "B_FILL", BFill);
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1018,11 +1021,10 @@ static void runMatMatMulAccum(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint;
   ExtraDefs << " -DK_DIM=" << K;
-  ExtraDefs << " -DA_FILL=" << AFill << "F";
-  ExtraDefs << " -DB_FILL=" << BFill << "F";
-  ExtraDefs << " -DC_FILL=" << CFill << "F";
+  STREAM_FLOAT(ExtraDefs, "A_FILL", AFill);
+  STREAM_FLOAT(ExtraDefs, "B_FILL", BFill);
+  STREAM_FLOAT(ExtraDefs, "C_FILL", CFill);
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1096,9 +1098,8 @@ static void runMatAccum(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint;
-  ExtraDefs << " -DLHS_FILL=" << LHSFill << "F";
-  ExtraDefs << " -DRHS_FILL=" << RHSFill << "F";
+  STREAM_FLOAT(ExtraDefs, "LHS_FILL", LHSFill);
+  STREAM_FLOAT(ExtraDefs, "RHS_FILL", RHSFill);
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1554,9 +1555,8 @@ static void runStoreMemory(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint;
   ExtraDefs << " -DOFFSET=" << 0;
-  ExtraDefs << " -DFILL_VALUE=" << FillValue << "F";
+  STREAM_FLOAT(ExtraDefs, "FILL_VALUE", FillValue);
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1635,9 +1635,8 @@ static void runAccumulateMemory(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint;
   ExtraDefs << " -DOFFSET=" << 0;
-  ExtraDefs << " -DFILL_VALUE=" << FillValue << "F";
+  STREAM_FLOAT(ExtraDefs, "FILL_VALUE", FillValue);
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -505,7 +505,7 @@ static void runSplatStore(ID3D12Device *Device,
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
-  ExtraDefs << std::showpoint << "-DFILL_VALUE=" << FillValue;
+  ExtraDefs << std::showpoint << "-DFILL_VALUE=" << FillValue << "F";
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -29,8 +29,8 @@
 #include <sstream>
 #include <string>
 
-#define STREAM_FLOAT(stream, name, value) \
-  stream << std::showpoint << " -D" << name << "=" << value << "F" \
+#define STREAM_FLOAT(stream, name, value)                                      \
+  stream << std::showpoint << " -D" << name << "=" << value << "F"             \
          << std::noshowpoint
 #include <variant>
 #include <vector>

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -937,8 +937,8 @@ static void runMatMatMul(ID3D12Device *Device,
   std::stringstream ExtraDefs;
   ExtraDefs << std::showpoint;
   ExtraDefs << " -DK_DIM=" << K;
-  ExtraDefs << " -DA_FILL=" << AFill;
-  ExtraDefs << " -DB_FILL=" << BFill;
+  ExtraDefs << " -DA_FILL=" << AFill << "F";
+  ExtraDefs << " -DB_FILL=" << BFill << "F";
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1020,9 +1020,9 @@ static void runMatMatMulAccum(ID3D12Device *Device,
   std::stringstream ExtraDefs;
   ExtraDefs << std::showpoint;
   ExtraDefs << " -DK_DIM=" << K;
-  ExtraDefs << " -DA_FILL=" << AFill;
-  ExtraDefs << " -DB_FILL=" << BFill;
-  ExtraDefs << " -DC_FILL=" << CFill;
+  ExtraDefs << " -DA_FILL=" << AFill << "F";
+  ExtraDefs << " -DB_FILL=" << BFill << "F";
+  ExtraDefs << " -DC_FILL=" << CFill << "F";
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1097,8 +1097,8 @@ static void runMatAccum(ID3D12Device *Device,
 
   std::stringstream ExtraDefs;
   ExtraDefs << std::showpoint;
-  ExtraDefs << " -DLHS_FILL=" << LHSFill;
-  ExtraDefs << " -DRHS_FILL=" << RHSFill;
+  ExtraDefs << " -DLHS_FILL=" << LHSFill << "F";
+  ExtraDefs << " -DRHS_FILL=" << RHSFill << "F";
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1556,7 +1556,7 @@ static void runStoreMemory(ID3D12Device *Device,
   std::stringstream ExtraDefs;
   ExtraDefs << std::showpoint;
   ExtraDefs << " -DOFFSET=" << 0;
-  ExtraDefs << " -DFILL_VALUE=" << FillValue;
+  ExtraDefs << " -DFILL_VALUE=" << FillValue << "F";
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1637,7 +1637,7 @@ static void runAccumulateMemory(ID3D12Device *Device,
   std::stringstream ExtraDefs;
   ExtraDefs << std::showpoint;
   ExtraDefs << " -DOFFSET=" << 0;
-  ExtraDefs << " -DFILL_VALUE=" << FillValue;
+  ExtraDefs << " -DFILL_VALUE=" << FillValue << "F";
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 


### PR DESCRIPTION
Float fill values streamed into compiler defines (e.g. -DFILL_VALUE=42) were losing their decimal point, causing HLSL to interpret them as integers. Add std::showpoint to all stringstreams that format float values into -D defines so they always emit a decimal point. Fixed this in:
SplatStore_Wave_16x16_F16
MatMatMul_Wave_16x16x16_F16
MatMatMulAccum_Wave_16x16x16_F16
MatAccum_Wave_16x16_F16
StoreMemory_Wave_16x16_F16
AccumulateMemory_Wave_16x16_F16

Also suffix fill value literals with F (e.g. -DFILL_VALUE=42.0000F) to ensure they are interpreted as float rather than unsuffixed floating point literals, which lack a concrete representation outside HLSL 202x and may cause clang codegen to select double.

Also fixes the computation of the flatenned coordinate in ElementAccess_Wave_16x16_F16.