### PR TITLE
Update nodiscard test

### DIFF
--- a/tools/clang/lib/AST/Decl.cpp
+++ b/tools/clang/lib/AST/Decl.cpp
@@ -2876,10 +2876,11 @@ bool FunctionDecl::hasUnusedResultAttr() const {
   QualType RetType = getReturnType();
   if (RetType->isRecordType()) {
     const CXXRecordDecl *Ret = RetType->getAsCXXRecordDecl();
-    const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(this);
-    if (Ret && Ret->hasAttr<WarnUnusedResultAttr>() &&
-        !(MD && MD->getCorrespondingMethodInClass(Ret, true)))
+    // HLSL Change Begin - nodiscard on a type should apply to all methods, even
+    // if they are not marked nodiscard themselves. This is the C++17 behavior.
+    if (Ret && Ret->hasAttr<WarnUnusedResultAttr>())
       return true;
+    // HLSL Change End
   }
   return hasAttr<WarnUnusedResultAttr>();
 }
@@ -2891,7 +2892,8 @@ Attr *FunctionDecl::getNoDiscardAttr() const {
     const CXXRecordDecl *Ret = RetType->getAsCXXRecordDecl();
     const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(this);
     if (Ret && Ret->hasAttr<WarnUnusedResultAttr>() &&
-        !(MD && MD->getCorrespondingMethodInClass(Ret, true)))
+        (!hasAttr<WarnUnusedResultAttr>() ||
+         !(MD && (MD->getCorrespondingMethodInClass(Ret, true)))))
       return Ret->getAttr<WarnUnusedResultAttr>();
   }
   return getAttr<WarnUnusedResultAttr>();

--- a/tools/clang/test/SemaHLSL/attributes/nodiscard.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/nodiscard.hlsl
@@ -8,6 +8,15 @@ using MatrixATy = Matrix<ComponentType::F32, 4, 4, MatrixUse::A, MatrixScope::Wa
 [nodiscard] int fn() { return 42; }
 [[nodiscard]] int fn2() { return 42; }
 
+struct [[nodiscard]] S {
+  int x;
+
+  [[clang::warn_unused_result]] static S fn4() { return (S)42; }
+  [[clang::warn_unused_result]] S fn5() { return (S)42; }
+};
+
+S fn3() { return (S)42; }
+
 [numthreads(4, 4, 4)]
 void main(uint ID : SV_GroupID)
 {
@@ -15,4 +24,8 @@ void main(uint ID : SV_GroupID)
   MatA1.Splat(1.0f); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   fn(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   fn2(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  fn3(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  S::fn4(); // expected-warning {{ignoring return value of function declared with 'warn_unused_result' attribute}}
+  S s;
+  s.fn5(); // expected-warning {{ignoring return value of function declared with 'warn_unused_result' attribute}}
 }

--- a/tools/clang/test/SemaHLSL/attributes/nodiscard.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/nodiscard.hlsl
@@ -13,6 +13,9 @@ struct [[nodiscard]] S {
 
   [[clang::warn_unused_result]] static S fn4() { return (S)42; }
   [[clang::warn_unused_result]] S fn5() { return (S)42; }
+
+  static S fn6() { return (S)42; }
+  S fn7() { return (S)42; }
 };
 
 S fn3() { return (S)42; }
@@ -28,4 +31,6 @@ void main(uint ID : SV_GroupID)
   S::fn4(); // expected-warning {{ignoring return value of function declared with 'warn_unused_result' attribute}}
   S s;
   s.fn5(); // expected-warning {{ignoring return value of function declared with 'warn_unused_result' attribute}}
+  S::fn6(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  s.fn7(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 }


### PR DESCRIPTION
This adds coverage of two uses missed in the original test. The first covers structs with nodiscard on the type declaration, the second covers selecting the method spelling of the attribute over the type attribute if both are present.