### PR TITLE
[SM6.10] Update InterlockedAccumulate Param Order

### DIFF
--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -652,7 +652,7 @@ OuterProduct(vector<InputElTy, M> VecA, vector<InputElTy, N> VecB) {
 
 template <typename InputElTy, SIZE_TYPE M>
 typename hlsl::enable_if<hlsl::is_arithmetic<InputElTy>::value, void>::type
-InterlockedAccumulate(RWByteAddressBuffer Res, vector<InputElTy, M> Vec,
+InterlockedAccumulate(vector<InputElTy, M> Vec, RWByteAddressBuffer Res,
                       uint StartOffset, uint Align = 64) {
   __builtin_LinAlg_VectorAccumulateToDescriptor(Vec, Res, StartOffset, Align);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/vectors.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/vectors.hlsl
@@ -193,9 +193,9 @@ void main(uint ID : SV_GroupID) {
   // CHECK: call void @dx.op.linAlgVectorAccumulateToDescriptor.v4f16(i32 -2147483617, <4 x half>
   // CHECK-SAME: <half 0xH4926, half 0xH4926, half 0xH4926, half 0xH4926>, %dx.types.Handle %{{[0-9]+}}, i32 0, i32 64)
   // CHECK-SAME: ; LinAlgVectorAccumulateToDescriptor(vector,handle,offset,align)
-  InterlockedAccumulate(RWBAB, vec1, 0);
+  InterlockedAccumulate(vec1, RWBAB, 0);
 
   // CHECK: call void @dx.op.linAlgVectorAccumulateToDescriptor.v8f16(i32 -2147483617, <8 x half> %{{[0-9]+}},
   // CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 8, i32 64) ; LinAlgVectorAccumulateToDescriptor(vector,handle,offset,align)
-  InterlockedAccumulate(RWBAB, vec2, 8);
+  InterlockedAccumulate(vec2, RWBAB, 8);
 }


### PR DESCRIPTION
Update the LinAlg header file in response to https://github.com/microsoft/hlsl-specs/pull/875

Swaps the InterlockedAccumulate parameters back to their original location