### PR TITLE
Skip static cbuffer variables in explicit layout indexing

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -309,6 +309,11 @@ bool shouldSkipInStructLayout(const Decl *decl) {
   // Ignore embeded function decls
   if (isa<FunctionDecl>(decl))
     return true;
+  // Ignore static variables. They are not part of struct-like explicit
+  // layouts and should not consume a member index.
+  if (const auto *varDecl = dyn_cast<VarDecl>(decl))
+    if (varDecl->getStorageClass() == StorageClass::SC_Static)
+      return true;
   // Ignore empty decls
   if (isa<EmptyDecl>(decl))
     return true;

--- a/tools/clang/test/CodeGenSPIRV/var.static-const.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.static-const.cbuffer.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T ps_6_0 -E main %s -spirv 2>&1 | FileCheck %s
+
+cbuffer MetadataCB {
+    uint m0; static const int c0 = 0;
+    uint m1; static const int c1 = 0;
+    uint m2; static const int c2 = 0;
+};
+
+float4 main() : SV_Target {
+    return float4(asfloat(m2), 0, 0, 0);
+}
+
+// CHECK: warning: cbuffer member initializer ignored since no Vulkan equivalent
+// CHECK: warning: cbuffer member initializer ignored since no Vulkan equivalent
+// CHECK: warning: cbuffer member initializer ignored since no Vulkan equivalent
+// CHECK: OpName %type_MetadataCB "type.MetadataCB"
+// CHECK-NEXT: OpMemberName %type_MetadataCB 0 "m0"
+// CHECK-NEXT: OpMemberName %type_MetadataCB 1 "m1"
+// CHECK-NEXT: OpMemberName %type_MetadataCB 2 "m2"
+// CHECK: %type_MetadataCB = OpTypeStruct %uint %uint %uint
+// CHECK: OpAccessChain %_ptr_Uniform_uint %MetadataCB %int_2


### PR DESCRIPTION
This fixes invalid SPIR-V generation when a `cbuffer` contains interleaved `static const` declarations.

Fixes #8537
