### PR TITLE
Adding Offload Test into DXC build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,10 +2,10 @@ trigger:
   - main
   - release*
 
-pr:
+pr: 
   - main
   - release*
-
+  
 resources:
 - repo: self
 
@@ -33,7 +33,7 @@ stages:
          configuration: Debug
          spirvBuildFlag: -spirvtest
          artifactName: ''
-        VS2022_Release_DXIL_Only:
+        VS2022_Release_NoSPIRV:
          configuration: Release
          spirvBuildFlag: ''
          artifactName: dxc_dxil_release
@@ -53,7 +53,7 @@ stages:
     - script: |
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
         call utils\hct\hcttest.cmd -$(configuration) exec
-      displayName: 'DXIL Execution Tests'
+      displayName: 'DXIL Execution Tests'        
     - script: |
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
         call utils\hct\hcttest.cmd -$(configuration) extdxil

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
         VS2022_Release_NoSPIRV:
          configuration: Release
          spirvBuildFlag: ''
-         artifactName: dxc_dxil_release
+         artifactName: ''
 
     steps:
     - checkout: self
@@ -236,9 +236,6 @@ stages:
       clean: all
     strategy:
       matrix:
-        dxil_release:
-          artifact: 'dxc_dxil_release'
-          runLavapipe: 'false'
         spirv_release:
           artifact: 'dxc_spirv_release'
           runLavapipe: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
         $dst = "$(Build.ArtifactStagingDirectory)\dxc"
         New-Item -ItemType Directory -Force -Path $dst | Out-Null
         foreach ($f in @("dxc.exe","dxv.exe","dxcompiler.dll","dxil.dll")) {
-          if (Test-Path "$bin\$f") { Copy-Item "$bin\$f" $dst } else { Write-Warning "missing $f" }
+          if (Test-Path "$bin\$f") { Copy-Item "$bin\$f" $dst } else { throw "Required file not found: $bin\$f" }
         }
       displayName: 'Stage DXC binaries'
       condition: and(succeeded(), ne(variables['artifactName'], ''))
@@ -201,14 +201,31 @@ stages:
         testResultsFiles: '**/testresults.xunit.xml'
       condition: succeededOrFailed()
 
+- stage: OffloadGate
+  dependsOn: []
+  jobs:
+  - job: gate
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none
+    - bash: |
+        run=true
+        if [ "$(Build.Reason)" = "PullRequest" ]; then
+          run=false
+          labels=$(curl -sf "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
+          for l in $labels; do [ "$l" = "run-offload-tests" ] && run=true; done
+        fi
+        echo "Build.Reason=$(Build.Reason) run=$run"
+        echo "##vso[task.setvariable variable=run;isOutput=true]$run"
+      name: decide
+
 - stage: OffloadTests
   displayName: 'Offload tests'
-  dependsOn: Build
-  condition: succeededOrFailed()
-  variables:
-    LAVAPIPE_VERSION: '26.1.2'
-    WARP_VERSION: '1.0.19'
-    VS_DEV: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+  dependsOn:
+  - Build
+  - OffloadGate
+  condition: and(succeededOrFailed(), eq(dependencies.OffloadGate.outputs['gate.decide.run'], 'true'))
 
   jobs:
   - job: Offload
@@ -246,10 +263,16 @@ stages:
         versionSpec: '3.11'
     - script: choco install ninja -y
       displayName: 'Install Ninja'
+    - pwsh: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vs = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $vs) { throw "Visual Studio with the VC toolset was not found" }
+        Write-Host "##vso[task.setvariable variable=VCVARS]$vs\VC\Auxiliary\Build\vcvars64.bat"
+      displayName: 'Find vcvars'
     - task: BatchScript@1
       displayName: 'Set up MSVC environment'
       inputs:
-        filename: '$(VS_DEV)'
+        filename: '$(VCVARS)'
         modifyEnvironment: true
 
     - pwsh: |
@@ -264,7 +287,7 @@ stages:
       condition: and(succeeded(), eq(variables['runLavapipe'], 'true'))
 
     - pwsh: |
-        $ver = "$(LAVAPIPE_VERSION)"
+        $ver = (Invoke-RestMethod "https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest" -Headers @{ "User-Agent" = "azure-pipelines" }).tag_name
         $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
         Invoke-WebRequest $url -OutFile "$(Agent.TempDirectory)\mesa.7z"
         7z x "$(Agent.TempDirectory)\mesa.7z" -o"$(Agent.TempDirectory)\mesa" -y | Out-Null
@@ -297,7 +320,6 @@ stages:
         -DGOLDENIMAGE_DIR=$(Agent.TempDirectory)/golden-images
         -DOFFLOADTEST_TEST_CLANG=Off
         -DOFFLOADTEST_ENABLE_DEBUG=Off
-        -DWARP_VERSION=$(WARP_VERSION)
         -DLLVM_LIT_ARGS="--xunit-xml-output=testresults.xunit.xml -v"
         llvm-project/llvm
       displayName: 'Configure LLVM + OffloadTest against DXC'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,10 +2,10 @@ trigger:
   - main
   - release*
 
-pr: 
+pr:
   - main
   - release*
-  
+
 resources:
 - repo: self
 
@@ -28,12 +28,15 @@ stages:
         VS2022_Release:
          configuration: Release
          spirvBuildFlag: -spirvtest
+         artifactName: dxc_spirv_release
         VS2022_Debug:
          configuration: Debug
          spirvBuildFlag: -spirvtest
-        VS2022_Release_NoSPIRV:
+         artifactName: ''
+        VS2022_Release_DXIL_Only:
          configuration: Release
          spirvBuildFlag: ''
+         artifactName: dxc_dxil_release
 
     steps:
     - checkout: self
@@ -50,7 +53,7 @@ stages:
     - script: |
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
         call utils\hct\hcttest.cmd -$(configuration) exec
-      displayName: 'DXIL Execution Tests'        
+      displayName: 'DXIL Execution Tests'
     - script: |
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
         call utils\hct\hcttest.cmd -$(configuration) extdxil
@@ -76,7 +79,27 @@ stages:
         call utils\hct\hcttest.cmd -$(configuration) compat-suite v1.8.2505.1
       displayName: 'DXIL Compat Suite Tests (1.8 point release)'
       condition: succeededOrFailed()
-    
+    - script: |
+        call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+        call utils\hct\hcttest.cmd -$(configuration) spirv
+      displayName: 'SPIR-V Tests'
+      condition: and(succeeded(), ne(variables['spirvBuildFlag'], ''))
+    - pwsh: |
+        $bin = "$(HLSL_BLD_DIR)\$(configuration)\bin"
+        $dst = "$(Build.ArtifactStagingDirectory)\dxc"
+        New-Item -ItemType Directory -Force -Path $dst | Out-Null
+        foreach ($f in @("dxc.exe","dxv.exe","dxcompiler.dll","dxil.dll")) {
+          if (Test-Path "$bin\$f") { Copy-Item "$bin\$f" $dst } else { Write-Warning "missing $f" }
+        }
+      displayName: 'Stage DXC binaries'
+      condition: and(succeeded(), ne(variables['artifactName'], ''))
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish DXC binaries'
+      condition: and(succeeded(), ne(variables['artifactName'], ''))
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)\dxc'
+        artifact: '$(artifactName)'
+
 
   - job: Nix
     timeoutInMinutes: 165
@@ -177,3 +200,142 @@ stages:
         testResultsFormat: 'JUnit'
         testResultsFiles: '**/testresults.xunit.xml'
       condition: succeededOrFailed()
+
+- stage: OffloadTests
+  displayName: 'Offload tests'
+  dependsOn: Build
+  condition: succeededOrFailed()
+  variables:
+    LAVAPIPE_VERSION: '26.1.2'
+    WARP_VERSION: '1.0.19'
+    VS_DEV: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+
+  jobs:
+  - job: Offload
+    timeoutInMinutes: 180
+    pool:
+      vmImage: windows-2025
+    workspace:
+      clean: all
+    strategy:
+      matrix:
+        dxil_release:
+          artifact: 'dxc_dxil_release'
+          runLavapipe: 'false'
+        spirv_release:
+          artifact: 'dxc_spirv_release'
+          runLavapipe: 'true'
+    steps:
+    - checkout: none
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download DXC binaries'
+      inputs:
+        artifact: '$(artifact)'
+        path: '$(Agent.TempDirectory)\dxc'
+
+    - pwsh: |
+        $dxc = Get-ChildItem "$(Agent.TempDirectory)\dxc" -Recurse -Filter dxc.exe | Select-Object -First 1
+        if (-not $dxc) { throw "dxc.exe not found in artifact $(artifact)" }
+        Write-Host "##vso[task.setvariable variable=DXC_DIR]$($dxc.Directory.FullName)"
+        Write-Host "DXC_DIR = $($dxc.Directory.FullName)"
+      displayName: 'Locate DXC_DIR'
+
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.11'
+    - script: choco install ninja -y
+      displayName: 'Install Ninja'
+    - task: BatchScript@1
+      displayName: 'Set up MSVC environment'
+      inputs:
+        filename: '$(VS_DEV)'
+        modifyEnvironment: true
+
+    - pwsh: |
+        $exe = "$(Agent.TempDirectory)\VulkanSDK.exe"
+        Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan_sdk.exe?Human=true" -OutFile $exe
+        Start-Process $exe -ArgumentList "--accept-licenses","--default-answer","--confirm-command","install" -Wait
+        $sdk = (Get-ChildItem "C:\VulkanSDK" -Directory | Sort-Object Name -Descending | Select-Object -First 1).FullName
+        if (-not $sdk) { throw "Vulkan SDK install dir not found under C:\VulkanSDK" }
+        Write-Host "##vso[task.setvariable variable=VULKAN_SDK]$sdk"
+        Write-Host "##vso[task.prependpath]$sdk\Bin"
+      displayName: 'Install Vulkan SDK'
+      condition: and(succeeded(), eq(variables['runLavapipe'], 'true'))
+
+    - pwsh: |
+        $ver = "$(LAVAPIPE_VERSION)"
+        $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
+        Invoke-WebRequest $url -OutFile "$(Agent.TempDirectory)\mesa.7z"
+        7z x "$(Agent.TempDirectory)\mesa.7z" -o"$(Agent.TempDirectory)\mesa" -y | Out-Null
+        $lvp = (Get-ChildItem "$(Agent.TempDirectory)\mesa" -Recurse -Filter "lvp_icd.x86_64.json" | Select-Object -First 1).FullName
+        if (-not $lvp) { throw "lavapipe ICD (lvp_icd.x86_64.json) not found in Mesa package" }
+        reg add "HKLM\SOFTWARE\Khronos\Vulkan\Drivers" /v "$lvp" /t REG_DWORD /d 0 /f /reg:64
+        Write-Host "##vso[task.setvariable variable=MESA_BIN]$(Split-Path $lvp)"
+        Write-Host "Registered lavapipe ICD: $lvp"
+      displayName: 'Install lavapipe (Mesa) and register the ICD'
+      condition: and(succeeded(), eq(variables['runLavapipe'], 'true'))
+
+    - pwsh: |
+        git clone --depth 1 https://github.com/llvm/offload-test-suite OffloadTest
+        git clone --depth 1 https://github.com/llvm/llvm-project llvm-project
+        git clone --depth 1 https://github.com/llvm/offload-golden-images golden-images
+        python -m pip install -r OffloadTest/test/requirements.txt
+        $py = (python -c "import sys; print(sys.executable)").Trim() -replace '\\','/'
+        Write-Host "##vso[task.setvariable variable=PYTHON_EXE]$py"
+      displayName: 'Checkout offload-test-suite + LLVM'
+      workingDirectory: '$(Agent.TempDirectory)'
+
+    - script: >
+        cmake -G Ninja -B llvm-project/build
+        -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=On
+        -DLLVM_EXTERNAL_PROJECTS=OffloadTest
+        -C llvm-project/clang/cmake/caches/HLSL.cmake
+        -DPython3_EXECUTABLE="$(PYTHON_EXE)"
+        -DDXC_DIR="$(DXC_DIR)"
+        -DLLVM_EXTERNAL_OFFLOADTEST_SOURCE_DIR=$(Agent.TempDirectory)/OffloadTest
+        -DGOLDENIMAGE_DIR=$(Agent.TempDirectory)/golden-images
+        -DOFFLOADTEST_TEST_CLANG=Off
+        -DOFFLOADTEST_ENABLE_DEBUG=Off
+        -DWARP_VERSION=$(WARP_VERSION)
+        -DLLVM_LIT_ARGS="--xunit-xml-output=testresults.xunit.xml -v"
+        llvm-project/llvm
+      displayName: 'Configure LLVM + OffloadTest against DXC'
+      workingDirectory: '$(Agent.TempDirectory)'
+
+    - pwsh: |
+        $line = (Select-String -Path "llvm-project/build/CMakeCache.txt" -Pattern '^Python3_EXECUTABLE:').Line
+        $py = ($line -split '=', 2)[1]
+        if (-not $py) { throw "Python3_EXECUTABLE not found in CMakeCache.txt" }
+        Write-Host "lit Python: $py"
+        & "$py" -m pip install -r OffloadTest/test/requirements.txt
+      displayName: 'Install offload requirements into lit Python'
+      workingDirectory: '$(Agent.TempDirectory)'
+
+    - script: cmake --build llvm-project/build --target hlsl-test-depends
+      displayName: 'Build offload test dependencies'
+      workingDirectory: '$(Agent.TempDirectory)'
+
+    - pwsh: |
+        $out = "$(Agent.TempDirectory)/results-d3d12-warp.xml" -replace '\\','/'
+        $env:LIT_OPTS = "--xunit-xml-output=$out"
+        cmake --build llvm-project/build --target check-hlsl-warp-d3d12
+      displayName: 'DirectX offload tests on WARP'
+      condition: succeededOrFailed()
+      workingDirectory: '$(Agent.TempDirectory)'
+
+    - pwsh: |
+        $env:PATH = "$(MESA_BIN);$env:PATH"
+        $env:VK_LOADER_DEBUG = "all"
+        $out = "$(Agent.TempDirectory)/results-vk-lavapipe.xml" -replace '\\','/'
+        $env:LIT_OPTS = "--xunit-xml-output=$out"
+        cmake --build llvm-project/build --target check-hlsl-vk
+      displayName: 'Vulkan offload tests on lavapipe'
+      condition: and(succeededOrFailed(), eq(variables['runLavapipe'], 'true'))
+      workingDirectory: '$(Agent.TempDirectory)'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: '$(Agent.TempDirectory)/results-*.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,13 @@
+parameters:
+  - name: lavapipeVersion
+    displayName: 'lavapipe (Mesa) version'
+    type: string
+    default: '26.1.2'
+  - name: warpVersion
+    displayName: 'WARP version'
+    type: string
+    default: '1.0.19'
+
 trigger:
   - main
   - release*
@@ -284,7 +294,7 @@ stages:
       condition: and(succeeded(), eq(variables['runLavapipe'], 'true'))
 
     - pwsh: |
-        $ver = (Invoke-RestMethod "https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest" -Headers @{ "User-Agent" = "azure-pipelines" }).tag_name
+        $ver = "${{ parameters.lavapipeVersion }}"
         $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/mesa3d-$ver-release-msvc.7z"
         Invoke-WebRequest $url -OutFile "$(Agent.TempDirectory)\mesa.7z"
         7z x "$(Agent.TempDirectory)\mesa.7z" -o"$(Agent.TempDirectory)\mesa" -y | Out-Null
@@ -317,6 +327,7 @@ stages:
         -DGOLDENIMAGE_DIR=$(Agent.TempDirectory)/golden-images
         -DOFFLOADTEST_TEST_CLANG=Off
         -DOFFLOADTEST_ENABLE_DEBUG=Off
+        -DWARP_VERSION=${{ parameters.warpVersion }}
         -DLLVM_LIT_ARGS="--xunit-xml-output=testresults.xunit.xml -v"
         llvm-project/llvm
       displayName: 'Configure LLVM + OffloadTest against DXC'


### PR DESCRIPTION
This patch adds a new stage into DXC build pipeline, it runs the offload-test agains the built binaries, it uses WARP for DXIL and lava-pipe for SPIRV builds. 

Part of: https://github.com/microsoft/hlsl-specs/issues/886