### PR TITLE
Disallow `auto` from infer types from `ResourceDescriptorHeap` and `SamplerDescriptorHeap`

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1196,6 +1196,17 @@ def HLSLHitObject : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+// HLSL Dynamic Resource Attribute
+// Marks the builtin `.Resource` / `.Sampler` placeholder record types used
+// for descriptor heap indexing (ResourceDescriptorHeap[i] /
+// SamplerDescriptorHeap[i]).
+def HLSLDynamicResource : InheritableAttr {
+  let Spellings = []; // No spellings!
+  let Args = [BoolArgument<"IsSampler">];
+  let Subjects = SubjectList<[CXXRecord]>;
+  let Documentation = [Undocumented];
+}
+
 // HLSL Parameter Attributes
 
 def HLSLMaxRecords : InheritableAttr {

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8066,6 +8066,10 @@ def err_hlsl_linalg_unsupported_stage : Error<
 def err_hlsl_pointers_unsupported : Error<
   "%select{pointers|references}0 are unsupported in HLSL">;
 
+def err_hlsl_auto_descriptor_heap : Error<
+  "'auto' cannot deduce the type of '%select{ResourceDescriptorHeap|SamplerDescriptorHeap}0'; "
+  "use a specific resource or sampler type instead">;
+
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -1319,6 +1319,8 @@ CXXRecordDecl *hlsl::DeclareResourceType(ASTContext &context, bool bSampler) {
   typeDeclBuilder.addField("h", GetHLSLObjectHandleType(context));
 
   CXXRecordDecl *recordDecl = typeDeclBuilder.getRecordDecl();
+  recordDecl->addAttr(
+      HLSLDynamicResourceAttr::CreateImplicit(context, bSampler));
 
   QualType indexType = context.UnsignedIntTy;
   QualType resultType = context.getRecordType(recordDecl);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -544,18 +544,16 @@ bool IsHLSLNodeInputType(clang::QualType type) {
 }
 
 bool IsHLSLDynamicResourceType(clang::QualType type) {
-  if (const RecordType *RT = type->getAs<RecordType>()) {
-    StringRef name = RT->getDecl()->getName();
-    return name == ".Resource";
-  }
+  if (const HLSLDynamicResourceAttr *Attr =
+          getAttr<HLSLDynamicResourceAttr>(type))
+    return !Attr->getIsSampler();
   return false;
 }
 
 bool IsHLSLDynamicSamplerType(clang::QualType type) {
-  if (const RecordType *RT = type->getAs<RecordType>()) {
-    StringRef name = RT->getDecl()->getName();
-    return name == ".Sampler";
-  }
+  if (const HLSLDynamicResourceAttr *Attr =
+          getAttr<HLSLDynamicResourceAttr>(type))
+    return Attr->getIsSampler();
   return false;
 }
 

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -6417,6 +6417,35 @@ static bool checkForConflictWithNonVisibleExternC(Sema &S, const T *ND,
   return false;
 }
 
+// HLSL Change Begin - detect initializers sourced from descriptor heap globals.
+static bool IsDescriptorHeapInitializer(const Expr *Init, bool &IsSampler) {
+  if (!Init)
+    return false;
+  Init = Init->IgnoreParenImpCasts();
+  // Peel one level of operator[] (the heap is indexed to produce a resource).
+  if (const auto *OpCall = dyn_cast<CXXOperatorCallExpr>(Init)) {
+    if (OpCall->getOperator() == OO_Subscript && OpCall->getNumArgs() >= 1)
+      Init = OpCall->getArg(0)->IgnoreParenImpCasts();
+  }
+  const auto *DRE = dyn_cast<DeclRefExpr>(Init);
+  if (!DRE)
+    return false;
+  const auto *VD = dyn_cast<VarDecl>(DRE->getDecl());
+  if (!VD || !VD->isImplicit())
+    return false;
+  StringRef Name = VD->getName();
+  if (Name == "ResourceDescriptorHeap") {
+    IsSampler = false;
+    return true;
+  }
+  if (Name == "SamplerDescriptorHeap") {
+    IsSampler = true;
+    return true;
+  }
+  return false;
+}
+// HLSL Change End
+
 void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
   // If the decl is already known invalid, don't check it.
   if (NewVD->isInvalidDecl())
@@ -9026,6 +9055,19 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
       RealDecl->setInvalidDecl();
       return;
     }
+
+    // HLSL Change Begin - disallow 'auto' deducing descriptor heap types.
+    if (getLangOpts().HLSL) {
+      bool IsSampler = false;
+      if (IsDescriptorHeapInitializer(DeduceInit, IsSampler)) {
+        Diag(VDecl->getLocation(), diag::err_hlsl_auto_descriptor_heap)
+            << IsSampler;
+        VDecl->setInvalidDecl();
+        return;
+      }
+    }
+    // HLSL Change End
+
     VDecl->setType(DeducedType);
     assert(VDecl->isLinkageValid());
 

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -6421,15 +6421,12 @@ static bool checkForConflictWithNonVisibleExternC(Sema &S, const T *ND,
 static bool IsDynamicHeapInitializer(const Expr *Init, bool &IsSampler) {
   if (!Init)
     return false;
-  const auto *RT = Init->IgnoreParenImpCasts()->getType()->getAs<RecordType>();
-  if (!RT)
-    return false;
-  StringRef N = RT->getDecl()->getName();
-  if (N == ".Sampler") {
+  QualType T = Init->IgnoreParenImpCasts()->getType();
+  if (hlsl::IsHLSLDynamicSamplerType(T)) {
     IsSampler = true;
     return true;
   }
-  if (N == ".Resource") {
+  if (hlsl::IsHLSLDynamicResourceType(T)) {
     IsSampler = false;
     return true;
   }

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -6418,11 +6418,6 @@ static bool checkForConflictWithNonVisibleExternC(Sema &S, const T *ND,
   return false;
 }
 
-// HLSL Change Begin - detect initializers sourced from descriptor heap globals.
-// The descriptor-heap globals have implicit record types tagged ".Resource" /
-// ".Sampler" (see DeclareResourceType in ASTContextHLSL.cpp). Leading-dot tag
-// names cannot be authored by user code, so the type alone identifies the
-// source -- covering both bare references and subscripted heap accesses.
 static bool IsDescriptorHeapInitializer(const Expr *Init, bool &IsSampler) {
   if (!Init)
     return false;
@@ -6441,7 +6436,6 @@ static bool IsDescriptorHeapInitializer(const Expr *Init, bool &IsSampler) {
   }
   return false;
 }
-// HLSL Change End
 
 void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
   // If the decl is already known invalid, don't check it.
@@ -9053,7 +9047,6 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
       return;
     }
 
-    // HLSL Change Begin - disallow 'auto' deducing descriptor heap types.
     if (getLangOpts().HLSL) {
       bool IsSampler = false;
       if (IsDescriptorHeapInitializer(DeduceInit, IsSampler)) {
@@ -9063,7 +9056,6 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
         return;
       }
     }
-    // HLSL Change End
 
     VDecl->setType(DeducedType);
     assert(VDecl->isLinkageValid());

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -6418,7 +6418,7 @@ static bool checkForConflictWithNonVisibleExternC(Sema &S, const T *ND,
   return false;
 }
 
-static bool IsDescriptorHeapInitializer(const Expr *Init, bool &IsSampler) {
+static bool IsDynamicHeapInitializer(const Expr *Init, bool &IsSampler) {
   if (!Init)
     return false;
   const auto *RT =
@@ -9049,7 +9049,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
 
     if (getLangOpts().HLSL) {
       bool IsSampler = false;
-      if (IsDescriptorHeapInitializer(DeduceInit, IsSampler)) {
+      if (IsDynamicHeapInitializer(DeduceInit, IsSampler)) {
         Diag(VDecl->getLocation(), diag::err_hlsl_auto_descriptor_heap)
             << IsSampler;
         VDecl->setInvalidDecl();

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -13,6 +13,7 @@
 
 #include "TypeLocBuilder.h"
 #include "dxc/DXIL/DxilSemantic.h" // HLSL Change
+#include "dxc/HlslIntrinsicOp.h"   // HLSL Change
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTLambda.h"
@@ -6418,28 +6419,24 @@ static bool checkForConflictWithNonVisibleExternC(Sema &S, const T *ND,
 }
 
 // HLSL Change Begin - detect initializers sourced from descriptor heap globals.
+// The descriptor-heap globals have implicit record types tagged ".Resource" /
+// ".Sampler" (see DeclareResourceType in ASTContextHLSL.cpp). Leading-dot tag
+// names cannot be authored by user code, so the type alone identifies the
+// source -- covering both bare references and subscripted heap accesses.
 static bool IsDescriptorHeapInitializer(const Expr *Init, bool &IsSampler) {
   if (!Init)
     return false;
-  Init = Init->IgnoreParenImpCasts();
-  // Peel one level of operator[] (the heap is indexed to produce a resource).
-  if (const auto *OpCall = dyn_cast<CXXOperatorCallExpr>(Init)) {
-    if (OpCall->getOperator() == OO_Subscript && OpCall->getNumArgs() >= 1)
-      Init = OpCall->getArg(0)->IgnoreParenImpCasts();
-  }
-  const auto *DRE = dyn_cast<DeclRefExpr>(Init);
-  if (!DRE)
+  const auto *RT =
+      Init->IgnoreParenImpCasts()->getType()->getAs<RecordType>();
+  if (!RT)
     return false;
-  const auto *VD = dyn_cast<VarDecl>(DRE->getDecl());
-  if (!VD || !VD->isImplicit())
-    return false;
-  StringRef Name = VD->getName();
-  if (Name == "ResourceDescriptorHeap") {
-    IsSampler = false;
+  StringRef N = RT->getDecl()->getName();
+  if (N == ".Sampler") {
+    IsSampler = true;
     return true;
   }
-  if (Name == "SamplerDescriptorHeap") {
-    IsSampler = true;
+  if (N == ".Resource") {
+    IsSampler = false;
     return true;
   }
   return false;

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -6421,8 +6421,7 @@ static bool checkForConflictWithNonVisibleExternC(Sema &S, const T *ND,
 static bool IsDynamicHeapInitializer(const Expr *Init, bool &IsSampler) {
   if (!Init)
     return false;
-  const auto *RT =
-      Init->IgnoreParenImpCasts()->getType()->getAs<RecordType>();
+  const auto *RT = Init->IgnoreParenImpCasts()->getType()->getAs<RecordType>();
   if (!RT)
     return false;
   StringRef N = RT->getDecl()->getName();

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic-resource-ast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic-resource-ast.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T ps_6_6 -ast-dump-implicit %s | FileCheck %s
+
+
+float4 main(float4 pos : SV_Position) : SV_Target {
+  Texture2D<float4> tex = ResourceDescriptorHeap[0];
+  SamplerState samp = SamplerDescriptorHeap[0];
+  return tex.Sample(samp, pos.xy);
+}
+
+// CHECK: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct .Resource definition
+// CHECK: HLSLDynamicResourceAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit
+
+// CHECK: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct .Sampler definition
+// CHECK: HLSLDynamicResourceAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit IsSampler

--- a/tools/clang/test/HLSLFileCheckLit/hlsl/auto/auto-no-descriptor-heap.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/hlsl/auto/auto-no-descriptor-heap.hlsl
@@ -1,33 +1,25 @@
 // RUN: %dxc -T ps_6_6 -HV 202x -verify %s
 
-// Test that 'auto' cannot be used to deduce the type of ResourceDescriptorHeap
-// or SamplerDescriptorHeap indexed values. Users must spell out a concrete
-// resource or sampler type so the heap entry can be cast to the intended kind.
 
 int someFunc() { return 7; }
 
 float4 main(float4 pos : SV_Position) : SV_Target {
-    // Indexed heap access -- the operator[] peel finds the heap DeclRefExpr.
     // expected-error@+1 {{'auto' cannot deduce the type of 'ResourceDescriptorHeap'}}
     auto tex = ResourceDescriptorHeap[0];
     // expected-error@+1 {{'auto' cannot deduce the type of 'SamplerDescriptorHeap'}}
     auto samp = SamplerDescriptorHeap[0];
 
-    // Bare heap reference -- no subscript, plain DeclRefExpr.
     // expected-error@+1 {{'auto' cannot deduce the type of 'ResourceDescriptorHeap'}}
     auto heap = ResourceDescriptorHeap;
     // expected-error@+1 {{'auto' cannot deduce the type of 'SamplerDescriptorHeap'}}
     auto sheap = SamplerDescriptorHeap;
 
-    // Parenthesized -- IgnoreParenImpCasts strips the ParenExpr.
     // expected-error@+1 {{'auto' cannot deduce the type of 'SamplerDescriptorHeap'}}
     auto pSamp = (SamplerDescriptorHeap[0]);
     // expected-error@+1 {{'auto' cannot deduce the type of 'ResourceDescriptorHeap'}}
     auto pHeap = (ResourceDescriptorHeap);
 
-    // Negative cases -- auto deduces a regular type; no diagnostic expected.
-    auto sum = 1 + 2;
-    auto called = someFunc();
+    // Negative case
     Texture2D<float4> tex2 = ResourceDescriptorHeap[1];
     auto sampled = tex2.Sample((SamplerState)SamplerDescriptorHeap[0], pos.xy);
 

--- a/tools/clang/test/HLSLFileCheckLit/hlsl/auto/auto-no-descriptor-heap.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/hlsl/auto/auto-no-descriptor-heap.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -T ps_6_6 -HV 202x -verify %s
+
+// Test that 'auto' cannot be used to deduce the type of ResourceDescriptorHeap
+// or SamplerDescriptorHeap indexed values. Users must spell out a concrete
+// resource or sampler type so the heap entry can be cast to the intended kind.
+
+int someFunc() { return 7; }
+
+float4 main(float4 pos : SV_Position) : SV_Target {
+    // Indexed heap access -- the operator[] peel finds the heap DeclRefExpr.
+    // expected-error@+1 {{'auto' cannot deduce the type of 'ResourceDescriptorHeap'}}
+    auto tex = ResourceDescriptorHeap[0];
+    // expected-error@+1 {{'auto' cannot deduce the type of 'SamplerDescriptorHeap'}}
+    auto samp = SamplerDescriptorHeap[0];
+
+    // Bare heap reference -- no subscript, plain DeclRefExpr.
+    // expected-error@+1 {{'auto' cannot deduce the type of 'ResourceDescriptorHeap'}}
+    auto heap = ResourceDescriptorHeap;
+    // expected-error@+1 {{'auto' cannot deduce the type of 'SamplerDescriptorHeap'}}
+    auto sheap = SamplerDescriptorHeap;
+
+    // Parenthesized -- IgnoreParenImpCasts strips the ParenExpr.
+    // expected-error@+1 {{'auto' cannot deduce the type of 'SamplerDescriptorHeap'}}
+    auto pSamp = (SamplerDescriptorHeap[0]);
+    // expected-error@+1 {{'auto' cannot deduce the type of 'ResourceDescriptorHeap'}}
+    auto pHeap = (ResourceDescriptorHeap);
+
+    // Negative cases -- auto deduces a regular type; no diagnostic expected.
+    auto sum = 1 + 2;
+    auto called = someFunc();
+    Texture2D<float4> tex2 = ResourceDescriptorHeap[1];
+    auto sampled = tex2.Sample((SamplerState)SamplerDescriptorHeap[0], pos.xy);
+
+    return float4(0, 0, 0, 0);
+}


### PR DESCRIPTION
This patch builds on top of https://github.com/microsoft/DirectXShaderCompiler/pull/8452, by disallowing auto to infer the types being read from dynamic sampler and resource heaps. 

Part of: https://github.com/microsoft/DirectXShaderCompiler/issues/8450