### PR TITLE
Fix modern MSVC compilation error on experimental/filesystem

### DIFF
--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -39,21 +39,17 @@
 #endif
 
 #if defined(_MSC_VER)
- // MSVC removed <experimental/filesystem> starting in VS 2019 16.3 (_MSC_VER >= 1922)
-  #if _MSC_VER < 1922
+  // MSVC removed <experimental/filesystem> starting in VS 2019 16.3 (_MSC_VER >= 1922)
+  #if (_MSC_VER >= 1920) && (_MSC_VER < 1922)
     #include <experimental/filesystem>
     namespace fs = std::experimental::filesystem;
   #else
     #include <filesystem>
     namespace fs = std::filesystem;
   #endif
-#elif defined(__has_include) && __has_include(<filesystem>) && \
-     (defined(__clang__) || !defined(__GNUC__) || __GNUC__ >= 8)
+#else
   #include <filesystem>
   namespace fs = std::filesystem;
-#else
-  #include <experimental/filesystem>
-  namespace fs = std::experimental::filesystem;
 #endif
  
 using namespace fs;

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -48,7 +48,7 @@
     namespace fs = std::filesystem;
   #endif
 #elif defined(__has_include) && __has_include(<filesystem>) && \
-     (!defined(__GNUC__) || __GNUC__ >= 8)
+     (defined(__clang__) || !defined(__GNUC__) || __GNUC__ >= 8)
   #include <filesystem>
   namespace fs = std::filesystem;
 #else
@@ -80,17 +80,17 @@ using namespace fs;
 
 #include <codecvt>
 
-// clang-format on
+    // clang-format on
 
-using namespace std;
-using namespace hlsl_test;
+    using namespace std;
+    using namespace hlsl_test;
 #ifdef _WIN32
 
-static uint8_t MaskCount(uint8_t V) {
-  DXASSERT_NOMSG(0 <= V && V <= 0xF);
-  static const uint8_t Count[16] = {0, 1, 1, 2, 1, 2, 2, 3,
-                                    1, 2, 2, 3, 2, 3, 3, 4};
-  return Count[V];
+    static uint8_t MaskCount(uint8_t V) {
+      DXASSERT_NOMSG(0 <= V && V <= 0xF);
+      static const uint8_t Count[16] = {0, 1, 1, 2, 1, 2, 2, 3,
+                                        1, 2, 2, 3, 2, 3, 3, 4};
+      return Count[V];
 }
 #endif
 

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -80,17 +80,17 @@ using namespace fs;
 
 #include <codecvt>
 
-    // clang-format on
+// clang-format on
 
-    using namespace std;
-    using namespace hlsl_test;
+using namespace std;
+using namespace hlsl_test;
 #ifdef _WIN32
 
-    static uint8_t MaskCount(uint8_t V) {
-      DXASSERT_NOMSG(0 <= V && V <= 0xF);
-      static const uint8_t Count[16] = {0, 1, 1, 2, 1, 2, 2, 3,
-                                        1, 2, 2, 3, 2, 3, 3, 4};
-      return Count[V];
+static uint8_t MaskCount(uint8_t V) {
+  DXASSERT_NOMSG(0 <= V && V <= 0xF);
+  static const uint8_t Count[16] = {0, 1, 1, 2, 1, 2, 2, 3,
+                                    1, 2, 2, 3, 2, 3, 3, 4};
+  return Count[V];
 }
 #endif
 

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -36,6 +36,7 @@
 #include <atlfile.h>
 #include <d3dcompiler.h>
 #pragma comment(lib, "d3dcompiler.lib")
+#endif
 
 #if defined(_MSC_VER)
  // MSVC removed <experimental/filesystem> starting in VS 2019 16.3 (_MSC_VER >= 1922)

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -36,13 +36,21 @@
 #include <atlfile.h>
 #include <d3dcompiler.h>
 #pragma comment(lib, "d3dcompiler.lib")
-#if _MSC_VER >= 1920
-#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#if defined(_MSC_VER)
+// MSVC removed <experimental/filesystem> starting in VS 2019 16.3 (_MSC_VER >- 1922)
+#if _MSC_VER < 1922
 #include  <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 #else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
 #endif
 #endif
+using namespace fs;
 
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
@@ -72,7 +80,6 @@ using namespace std;
 using namespace hlsl_test;
 #ifdef _WIN32
 
-using namespace std::experimental::filesystem;
 
 static uint8_t MaskCount(uint8_t V) {
   DXASSERT_NOMSG(0 <= V && V <= 0xF);

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -36,21 +36,26 @@
 #include <atlfile.h>
 #include <d3dcompiler.h>
 #pragma comment(lib, "d3dcompiler.lib")
+
 #if defined(_MSC_VER)
-// MSVC removed <experimental/filesystem> starting in VS 2019 16.3 (_MSC_VER >- 1922)
-#if _MSC_VER < 1922
-#include  <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+ // MSVC removed <experimental/filesystem> starting in VS 2019 16.3 (_MSC_VER >= 1922)
+  #if _MSC_VER < 1922
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+  #else
+    #include <filesystem>
+    namespace fs = std::filesystem;
+  #endif
+#elif defined(__has_include) && __has_include(<filesystem>) && \
+     (!defined(__GNUC__) || __GNUC__ >= 8)
+  #include <filesystem>
+  namespace fs = std::filesystem;
 #else
-#include <filesystem>
-namespace fs = std::filesystem;
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
 #endif
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-#endif
-using namespace fs;
+ 
+ using namespace fs;
 
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -55,7 +55,7 @@
   namespace fs = std::experimental::filesystem;
 #endif
  
- using namespace fs;
+using namespace fs;
 
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
@@ -84,7 +84,6 @@
 using namespace std;
 using namespace hlsl_test;
 #ifdef _WIN32
-
 
 static uint8_t MaskCount(uint8_t V) {
   DXASSERT_NOMSG(0 <= V && V <= 0xF);


### PR DESCRIPTION
Modern MSVC deperecated `experimental/filesystem`.
This causes build failures when building DXC with MSVC.
The deprecation occurred on version 1922, so we should account for this removal, instead of silencing deprecation warnings.
