### PR TITLE
[MSVC] Fix a warning that is a default-error on modern MSVC

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -576,7 +576,7 @@ namespace llvm {
 // allowed), but (b) misclassifies the the construction as nothrow. Newer libc++
 // releases reject user specializations of this trait outright, and also compute
 // the trait correctly without help.
-#if !defined(_LIBCPP_VERSION)
+#if !defined(_LIBCPP_VERSION) && (!defined(_MSC_VER) || _MSC_VER < 1951)
 namespace std {
   template<>
   struct is_nothrow_constructible <std::string, llvm::StringRef>

--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -576,7 +576,8 @@ namespace llvm {
 // allowed), but (b) misclassifies the the construction as nothrow. Newer libc++
 // releases reject user specializations of this trait outright, and also compute
 // the trait correctly without help.
-#if !defined(_LIBCPP_VERSION) && (!defined(_MSC_VER) || _MSC_VER < 1951)
+#if !defined(_LIBCPP_VERSION) &&                                               \
+    !(defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202604L)
 namespace std {
   template<>
   struct is_nothrow_constructible <std::string, llvm::StringRef>


### PR DESCRIPTION
There are warnings emitted:
```
C:\actions-runner\_work\offload-test-suite\offload-test-suite\DXC\include\llvm/ADT/StringRef.h(582): error C2220: the following warning is treated  as an error                                                                                                                                         
C:\actions-runner\_work\offload-test-suite\offload-test-suite\DXC\include\llvm/ADT/StringRef.h(582): warning C5285: cannot declare a specialization for 'std::is_nothrow_constructible': Specializing this standard library template is forbidden by N5014 [meta.rqmts]/4                               
C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.51.36231\include\type_traits(1014): note: see declaration of                 'std::is_nothrow_constructible'                                                                                                                     
C:\actions-runner\_work\offload-test-suite\offload-test-suite\DXC\include\llvm/ADT/StringRef.h(582): note: to simplify migration, consider the      temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings              
```
that can be remedied by guarding the specialization against the MSVC STL version that forbids it.
This PR adds an extra condition (!(defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE >= 202604L)) to skip the std::is_nothrow_constructible specializations on MSVC STL releases that enforce N5014 [meta.rqmts]/4. This is more precise than checking _MSC_VER because the restriction comes from the STL headers, not the compiler itself. Newer STL versions compute the trait correctly without the workaround.

The build fails because /WX treats the warning as an error (C2220).
Assisted by: Github Copilot
Resolves https://github.com/microsoft/DirectXShaderCompiler/issues/8449