### PR TITLE
Cherry Pick for release 1.9: [NFC][HLSLExec][LongVectors] Make derivative test literals explicitly typed

### DIFF
--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1440,14 +1440,14 @@ template <typename T> struct ExpectedBuilder<OpType::ModF, T> {
 // The value of A in each lane is computed by : A = A + LaneID*2
 //
 // Top right (lane 1) - Top Left (lane 0)
-DEFAULT_OP_1(OpType::DerivativeDdx, ((A + 2) - (A + 0)));
+DEFAULT_OP_1(OpType::DerivativeDdx, ((A + T(2.0f)) - (A + T(0.0f))));
 // Lower left (lane 2) -  Top Left (lane 0)
-DEFAULT_OP_1(OpType::DerivativeDdy, ((A + 4) - (A + 0)));
+DEFAULT_OP_1(OpType::DerivativeDdy, ((A + T(4.0f)) - (A + T(0.0f))));
 
 // Bottom right (lane 3) - Bottom left (lane 2)
-DEFAULT_OP_1(OpType::DerivativeDdxFine, ((A + 6) - (A + 4)));
+DEFAULT_OP_1(OpType::DerivativeDdxFine, ((A + T(6.0f)) - (A + T(4.0f))));
 // Bottom right (lane 3) - Top right (lane 1)
-DEFAULT_OP_1(OpType::DerivativeDdyFine, ((A + 6) - (A + 2)));
+DEFAULT_OP_1(OpType::DerivativeDdyFine, ((A + T(6.0f)) - (A + T(2.0f))));
 
 //
 // Quad Read Ops


### PR DESCRIPTION
Cherry pick 505629f6106892053a748644fe67e6a19635b0c9 from https://github.com/microsoft/DirectXShaderCompiler/pull/8516

Wrap the bare integer literals in the DerivativeDdx/DerivativeDdy expected-result expressions in T(...) so the arithmetic resolves cleanly under clang's stricter overload resolution.

Previously: `((A + 2) - (A + 0))` — `A` is of template parameter type `T` (e.g. `HLSLHalf_t`, `HLSLMin16Float_t`). `T + int` has no unambiguous overload for those wrapper types and clang rejects it; MSVC accepted via implicit-conversion ranking.

Now: `((A + T(2.0f)) - (A + T(0.0f)))` — the literal is constructed as `T` first, so `operator+` resolves to the type's own implementation. The value is bit-identical to the previous code path on MSVC.

No behavior change. Affects only the 4 `DEFAULT_OP_1(OpType::DerivativeDd[xy][Fine?], ...)` rows around line 1352.