### PR TITLE
[NFC] Replacing .Resource and .Sampler with attribute check

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1021,8 +1021,9 @@ bool isResourceDescriptorHeap(const Decl *D) {
 }
 
 bool isResourceDescriptorHeap(QualType T) {
-  const RecordType *RT = T->getAs<RecordType>();
-  return RT && RT->getDecl()->getName() == ".Resource";
+  const HLSLDynamicResourceAttr *Attr =
+          getAttr<HLSLDynamicResourceAttr>(T);
+  return Attr && !Attr->getIsSampler();
 }
 
 bool isSamplerDescriptorHeap(const Decl *D) {
@@ -1031,8 +1032,9 @@ bool isSamplerDescriptorHeap(const Decl *D) {
 }
 
 bool isSamplerDescriptorHeap(QualType T) {
-  const RecordType *RT = T->getAs<RecordType>();
-  return RT && RT->getDecl()->getName() == ".Sampler";
+  const HLSLDynamicResourceAttr *Attr =
+          getAttr<HLSLDynamicResourceAttr>(T);
+  return Attr && Attr->getIsSampler();
 }
 
 bool isAKindOfStructuredOrByteBuffer(QualType type) {

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1021,8 +1021,7 @@ bool isResourceDescriptorHeap(const Decl *D) {
 }
 
 bool isResourceDescriptorHeap(QualType T) {
-  const HLSLDynamicResourceAttr *Attr =
-          getAttr<HLSLDynamicResourceAttr>(T);
+  const HLSLDynamicResourceAttr *Attr = T->getAs<HLSLDynamicResourceAttr>();
   return Attr && !Attr->getIsSampler();
 }
 
@@ -1032,8 +1031,7 @@ bool isSamplerDescriptorHeap(const Decl *D) {
 }
 
 bool isSamplerDescriptorHeap(QualType T) {
-  const HLSLDynamicResourceAttr *Attr =
-          getAttr<HLSLDynamicResourceAttr>(T);
+  const HLSLDynamicResourceAttr *Attr = T->getAs<HLSLDynamicResourceAttr>();
   return Attr && Attr->getIsSampler();
 }
 

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -23,6 +23,25 @@ clang::DiagnosticBuilder emitError(const clang::ASTContext &astContext,
       clang::DiagnosticsEngine::Error, message);
   return astContext.getDiagnostics().Report(srcLoc, diagId);
 }
+
+// Returns the attribute of the given type attached to the record declaration
+// behind \p type, or nullptr if there is none. Attributes live on the
+// declaration, so they cannot be retrieved with QualType::getAs (which only
+// navigates the clang::Type hierarchy).
+template <typename AttrType> AttrType *getAttr(clang::QualType type) {
+  type = type.getCanonicalType();
+  if (const clang::RecordType *RT = type->getAs<clang::RecordType>()) {
+    if (const auto *Spec =
+            clang::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+                RT->getDecl()))
+      if (const auto *Template = clang::dyn_cast<clang::ClassTemplateDecl>(
+              Spec->getSpecializedTemplate()))
+        return Template->getTemplatedDecl()->getAttr<AttrType>();
+    if (const auto *Decl = clang::dyn_cast<clang::CXXRecordDecl>(RT->getDecl()))
+      return Decl->getAttr<AttrType>();
+  }
+  return nullptr;
+}
 } // namespace
 
 namespace clang {
@@ -1021,7 +1040,7 @@ bool isResourceDescriptorHeap(const Decl *D) {
 }
 
 bool isResourceDescriptorHeap(QualType T) {
-  const HLSLDynamicResourceAttr *Attr = T->getAs<HLSLDynamicResourceAttr>();
+  const HLSLDynamicResourceAttr *Attr = getAttr<HLSLDynamicResourceAttr>(T);
   return Attr && !Attr->getIsSampler();
 }
 
@@ -1031,7 +1050,7 @@ bool isSamplerDescriptorHeap(const Decl *D) {
 }
 
 bool isSamplerDescriptorHeap(QualType T) {
-  const HLSLDynamicResourceAttr *Attr = T->getAs<HLSLDynamicResourceAttr>();
+  const HLSLDynamicResourceAttr *Attr = getAttr<HLSLDynamicResourceAttr>(T);
   return Attr && Attr->getIsSampler();
 }
 


### PR DESCRIPTION
This patch cleans up a few places that use a string check to use an attribute check.