### PR TITLE
[Bugfix][SM6.10] Allow LinAlgMatrix type in the validator

### DIFF
--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -2414,6 +2414,9 @@ static bool ValidateType(Type *Ty, ValidationContext &ValCtx,
       // Allow HitObject type.
       if (ST == HlslOP->GetHitObjectType())
         return true;
+      // Allow LinAlgMatrix type.
+      if (dxilutil::IsHLSLLinAlgMatrixType(ST))
+        return true;
       if (IsDxilBuiltinStructType(ST, HlslOP)) {
         ValCtx.EmitTypeError(Ty, ValidationRule::InstrDxilStructUser);
         Result = false;

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-type-allowed-in-dxil.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-type-allowed-in-dxil.ll
@@ -2,14 +2,12 @@
 
 ; CHECK-NOT: uses a reserved prefix.
 ; CHECK-NOT: Validation failed.
+; CHECK: Validation succeeded.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 
-%dx.types.Handle = type { i8* }
-%dx.types.ResBind = type { i32, i32, i32, i8 }
 %dx.types.LinAlgMatrixC8M16N16U0S0 = type { i8* }
-%dx.types.ResourceProperties = type { i32, i32 }
 %struct.ByteAddressBuffer = type { i32 }
 
 define void @main() {

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-type-allowed-in-dxil.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-type-allowed-in-dxil.ll
@@ -1,0 +1,37 @@
+; RUN: %dxv %s 2>&1 | FileCheck %s
+
+; CHECK-NOT: uses a reserved prefix.
+; CHECK-NOT: Validation failed.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.ResBind = type { i32, i32, i32, i8 }
+%dx.types.LinAlgMatrixC8M16N16U0S0 = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+%struct.ByteAddressBuffer = type { i32 }
+
+define void @main() {
+  %1 = alloca %dx.types.LinAlgMatrixC8M16N16U0S0
+  ret void
+}
+
+!dx.targetTypes = !{!0}
+!llvm.ident = !{!1}
+!dx.version = !{!2}
+!dx.valver = !{!2}
+!dx.shaderModel = !{!3}
+!dx.resources = !{!4}
+!dx.entryPoints = !{!7}
+
+!0 = !{%dx.types.LinAlgMatrixC8M16N16U0S0 undef, i32 8, i32 16, i32 16, i32 0, i32 0}
+!1 = !{!"dxc(private) 1.9.0.5348 (issue-8433, 167fd829e-dirty)"}
+!2 = !{i32 1, i32 10}
+!3 = !{!"cs", i32 6, i32 10}
+!4 = !{!5, null, null, null}
+!5 = !{!6}
+!6 = !{i32 0, %struct.ByteAddressBuffer* undef, !"", i32 0, i32 0, i32 1, i32 11, i32 0, null}
+!7 = !{void ()* @main, !"main", null, !4, !8}
+!8 = !{i32 0, i64 8388625, i32 4, !9}
+!9 = !{i32 8, i32 1, i32 1}


### PR DESCRIPTION
Fixes #8433 

The validator was rejecting `%dx.types.LinAlgMatrix***` types causing debug build to be rejected. This PR notes that type as an allowed type