### PR TITLE
Set sampler feedback shader flag when sampler feedback operations are used (and validator version >= 1.9)

### DIFF
--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -586,6 +586,8 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
           continue;
         if (hlsl::OP::IsDxilOpWave(dxilOp))
           hasWaveOps = true;
+        if (hlsl::OP::IsDxilOpFeedback(dxilOp))
+          hasSamplerFeedback = true;
         switch (dxilOp) {
         case DXIL::OpCode::CheckAccessFullyMapped:
           hasCheckAccessFully = true;
@@ -820,6 +822,11 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
   if (requiresGroup && DXIL::CompareVersions(valMajor, valMinor, 1, 8) < 0) {
     // Before validator version 1.8, RequiresGroup flag did not exist.
     requiresGroup = false;
+  }
+  if (hasSamplerFeedback &&
+      DXIL::CompareVersions(valMajor, valMinor, 1, 9) < 0) {
+    // Before validator version 1.9, SamplerFeedback flag was not set.
+    hasSamplerFeedback = false;
   }
 
   flag.SetEnableDoublePrecision(hasDouble);

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/FeedbackTexture/feedback_shader_flag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/FeedbackTexture/feedback_shader_flag.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -E main -T ps_6_5 %s | FileCheck %s -check-prefix=FLAG
+// RUN: %dxc -E main -T ps_6_5 -validator-version 1.8 %s | FileCheck %s -check-prefix=NOFLAG
+
+// Verify that the Sampler feedback shader feature flag is set when any
+// sampler feedback instruction is used, and that it is gated off for
+// validator versions before 1.9.
+
+// FLAG: Note: shader requires additional functionality:
+// FLAG: Sampler feedback
+
+// NOFLAG-NOT: Sampler feedback
+
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> feedbackMinMip;
+Texture2D<float> texture2D;
+SamplerState samp;
+
+float main() : SV_Target {
+  feedbackMinMip.WriteSamplerFeedback(texture2D, samp, (float2)0);
+  return 0;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/8533

This PR sets the sampler feedback DXIL feature flag in the presence of sampler feedback operations when the validator version is >= 1.9.
A lit test has also added to verify the functionality.

Assisted-by: Claude Opus 4.8