### PR TITLE
[HLSL] Preserve coherence qualifiers on resource flat-conversions

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -9589,6 +9589,10 @@ clang::ExprResult HLSLExternalSource::PerformHLSLConversion(
     clang::Sema::CheckedConversionKind CCK) {
   QualType sourceType = From->getType();
   sourceType = GetStructuralForm(sourceType);
+
+  // Store off the type attributes that could be accidentially dropped.
+  const bool targetGloballyCoherent = hlsl::HasHLSLGloballyCoherent(targetType);
+  const bool targetReorderCoherent = hlsl::HasHLSLReorderCoherent(targetType);
   targetType = GetStructuralForm(targetType);
   ArTypeInfo SourceInfo, TargetInfo;
   CollectInfo(sourceType, &SourceInfo);
@@ -9605,9 +9609,23 @@ clang::ExprResult HLSLExternalSource::PerformHLSLConversion(
     //    convert that to an array of casts under a special kind of flat
     //    flat conversion node?  What do component conversion casts cast
     //    from?  We don't have a From expression for individiual components.
+    QualType flatCastType = targetType.getUnqualifiedType();
+    // Preserve coherence qualifiers when converting to a resource type so the
+    // converted expression's type still reflects the coherence of its
+    // destination.
+    if (hlsl::IsHLSLResourceType(flatCastType)) {
+      if (targetGloballyCoherent)
+        flatCastType = m_context->getAttributedType(
+            AttributedType::attr_hlsl_globallycoherent, flatCastType,
+            flatCastType);
+      else if (targetReorderCoherent)
+        flatCastType = m_context->getAttributedType(
+            AttributedType::attr_hlsl_reordercoherent, flatCastType,
+            flatCastType);
+    }
     From = m_sema
-               ->ImpCastExprToType(From, targetType.getUnqualifiedType(),
-                                   CK_FlatConversion, From->getValueKind(),
+               ->ImpCastExprToType(From, flatCastType, CK_FlatConversion,
+                                   From->getValueKind(),
                                    /*BasePath=*/0, CCK)
                .get();
     break;

--- a/tools/clang/test/CodeGenDXIL/hlsl/attributes/coherent_flat_conversion.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/attributes/coherent_flat_conversion.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+// REQUIRES: dxil-1-9
+
+// Initializing a coherent resource from ResourceDescriptorHeap[] goes through a
+// flat-conversion. Verify the coherence qualifier of the destination is carried
+// through to the annotated handle properties in the generated DXIL.
+
+RWBuffer<float> OutBuf : register(u0);
+
+// CHECK: call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218
+// CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 20491, i32 0 })
+// CHECK-SAME: resource: globallycoherent RWByteAddressBuffer
+[shader("raygeneration")]
+void glc_entry()
+{
+  globallycoherent RWByteAddressBuffer buf = ResourceDescriptorHeap[0];
+  buf.Store(0, 0);
+}
+
+// CHECK: call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218
+// CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 69642, i32 265 })
+// CHECK-SAME: resource: reordercoherent RWTypedBuffer<F32>
+[shader("raygeneration")]
+void rc_entry()
+{
+  reordercoherent RWBuffer<float> buf = ResourceDescriptorHeap[1];
+  OutBuf[0] = buf[0];
+}

--- a/tools/clang/test/SemaHLSL/attributes/coherent_flat_conversion_ast.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/coherent_flat_conversion_ast.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T lib_6_9 -ast-dump %s | FileCheck %s
+// REQUIRES: dxil-1-9
+
+// Initializing a coherent resource from ResourceDescriptorHeap[] produces an
+// ICK_Flat_Conversion. Verify the converted expression's type still carries the
+// coherence qualifier of its destination instead of dropping it.
+
+[shader("raygeneration")]
+void main()
+{
+  // CHECK: VarDecl {{.*}} used glcBuf 'globallycoherent RWByteAddressBuffer':'RWByteAddressBuffer' cinit
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'globallycoherent RWByteAddressBuffer':'RWByteAddressBuffer' <FlatConversion>
+  globallycoherent RWByteAddressBuffer glcBuf = ResourceDescriptorHeap[0];
+  glcBuf.Store(0, 0);
+
+  // CHECK: VarDecl {{.*}} used rcBuf 'reordercoherent RWBuffer<float4>':'RWBuffer<vector<float, 4> >' cinit
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'reordercoherent RWBuffer<vector<float, 4> >':'RWBuffer<vector<float, 4> >' <FlatConversion>
+  reordercoherent RWBuffer<float4> rcBuf = ResourceDescriptorHeap[1];
+  rcBuf[0] = 5;
+}


### PR DESCRIPTION
PerformHLSLConversion forced the ICK_Flat_Conversion cast target to the structural/unqualified type, discarding the 'globallycoherent' (and 'reordercoherent') AttributedType. As a result, the converted expression's
type no longer reflected the coherence of its destination, forcing consumers
to reconstruct that information from declarations.

Re-apply the coherence AttributedType to the flat-conversion result when the
target is a resource type, so the converted expression's type carries the
coherence of its destination (e.g. a ResourceDescriptorHeap[] access used to
initialize a 'globallycoherent' resource).

Assisted by Claude Opus 4.8