### PR TITLE
[202x] Support >> without spaces

### DIFF
--- a/tools/clang/lib/Parse/ParseExpr.cpp
+++ b/tools/clang/lib/Parse/ParseExpr.cpp
@@ -254,9 +254,11 @@ static bool isFoldOperator(tok::TokenKind Kind) {
 /// precedence of at least \p MinPrec.
 ExprResult
 Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
-  prec::Level NextTokPrec = getBinOpPrecedence(Tok.getKind(),
-                                               GreaterThanIsOperator,
-                                               getLangOpts().CPlusPlus11);
+  prec::Level NextTokPrec =
+      getBinOpPrecedence(Tok.getKind(), GreaterThanIsOperator,
+                         getLangOpts().CPlusPlus11 ||
+                             (getLangOpts().HLSL && getLangOpts().HLSLVersion >=
+                                                        hlsl::LangStd::v202x));
   SourceLocation ColonLoc;
 
   while (1) {
@@ -390,8 +392,11 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
     // Remember the precedence of this operator and get the precedence of the
     // operator immediately to the right of the RHS.
     prec::Level ThisPrec = NextTokPrec;
-    NextTokPrec = getBinOpPrecedence(Tok.getKind(), GreaterThanIsOperator,
-                                     getLangOpts().CPlusPlus11);
+    NextTokPrec = getBinOpPrecedence(
+        Tok.getKind(), GreaterThanIsOperator,
+        getLangOpts().CPlusPlus11 ||
+            (getLangOpts().HLSL &&
+             getLangOpts().HLSLVersion >= hlsl::LangStd::v202x));
 
     // Assignment and conditional expressions are right-associative.
     bool isRightAssoc = ThisPrec == prec::Conditional ||
@@ -424,8 +429,11 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
         LHS = ExprError();
       }
 
-      NextTokPrec = getBinOpPrecedence(Tok.getKind(), GreaterThanIsOperator,
-                                       getLangOpts().CPlusPlus11);
+      NextTokPrec = getBinOpPrecedence(
+          Tok.getKind(), GreaterThanIsOperator,
+          getLangOpts().CPlusPlus11 ||
+              (getLangOpts().HLSL &&
+               getLangOpts().HLSLVersion >= hlsl::LangStd::v202x));
     }
 
     if (!RHS.isInvalid() && RHSIsInitList) {

--- a/tools/clang/lib/Parse/ParseTemplate.cpp
+++ b/tools/clang/lib/Parse/ParseTemplate.cpp
@@ -840,7 +840,9 @@ bool Parser::ParseGreaterThanInTemplateList(SourceLocation &RAngleLoc,
       Hint2 = FixItHint::CreateInsertion(Next.getLocation(), " ");
 
     unsigned DiagId = diag::err_two_right_angle_brackets_need_space;
-    if (getLangOpts().CPlusPlus11 &&
+    if ((getLangOpts().CPlusPlus11 ||
+         (getLangOpts().HLSL &&
+          getLangOpts().HLSLVersion >= hlsl::LangStd::v202x)) &&
         (Tok.is(tok::greatergreater) || Tok.is(tok::greatergreatergreater)))
       DiagId = diag::warn_cxx98_compat_two_right_angle_brackets;
     else if (Tok.is(tok::greaterequal))

--- a/tools/clang/test/SemaHLSL/v2021/templates/template-right-angle-brackets.hlsl
+++ b/tools/clang/test/SemaHLSL/v2021/templates/template-right-angle-brackets.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -T lib_6_3 -HV 2021 -verify %s
+
+// In HLSL 2021, two consecutive right angle brackets (>>) in a template
+// argument list must be separated by a space. Using >> without spaces should
+// produce an error.
+
+template<typename T>
+struct Outer { T val; };
+
+template<typename T>
+struct Inner { T val; };
+
+// Nested template type using >> without space: should be an error in HLSL 2021.
+Outer<Inner<float>> g_nested; // expected-error {{a space is required between consecutive right angle brackets (use '> >')}}
+
+template<typename T>
+struct Wrapper {
+  Outer<Inner<T>> field; // expected-error {{a space is required between consecutive right angle brackets (use '> >')}}
+};
+
+// Function return type with nested template and >>.
+Outer<Inner<int>> getVal(); // expected-error {{a space is required between consecutive right angle brackets (use '> >')}}
+
+// Function parameter with nested template and >>.
+void takeVal(Outer<Inner<int>> v); // expected-error {{a space is required between consecutive right angle brackets (use '> >')}}
+
+// Three right angle brackets (>>>) in a template should also error.
+template<typename T, typename U>
+struct Pair { T first; U second; };
+
+Outer<Pair<float, Inner<int>>> g_triple; // expected-error {{a space is required between consecutive right angle brackets (use '> >')}}

--- a/tools/clang/test/SemaHLSL/v202x/templates/template-right-angle-brackets.hlsl
+++ b/tools/clang/test/SemaHLSL/v202x/templates/template-right-angle-brackets.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -T lib_6_3 -HV 202x -verify %s
+// RUN: %dxc -T lib_6_3 -HV 202x -ast-dump %s 2>&1 | FileCheck %s
+
+// In HLSL 202x, two consecutive right angle brackets (>>) are allowed in
+// template argument lists without spaces, matching C++11 behavior. No
+// diagnostic should be emitted for >> or >>> in this mode.
+
+// expected-no-diagnostics
+
+template<typename T>
+struct Outer { T val; };
+
+template<typename T>
+struct Inner { T val; };
+
+// Nested template type using >> without space: no error in HLSL 202x.
+// CHECK: VarDecl {{.*}} g_nested 'Outer<Inner<float> >'
+Outer<Inner<float>> g_nested;
+
+template<typename T>
+struct Wrapper {
+  // CHECK: FieldDecl {{.*}} field 'Outer<Inner<T> >'
+  Outer<Inner<T>> field;
+};
+
+// Function return type with nested template using >>.
+// CHECK: FunctionDecl {{.*}} getVal 'Outer<Inner<int> > ()'
+Outer<Inner<int>> getVal();
+
+// Function parameter using >>.
+// CHECK: FunctionDecl {{.*}} takeVal 'void (Outer<Inner<int> >)'
+void takeVal(Outer<Inner<int>> v);
+
+// Three right angle brackets (>>>) in a template: no error in HLSL 202x.
+template<typename T, typename U>
+struct Pair { T first; U second; };
+
+// CHECK: VarDecl {{.*}} g_triple 'Outer<Pair<float, Inner<int> > >'
+Outer<Pair<float, Inner<int>>> g_triple;


### PR DESCRIPTION
This allows HLSL templates to have double closing angle brackets without a space between them matching C++11 template parsing.