### PR TITLE
Prevent experimental RDAT on released shader models

### DIFF
--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1006,6 +1006,12 @@ private:
 
   unsigned m_ValMajor, m_ValMinor;
 
+  // Prerelease data is guarded behind this flag. Only supported when targeting
+  // a prerelease shader model. When transitioning data to release, look for
+  // uses of this flag to update code to check the validator version for the new
+  // release version instead.
+  bool m_AllowPrereleaseData = false;
+
   void
   FindUsingFunctions(const llvm::Value *User,
                      llvm::SmallVectorImpl<const llvm::Function *> &functions) {
@@ -1547,8 +1553,7 @@ private:
             if (entryProps.props.IsNode()) {
               shaderInfo = AddShaderNodeInfo(DM, function, entryProps, *pInfo2,
                                              TGSMInFunc[&function]);
-            } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) >
-                       0) {
+            } else if (m_AllowPrereleaseData) {
               shaderInfo =
                   AddShaderInfo(function, entryProps, *pInfo2,
                                 compatInfo.shaderFlags, TGSMInFunc[&function]);
@@ -1658,6 +1663,14 @@ public:
     mod.GetValidatorVersion(m_ValMajor, m_ValMinor);
     RDAT::RuntimeDataPartType maxAllowedType =
         RDAT::MaxPartTypeForValVer(m_ValMajor, m_ValMinor);
+
+    // Only write prerelease tables if the shader model is prerelease, to avoid
+    // writing prerelease data into release shader models, which might not be
+    // comatible with newer runtimes.
+    m_AllowPrereleaseData = mod.GetShaderModel()->IsPreReleaseShaderModel();
+    if (!m_AllowPrereleaseData)
+      maxAllowedType =
+          std::min(maxAllowedType, RDAT::RuntimeDataPartType::LastRelease);
 
     mod.ComputeShaderCompatInfo();
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/amp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/amp-groupshared.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_7 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -T lib_6_10 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
@@ -64,7 +64,7 @@
 // CHECK:    FunctionCount: 1
 // CHECK:  ID3D12FunctionReflection:
 // CHECK:    D3D12_FUNCTION_DESC: Name: amplification
-// CHECK:      Shader Version: Amplification 6.7
+// CHECK:      Shader Version: Amplification 6.10
 // CHECK:      Flags: 0
 // CHECK:      ConstantBuffers: 0
 // CHECK:      BoundResources: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_5 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -T lib_6_10 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
@@ -82,7 +82,7 @@
 // CHECK:    FunctionCount: 1
 // CHECK:  ID3D12FunctionReflection:
 // CHECK:    D3D12_FUNCTION_DESC: Name: main
-// CHECK:      Shader Version: Compute 6.5
+// CHECK:      Shader Version: Compute 6.10
 // CHECK:      Creator: <nullptr>
 // CHECK:      Flags: 0
 // CHECK:      ConstantBuffers: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -exports VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;PS_RENAMED=PSMain -T lib_6_3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -exports VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;PS_RENAMED=PSMain -T lib_6_10 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<float> T_unused;
 
@@ -154,7 +154,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:     FunctionCount: 3
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?PS_RENAMED{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
@@ -179,7 +179,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
@@ -194,7 +194,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: PS_RENAMED
-// CHECK:       Shader Version: Pixel 6.3
+// CHECK:       Shader Version: Pixel 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -exports VSMain;VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;RayGen1,RayGen2=RayGen -T lib_6_3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -exports VSMain;VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;RayGen1,RayGen2=RayGen -T lib_6_10 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<int> T0;
 
@@ -166,7 +166,7 @@ void RayGen() {
 // CHECK:     FunctionCount: 4
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGen1{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: RayGeneration 6.3
+// CHECK:       Shader Version: RayGeneration 6.10
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: U0
@@ -181,7 +181,7 @@ void RayGen() {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGen2{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: RayGeneration 6.3
+// CHECK:       Shader Version: RayGeneration 6.10
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: U0
@@ -196,7 +196,7 @@ void RayGen() {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
@@ -211,7 +211,7 @@ void RayGen() {
 // CHECK:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: VSMain
-// CHECK:       Shader Version: Vertex 6.3
+// CHECK:       Shader Version: Vertex 6.10
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -exports PSMain,PSMain_Clone1,PSMain_Clone2=PSMain -T lib_6_3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -exports PSMain,PSMain_Clone1,PSMain_Clone2=PSMain -T lib_6_10 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<int> T0;
 
@@ -207,7 +207,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:     FunctionCount: 6
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
@@ -232,7 +232,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain_Clone1{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
@@ -257,7 +257,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain_Clone2{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
@@ -282,7 +282,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: PSMain
-// CHECK:       Shader Version: Pixel 6.3
+// CHECK:       Shader Version: Pixel 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
@@ -307,7 +307,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: PSMain_Clone1
-// CHECK:       Shader Version: Pixel 6.3
+// CHECK:       Shader Version: Pixel 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
@@ -332,7 +332,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: PSMain_Clone2
-// CHECK:       Shader Version: Pixel 6.3
+// CHECK:       Shader Version: Pixel 6.10
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
 // CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -T lib_6_3 -exports HSMain1;HSMain3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -T lib_6_10 -exports HSMain1;HSMain3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<float> T_unused;
 
@@ -278,24 +278,24 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:     FunctionCount: 5
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSMain1{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK-NOT:     D3D12_FUNCTION_DESC: Name: \01?HSMain2{{[@$?.A-Za-z0-9_]+}}
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSMain3{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+}}
-// CHECK:       Shader Version: Library 6.3
+// CHECK:       Shader Version: Library 6.10
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK-NOT:     D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc2{{[@$?.A-Za-z0-9_]+}}
 // CHECK:     D3D12_FUNCTION_DESC: Name: HSMain1
-// CHECK:       Shader Version: Hull 6.3
+// CHECK:       Shader Version: Hull 6.10
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
 // CHECK-NOT:     D3D12_FUNCTION_DESC: Name: HSMain2
 // CHECK:     D3D12_FUNCTION_DESC: Name: HSMain3
-// CHECK:       Shader Version: Hull 6.3
+// CHECK:       Shader Version: Hull 6.10
 // CHECK:       BoundResources: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_7 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -T lib_6_10 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
@@ -153,7 +153,7 @@
 // CHECK:    FunctionCount: 1
 // CHECK:  ID3D12FunctionReflection:
 // CHECK:    D3D12_FUNCTION_DESC: Name: main
-// CHECK:      Shader Version: Mesh 6.7
+// CHECK:      Shader Version: Mesh 6.10
 // CHECK:      Creator: <nullptr>
 // CHECK:      Flags: 0
 // CHECK:      ConstantBuffers: 0


### PR DESCRIPTION
Normally, what's allowed in RDAT is based on the validator version in order to be compatible with a released validator. However, for in-development/experimental RDAT, we should base this on whether the shader model is experimental instead.

This change makes it so that an experimental shader model is required as a target to get experimental tables in RDAT.

Fixes #8272

Draft because it depends on #8523