### PR TITLE
Add [[nodiscard]] attribute

### DIFF
--- a/tools/clang/include/clang/AST/Decl.h
+++ b/tools/clang/include/clang/AST/Decl.h
@@ -2079,6 +2079,10 @@ public:
   /// operators.
   bool hasUnusedResultAttr() const;
 
+  // HLSL Change Begin - Add support for nodiscard attribute.
+  Attr *getNoDiscardAttr() const;
+  // HLSL Change Ends
+
   /// \brief Returns the storage class as written in the source. For the
   /// computed linkage of symbol, see getLinkage.
   StorageClass getStorageClass() const { return StorageClass(SClass); }

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -2470,13 +2470,16 @@ def WarnUnused : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+// HLSL Change Begin - add C++11 spelling.
 def WarnUnusedResult : InheritableAttr {
-  let Spellings = [GCC<"warn_unused_result">,
+  let Spellings = [CXX11<"", "nodiscard", 2017>,
+                   GCC<"warn_unused_result">,
                    CXX11<"clang", "warn_unused_result">];
   let Subjects = SubjectList<[ObjCMethod, CXXRecord, FunctionLike], WarnDiag,
                              "ExpectedFunctionMethodOrClass">;
   let Documentation = [Undocumented];
 }
+// HLSL Change End - add C++11 spelling.
 
 def Weak : InheritableAttr {
   let Spellings = [GCC<"weak">];

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -2472,8 +2472,7 @@ def WarnUnused : InheritableAttr {
 
 // HLSL Change Begin - add C++11 spelling.
 def WarnUnusedResult : InheritableAttr {
-  let Spellings = [CXX11<"", "nodiscard", 2017>,
-                   GCC<"warn_unused_result">,
+  let Spellings = [CXX11<"", "nodiscard", 2017>, GCC<"warn_unused_result">,
                    CXX11<"clang", "warn_unused_result">];
   let Subjects = SubjectList<[ObjCMethod, CXXRecord, FunctionLike], WarnDiag,
                              "ExpectedFunctionMethodOrClass">;

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6368,9 +6368,11 @@ def warn_side_effects_unevaluated_context : Warning<
 def warn_side_effects_typeid : Warning<
   "expression with side effects will be evaluated despite being used as an "
   "operand to 'typeid'">, InGroup<PotentiallyEvaluatedExpression>;
+// HLSL Change Begin - allow attribute spelling to come in.
 def warn_unused_result : Warning<
-  "ignoring return value of function declared with warn_unused_result "
-  "attribute">, InGroup<DiagGroup<"unused-result">>;
+  "ignoring return value of function declared with %0 attribute">, 
+  InGroup<DiagGroup<"unused-result">>;
+// HLSL Change End
 def warn_unused_volatile : Warning<
   "expression result unused; assign into a variable to force a volatile load">,
   InGroup<DiagGroup<"unused-volatile-lvalue">>;

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6369,9 +6369,9 @@ def warn_side_effects_typeid : Warning<
   "expression with side effects will be evaluated despite being used as an "
   "operand to 'typeid'">, InGroup<PotentiallyEvaluatedExpression>;
 // HLSL Change Begin - allow attribute spelling to come in.
-def warn_unused_result : Warning<
-  "ignoring return value of function declared with %0 attribute">, 
-  InGroup<DiagGroup<"unused-result">>;
+def warn_unused_result
+    : Warning<"ignoring return value of function declared with %0 attribute">,
+      InGroup<DiagGroup<"unused-result">>;
 // HLSL Change End
 def warn_unused_volatile : Warning<
   "expression result unused; assign into a variable to force a volatile load">,

--- a/tools/clang/lib/AST/Decl.cpp
+++ b/tools/clang/lib/AST/Decl.cpp
@@ -2884,6 +2884,20 @@ bool FunctionDecl::hasUnusedResultAttr() const {
   return hasAttr<WarnUnusedResultAttr>();
 }
 
+// HLSL Change Begin - support nodiscard attr.
+Attr *FunctionDecl::getNoDiscardAttr() const {
+  QualType RetType = getReturnType();
+  if (RetType->isRecordType()) {
+    const CXXRecordDecl *Ret = RetType->getAsCXXRecordDecl();
+    const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(this);
+    if (Ret && Ret->hasAttr<WarnUnusedResultAttr>() &&
+        !(MD && MD->getCorrespondingMethodInClass(Ret, true)))
+      return Ret->getAttr<WarnUnusedResultAttr>();
+  }
+  return getAttr<WarnUnusedResultAttr>();
+}
+// HLSL Change End
+
 /// \brief For an inline function definition in C, or for a gnu_inline function
 /// in C++, determine whether the definition will be externally visible.
 ///

--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -289,8 +289,9 @@ class Matrix {
   }
 
   template <typename T>
-  static typename hlsl::enable_if<hlsl::is_arithmetic<T>::value, Matrix>::type
-  Splat(T Val) {
+  [[nodiscard]] static
+      typename hlsl::enable_if<hlsl::is_arithmetic<T>::value, Matrix>::type
+      Splat(T Val) {
     Matrix Result;
     __builtin_LinAlg_FillMatrix(Result.__handle, Val);
     return Result;

--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -248,8 +248,7 @@ void Sema::DiagnoseUnusedExprResult(const Stmt *S) {
         // HLSL Change Begin - allow attribute spelling to come in.
         Attr *NoDiscardAttr = Func ? Func->getNoDiscardAttr()
                                    : FD->getAttr<WarnUnusedResultAttr>();
-        Diag(Loc, diag::warn_unused_result)
-            << NoDiscardAttr << R1 << R2;
+        Diag(Loc, diag::warn_unused_result) << NoDiscardAttr << R1 << R2;
         // HLSL Change End
         return;
       }

--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -245,7 +245,12 @@ void Sema::DiagnoseUnusedExprResult(const Stmt *S) {
       const FunctionDecl *Func = dyn_cast<FunctionDecl>(FD);
       if (Func ? Func->hasUnusedResultAttr()
                : FD->hasAttr<WarnUnusedResultAttr>()) {
-        Diag(Loc, diag::warn_unused_result) << R1 << R2;
+        // HLSL Change Begin - allow attribute spelling to come in.
+        Attr *NoDiscardAttr = Func ? Func->getNoDiscardAttr()
+                                   : FD->getAttr<WarnUnusedResultAttr>();
+        Diag(Loc, diag::warn_unused_result)
+            << NoDiscardAttr << R1 << R2;
+        // HLSL Change End
         return;
       }
       if (ShouldSuppress)
@@ -270,7 +275,10 @@ void Sema::DiagnoseUnusedExprResult(const Stmt *S) {
     const ObjCMethodDecl *MD = ME->getMethodDecl();
     if (MD) {
       if (MD->hasAttr<WarnUnusedResultAttr>()) {
-        Diag(Loc, diag::warn_unused_result) << R1 << R2;
+        // HLSL Change Begin - allow attribute spelling to come in.
+        Diag(Loc, diag::warn_unused_result)
+            << MD->getAttr<WarnUnusedResultAttr>() << R1 << R2;
+        // HLSL Change End
         return;
       }
     }

--- a/tools/clang/test/SemaHLSL/attributes/nodiscard.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/nodiscard.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -I %hlsl_headers -T cs_6_10 -verify %s
+
+#include <dx/linalg.h>
+using namespace dx::linalg;
+
+using MatrixATy = Matrix<ComponentType::F32, 4, 4, MatrixUse::A, MatrixScope::Wave>;
+
+[nodiscard] int fn() { return 42; }
+[[nodiscard]] int fn2() { return 42; }
+
+[numthreads(4, 4, 4)]
+void main(uint ID : SV_GroupID)
+{
+  MatrixATy MatA1;
+  MatA1.Splat(1.0f); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  fn(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  fn2(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+}


### PR DESCRIPTION
This PR adds support for the `[[nodiscard]]` attribute so that diagnostics can be easily issued for cases where return types of functions should not be discarded.

This came up in feedback about the `Matrix::Fill` function in the linear algebra specification.