### PR TITLE
[SM6.10] LinAlg Validation: Validate Params and K Dim

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3209,6 +3209,7 @@ INSTR.ILLEGALDXILOPCODE                               DXILOpCode must be valid o
 INSTR.ILLEGALDXILOPFUNCTION                           '%0' is not a DXILOpFuncition for DXILOpcode '%1'.
 INSTR.IMMBIASFORSAMPLEB                               bias amount for sample_b must be in the range [%0,%1], but %2 was specified as an immediate.
 INSTR.INBOUNDSACCESS                                  Access to out-of-bounds memory is disallowed.
+INSTR.LINALGILLEGALKDIM                               Matrix K Dimension out of bounds. K=%0 must be >= %1 and <= %2.
 INSTR.MAYREORDERTHREADUNDEFCOHERENCEHINTPARAM         Use of undef coherence hint or num coherence hint bits in MaybeReorderThread.
 INSTR.MINPRECISIONNOTPRECISE                          Instructions marked precise may not refer to minprecision values.
 INSTR.MINPRECISONBITCAST                              Bitcast on minprecison types is not allowed.

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -155,6 +155,9 @@ const unsigned kMinWaveSize = 4;
 const unsigned kMaxWaveSize = 128;
 const unsigned kDefaultMaxVectorLength = 4;
 const unsigned kSM69MaxVectorLength = 1024;
+const unsigned kLinAlgThreadGroupMatrixMaxK = 1024;
+const unsigned kLinAlgWaveThreadMatrixMaxK = 128;
+const unsigned kLinAlgMatrixMinK = 4;
 
 const float kMaxMipLodBias = 15.99f;
 const float kMinMipLodBias = -16.0f;

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -155,9 +155,10 @@ const unsigned kMinWaveSize = 4;
 const unsigned kMaxWaveSize = 128;
 const unsigned kDefaultMaxVectorLength = 4;
 const unsigned kSM69MaxVectorLength = 1024;
-const unsigned kLinAlgThreadGroupMatrixMaxK = 1024;
-const unsigned kLinAlgWaveThreadMatrixMaxK = 128;
+const unsigned kLinAlgMatrixMaxK = 128;
 const unsigned kLinAlgMatrixMinK = 4;
+const unsigned kLinAlgThreadGroupMatrixMaxK = 1024;
+const unsigned kLinAlgThreadGroupMatrixMinK = 1;
 
 const float kMaxMipLodBias = 15.99f;
 const float kMinMipLodBias = -16.0f;

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -975,7 +975,7 @@ static void ValidateImmOperandForMathDxilOp(CallInst *CI, DXIL::OpCode Opcode,
 }
 
 static void ValidateLinAlgOpParameters(CallInst *CI,
-                                     ValidationContext &ValCtx) {
+                                       ValidationContext &ValCtx) {
   for (uint32_t Idx = 0; Idx < CI->getNumArgOperands(); ++Idx) {
     Value *Arg = CI->getArgOperand(Idx);
     Type *Ty = Arg->getType();
@@ -997,31 +997,29 @@ static void ValidateLinAlgOpParameters(CallInst *CI,
 }
 
 static void ValidateLinAlgOpReturn(CallInst *CI, ValidationContext &ValCtx) {
-    Type *Ty = CI->getType();
-    assert(dxilutil::IsHLSLLinAlgMatrixType(Ty) && "CI must result a matrix");
+  Type *Ty = CI->getType();
+  assert(dxilutil::IsHLSLLinAlgMatrixType(Ty) && "CI must return a matrix");
 
-    // Metadata is malformed if we don't have metadata
-    auto it = ValCtx.TargetTypeMap.find(Ty);
-    if (it == ValCtx.TargetTypeMap.end()) {
-      ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
-      return;
-    }
+  // Metadata is malformed if we don't have metadata
+  auto it = ValCtx.TargetTypeMap.find(Ty);
+  if (it == ValCtx.TargetTypeMap.end()) {
+    ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
+    return;
+  }
 
-    LinAlgTargetType LATT = it->second;
+  LinAlgTargetType LATT = it->second;
 
-    // Validate the K dim is in bounds. Which dim is K depends on use.
-    // This validation isn't applied to an accumulator matrix
-    if (LATT.Use != DXIL::MatrixUse::Accumulator) {
-      unsigned MinK = 4;
-      unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
-      unsigned MaxK = (LATT.Scope == DXIL::MatrixScope::ThreadGroup) ? 1024 : 128;
-      if (K < MinK || K > MaxK)
-        ValCtx.EmitInstrFormatError(
-            CI, ValidationRule::InstrLinAlgIllegalKDim,
-            {std::to_string(K),
-             std::to_string(MinK),
-             std::to_string(MaxK)});
-    }
+  // Validate the K dim is in bounds. Which dim is K depends on use.
+  // This validation isn't applied to an accumulator matrix
+  if (LATT.Use != DXIL::MatrixUse::Accumulator) {
+    unsigned MinK = 4;
+    unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
+    unsigned MaxK = (LATT.Scope == DXIL::MatrixScope::ThreadGroup) ? 1024 : 128;
+    if (K < MinK || K > MaxK)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgIllegalKDim,
+          {std::to_string(K), std::to_string(MinK), std::to_string(MaxK)});
+  }
 }
 
 // Validate the type-defined mask compared to the store value mask which
@@ -2243,7 +2241,7 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
     ValidateLinAlgOpParameters(CI, ValCtx);
     break;
   }
-  case DXIL::OpCode::LinAlgFillMatrix: 
+  case DXIL::OpCode::LinAlgFillMatrix:
   case DXIL::OpCode::LinAlgCopyConvertMatrix:
   case DXIL::OpCode::LinAlgMatrixLoadFromDescriptor:
   case DXIL::OpCode::LinAlgMatrixLoadFromMemory:

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -984,25 +984,25 @@ static void ValidateLinAlgOpParameters(CallInst *CI,
     if (isa<UndefValue>(Arg))
       ValCtx.EmitInstrError(CI, ValidationRule::InstrNoReadingUninitialized);
 
-    // If we have a LinAlg Matrix validate it
+    // If we have a LinAlg Matrix, validate that we have correct metadata.
     if (!dxilutil::IsHLSLLinAlgMatrixType(Ty))
       continue;
-
-    // Metadata is malformed if we don't have metadata
-    if (ValCtx.TargetTypeMap.find(Ty) == ValCtx.TargetTypeMap.end()) {
+    if (ValCtx.LinAlgTargetTypeMap.find(Ty) ==
+        ValCtx.LinAlgTargetTypeMap.end()) {
       ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
       continue;
     }
   }
 }
 
-static void ValidateLinAlgOpReturn(CallInst *CI, ValidationContext &ValCtx) {
+static void ValidateLinAlgOpReturnMatrix(CallInst *CI,
+                                         ValidationContext &ValCtx) {
   Type *Ty = CI->getType();
   assert(dxilutil::IsHLSLLinAlgMatrixType(Ty) && "CI must return a matrix");
 
   // Metadata is malformed if we don't have metadata
-  auto it = ValCtx.TargetTypeMap.find(Ty);
-  if (it == ValCtx.TargetTypeMap.end()) {
+  auto it = ValCtx.LinAlgTargetTypeMap.find(Ty);
+  if (it == ValCtx.LinAlgTargetTypeMap.end()) {
     ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
     return;
   }
@@ -1012,9 +1012,11 @@ static void ValidateLinAlgOpReturn(CallInst *CI, ValidationContext &ValCtx) {
   // Validate the K dim is in bounds. Which dim is K depends on use.
   // This validation isn't applied to an accumulator matrix
   if (LATT.Use != DXIL::MatrixUse::Accumulator) {
-    unsigned MinK = 4;
+    unsigned MinK = DXIL::kLinAlgMatrixMinK;
     unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
-    unsigned MaxK = (LATT.Scope == DXIL::MatrixScope::ThreadGroup) ? 1024 : 128;
+    unsigned MaxK = (LATT.Scope == DXIL::MatrixScope::ThreadGroup)
+                        ? DXIL::kLinAlgThreadGroupMatrixMaxK
+                        : DXIL::kLinAlgWaveThreadMatrixMaxK;
     if (K < MinK || K > MaxK)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgIllegalKDim,
@@ -2250,7 +2252,7 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
   case DXIL::OpCode::LinAlgMatrixAccumulate:
   case DXIL::OpCode::LinAlgMatrixMultiplyAccumulate:
   case DXIL::OpCode::LinAlgMatrixOuterProduct: {
-    ValidateLinAlgOpReturn(CI, ValCtx);
+    ValidateLinAlgOpReturnMatrix(CI, ValCtx);
     ValidateLinAlgOpParameters(CI, ValCtx);
     break;
   }

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -974,6 +974,19 @@ static void ValidateImmOperandForMathDxilOp(CallInst *CI, DXIL::OpCode Opcode,
   }
 }
 
+static void ValidateLinAlgNoUndefMatrixVector(CallInst *CI,
+                                              ValidationContext &ValCtx) {
+  for (uint32_t Idx = 0; Idx < CI->getNumArgOperands(); ++Idx) {
+    Value *Arg = CI->getArgOperand(Idx);
+    Type *Ty = Arg->getType();
+    if (!isa<UndefValue>(Arg))
+      continue;
+
+    if (Ty->isVectorTy() || dxilutil::IsHLSLLinAlgMatrixType(Ty))
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrNoReadingUninitialized);
+  }
+}
+
 // Validate the type-defined mask compared to the store value mask which
 // indicates which parts were defined returns true if caller should continue
 // validation
@@ -1713,7 +1726,7 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
       ShaderKind = DXIL::ShaderKind::Hull;
   }
 
-  // These shader models are treted like compute
+  // These shader models are treated like compute
   bool IsCSLike = ShaderKind == DXIL::ShaderKind::Compute ||
                   ShaderKind == DXIL::ShaderKind::Mesh ||
                   ShaderKind == DXIL::ShaderKind::Amplification ||
@@ -2177,6 +2190,32 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
       ValCtx.EmitInstrFormatError(CI, ValidationRule::SmIsSpecialFloat, {});
     break;
   }
+
+  // LinAlg Operations
+  case DXIL::OpCode::LinAlgFillMatrix:
+  case DXIL::OpCode::LinAlgCopyConvertMatrix:
+  case DXIL::OpCode::LinAlgMatrixLoadFromDescriptor:
+  case DXIL::OpCode::LinAlgMatrixLoadFromMemory:
+  case DXIL::OpCode::LinAlgMatrixLength:
+  case DXIL::OpCode::LinAlgMatrixGetCoordinate:
+  case DXIL::OpCode::LinAlgMatrixGetElement:
+  case DXIL::OpCode::LinAlgMatrixSetElement:
+  case DXIL::OpCode::LinAlgMatrixStoreToDescriptor:
+  case DXIL::OpCode::LinAlgMatrixStoreToMemory:
+  case DXIL::OpCode::LinAlgMatrixMultiply:
+  case DXIL::OpCode::LinAlgMatrixAccumulate:
+  case DXIL::OpCode::LinAlgMatrixMultiplyAccumulate:
+  case DXIL::OpCode::LinAlgMatVecMul:
+  case DXIL::OpCode::LinAlgMatVecMulAdd:
+  case DXIL::OpCode::LinAlgMatrixAccumulateToDescriptor:
+  case DXIL::OpCode::LinAlgMatrixAccumulateToMemory:
+  case DXIL::OpCode::LinAlgMatrixOuterProduct:
+  case DXIL::OpCode::LinAlgConvert:
+  case DXIL::OpCode::LinAlgVectorAccumulateToDescriptor: {
+    ValidateLinAlgNoUndefMatrixVector(CI, ValCtx);
+    break;
+  }
+
   default:
     // TODO: make sure every Opcode is checked.
     // Skip opcodes don't need special check.

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -974,17 +974,54 @@ static void ValidateImmOperandForMathDxilOp(CallInst *CI, DXIL::OpCode Opcode,
   }
 }
 
-static void ValidateLinAlgNoUndefMatrixVector(CallInst *CI,
-                                              ValidationContext &ValCtx) {
+static void ValidateLinAlgOpParameters(CallInst *CI,
+                                     ValidationContext &ValCtx) {
   for (uint32_t Idx = 0; Idx < CI->getNumArgOperands(); ++Idx) {
     Value *Arg = CI->getArgOperand(Idx);
     Type *Ty = Arg->getType();
-    if (!isa<UndefValue>(Arg))
+
+    // No parameters may be undef
+    if (isa<UndefValue>(Arg))
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrNoReadingUninitialized);
+
+    // If we have a LinAlg Matrix validate it
+    if (!dxilutil::IsHLSLLinAlgMatrixType(Ty))
       continue;
 
-    if (Ty->isVectorTy() || dxilutil::IsHLSLLinAlgMatrixType(Ty))
-      ValCtx.EmitInstrError(CI, ValidationRule::InstrNoReadingUninitialized);
+    // Metadata is malformed if we don't have metadata
+    if (ValCtx.TargetTypeMap.find(Ty) == ValCtx.TargetTypeMap.end()) {
+      ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
+      continue;
+    }
   }
+}
+
+static void ValidateLinAlgOpReturn(CallInst *CI, ValidationContext &ValCtx) {
+    Type *Ty = CI->getType();
+    assert(dxilutil::IsHLSLLinAlgMatrixType(Ty) && "CI must result a matrix");
+
+    // Metadata is malformed if we don't have metadata
+    auto it = ValCtx.TargetTypeMap.find(Ty);
+    if (it == ValCtx.TargetTypeMap.end()) {
+      ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
+      return;
+    }
+
+    LinAlgTargetType LATT = it->second;
+
+    // Validate the K dim is in bounds. Which dim is K depends on use.
+    // This validation isn't applied to an accumulator matrix
+    if (LATT.Use != DXIL::MatrixUse::Accumulator) {
+      unsigned MinK = 4;
+      unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
+      unsigned MaxK = (LATT.Scope == DXIL::MatrixScope::ThreadGroup) ? 1024 : 128;
+      if (K < MinK || K > MaxK)
+        ValCtx.EmitInstrFormatError(
+            CI, ValidationRule::InstrLinAlgIllegalKDim,
+            {std::to_string(K),
+             std::to_string(MinK),
+             std::to_string(MaxK)});
+    }
 }
 
 // Validate the type-defined mask compared to the store value mask which
@@ -2192,27 +2229,31 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
   }
 
   // LinAlg Operations
-  case DXIL::OpCode::LinAlgFillMatrix:
-  case DXIL::OpCode::LinAlgCopyConvertMatrix:
-  case DXIL::OpCode::LinAlgMatrixLoadFromDescriptor:
-  case DXIL::OpCode::LinAlgMatrixLoadFromMemory:
   case DXIL::OpCode::LinAlgMatrixLength:
   case DXIL::OpCode::LinAlgMatrixGetCoordinate:
   case DXIL::OpCode::LinAlgMatrixGetElement:
-  case DXIL::OpCode::LinAlgMatrixSetElement:
   case DXIL::OpCode::LinAlgMatrixStoreToDescriptor:
   case DXIL::OpCode::LinAlgMatrixStoreToMemory:
-  case DXIL::OpCode::LinAlgMatrixMultiply:
-  case DXIL::OpCode::LinAlgMatrixAccumulate:
-  case DXIL::OpCode::LinAlgMatrixMultiplyAccumulate:
   case DXIL::OpCode::LinAlgMatVecMul:
   case DXIL::OpCode::LinAlgMatVecMulAdd:
   case DXIL::OpCode::LinAlgMatrixAccumulateToDescriptor:
   case DXIL::OpCode::LinAlgMatrixAccumulateToMemory:
-  case DXIL::OpCode::LinAlgMatrixOuterProduct:
   case DXIL::OpCode::LinAlgConvert:
   case DXIL::OpCode::LinAlgVectorAccumulateToDescriptor: {
-    ValidateLinAlgNoUndefMatrixVector(CI, ValCtx);
+    ValidateLinAlgOpParameters(CI, ValCtx);
+    break;
+  }
+  case DXIL::OpCode::LinAlgFillMatrix: 
+  case DXIL::OpCode::LinAlgCopyConvertMatrix:
+  case DXIL::OpCode::LinAlgMatrixLoadFromDescriptor:
+  case DXIL::OpCode::LinAlgMatrixLoadFromMemory:
+  case DXIL::OpCode::LinAlgMatrixSetElement:
+  case DXIL::OpCode::LinAlgMatrixMultiply:
+  case DXIL::OpCode::LinAlgMatrixAccumulate:
+  case DXIL::OpCode::LinAlgMatrixMultiplyAccumulate:
+  case DXIL::OpCode::LinAlgMatrixOuterProduct: {
+    ValidateLinAlgOpReturn(CI, ValCtx);
+    ValidateLinAlgOpParameters(CI, ValCtx);
     break;
   }
 

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1014,9 +1014,11 @@ static void ValidateLinAlgOpReturnMatrix(CallInst *CI,
   if (LATT.Use != DXIL::MatrixUse::Accumulator) {
     unsigned MinK = DXIL::kLinAlgMatrixMinK;
     unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
-    unsigned MaxK = (LATT.Scope == DXIL::MatrixScope::ThreadGroup)
-                        ? DXIL::kLinAlgThreadGroupMatrixMaxK
-                        : DXIL::kLinAlgWaveThreadMatrixMaxK;
+    unsigned MaxK = DXIL::kLinAlgMatrixMaxK;
+    if (LATT.Scope == DXIL::MatrixScope::ThreadGroup) {
+      MinK = DXIL::kLinAlgThreadGroupMatrixMinK;
+      MaxK = DXIL::kLinAlgThreadGroupMatrixMaxK;
+    }
     if (K < MinK || K > MaxK)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgIllegalKDim,

--- a/lib/DxilValidation/DxilValidationUtils.cpp
+++ b/lib/DxilValidation/DxilValidationUtils.cpp
@@ -11,6 +11,7 @@
 
 #include "DxilValidationUtils.h"
 
+#include <limits>
 #include <optional>
 
 #include "dxc/DXIL/DxilEntryProps.h"
@@ -63,13 +64,15 @@ TryAddLinAlgTargetType(MDTuple *MDT,
     ConstantInt *CI = dyn_cast<ConstantInt>(ConstMDI->getValue());
     if (!CI)
       return;
-    Ints[I] = CI->getLimitedValue();
+    Ints[I] = CI->getLimitedValue(std::numeric_limits<unsigned>::max());
   }
 
-  Map.try_emplace(
-      Ty, LinAlgTargetType{static_cast<DXIL::ComponentType>(Ints[0]), Ints[1],
-                           Ints[2], static_cast<DXIL::MatrixUse>(Ints[3]),
-                           static_cast<DXIL::MatrixScope>(Ints[4])});
+  Map.try_emplace(Ty,
+                  LinAlgTargetType{static_cast<DXIL::ComponentType>(Ints[0]),
+                                   static_cast<unsigned>(Ints[1]),
+                                   static_cast<unsigned>(Ints[2]),
+                                   static_cast<DXIL::MatrixUse>(Ints[3]),
+                                   static_cast<DXIL::MatrixScope>(Ints[4])});
 }
 
 ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,

--- a/lib/DxilValidation/DxilValidationUtils.cpp
+++ b/lib/DxilValidation/DxilValidationUtils.cpp
@@ -41,38 +41,35 @@ EntryStatus::EntryStatus(DxilEntryProps &entryProps)
       entryProps.sig.PatchConstOrPrimSignature.GetElements().size(), 0);
 }
 
-static std::optional<std::tuple<Type *, LinAlgTargetType>>
-TryMakeLinAlgTargetType(MDTuple *MDT) {
+static void
+TryAddLinAlgTargetType(MDTuple *MDT,
+                       std::unordered_map<Type *, LinAlgTargetType> &Map) {
   if (!MDT || MDT->getNumOperands() != 6)
-    return std::nullopt;
+    return;
 
   ConstantAsMetadata *ConstMD0 =
       dyn_cast<ConstantAsMetadata>(MDT->getOperand(0).get());
   if (!ConstMD0)
-    return std::nullopt;
+    return;
 
   Type *Ty = ConstMD0->getValue()->getType();
-  ConstantInt *Ints[5];
+  uint64_t Ints[5];
 
   for (size_t I = 0; I < 5; ++I) {
     ConstantAsMetadata *ConstMDI =
         dyn_cast<ConstantAsMetadata>(MDT->getOperand(I + 1).get());
     if (!ConstMDI)
-      return std::nullopt;
+      return;
     ConstantInt *CI = dyn_cast<ConstantInt>(ConstMDI->getValue());
     if (!CI)
-      return std::nullopt;
-    Ints[I] = CI;
+      return;
+    Ints[I] = CI->getLimitedValue();
   }
 
-  LinAlgTargetType LATT;
-  LATT.Type = static_cast<DXIL::ComponentType>(Ints[0]->getLimitedValue());
-  LATT.M = Ints[1]->getLimitedValue();
-  LATT.N = Ints[2]->getLimitedValue();
-  LATT.Use = static_cast<DXIL::MatrixUse>(Ints[3]->getLimitedValue());
-  LATT.Scope = static_cast<DXIL::MatrixScope>(Ints[4]->getLimitedValue());
-
-  return {{Ty, LATT}};
+  Map.try_emplace(
+      Ty, LinAlgTargetType{static_cast<DXIL::ComponentType>(Ints[0]), Ints[1],
+                           Ints[2], static_cast<DXIL::MatrixUse>(Ints[3]),
+                           static_cast<DXIL::MatrixScope>(Ints[4])});
 }
 
 ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,
@@ -132,11 +129,7 @@ ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,
   if (NMD) {
     for (llvm::MDNode *MDN : NMD->operands()) {
       MDTuple *MDT = dyn_cast<MDTuple>(MDN);
-      std::optional<std::tuple<Type *, LinAlgTargetType>> LATTOpt =
-          TryMakeLinAlgTargetType(MDT);
-      if (!LATTOpt)
-        continue;
-      TargetTypeMap.try_emplace(std::get<0>(*LATTOpt), std::get<1>(*LATTOpt));
+      TryAddLinAlgTargetType(MDT, LinAlgTargetTypeMap);
     }
   }
 }

--- a/lib/DxilValidation/DxilValidationUtils.cpp
+++ b/lib/DxilValidation/DxilValidationUtils.cpp
@@ -136,10 +136,7 @@ ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,
           TryMakeLinAlgTargetType(MDT);
       if (!LATTOpt)
         continue;
-      Type *Ty;
-      LinAlgTargetType LATT;
-      std::tie(Ty, LATT) = *LATTOpt;
-      TargetTypeMap.try_emplace(Ty, LATT);
+      TargetTypeMap.try_emplace(std::get<0>(*LATTOpt), std::get<1>(*LATTOpt));
     }
   }
 }

--- a/lib/DxilValidation/DxilValidationUtils.cpp
+++ b/lib/DxilValidation/DxilValidationUtils.cpp
@@ -11,6 +11,8 @@
 
 #include "DxilValidationUtils.h"
 
+#include <optional>
+
 #include "dxc/DXIL/DxilEntryProps.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
@@ -37,6 +39,39 @@ EntryStatus::EntryStatus(DxilEntryProps &entryProps)
   outputCols.resize(entryProps.sig.OutputSignature.GetElements().size(), 0);
   patchConstOrPrimCols.resize(
       entryProps.sig.PatchConstOrPrimSignature.GetElements().size(), 0);
+}
+
+static std::optional<std::tuple<Type*, LinAlgTargetType>> TryMakeLinAlgTargetType(MDTuple *MDT) {
+  if (!MDT || MDT->getNumOperands() != 6)
+    return std::nullopt;
+
+  ConstantAsMetadata *ConstMD0 =
+      dyn_cast<ConstantAsMetadata>(MDT->getOperand(0).get());
+  if (!ConstMD0)
+    return std::nullopt;
+
+  Type *Ty = ConstMD0->getValue()->getType();
+  ConstantInt *Ints[5];
+
+  for (size_t I = 0; I < 5; ++I) {
+    ConstantAsMetadata *ConstMDI =
+        dyn_cast<ConstantAsMetadata>(MDT->getOperand(I + 1).get());
+    if (!ConstMDI)
+      return std::nullopt;
+    ConstantInt *CI = dyn_cast<ConstantInt>(ConstMDI->getValue());
+    if (!CI)
+      return std::nullopt;
+    Ints[I] = CI;
+  }
+
+  LinAlgTargetType LATT;
+  LATT.Type = static_cast<DXIL::ComponentType>(Ints[0]->getLimitedValue());
+  LATT.M = Ints[1]->getLimitedValue();
+  LATT.N = Ints[2]->getLimitedValue();
+  LATT.Use = static_cast<DXIL::MatrixUse>(Ints[3]->getLimitedValue());
+  LATT.Scope = static_cast<DXIL::MatrixScope>(Ints[4]->getLimitedValue());
+
+  return {{Ty, LATT}};
 }
 
 ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,
@@ -87,6 +122,22 @@ ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,
     if (props.IsHS()) {
       PatchConstantFuncMap[props.ShaderProps.HS.patchConstantFunc].emplace_back(
           Entry);
+    }
+  }
+
+  // Capture the TargetTypes metadata in the validation context
+  // if it is present and valid.
+  NamedMDNode *NMD = M.getNamedMetadata("dx.targetTypes");
+  if (NMD) {
+    for (llvm::MDNode *MDN : NMD->operands()) {
+      MDTuple *MDT = dyn_cast<MDTuple>(MDN);
+      std::optional<std::tuple<Type*, LinAlgTargetType>> LATTOpt = TryMakeLinAlgTargetType(MDT);
+      if (!LATTOpt)
+        continue;
+      Type* Ty;
+      LinAlgTargetType LATT;
+      std::tie(Ty, LATT) = *LATTOpt;
+      TargetTypeMap.try_emplace(Ty, LATT);
     }
   }
 }

--- a/lib/DxilValidation/DxilValidationUtils.cpp
+++ b/lib/DxilValidation/DxilValidationUtils.cpp
@@ -41,7 +41,8 @@ EntryStatus::EntryStatus(DxilEntryProps &entryProps)
       entryProps.sig.PatchConstOrPrimSignature.GetElements().size(), 0);
 }
 
-static std::optional<std::tuple<Type*, LinAlgTargetType>> TryMakeLinAlgTargetType(MDTuple *MDT) {
+static std::optional<std::tuple<Type *, LinAlgTargetType>>
+TryMakeLinAlgTargetType(MDTuple *MDT) {
   if (!MDT || MDT->getNumOperands() != 6)
     return std::nullopt;
 
@@ -131,10 +132,11 @@ ValidationContext::ValidationContext(Module &llvmModule, Module *DebugModule,
   if (NMD) {
     for (llvm::MDNode *MDN : NMD->operands()) {
       MDTuple *MDT = dyn_cast<MDTuple>(MDN);
-      std::optional<std::tuple<Type*, LinAlgTargetType>> LATTOpt = TryMakeLinAlgTargetType(MDT);
+      std::optional<std::tuple<Type *, LinAlgTargetType>> LATTOpt =
+          TryMakeLinAlgTargetType(MDT);
       if (!LATTOpt)
         continue;
-      Type* Ty;
+      Type *Ty;
       LinAlgTargetType LATT;
       std::tie(Ty, LATT) = *LATTOpt;
       TargetTypeMap.try_emplace(Ty, LATT);

--- a/lib/DxilValidation/DxilValidationUtils.h
+++ b/lib/DxilValidation/DxilValidationUtils.h
@@ -36,6 +36,7 @@ class Value;
 class GlobalVariable;
 class Instruction;
 class Type;
+class MDTuple;
 } // namespace llvm
 
 namespace hlsl {
@@ -63,6 +64,14 @@ struct EntryStatus {
   EntryStatus(DxilEntryProps &entryProps);
 };
 
+struct LinAlgTargetType {
+  DXIL::ComponentType Type;
+  unsigned M;
+  unsigned N;
+  DXIL::MatrixUse Use;
+  DXIL::MatrixScope Scope;
+};
+
 struct ValidationContext {
   bool Failed = false;
   Module &M;
@@ -80,6 +89,7 @@ struct ValidationContext {
   std::unordered_map<Value *, DxilResourceProperties> ResPropMap;
   std::unordered_map<Function *, std::vector<Function *>> PatchConstantFuncMap;
   std::unordered_map<Function *, std::unique_ptr<EntryStatus>> entryStatusMap;
+  std::unordered_map<Type *, LinAlgTargetType> TargetTypeMap;
   bool isLibProfile;
   const unsigned kDxilControlFlowHintMDKind;
   const unsigned kDxilPreciseMDKind;

--- a/lib/DxilValidation/DxilValidationUtils.h
+++ b/lib/DxilValidation/DxilValidationUtils.h
@@ -36,7 +36,6 @@ class Value;
 class GlobalVariable;
 class Instruction;
 class Type;
-class MDTuple;
 } // namespace llvm
 
 namespace hlsl {
@@ -89,7 +88,7 @@ struct ValidationContext {
   std::unordered_map<Value *, DxilResourceProperties> ResPropMap;
   std::unordered_map<Function *, std::vector<Function *>> PatchConstantFuncMap;
   std::unordered_map<Function *, std::unique_ptr<EntryStatus>> entryStatusMap;
-  std::unordered_map<Type *, LinAlgTargetType> TargetTypeMap;
+  std::unordered_map<Type *, LinAlgTargetType> LinAlgTargetTypeMap;
   bool isLibProfile;
   const unsigned kDxilControlFlowHintMDKind;
   const unsigned kDxilPreciseMDKind;

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/copyconvertmatrix/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/copyconvertmatrix/nominal.hlsl
@@ -7,12 +7,15 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call %dx.types.LinAlgMatrixC4M5N4U1S2 @dx.op.linAlgCopyConvertMatrix.mC4M5N4U1S2.mC2M5N4U1S2
-  // CHECK-SAME: (i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 {{.*}}, i1 false)  
+  // CHECK-SAME: (i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 %{{.*}}, i1 false)  
   // CHECK-SAME: ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2*, %dx.types.LinAlgMatrixC2M5N4U1S2, i1)"
-  // CHECK2-SAME: (i32 401, %dx.types.LinAlgMatrixC4M5N4U1S2* {{.*}}, %dx.types.LinAlgMatrixC2M5N4U1S2 {{.*}}, i1 false)
+  // CHECK2-SAME: (i32 401, %dx.types.LinAlgMatrixC4M5N4U1S2* %{{.*}}, %dx.types.LinAlgMatrixC2M5N4U1S2 {{.*}}, i1 false)
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(2, 5, 4, 1, 2)]] mat1;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat2;
+
+  __builtin_LinAlg_FillMatrix(mat1, 1);
+
   __builtin_LinAlg_CopyConvertMatrix(mat2, mat1, false);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulate/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulate/nominal.hlsl
@@ -9,9 +9,12 @@ void main() {
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat1;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(1, 1, 1, 0, 0)]] mat2;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(2, 2, 2, 2, 2)]] mat3;
-  
+
+  __builtin_LinAlg_FillMatrix(mat1, 1);
+  __builtin_LinAlg_FillMatrix(mat2, 2);
+
   // CHECK: call %dx.types.LinAlgMatrixC2M2N2U2S2 @dx.op.linAlgMatrixAccumulate.mC2M2N2U2S2.mC1M1N1U0S0.mC5M3N4U0S
-  // CHECK-SAME: (i32 -2147483624, %dx.types.LinAlgMatrixC1M1N1U0S0 {{.*}}, %dx.types.LinAlgMatrixC5M3N4U0S0 {{.*}}) ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  // CHECK-SAME: (i32 -2147483624, %dx.types.LinAlgMatrixC1M1N1U0S0 %{{.*}}, %dx.types.LinAlgMatrixC5M3N4U0S0 %{{.*}}) ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC2M2N2U2S2*, %dx.types.LinAlgMatrixC1M1N1U0S0,
   // CHECK2-SAME:  %dx.types.LinAlgMatrixC5M3N4U0S0)"(i32 411, %dx.types.LinAlgMatrixC2M2N2U2S2* %mat3,

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulate/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulate/nominal.hlsl
@@ -6,18 +6,18 @@
 void main() {
   // CHECK-LABEL: define void @main()
 
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat1;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(1, 1, 1, 0, 0)]] mat2;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(2, 2, 2, 2, 2)]] mat3;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 0, 0)]] mat1;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 0, 0)]] mat2;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 0, 0)]] mat3;
 
   __builtin_LinAlg_FillMatrix(mat1, 1);
   __builtin_LinAlg_FillMatrix(mat2, 2);
 
-  // CHECK: call %dx.types.LinAlgMatrixC2M2N2U2S2 @dx.op.linAlgMatrixAccumulate.mC2M2N2U2S2.mC1M1N1U0S0.mC5M3N4U0S
-  // CHECK-SAME: (i32 -2147483624, %dx.types.LinAlgMatrixC1M1N1U0S0 %{{.*}}, %dx.types.LinAlgMatrixC5M3N4U0S0 %{{.*}}) ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  // CHECK: call %dx.types.LinAlgMatrixC5M4N4U0S0 @dx.op.linAlgMatrixAccumulate.mC5M4N4U0S0.mC5M4N4U0S0.mC5M4N4U0S0
+  // CHECK-SAME: (i32 -2147483624, %dx.types.LinAlgMatrixC5M4N4U0S0 %{{.*}}, %dx.types.LinAlgMatrixC5M4N4U0S0 %{{.*}}) ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC2M2N2U2S2*, %dx.types.LinAlgMatrixC1M1N1U0S0,
-  // CHECK2-SAME:  %dx.types.LinAlgMatrixC5M3N4U0S0)"(i32 411, %dx.types.LinAlgMatrixC2M2N2U2S2* %mat3,
-  // CHECK2-SAME: %dx.types.LinAlgMatrixC1M1N1U0S0 %{{[0-9]+}}, %dx.types.LinAlgMatrixC5M3N4U0S0 %{{[0-9]+}})
+  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M4N4U0S0*, %dx.types.LinAlgMatrixC5M4N4U0S0,
+  // CHECK2-SAME:  %dx.types.LinAlgMatrixC5M4N4U0S0)"(i32 411, %dx.types.LinAlgMatrixC5M4N4U0S0* %mat3,
+  // CHECK2-SAME: %dx.types.LinAlgMatrixC5M4N4U0S0 %{{[0-9]+}}, %dx.types.LinAlgMatrixC5M4N4U0S0 %{{[0-9]+}})
   __builtin_LinAlg_MatrixAccumulate(mat3, mat2, mat1);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulatetodescriptor/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulatetodescriptor/nominal.hlsl
@@ -9,11 +9,12 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U1S2(i32 -2147483621,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, %dx.types.Handle %{{.*}}, i32 5, i32 5, i32 5, i32 4)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, %dx.types.Handle %{{.*}}, i32 5, i32 5, i32 5, i32 4)
   // CHECK-SAME: ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2, %dx.types.Handle, i32, i32, i32, i32)"
-  // CHECK2-SAME: (i32 415, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, %dx.types.Handle {{.*}}, i32 5, i32 5, i32 5, i32 4)
+  // CHECK2-SAME: (i32 415, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, %dx.types.Handle {{.*}}, i32 5, i32 5, i32 5, i32 4)
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   __builtin_LinAlg_MatrixAccumulateToDescriptor(mat, outbuf, 5, 5, 5, 4);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulatetomemory/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulatetomemory/nominal.hlsl
@@ -10,14 +10,15 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call void @dx.op.linAlgMatrixAccumulateToMemory.mC4M5N4U1S2.f32(i32 -2147483620,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, float addrspace(3)* getelementptr inbounds ([64 x float],
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, float addrspace(3)* getelementptr inbounds ([64 x float],
   // CHECK-SAME: [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 1, i32 2, i32 3)  
   // CHECK-SAME: ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2,
   // CHECK2-SAME: [64 x float] addrspace(3)*, i32, i32, i32)"(i32 416, 
-  // CHECK2-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA",
+  // CHECK2-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA",
   // CHECK2-SAME: i32 1, i32 2, i32 3)
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   __builtin_LinAlg_MatrixAccumulateToMemory(mat, SharedArr, 1, 2, 3);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixgetcoordinate/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixgetcoordinate/nominal.hlsl
@@ -7,11 +7,12 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call <2 x i32> @dx.op.linAlgMatrixGetCoordinate.mC4M5N4U1S2(i32 -2147483631,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1) 
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1) 
   // CHECK-SAME: ; LinAlgMatrixGetCoordinate(matrix,threadLocalIndex)
 
   // CHECK2: call <2 x i32> @"dx.hl.op..<2 x i32> (i32, %dx.types.LinAlgMatrixC4M5N4U1S2, i32)"
-  // CHECK2-SAME: (i32 403, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)
+  // CHECK2-SAME: (i32 403, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   uint2 coord = __builtin_LinAlg_MatrixGetCoordinate(mat, 1);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixgetelement/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixgetelement/nominal.hlsl
@@ -9,39 +9,40 @@ void main() {
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
 
   // CHECK: call i32 @dx.op.linAlgMatrixGetElement.i32.mC4M5N4U1S2(i32 -2147483630,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 0)  
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 0)  
   // CHECK-SAME: ; LinAlgMatrixGetElement(matrix,threadLocalIndex)
 
   // CHECK2: call void @"dx.hl.op..void (i32, i32*, %dx.types.LinAlgMatrixC4M5N4U1S2, i32)"
-  // CHECK2-SAME: (i32 404, i32* %elem1, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 0)
+  // CHECK2-SAME: (i32 404, i32* %elem1, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 0)
   uint elem1;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   __builtin_LinAlg_MatrixGetElement(elem1, mat, 0);
 
   // CHECK: call float @dx.op.linAlgMatrixGetElement.f32.mC4M5N4U1S2(i32 -2147483630,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)  
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)  
   // CHECK-SAME: ; LinAlgMatrixGetElement(matrix,threadLocalIndex)
 
   // CHECK2: call void @"dx.hl.op..void (i32, float*, %dx.types.LinAlgMatrixC4M5N4U1S2, i32)"
-  // CHECK2-SAME: (i32 404, float* %elem2, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)
+  // CHECK2-SAME: (i32 404, float* %elem2, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)
   float elem2;
   __builtin_LinAlg_MatrixGetElement(elem2, mat, 1);
 
   // CHECK: call double @dx.op.linAlgMatrixGetElement.f64.mC4M5N4U1S2(i32 -2147483630,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)  
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)  
   // CHECK-SAME: ; LinAlgMatrixGetElement(matrix,threadLocalIndex)
 
   // CHECK2: call void @"dx.hl.op..void (i32, double*, %dx.types.LinAlgMatrixC4M5N4U1S2, i32)"
-  // CHECK2-SAME: (i32 404, double* %elem3, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)
+  // CHECK2-SAME: (i32 404, double* %elem3, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)
   double elem3;
   __builtin_LinAlg_MatrixGetElement(elem3, mat, 1);
 
 
   // CHECK: call i64 @dx.op.linAlgMatrixGetElement.i64.mC4M5N4U1S2(i32 -2147483630,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)  
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)  
   // CHECK-SAME: ; LinAlgMatrixGetElement(matrix,threadLocalIndex)
 
   // CHECK2: call void @"dx.hl.op..void (i32, i64*, %dx.types.LinAlgMatrixC4M5N4U1S2, i32)"
-  // CHECK2-SAME: (i32 404, i64* %elem4, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1)
+  // CHECK2-SAME: (i32 404, i64* %elem4, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1)
   int64_t elem4;
   __builtin_LinAlg_MatrixGetElement(elem4, mat, 1);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixlength/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixlength/nominal.hlsl
@@ -7,10 +7,11 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call i32 @dx.op.linAlgMatrixLength.mC4M5N4U1S2(i32 -2147483632,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}})  ; LinAlgMatrixLength(matrix)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}})  ; LinAlgMatrixLength(matrix)
 
   // CHECK2: call i32 @"dx.hl.op..i32 (i32, %dx.types.LinAlgMatrixC4M5N4U1S2)"
-  // CHECK2-SAME: (i32 405, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}})
+  // CHECK2-SAME: (i32 405, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}})
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   uint len = __builtin_LinAlg_MatrixLength(mat);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixloadfromdescriptor/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixloadfromdescriptor/nominal.hlsl
@@ -8,12 +8,12 @@ ByteAddressBuffer inbuf;
 void main() {
   // CHECK-LABEL: define void @main()
 
-  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC1M1N1U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC1M1N1U0S0
+  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC1M4N4U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC1M4N4U0S0
   // CHECK-SAME: (i32 -2147483634, %dx.types.Handle %{{.*}}, i32 0, i32 0, i32 0, i32 4) 
   // CHECK-SAME: ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC1M1N1U0S0*, %dx.types.Handle, i32, i32, i32, i32)
-  // CHECK2-SAME: "(i32 406, %dx.types.LinAlgMatrixC1M1N1U0S0* %mat, %dx.types.Handle {{.*}}, i32 0, i32 0, i32 0, i32 4)
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(1, 1, 1, 0, 0)]] mat;
+  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC1M4N4U0S0*, %dx.types.Handle, i32, i32, i32, i32)
+  // CHECK2-SAME: "(i32 406, %dx.types.LinAlgMatrixC1M4N4U0S0* %mat, %dx.types.Handle {{.*}}, i32 0, i32 0, i32 0, i32 4)
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(1, 4, 4, 0, 0)]] mat;
   __builtin_LinAlg_MatrixLoadFromDescriptor(mat, inbuf, 0, 0, 0, 4);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixmatrixmultiply/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixmatrixmultiply/nominal.hlsl
@@ -7,12 +7,13 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call %dx.types.LinAlgMatrixC4M5N4U1S2 @dx.op.linAlgMatrixMultiply.mC4M5N4U1S2.mC4M5N4U1S2.mC4M5N4U1S2(i32 -2147483625,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}) ; LinAlgMatrixMultiply(matrixA,matrixB)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}) ; LinAlgMatrixMultiply(matrixA,matrixB)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2*, %dx.types.LinAlgMatrixC4M5N4U1S2,
   // CHECK2-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2)"(i32 412, %dx.types.LinAlgMatrixC4M5N4U1S2* %mat2,
   // CHECK2-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{[0-9]+}}, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{[0-9]+}})
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat1;
+  __builtin_LinAlg_FillMatrix(mat1, 1);
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat2;
   __builtin_LinAlg_MatrixMatrixMultiply(mat2, mat1, mat1);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixmatrixmultiplyaccumulate/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixmatrixmultiplyaccumulate/nominal.hlsl
@@ -6,8 +6,8 @@
 void main() {
   // CHECK-LABEL: define void @main()
 
-  // The FillMatrix calls are similar enough the start matching the CHECK-SAME
-  // lines so we consume them first.
+  // The FillMatrix calls are similar enough that they start matching
+  // the CHECK-SAME lines so we consume them first.
   // CHECK: ; LinAlgFillMatrix(value)
   // CHECK: ; LinAlgFillMatrix(value)
   // CHECK: ; LinAlgFillMatrix(value)

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixmatrixmultiplyaccumulate/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixmatrixmultiplyaccumulate/nominal.hlsl
@@ -6,17 +6,26 @@
 void main() {
   // CHECK-LABEL: define void @main()
 
+  // The FillMatrix calls are similar enough the start matching the CHECK-SAME
+  // lines so we consume them first.
+  // CHECK: ; LinAlgFillMatrix(value)
+  // CHECK: ; LinAlgFillMatrix(value)
+  // CHECK: ; LinAlgFillMatrix(value)
+
   // CHECK: call %dx.types.LinAlgMatrixC4M5N3U1S2
   // CHECK-SAME: @dx.op.linAlgMatrixMultiplyAccumulate.mC4M5N3U1S2.mC4M5N4U1S2.mC4M4N3U1S2.mC4M5N3U1S2
-  // CHECK-SAME: (i32 -2147483637, %dx.types.LinAlgMatrixC4M5N4U1S2 undef, %dx.types.LinAlgMatrixC4M4N3U1S2 undef, 
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N3U1S2 undef) ; LinAlgMatrixMultiplyAccumulate(matrixA,matrixB,matrixC)
-  
+  // CHECK-SAME: (i32 -2147483637, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{[0-9]+}}, %dx.types.LinAlgMatrixC4M4N3U1S2 %{{[0-9]+}},
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N3U1S2 %{{[0-9]+}}) ; LinAlgMatrixMultiplyAccumulate(matrixA,matrixB,matrixC)
+
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N3U1S2*, %dx.types.LinAlgMatrixC4M5N4U1S2,
   // CHECK2-SAME: %dx.types.LinAlgMatrixC4M4N3U1S2, %dx.types.LinAlgMatrixC4M5N3U1S2)"(i32 413,
-  // CHECK2-SAME: %dx.types.LinAlgMatrixC4M5N3U1S2* {{.*}}, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{[0-9]+}},
+  // CHECK2-SAME: %dx.types.LinAlgMatrixC4M5N3U1S2* %{{.*}}, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{[0-9]+}},
   // CHECK2-SAME: %dx.types.LinAlgMatrixC4M4N3U1S2 %{{[0-9]+}}, %dx.types.LinAlgMatrixC4M5N3U1S2 %{{[0-9]+}})
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat1;
+  __builtin_LinAlg_FillMatrix(mat1, 1);
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 4, 3, 1, 2)]] mat2;
+  __builtin_LinAlg_FillMatrix(mat2, 2);
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 3, 1, 2)]] mat3;
+  __builtin_LinAlg_FillMatrix(mat3, 3);
   __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(mat3, mat1, mat2, mat3);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixsetelement/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixsetelement/nominal.hlsl
@@ -10,13 +10,15 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call %dx.types.LinAlgMatrixC4M5N4U1S2 @dx.op.linAlgMatrixSetElement.mC4M5N4U1S2.mC4M5N4U1S2.i32
-  // CHECK-SAME: (i32 -2147483629, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1, i32 5)
+  // CHECK-SAME: (i32 -2147483629, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1, i32 5)
   // CHECK-SAME: ; LinAlgMatrixSetElement(matrix,threadLocalIndex,value)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2*, %dx.types.LinAlgMatrixC4M5N4U1S2, i32, i32)
-  // CHECK2-SAME: "(i32 408, %dx.types.LinAlgMatrixC4M5N4U1S2* {{.*}}, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i32 1, i32 5)
+  // CHECK2-SAME: "(i32 408, %dx.types.LinAlgMatrixC4M5N4U1S2* %{{.*}}, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i32 1, i32 5)
 
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat1;
+  __builtin_LinAlg_FillMatrix(mat1, 1);
+
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat2;
   __builtin_LinAlg_MatrixSetElement(mat2, mat1, 1, 5);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixstoretodescriptor/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixstoretodescriptor/nominal.hlsl
@@ -9,11 +9,12 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call void @dx.op.linAlgMatrixStoreToDescriptor.mC4M5N4U1S2(i32 -2147483628,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, %dx.types.Handle %{{.*}}, i32 1, i32 1, i32 0, i32 4)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, %dx.types.Handle %{{.*}}, i32 1, i32 1, i32 0, i32 4)
   // CHECK-SAME:  ; LinAlgMatrixStoreToDescriptor(matrix,handle,offset,stride,layout,align)
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2, %dx.types.Handle, i32, i32, i32, i32)
-  // CHECK2-SAME: "(i32 409, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, %dx.types.Handle {{.*}}, i32 1, i32 1, i32 0, i32 4)
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat1;
-  __builtin_LinAlg_MatrixStoreToDescriptor(mat1, outbuf, 1, 1, 0, 4);
+  // CHECK2-SAME: "(i32 409, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, %dx.types.Handle {{.*}}, i32 1, i32 1, i32 0, i32 4)
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
+  __builtin_LinAlg_MatrixStoreToDescriptor(mat, outbuf, 1, 1, 0, 4);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixstoretomemory/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixstoretomemory/nominal.hlsl
@@ -10,7 +10,7 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   // CHECK: call void @dx.op.linAlgMatrixStoreToMemory.mC4M5N4U1S2.f32(i32 -2147483627, 
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, float addrspace(3)* getelementptr
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, float addrspace(3)* getelementptr
   // CHECK-SAME: inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA",
   // CHECK-SAME: i32 0, i32 0), i32 1, i32 2, i32 3)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
@@ -18,5 +18,6 @@ void main() {
   // CHECK2-SAME: (i32 410, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA",
   // CHECK2-SAME: i32 1, i32 2, i32 3)
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   __builtin_LinAlg_MatrixStoreToMemory(mat, SharedArr, 1, 2, 3);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiply/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiply/nominal.hlsl
@@ -7,14 +7,15 @@ void main() {
   // CHECK-LABEL: define void @main()
 
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat;
+  __builtin_LinAlg_FillMatrix(mat, 1);
   float4 vec = {1,2,3,4};
   float4 result;
 
   // CHECK: call <4 x float> @dx.op.linAlgMatVecMul.v4f32.mC4M5N4U1S2.v4f32(i32 -2147483623,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i1 true, <4 x float> <float 1.000000e+00, float 2.000000e+00,
+  // CHECK-SAME: %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i1 true, <4 x float> <float 1.000000e+00, float 2.000000e+00,
   // CHECK-SAME: float 3.000000e+00, float 4.000000e+00>, i32 1)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
 
   // CHECK2: call void @"dx.hl.op..void (i32, <4 x float>*, %dx.types.LinAlgMatrixC4M5N4U1S2, i1, <4 x float>, i32)
-  // CHECK2-SAME: "(i32 418, <4 x float>* %result, %dx.types.LinAlgMatrixC4M5N4U1S2 {{.*}}, i1 true, <4 x float> {{.*}}, i32 1)
+  // CHECK2-SAME: "(i32 418, <4 x float>* %result, %dx.types.LinAlgMatrixC4M5N4U1S2 %{{.*}}, i1 true, <4 x float> %{{.*}}, i32 1)
   __builtin_LinAlg_MatrixVectorMultiply(result, mat, true, vec, 1);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiplyadd/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiplyadd/nominal.hlsl
@@ -6,12 +6,13 @@
 void main() {
   // CHECK-LABEL: define void @main()
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat1;
+  __builtin_LinAlg_FillMatrix(mat1, 1);
   float4 vec = {1,2,3,4};
-  float4 result;
+  float4 result = 0;
 
   // CHECK: call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC5M3N4U0S0.v4f32.v4f32(i32 -2147483622,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC5M3N4U0S0 {{.*}}, i1 true, <4 x float> <float 1.000000e+00,
-  // CHECK-SAME: float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, i32 1, <4 x float> {{.*}}, i32 0)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC5M3N4U0S0 %{{.*}}, i1 true, <4 x float> <float 1.000000e+00,
+  // CHECK-SAME: float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, i32 1, <4 x float> zeroinitializer, i32 0)
   // CHECK-SAME: ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector,biasInterpretation)
 
   // CHECK2: call void @"dx.hl.op..void (i32, <4 x float>*, %dx.types.LinAlgMatrixC5M3N4U0S0, i1, <4 x float>,
@@ -21,12 +22,13 @@ void main() {
   __builtin_LinAlg_MatrixVectorMultiplyAdd(result, mat1, true, vec, 1, result, 0);
 
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat2;
+  __builtin_LinAlg_FillMatrix(mat2, 2);
   double4 vec2 = {1,2,3,4};
-  double4 result2;
+  double4 result2 = 0;
 
   // CHECK: call <4 x double> @dx.op.linAlgMatVecMulAdd.v4f64.mC5M3N4U0S0.v4f64.v4f64(i32 -2147483622,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC5M3N4U0S0 {{.*}}, i1 true, <4 x double> <double 1.000000e+00,
-  // CHECK-SAME: double 2.000000e+00, double 3.000000e+00, double 4.000000e+00>, i32 1, <4 x double> {{.*}}, i32 0)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC5M3N4U0S0 %{{.*}}, i1 true, <4 x double> <double 1.000000e+00,
+  // CHECK-SAME: double 2.000000e+00, double 3.000000e+00, double 4.000000e+00>, i32 1, <4 x double> zeroinitializer, i32 0)
   // CHECK-SAME: ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector,biasInterpretation)
 
   // CHECK2: call void @"dx.hl.op..void (i32, <4 x double>*, %dx.types.LinAlgMatrixC5M3N4U0S0, i1, <4 x double>,
@@ -36,12 +38,13 @@ void main() {
   __builtin_LinAlg_MatrixVectorMultiplyAdd(result2, mat2, true, vec2, 1, result2, 0);
 
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat3;
+  __builtin_LinAlg_FillMatrix(mat3, 3);
   vector<int64_t, 4> vec3 = {1,2,3,4};
-  vector<int64_t, 4> result3;
+  vector<int64_t, 4> result3 = 0;
 
   // CHECK: call <4 x i64> @dx.op.linAlgMatVecMulAdd.v4i64.mC5M3N4U0S0.v4i64.v4i64(i32 -2147483622,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC5M3N4U0S0 {{.*}}, i1 true, <4 x i64> <i64 1,
-  // CHECK-SAME: i64 2, i64 3, i64 4>, i32 1, <4 x i64> {{.*}}, i32 0)
+  // CHECK-SAME: %dx.types.LinAlgMatrixC5M3N4U0S0 %{{.*}}, i1 true, <4 x i64> <i64 1,
+  // CHECK-SAME: i64 2, i64 3, i64 4>, i32 1, <4 x i64> zeroinitializer, i32 0)
   // CHECK-SAME: ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector,biasInterpretation)
 
   // CHECK2: call void @"dx.hl.op..void (i32, <4 x i64>*, %dx.types.LinAlgMatrixC5M3N4U0S0, i1, <4 x i64>,
@@ -50,8 +53,13 @@ void main() {
 
   __builtin_LinAlg_MatrixVectorMultiplyAdd(result3, mat3, true, vec3, 1, result3, 0);
 
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(17, 8, 8, 0, 0)]] mat4;
+  __builtin_LinAlg_FillMatrix(mat4, 4);
+  vector<int8_t4_packed, 8> vec4 = 0;
+  vector<int8_t4_packed, 8> result4 = 0;
+
   // CHECK: call <8 x i32> @dx.op.linAlgMatVecMulAdd.v8i32.mC17M8N8U0S0.v8i32.v8i32(i32 -2147483622,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC17M8N8U0S0 {{.*}}, i1 true, <8 x i32> zeroinitializer,
+  // CHECK-SAME: %dx.types.LinAlgMatrixC17M8N8U0S0 %{{.*}}, i1 true, <8 x i32> zeroinitializer,
   // CHECK-SAME: i32 1, <8 x i32> zeroinitializer, i32 0)
   // CHECK-SAME: ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector,biasInterpretation)
 
@@ -59,8 +67,5 @@ void main() {
   // CHECK2-SAME: i32, <8 x i32>, i32)"(i32 419, <8 x i32>* %result4, %dx.types.LinAlgMatrixC17M8N8U0S0 %{{[0-9]+}},
   // CHECK2-SAME: i1 true, <8 x i32> %{{[0-9]+}}, i32 1, <8 x i32> %{{[0-9]+}}, i32 0)
 
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(17, 8, 8, 0, 0)]] mat4;
-  vector<int8_t4_packed, 8> vec4 = 0;
-  vector<int8_t4_packed, 8> result4 = 0;
   __builtin_LinAlg_MatrixVectorMultiplyAdd(result4, mat4, true, vec4, 1, result4, 0);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-compute.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-compute.hlsl
@@ -15,6 +15,8 @@ uint useMatrix1() {
 
   // Matrix<ComponentType::U32, 3, 3, MatrixUse::A, MatrixScope::Thread> m;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 3, 0, 0)]] mat2;
+  // mat2 = Matrix::Splat(1);
+  __builtin_LinAlg_FillMatrix(mat2, 1);
   // return mat2.Length();
   return __builtin_LinAlg_MatrixLength(mat2);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-compute.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-compute.hlsl
@@ -13,8 +13,8 @@ uint useMatrix1() {
   // mat1 = Matrix::Splat(5);
   __builtin_LinAlg_FillMatrix(mat1, 5);
 
-  // Matrix<ComponentType::U32, 3, 3, MatrixUse::A, MatrixScope::Thread> m;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 3, 0, 0)]] mat2;
+  // Matrix<ComponentType::U32, 8, 8, MatrixUse::A, MatrixScope::Thread> m;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 8, 0, 0)]] mat2;
   // mat2 = Matrix::Splat(1);
   __builtin_LinAlg_FillMatrix(mat2, 1);
   // return mat2.Length();
@@ -39,5 +39,5 @@ void main() {
 
 // CHECK: !dx.targetTypes = !{!{{[0-9]+}}, !{{[0-9]+}}}
 // CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC4M4N5U0S0 undef, i32 4, i32 4, i32 5, i32 0, i32 0}
-// CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC5M3N3U0S0 undef, i32 5, i32 3, i32 3, i32 0, i32 0}
+// CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC5M8N8U0S0 undef, i32 5, i32 8, i32 8, i32 0, i32 0}
 // CHECK-NOT: !{%dx.types.LinAlgMatrixC10M2N2U1S1 undef, i32 10, i32 2, i32 2, i32 1, i32 1}

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-lib.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-lib.hlsl
@@ -31,7 +31,7 @@ uint useMatrix1() {
 
 uint useMatrix2() {
   // Matrix<ComponentType::F64, 2, 2, MatrixUse::B, MatrixScope::Wave> m;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(10, 2, 2, 1, 1)]] mat2;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(10, 4, 4, 1, 1)]] mat2;
   // Matrix::Splat(1)
   __builtin_LinAlg_FillMatrix(mat2, 1);
   // return mat2.Length();
@@ -76,7 +76,7 @@ void CSMain3() {
 // Target types in lib1
 // LIB1: !dx.targetTypes = !{![[TT1:.*]], ![[TT2:.*]]}
 // LIB1: ![[TT1]] = !{%dx.types.LinAlgMatrixC4M4N5U0S0 undef, i32 4, i32 4, i32 5, i32 0, i32 0}
-// LIB1: ![[TT2]] = !{%dx.types.LinAlgMatrixC10M2N2U1S1 undef, i32 10, i32 2, i32 2, i32 1, i32 1}
+// LIB1: ![[TT2]] = !{%dx.types.LinAlgMatrixC10M4N4U1S1 undef, i32 10, i32 4, i32 4, i32 1, i32 1}
 
 // Target types in lib2
 // LIB2: !dx.targetTypes = !{![[TT3:.*]]}
@@ -93,6 +93,6 @@ void CSMain3() {
 
 // CSMain3 uses two types of matrices
 // CSMAIN3: !dx.targetTypes = !{!{{[0-9]+}}, !{{[0-9]+}}}
-// CSMAIN3-DAG: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC10M2N2U1S1 undef, i32 10, i32 2, i32 2, i32 1, i32 1}
+// CSMAIN3-DAG: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC10M4N4U1S1 undef, i32 10, i32 4, i32 4, i32 1, i32 1}
 // CSMAIN3-DAG: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC5M6N6U2S2 undef, i32 5, i32 6, i32 6, i32 2, i32 2}
-// CSMAIN3-NOT: !{%dx.types.LinAlgMatrixC10M2N2U1S1
+// CSMAIN3-NOT: !{%dx.types.LinAlgMatrixC10M4N4U1S1

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-lib.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-lib.hlsl
@@ -32,6 +32,8 @@ uint useMatrix1() {
 uint useMatrix2() {
   // Matrix<ComponentType::F64, 2, 2, MatrixUse::B, MatrixScope::Wave> m;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(10, 2, 2, 1, 1)]] mat2;
+  // Matrix::Splat(1)
+  __builtin_LinAlg_FillMatrix(mat2, 1);
   // return mat2.Length();
   return __builtin_LinAlg_MatrixLength(mat2);
 }

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-as.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-as.ll
@@ -1,22 +1,35 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixMultiply not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixAccumulate not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixLength not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgFillMatrix not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixGetElement not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixSetElement not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model as_6_10.
-; CHECK: Function:  mainAS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  mainAS: error: Function uses features incompatible with the shader stage (as) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: mainAS: error: Opcode LinAlgMatrixMultiply not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixAccumulate not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixLength not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgFillMatrix not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixGetElement not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixSetElement not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: mainAS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model as_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: mainAS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: mainAS: error: Function uses features incompatible with the shader stage (as) of the entry function.
+; CHECK-NEXT: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
@@ -41,14 +54,17 @@ define void @mainAS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -131,6 +147,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-cs.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-cs.ll
@@ -115,6 +115,8 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-cs.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-cs.ll
@@ -25,14 +25,17 @@ define void @mainCS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -112,6 +115,7 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ds.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ds.ll
@@ -1,22 +1,36 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixMultiply not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixLength not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgFillMatrix not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixGetElement not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixSetElement not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ds_6_10.
-; CHECK: Function:  MainDS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  MainDS: error: Function uses features incompatible with the shader stage (ds) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: MainDS: error: Opcode LinAlgMatrixMultiply not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixLength not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgFillMatrix not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixGetElement not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixSetElement not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: MainDS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ds_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: MainDS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: MainDS: error: Function uses features incompatible with the shader stage (ds) of the entry function.
+; CHECK-NEXT: Function: MainDS: error: Function requires a visible group, but is called from a shader without one.
+; CHECK-NEXT: Validation failed.
 
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
@@ -41,14 +55,17 @@ define void @MainDS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -136,6 +153,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-gs.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-gs.ll
@@ -1,22 +1,36 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixMultiply not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixAccumulate not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixLength not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgFillMatrix not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixGetElement not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixSetElement not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model gs_6_10.
-; CHECK: Function:  MainGS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  MainGS: error: Function uses features incompatible with the shader stage (gs) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: MainGS: error: Opcode LinAlgMatrixMultiply not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixAccumulate not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixLength not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgFillMatrix not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixGetElement not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixSetElement not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: MainGS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model gs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: MainGS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: MainGS: error: Function uses features incompatible with the shader stage (gs) of the entry function.
+; CHECK-NEXT: Function: MainGS: error: Function requires a visible group, but is called from a shader without one.
+; CHECK-NEXT: Validation failed.
 
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
@@ -41,14 +55,17 @@ define void @MainGS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -135,6 +152,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-hs.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-hs.ll
@@ -1,23 +1,36 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixMultiply not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixAccumulate not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixLength not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgFillMatrix not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixGetElement not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixSetElement not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model hs_6_10.
-; CHECK: Function:  MainHS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  MainHS: error: Function uses features incompatible with the shader stage (hs) of the entry function.
-; CHECK: Validation failed.
-
+; CHECK: Function: MainHS: error: Opcode LinAlgMatrixMultiply not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixAccumulate not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixLength not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgFillMatrix not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixGetElement not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixSetElement not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: MainHS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model hs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: MainHS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: MainHS: error: Function uses features incompatible with the shader stage (hs) of the entry function.
+; CHECK-NEXT: Function: MainHS: error: Function requires a visible group, but is called from a shader without one.
+; CHECK-NEXT: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
@@ -41,14 +54,17 @@ define void @MainHS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -141,6 +157,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-max-k-dim.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-max-k-dim.ll
@@ -18,12 +18,12 @@ target triple = "dxil-ms-dx"
 %dx.types.LinAlgMatrixC8M3N16U1S0 = type { i8* }
 %dx.types.LinAlgMatrixC8M16N1025U0S2 = type { i8* }
 %dx.types.LinAlgMatrixC8M1025N16U0S2 = type { i8* }
-%dx.types.LinAlgMatrixC8M16N3U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N0U0S2 = type { i8* }
 %dx.types.LinAlgMatrixC8M3N16U0S2 = type { i8* }
 %dx.types.LinAlgMatrixC8M129N1025U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC8M1025N129U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC8M129N3U1S2 = type { i8* }
-%dx.types.LinAlgMatrixC8M3N129U1S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M0N129U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC8M128N128U0S0 = type { i8* }
 %dx.types.LinAlgMatrixC8M128N128U1S0 = type { i8* }
 %dx.types.LinAlgMatrixC8M1024N1024U0S2 = type { i8* }
@@ -71,31 +71,31 @@ define void @main() {
   ; Matrix<F16, 16, 3, B, Thread> - M is K so pass
   %mC8M16N3U1S0 = call %dx.types.LinAlgMatrixC8M16N3U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U1S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 4 and <= 1024.
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 1 and <= 1024.
   ; CHECK-NEXT: note: at '%mC8M16N1025U0S2
   ; Matrix<F16, 1025, 16, A, ThreadGroup> - N is K so pass
   %mC8M1025N16U0S2 = call %dx.types.LinAlgMatrixC8M1025N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N16U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
   ; Matrix<F16, 16, 1025, A, ThreadGroup> - N is K so fail
   %mC8M16N1025U0S2 = call %dx.types.LinAlgMatrixC8M16N1025U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N1025U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 1024.
-  ; CHECK-NEXT: note: at '%mC8M16N3U0S2
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=0 must be >= 1 and <= 1024.
+  ; CHECK-NEXT: note: at '%mC8M16N0U0S2
   ; Matrix<F16, 16, 3, A, ThreadGroup> - N is K so fail
-  %mC8M16N3U0S2 = call %dx.types.LinAlgMatrixC8M16N3U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC8M16N0U0S2 = call %dx.types.LinAlgMatrixC8M16N0U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N0U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
   ; Matrix<F16, 3, 16, A, ThreadGroup> - N is K so pass
   %mC8M3N16U0S2 = call %dx.types.LinAlgMatrixC8M3N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 4 and <= 1024.
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 1 and <= 1024.
   ; CHECK-NEXT: note: at '%mC8M1025N129U1S2
   ; Matrix<F16, 1025, 129, B, ThreadGroup> - M is K so fail
   %mC8M1025N129U1S2 = call %dx.types.LinAlgMatrixC8M1025N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N129U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
   ; Matrix<F16, 129, 1025, B, ThreadGroup> - M is K so pass
   %mC8M129N1025U1S2 = call %dx.types.LinAlgMatrixC8M129N1025U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N1025U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 1024.
-  ; CHECK-NEXT: note: at '%mC8M3N129U1S2
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=0 must be >= 1 and <= 1024.
+  ; CHECK-NEXT: note: at '%mC8M0N129U1S2
   ; Matrix<F16, 3, 129, B, ThreadGroup> - M is K so fail
-  %mC8M3N129U1S2 = call %dx.types.LinAlgMatrixC8M3N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N129U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC8M0N129U1S2 = call %dx.types.LinAlgMatrixC8M0N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M0N129U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
   ; Matrix<F16, 129, 3, B, ThreadGroup> - M is K so pass
   %mC8M129N3U1S2 = call %dx.types.LinAlgMatrixC8M129N3U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N3U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
 
@@ -153,7 +153,7 @@ declare %dx.types.LinAlgMatrixC8M16N1025U0S2 @dx.op.linAlgMatrixLoadFromDescript
 declare %dx.types.LinAlgMatrixC8M1025N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N16U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
-declare %dx.types.LinAlgMatrixC8M16N3U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+declare %dx.types.LinAlgMatrixC8M16N0U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N0U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC8M3N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
@@ -168,7 +168,7 @@ declare %dx.types.LinAlgMatrixC8M1025N129U1S2 @dx.op.linAlgMatrixLoadFromDescrip
 declare %dx.types.LinAlgMatrixC8M129N3U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N3U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
-declare %dx.types.LinAlgMatrixC8M3N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N129U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+declare %dx.types.LinAlgMatrixC8M0N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M0N129U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC8M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M128N128U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
@@ -210,12 +210,12 @@ attributes #1 = { nounwind readnone }
 !8 = !{%dx.types.LinAlgMatrixC8M3N16U1S0 undef, i32 8, i32 3, i32 16, i32 1, i32 0}
 !9 = !{%dx.types.LinAlgMatrixC8M16N1025U0S2 undef, i32 8, i32 16, i32 1025, i32 0, i32 2}
 !10 = !{%dx.types.LinAlgMatrixC8M1025N16U0S2 undef, i32 8, i32 1025, i32 16, i32 0, i32 2}
-!11 = !{%dx.types.LinAlgMatrixC8M16N3U0S2 undef, i32 8, i32 16, i32 3, i32 0, i32 2}
+!11 = !{%dx.types.LinAlgMatrixC8M16N0U0S2 undef, i32 8, i32 16, i32 0, i32 0, i32 2}
 !12 = !{%dx.types.LinAlgMatrixC8M3N16U0S2 undef, i32 8, i32 3, i32 16, i32 0, i32 2}
 !13 = !{%dx.types.LinAlgMatrixC8M129N1025U1S2 undef, i32 8, i32 129, i32 1025, i32 1, i32 2}
 !14 = !{%dx.types.LinAlgMatrixC8M1025N129U1S2 undef, i32 8, i32 1025, i32 129, i32 1, i32 2}
 !15 = !{%dx.types.LinAlgMatrixC8M129N3U1S2 undef, i32 8, i32 129, i32 3, i32 1, i32 2}
-!16 = !{%dx.types.LinAlgMatrixC8M3N129U1S2 undef, i32 8, i32 3, i32 129, i32 1, i32 2}
+!16 = !{%dx.types.LinAlgMatrixC8M0N129U1S2 undef, i32 8, i32 0, i32 129, i32 1, i32 2}
 !17 = !{!"dxc(private) 1.9.0.15241 (main, 1f63535ae)"}
 !18 = !{i32 1, i32 10}
 !19 = !{!"cs", i32 6, i32 10}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-max-k-dim.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-max-k-dim.ll
@@ -1,0 +1,231 @@
+; REQUIRES: dxil-1-10
+; RUN: not %dxv %s 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.ResBind = type { i32, i32, i32, i8 }
+%dx.types.LinAlgMatrixC4M16N16U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M1025N1025U2S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N129U0S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M129N16U0S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N3U0S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M3N16U0S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N129U1S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M129N16U1S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N3U1S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M3N16U1S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N1025U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M1025N16U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M16N3U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M3N16U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M129N1025U1S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M1025N129U1S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M129N3U1S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M3N129U1S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M128N128U0S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M128N128U1S0 = type { i8* }
+%dx.types.LinAlgMatrixC8M1024N1024U0S2 = type { i8* }
+%dx.types.LinAlgMatrixC8M1024N1024U1S2 = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+%struct.RWByteAddressBuffer = type { i32 }
+
+define void @main() {
+  %1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 1 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+  %handle = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+
+  ; Matrix<F16, 1025, 1025, Accumulator, Thread> - its not possible to statically determine which dim is K on Accumulator so no validation occurs
+  %mC8M1025N1025U2S0 = call %dx.types.LinAlgMatrixC8M1025N1025U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N1025U2S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK: Function: main: error: Metadata must be well-formed in operand count and types.
+  ; CHECK-NEXT: note: at '%mC4M16N16U0S2
+  ; Matrix<I32, 16, 16, A, ThreadGroup> - missing metadata
+  %mC4M16N16U0S2 = call %dx.types.LinAlgMatrixC4M16N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M16N16U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=129 must be >= 4 and <= 128.
+  ; CHECK-NEXT: note: at '%mC8M16N129U0S0
+  ; Matrix<F16, 129, 16, A, Thread> - N is K so pass
+  %mC8M129N16U0S0 = call %dx.types.LinAlgMatrixC8M129N16U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N16U0S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 16, 129, A, Thread> - N is K so fail
+  %mC8M16N129U0S0 = call %dx.types.LinAlgMatrixC8M16N129U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U0S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 128.
+  ; CHECK-NEXT: note: at '%mC8M16N3U0S0
+  ; Matrix<F16, 3, 16, A, Thread> - N is K so pass
+  %mC8M3N16U0S0 = call %dx.types.LinAlgMatrixC8M3N16U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 16, 3, A, Thread> - N is K so fail
+  %mC8M16N3U0S0 = call %dx.types.LinAlgMatrixC8M16N3U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=129 must be >= 4 and <= 128.
+  ; CHECK-NEXT: note: at '%mC8M129N16U1S0
+  ; Matrix<F16, 129, 16, B, Thread> - M is K so fail
+  %mC8M129N16U1S0 = call %dx.types.LinAlgMatrixC8M129N16U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N16U1S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 16, 129, B, Thread> - M is K so pass
+  %mC8M16N129U1S0 = call %dx.types.LinAlgMatrixC8M16N129U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U1S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 128.
+  ; CHECK-NEXT: note: at '%mC8M3N16U1S0
+  ; Matrix<F16, 3, 16, B, Thread> - M is K so fail
+  %mC8M3N16U1S0 = call %dx.types.LinAlgMatrixC8M3N16U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U1S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 16, 3, B, Thread> - M is K so pass
+  %mC8M16N3U1S0 = call %dx.types.LinAlgMatrixC8M16N3U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U1S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 4 and <= 1024.
+  ; CHECK-NEXT: note: at '%mC8M16N1025U0S2
+  ; Matrix<F16, 1025, 16, A, ThreadGroup> - N is K so pass
+  %mC8M1025N16U0S2 = call %dx.types.LinAlgMatrixC8M1025N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N16U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 16, 1025, A, ThreadGroup> - N is K so fail
+  %mC8M16N1025U0S2 = call %dx.types.LinAlgMatrixC8M16N1025U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N1025U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 1024.
+  ; CHECK-NEXT: note: at '%mC8M16N3U0S2
+  ; Matrix<F16, 16, 3, A, ThreadGroup> - N is K so fail
+  %mC8M16N3U0S2 = call %dx.types.LinAlgMatrixC8M16N3U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 3, 16, A, ThreadGroup> - N is K so pass
+  %mC8M3N16U0S2 = call %dx.types.LinAlgMatrixC8M3N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 4 and <= 1024.
+  ; CHECK-NEXT: note: at '%mC8M1025N129U1S2
+  ; Matrix<F16, 1025, 129, B, ThreadGroup> - M is K so fail
+  %mC8M1025N129U1S2 = call %dx.types.LinAlgMatrixC8M1025N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N129U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 129, 1025, B, ThreadGroup> - M is K so pass
+  %mC8M129N1025U1S2 = call %dx.types.LinAlgMatrixC8M129N1025U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N1025U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 1024.
+  ; CHECK-NEXT: note: at '%mC8M3N129U1S2
+  ; Matrix<F16, 3, 129, B, ThreadGroup> - M is K so fail
+  %mC8M3N129U1S2 = call %dx.types.LinAlgMatrixC8M3N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N129U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 129, 3, B, ThreadGroup> - M is K so pass
+  %mC8M129N3U1S2 = call %dx.types.LinAlgMatrixC8M129N3U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N3U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+
+  ; Below are just barely in bounds. No validation errors should be emitted.
+
+  ; Matrix<F16, 128, 128, A, Thread>
+  %mC8M128N128U0S0 = call %dx.types.LinAlgMatrixC8M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M128N128U0S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 128, 128, B, Thread>
+  %mC8M128N128U1S0 = call %dx.types.LinAlgMatrixC8M128N128U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M128N128U1S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 1024, 1024, A, ThreadGroup>
+  %mC8M1024N1024U0S2 = call %dx.types.LinAlgMatrixC8M1024N1024U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1024N1024U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  ; Matrix<F16, 1024, 1024, B, ThreadGroup>
+  %mC8M1024N1024U1S2 = call %dx.types.LinAlgMatrixC8M1024N1024U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1024N1024U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  ; CHECK-NEXT: Validation failed.
+
+  ret void
+}
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M16N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M16N16U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M1025N1025U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N1025U2S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M16N129U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M129N16U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N16U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M16N3U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M3N16U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M16N129U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U1S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M129N16U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N16U1S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M16N3U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U1S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M3N16U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U1S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M16N1025U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N1025U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M1025N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N16U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M16N3U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M3N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M129N1025U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N1025U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M1025N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N129U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M129N3U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N3U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M3N129U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N129U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M128N128U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M128N128U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M128N128U1S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M1024N1024U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1024N1024U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M1024N1024U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1024N1024U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!dx.targetTypes = !{!0,!1,!2,!3,!4,!5,!6,!7,!8,!9,!10,!11,!12,!13,!14,!15,!16,!26,!27,!28,!29}
+!llvm.ident = !{!17}
+!dx.version = !{!18}
+!dx.valver = !{!18}
+!dx.shaderModel = !{!19}
+!dx.resources = !{!20}
+!dx.entryPoints = !{!23}
+
+!0 = !{%dx.types.LinAlgMatrixC8M1025N1025U2S0 undef, i32 8, i32 1025, i32 1025, i32 2, i32 0}
+!1 = !{%dx.types.LinAlgMatrixC8M16N129U0S0 undef, i32 8, i32 16, i32 129, i32 0, i32 0}
+!2 = !{%dx.types.LinAlgMatrixC8M129N16U0S0 undef, i32 8, i32 129, i32 16, i32 0, i32 0}
+!3 = !{%dx.types.LinAlgMatrixC8M16N3U0S0 undef, i32 8, i32 16, i32 3, i32 0, i32 0}
+!4 = !{%dx.types.LinAlgMatrixC8M3N16U0S0 undef, i32 8, i32 3, i32 16, i32 0, i32 0}
+!5 = !{%dx.types.LinAlgMatrixC8M16N129U1S0 undef, i32 8, i32 16, i32 129, i32 1, i32 0}
+!6 = !{%dx.types.LinAlgMatrixC8M129N16U1S0 undef, i32 8, i32 129, i32 16, i32 1, i32 0}
+!7 = !{%dx.types.LinAlgMatrixC8M16N3U1S0 undef, i32 8, i32 16, i32 3, i32 1, i32 0}
+!8 = !{%dx.types.LinAlgMatrixC8M3N16U1S0 undef, i32 8, i32 3, i32 16, i32 1, i32 0}
+!9 = !{%dx.types.LinAlgMatrixC8M16N1025U0S2 undef, i32 8, i32 16, i32 1025, i32 0, i32 2}
+!10 = !{%dx.types.LinAlgMatrixC8M1025N16U0S2 undef, i32 8, i32 1025, i32 16, i32 0, i32 2}
+!11 = !{%dx.types.LinAlgMatrixC8M16N3U0S2 undef, i32 8, i32 16, i32 3, i32 0, i32 2}
+!12 = !{%dx.types.LinAlgMatrixC8M3N16U0S2 undef, i32 8, i32 3, i32 16, i32 0, i32 2}
+!13 = !{%dx.types.LinAlgMatrixC8M129N1025U1S2 undef, i32 8, i32 129, i32 1025, i32 1, i32 2}
+!14 = !{%dx.types.LinAlgMatrixC8M1025N129U1S2 undef, i32 8, i32 1025, i32 129, i32 1, i32 2}
+!15 = !{%dx.types.LinAlgMatrixC8M129N3U1S2 undef, i32 8, i32 129, i32 3, i32 1, i32 2}
+!16 = !{%dx.types.LinAlgMatrixC8M3N129U1S2 undef, i32 8, i32 3, i32 129, i32 1, i32 2}
+!17 = !{!"dxc(private) 1.9.0.15241 (main, 1f63535ae)"}
+!18 = !{i32 1, i32 10}
+!19 = !{!"cs", i32 6, i32 10}
+!20 = !{null, !21, null, null}
+!21 = !{!22}
+!22 = !{i32 0, %struct.RWByteAddressBuffer* undef, !"", i32 0, i32 0, i32 1, i32 11, i1 false, i1 false, i1 false, null}
+!23 = !{void ()* @main, !"main", null, !20, !24}
+!24 = !{i32 0, i64 8589934608, i32 4, !25}
+!25 = !{i32 4, i32 4, i32 4}
+!26 = !{%dx.types.LinAlgMatrixC8M128N128U0S0 undef, i32 8, i32 128, i32 128, i32 0, i32 0}
+!27 = !{%dx.types.LinAlgMatrixC8M128N128U1S0 undef, i32 8, i32 128, i32 128, i32 1, i32 0}
+!28 = !{%dx.types.LinAlgMatrixC8M1024N1024U0S2 undef, i32 8, i32 1024, i32 1024, i32 0, i32 2}
+!29 = !{%dx.types.LinAlgMatrixC8M1024N1024U1S2 undef, i32 8, i32 1024, i32 1024, i32 1, i32 2}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ms.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ms.ll
@@ -1,22 +1,35 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixMultiply not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixLength not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgFillMatrix not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixGetElement not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixSetElement not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ms_6_10.
-; CHECK: Function:  mainMeS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  mainMeS: error: Function uses features incompatible with the shader stage (ms) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: mainMeS: error: Opcode LinAlgMatrixMultiply not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixLength not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgFillMatrix not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixGetElement not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixSetElement not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: mainMeS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ms_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: mainMeS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: mainMeS: error: Function uses features incompatible with the shader stage (ms) of the entry function.
+; CHECK-NEXT: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
@@ -41,14 +54,17 @@ define void @mainMeS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -134,6 +150,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-node.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-node.ll
@@ -1,22 +1,35 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(node).
-; CHECK: Function:  mainNS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  mainNS: error: Function uses features incompatible with the shader stage (node) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: mainNS: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: mainNS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(node).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: mainNS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: mainNS: error: Function uses features incompatible with the shader stage (node) of the entry function.
+; CHECK-NEXT: Validation failed.
 
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
@@ -42,14 +55,17 @@ define void @mainNS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -131,6 +147,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0
 
 ; Function Attrs: nounwind
@@ -180,9 +199,6 @@ declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.
 
 ; Function Attrs: nounwind readnone
 declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #1
-
-; Function Attrs: nounwind
-declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #0
 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ps.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-ps.ll
@@ -1,22 +1,36 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixMultiply not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixLength not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgFillMatrix not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixGetElement not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixSetElement not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ps_6_10.
-; CHECK: Function:  mainPS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  mainPS: error: Function uses features incompatible with the shader stage (ps) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: mainPS: error: Opcode LinAlgMatrixMultiply not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixAccumulate not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixLength not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgFillMatrix not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixGetElement not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixSetElement not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: mainPS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model ps_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: mainPS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: mainPS: error: Function uses features incompatible with the shader stage (ps) of the entry function.
+; CHECK-NEXT: Function: mainPS: error: Function requires a visible group, but is called from a shader without one.
+; CHECK-NEXT: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
@@ -40,14 +54,17 @@ define void @mainPS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -132,6 +149,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-raytracing.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-raytracing.ll
@@ -1,116 +1,201 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(raygeneration).
+; CHECK: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixMultiply not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixAccumulate not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixLength not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgCopyConvertMatrix not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgFillMatrix not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixGetElement not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixSetElement not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(miss).
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(closesthit).
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(anyhit).
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(callable).
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(intersection).
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(miss).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(closesthit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(anyhit).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(callable).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(intersection).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model lib_6_10(raygeneration).
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
 
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  {{.*}}MainRG{{.*}}: error: Function uses features incompatible with the shader stage (raygeneration) of the entry function.
 
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  {{.*}}MainIS{{.*}}: error: Function uses features incompatible with the shader stage (intersection) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Function uses features incompatible with the shader stage (raygeneration) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainRG{{.*}}: error: Function requires a visible group, but is called from a shader without one.
 
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  {{.*}}MainCL{{.*}}: error: Function uses features incompatible with the shader stage (callable) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Function uses features incompatible with the shader stage (intersection) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainIS{{.*}}: error: Function requires a visible group, but is called from a shader without one.
 
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  {{.*}}MainAH{{.*}}: error: Function uses features incompatible with the shader stage (anyhit) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Function uses features incompatible with the shader stage (callable) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainCL{{.*}}: error: Function requires a visible group, but is called from a shader without one.
 
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  {{.*}}MainCH{{.*}}: error: Function uses features incompatible with the shader stage (closesthit) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Function uses features incompatible with the shader stage (anyhit) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainAH{{.*}}: error: Function requires a visible group, but is called from a shader without one.
 
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  {{.*}}MainMS{{.*}}: error: Function uses features incompatible with the shader stage (miss) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Function uses features incompatible with the shader stage (closesthit) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainCH{{.*}}: error: Function requires a visible group, but is called from a shader without one.
 
-; CHECK: Validation failed.
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Function uses features incompatible with the shader stage (miss) of the entry function.
+; CHECK-NEXT: Function: {{.*}}MainMS{{.*}}: error: Function requires a visible group, but is called from a shader without one.
+
+; CHECK-NEXT: Validation failed.
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
@@ -134,9 +219,12 @@ define void @"\01?MainRG@@YAXXZ"() #0 {
   ;
   ; Built-ins allowed in all stages
   ;
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout)
   %v4 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32 -2147483619, <4 x i32> <i32 9, i32 9, i32 9, i32 9>, <4 x i32> <i32 3, i32 3, i32 3, i32 3>)  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   %v5 = call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
@@ -171,9 +259,12 @@ define void @"\01?MainIS@@YAXXZ"() #0 {
   ;
   ; Built-ins allowed in all stages
   ;
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout)
   %v4 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32 -2147483619, <4 x i32> <i32 9, i32 9, i32 9, i32 9>, <4 x i32> <i32 3, i32 3, i32 3, i32 3>)  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   %v5 = call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
@@ -208,9 +299,12 @@ define void @"\01?MainCL@@YAXUAttribs@@@Z"(%struct.Attribs* noalias nocapture %a
   ;
   ; Built-ins allowed in all stages
   ;
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout)
   %v4 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32 -2147483619, <4 x i32> <i32 9, i32 9, i32 9, i32 9>, <4 x i32> <i32 3, i32 3, i32 3, i32 3>)  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   %v5 = call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
@@ -245,9 +339,12 @@ define void @"\01?MainAH@@YAXURayPayload@@UAttribs@@@Z"(%struct.RayPayload* noal
   ;
   ; Built-ins allowed in all stages
   ;
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout)
   %v4 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32 -2147483619, <4 x i32> <i32 9, i32 9, i32 9, i32 9>, <4 x i32> <i32 3, i32 3, i32 3, i32 3>)  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   %v5 = call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
@@ -282,9 +379,12 @@ define void @"\01?MainCH@@YAXURayPayload@@UAttribs@@@Z"(%struct.RayPayload* noal
   ;
   ; Built-ins allowed in all stages
   ;
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout)
   %v4 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32 -2147483619, <4 x i32> <i32 9, i32 9, i32 9, i32 9>, <4 x i32> <i32 3, i32 3, i32 3, i32 3>)  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   %v5 = call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
@@ -319,9 +419,12 @@ define void @"\01?MainMS@@YAXURayPayload@@@Z"(%struct.RayPayload* noalias nocapt
   ;
   ; Built-ins allowed in all stages
   ;
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout)
   %v4 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32 -2147483619, <4 x i32> <i32 9, i32 9, i32 9, i32 9>, <4 x i32> <i32 3, i32 3, i32 3, i32 3>)  ; LinAlgMatrixOuterProduct(vectorA,vectorB)
   %v5 = call i32 @dx.op.linAlgMatrixQueryAccumulatorLayout(i32 -2147483626)  ; LinAlgMatrixQueryAccumulatorLayout()
@@ -366,6 +469,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-undef-param.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-undef-param.ll
@@ -1,0 +1,62 @@
+; REQUIRES: dxil-1-10
+; RUN: not %dxv %s 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.ResBind = type { i32, i32, i32, i8 }
+%dx.types.LinAlgMatrixC4M16N16U0S2 = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+%struct.RWByteAddressBuffer = type { i32 }
+
+define void @main() {
+  %1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 1 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+  %handle = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+
+  ; CHECK: Function: main: error: Instructions should not read uninitialized value.
+  ; CHECK-NEXT: note: at {{.*}}@dx.op.linAlgMatrixAccumulateToDescriptor
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M16N16U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M16N16U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+
+  ; CHECK: Function: main: error: Instructions should not read uninitialized value.
+  ; CHECK-NEXT: note: at {{.*}}@dx.op.linAlgMatrixLength
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M16N16U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M16N16U0S2 undef)  ; LinAlgMatrixLength(matrix)
+
+  ; CHECK-NEXT: Validation failed.
+
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #1
+
+; Function Attrs: nounwind
+declare void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M16N16U0S2(i32, %dx.types.LinAlgMatrixC4M16N16U0S2, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare i32 @dx.op.linAlgMatrixLength.mC4M16N16U0S2(i32, %dx.types.LinAlgMatrixC4M16N16U0S2) #0
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!dx.targetTypes = !{!0}
+!llvm.ident = !{!17}
+!dx.version = !{!18}
+!dx.valver = !{!18}
+!dx.shaderModel = !{!19}
+!dx.resources = !{!20}
+!dx.entryPoints = !{!23}
+
+!0 = !{%dx.types.LinAlgMatrixC4M16N16U0S2 undef, i32 4, i32 16, i32 16, i32 0, i32 2}
+!17 = !{!"dxc(private) 1.9.0.15241 (main, 1f63535ae)"}
+!18 = !{i32 1, i32 10}
+!19 = !{!"cs", i32 6, i32 10}
+!20 = !{null, !21, null, null}
+!21 = !{!22}
+!22 = !{i32 0, %struct.RWByteAddressBuffer* undef, !"", i32 0, i32 0, i32 1, i32 11, i1 false, i1 false, i1 false, null}
+!23 = !{void ()* @main, !"main", null, !20, !24}
+!24 = !{i32 0, i64 8589934608, i32 4, !25}
+!25 = !{i32 4, i32 4, i32 4}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-vs.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-vs.ll
@@ -1,22 +1,36 @@
 ; REQUIRES: dxil-1-10
 ; RUN: not %dxv %s 2>&1 | FileCheck %s
 
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixMultiply not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixAccumulate not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixLength not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgFillMatrix not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixGetElement not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixSetElement not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model vs_6_10.
-; CHECK: Function:  mainVS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
-; CHECK: Function:  mainVS: error: Function uses features incompatible with the shader stage (vs) of the entry function.
-; CHECK: Validation failed.
+; CHECK: Function: mainVS: error: Opcode LinAlgMatrixMultiply not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiply
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixAccumulate not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixStoreToDescriptor not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixLength not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLength
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgCopyConvertMatrix not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgFillMatrix not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixGetCoordinate not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixGetElement not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixMultiplyAccumulate not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixMultiplyAccumulate
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixSetElement not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixStoreToMemory not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixAccumulateToMemory not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory
+; CHECK-NEXT: Function: mainVS: error: Opcode LinAlgMatrixLoadFromMemory not valid in shader model vs_6_10.
+; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory
+; CHECK-NEXT: Function: mainVS: error: Entry function performs some operation that is incompatible with the shader stage or other entry properties.  See other errors for details.
+; CHECK-NEXT: Function: mainVS: error: Function uses features incompatible with the shader stage (vs) of the entry function.
+; CHECK-NEXT: Function: mainVS: error: Function requires a visible group, but is called from a shader without one.
+; CHECK-NEXT: Validation failed.
 
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
@@ -41,14 +55,17 @@ define void @mainVS() {
   ; Built-ins allowed in all stages
   ;
 
+  %mC4M5N4U0S2 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC4M4N5U1S2 = call %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+
   ; dx.op.linAlgMatrixAccumulate
-  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.LinAlgMatrixC4M4N5U1S2 undef)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
+  %v1 = call %dx.types.LinAlgMatrixC4M5N4U2S2 @dx.op.linAlgMatrixAccumulate.mC4M5N4U2S2.mC4M5N4U0S2.mC4M4N5U1S2(i32 -2147483624, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.LinAlgMatrixC4M4N5U1S2 %mC4M4N5U1S2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
   ; dx.op.linAlgMatrixAccumulateToDescriptor
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 undef, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC4M5N4U0S2(i32 -2147483621, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2, %dx.types.Handle %handle, i32 1, i32 2, i32 3, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout)
 
   ; dx.op.linAlgMatrixLength
-  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 undef)  ; LinAlgMatrixLength(matrix)
+  %v2 = call i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32 -2147483632, %dx.types.LinAlgMatrixC4M5N4U0S2 %mC4M5N4U0S2)  ; LinAlgMatrixLength(matrix)
 
   ; dx.op.linAlgMatrixLoadFromDescriptor
   %v3 = call %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32 -2147483634, %dx.types.Handle %handle, i32 5, i32 5, i32 5, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
@@ -133,6 +150,9 @@ declare i32 @dx.op.linAlgMatrixLength.mC4M5N4U0S2(i32, %dx.types.LinAlgMatrixC4M
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M5N4U0S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC4M4N5U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M4N5U1S2(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC4M5N4U0S2 @dx.op.linAlgMatrixOuterProduct.mC4M5N4U0S2.v4i32.v4i32(i32, <4 x i32>, <4 x i32>) #0

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8636,6 +8636,10 @@ class db_dxil(object):
             "Instr.ReorderCoherentRequiresSM69",
             "reordercoherent requires SM 6.9 or later.",
         )
+        self.add_valrule(
+            "Instr.LinAlgIllegalKDim",
+            "Matrix K Dimension out of bounds. K=%0 must be >= %1 and <= %2.",
+        )
 
         # Some legacy rules:
         # - space is only supported for shader targets 5.1 and higher


### PR DESCRIPTION
Add the following validation rules:
 - `undef` is disallowed as a LinAlg builtin parameter
 - LinAlg types without metadata are disallowed as LinAlg builtin parameters and return types
 - LinAlg type returned from a LinAlg builtin must have a valid K dimension

The vast majority of the change is updating tests that were previously out of spec as well as adding new tests that intentionally raise the new validation failures.

Some of the tests are fixed by using the fillmatrix builtin to have an actual matrix SSA value. This will be invalid in some cases but those invalid uses will be much easier to fix as they are found/disallowed by future validation PRs