### PR TITLE
[SPIRV] Legalize OpCopyLogical of OpCompositeConstruct

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.initlist.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.buffer-pointer.initlist.hlsl
@@ -11,11 +11,9 @@ cbuffer Test {
 
 [numthreads(256, 1, 1)]
 void main(in uint3 threadId : SV_DispatchThreadID) {
-// CHECK: [[AC:%[_0-9A-Za-z]*]] = OpAccessChain %_ptr_Uniform__ptr_PhysicalStorageBuffer_float %Test %int_0
-// CHECK: [[PTR:%[_0-9A-Za-z]*]] = OpLoad %_ptr_PhysicalStorageBuffer_float [[AC]]
+// CHECK: [[LD:%[_0-9A-Za-z]*]] = OpLoad %_ptr_PhysicalStorageBuffer_float
     BufferAccessor<float> accessor = BufferAccessor<float>(buffer);
 
-// CHECK: [[VAL:%[_0-9A-Za-z]*]] = OpLoad %float [[PTR]] Aligned 4
-// CHECK: OpStore [[PTR]] [[VAL]] Aligned 4
+// CHECK: OpLoad %float [[LD]] Aligned 4
     buffer.Get() = accessor.ptr.Get();
 }


### PR DESCRIPTION
This PR accommodates a fix to the optimizer in https://github.com/KhronosGroup/SPIRV-Tools/pull/6746.  We can see that the test was checking for artifacts that are now optimized away.  This is an improvement and the new test shown here reflects that.

It doesn't appear that commits combine SPIRV-TOOLS submodule updates like this one.  But I wanted to publish the test that will be required when https://github.com/KhronosGroup/SPIRV-Tools/pull/6746 merges.