### PR TITLE
Prevent experimental RDAT on v1.9

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -83,6 +83,7 @@ enum class RuntimeDataPartType : uint32_t {
 
   LastPlus1,
   LastExperimental = LastPlus1 - 1,
+  LastRelease = Last_1_8,
 
   DxilPdbInfoTable = RDAT_PART_ID_WITH_GROUP(RuntimeDataGroup::PdbInfo, 1),
   DxilPdbInfoSourceTable =
@@ -99,8 +100,8 @@ inline RuntimeDataPartType MaxPartTypeForValVer(unsigned Major,
              ? RuntimeDataPartType::Last_1_3
          : DXIL::CompareVersions(Major, Minor, 1, 8) < 0
              ? RuntimeDataPartType::Last_1_4
-         : DXIL::CompareVersions(Major, Minor, 1, 8) == 0
-             ? RuntimeDataPartType::Last_1_8
+         : DXIL::CompareVersions(Major, Minor, 1, 9) <= 0
+             ? RuntimeDataPartType::LastRelease
              : RuntimeDataPartType::LastExperimental;
 }
 


### PR DESCRIPTION
In the 1.9 release, we are potentially emitting experimental RDAT tables, depending on the contents of the library. These could break/crash when read by a future version of the D3D runtime with any changes to final RDAT that conflict with current pre-release tables.

This change adds `RuntimeDataPartType::LastRelease` and updates the `MaxPartTypeForValVer` function to require 1.10 for pre-release tables.

This change would prevent a released compiler version `1.9` from including pre-release RDAT tables, but does not prevent main from producing pre-release RDAT tables where the validator version is already `1.10`.

Addresses #8272 for a release branch, but not completely for main. Recommend merging and cherry-picking this to the release branch. PR #8524 will address the remainder of the issue for main.