### PR TITLE
Add a cherry-pick skill for copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# GitHub Copilot Instructions
+
+These instructions guide GitHub Copilot and other AI coding agents when working
+in this repository.
+
+## Cherry-picking commits
+
+When cherry-picking a change (for example, backporting a fix to a release
+branch):
+
+1. **Cherry-pick commits, not PRs.** Identify the specific commit SHA to
+   cherry-pick. If the source PR was squash-merged, that is the single squashed
+   commit produced on the target branch.
+2. **Use `git cherry-pick -x`** so the new commit message records the source
+   commit in the standard git format:
+
+   ```
+   (cherry picked from commit <sha>)
+   ```
+
+3. **Create a topic branch** off the destination branch and apply the
+   cherry-pick there.
+4. **Open the PR** with:
+   - **Title:** start with `[Cherry-Pick]`, followed by the cherry-picked
+     commit's subject line. For example:
+
+     ```
+     [Cherry-Pick] <original commit subject>
+     ```
+
+   - **Description:** the cherry-picked commit's message body verbatim,
+     including the trailing `(cherry picked from commit <sha>)` line. Because
+     PRs are squash-merged, the PR description becomes the merge commit message,
+     so it must match the cherry-picked commit message.
+
+### Example
+
+Title:
+
+```
+[Cherry-Pick] Fix cast between semantically different integer types (#8414)
+```
+
+Description:
+
+```
+This patch fixes 2 instances of internal issues; C6214: Cast between
+semantically different integer types.
+
+(cherry picked from commit 32beebfd584c59662392779184240c6d407d5346)
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,51 +1,7 @@
 # GitHub Copilot Instructions
 
-These instructions guide GitHub Copilot and other AI coding agents when working
-in this repository.
+## Cherry-picking
 
-## Cherry-picking commits
-
-When cherry-picking a change (for example, backporting a fix to a release
-branch):
-
-1. **Cherry-pick commits, not PRs.** Identify the specific commit SHA to
-   cherry-pick. If the source PR was squash-merged, that is the single squashed
-   commit produced on the target branch.
-2. **Use `git cherry-pick -x`** so the new commit message records the source
-   commit in the standard git format:
-
-   ```
-   (cherry picked from commit <sha>)
-   ```
-
-3. **Create a topic branch** off the destination branch and apply the
-   cherry-pick there.
-4. **Open the PR** with:
-   - **Title:** start with `[Cherry-Pick]`, followed by the cherry-picked
-     commit's subject line. For example:
-
-     ```
-     [Cherry-Pick] <original commit subject>
-     ```
-
-   - **Description:** the cherry-picked commit's message body verbatim,
-     including the trailing `(cherry picked from commit <sha>)` line. Because
-     PRs are squash-merged, the PR description becomes the merge commit message,
-     so it must match the cherry-picked commit message.
-
-### Example
-
-Title:
-
-```
-[Cherry-Pick] Fix cast between semantically different integer types (#8414)
-```
-
-Description:
-
-```
-This patch fixes 2 instances of internal issues; C6214: Cast between
-semantically different integer types.
-
-(cherry picked from commit 32beebfd584c59662392779184240c6d407d5346)
-```
+Use `git cherry-pick -x` for cherry picks so the commit message records the
+source commit SHA. Keep the cherry-pick commit message as git generates it by
+default, and prefix the PR title with `[Cherry-Pick]`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,0 @@
-# GitHub Copilot Instructions
-
-## Cherry-picking
-
-Use `git cherry-pick -x` for cherry picks so the commit message records the
-source commit SHA. Keep the cherry-pick commit message as git generates it by
-default, and prefix the PR title with `[Cherry-Pick]`.

--- a/.github/skills/cherry-pick/SKILL.md
+++ b/.github/skills/cherry-pick/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: cherry-pick
+description: Cherry-pick a commit onto another branch and open the PR. Use when the user asks to cherry-pick or backport a commit or PR to a release branch.
+---
+
+# Cherry-picking commits
+
+Use this when asked to cherry-pick or backport a change.
+
+1. Identify the source commit SHA to cherry-pick. If the source PR was
+   squash-merged, the single squashed commit on the target branch is what you
+   cherry-pick.
+2. Create a topic branch off the destination branch.
+3. Apply the change with `git cherry-pick -x <sha>` so the commit message
+   records the source commit in git's standard format:
+
+   ```
+   (cherry picked from commit <sha>)
+   ```
+
+   Keep the cherry-pick commit message as git generates it by default.
+4. Open the PR with the title prefixed `[Cherry-Pick]`, followed by the
+   original commit subject.

--- a/.github/skills/cherry-pick/SKILL.md
+++ b/.github/skills/cherry-pick/SKILL.md
@@ -5,19 +5,6 @@ description: Cherry-pick a commit onto another branch and open the PR. Use when 
 
 # Cherry-picking commits
 
-Use this when asked to cherry-pick or backport a change.
-
-1. Identify the source commit SHA to cherry-pick. If the source PR was
-   squash-merged, the single squashed commit on the target branch is what you
-   cherry-pick.
-2. Create a topic branch off the destination branch.
-3. Apply the change with `git cherry-pick -x <sha>` so the commit message
-   records the source commit in git's standard format:
-
-   ```
-   (cherry picked from commit <sha>)
-   ```
-
-   Keep the cherry-pick commit message as git generates it by default.
-4. Open the PR with the title prefixed `[Cherry-Pick]`, followed by the
-   original commit subject.
+Cherry-pick the commit with `git cherry-pick -x <sha>` so the source SHA is
+recorded in git's standard format. Keep the commit message as git generates it
+by default. Prefix the PR title with `[Cherry-Pick]`.


### PR DESCRIPTION
Adds a cherry-pick skill at `.github/skills/cherry-pick/SKILL.md`.

Rather than putting the convention in `.github/copilot-instructions.md` (which is injected into every prompt), a skill is auto-discovered from the repo and only loaded on demand when a cherry-pick is actually being done. The skill captures:

- Cherry-pick commits using `git cherry-pick -x` so the source SHA is recorded in git's standard format.
- Keep the cherry-pick commit message as git generates it by default.
- Prefix the PR title with `[Cherry-Pick]`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>