### PR TITLE
[NFC] Remove assert from SPV Work Graphs

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -490,7 +490,6 @@ bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);
 bool IsHLSLRWNodeInputRecordType(clang::QualType type);
 bool IsHLSLRONodeInputRecordType(clang::QualType type);
 bool IsHLSLDispatchNodeInputRecordType(clang::QualType type);
-bool IsHLSLNodeRecordArrayType(clang::QualType type);
 bool IsHLSLNodeOutputType(clang::QualType type);
 bool IsHLSLEmptyNodeRecordType(clang::QualType type);
 

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -604,14 +604,9 @@ bool IsHLSLNodeOutputType(clang::QualType type) {
 }
 
 bool IsHLSLNodeRecordArrayType(clang::QualType type) {
-  if (const RecordType *RT = type->getAs<RecordType>()) {
-    StringRef name = RT->getDecl()->getName();
-    if (name == "ThreadNodeOutputRecords" || name == "GroupNodeOutputRecords" ||
-        name == "GroupNodeInputRecords" || name == "RWGroupNodeInputRecords" ||
-        name == "EmptyNodeInput")
-      return true;
-  }
-  return false;
+  return ((static_cast<uint32_t>(GetNodeIOType(type)) &
+           static_cast<uint32_t>(DXIL::NodeIOFlags::NodeArray)) ==
+          static_cast<uint32_t>(DXIL::NodeIOFlags::NodeArray));
 }
 
 bool IsHLSLEmptyNodeRecordType(clang::QualType type) {

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -603,12 +603,6 @@ bool IsHLSLNodeOutputType(clang::QualType type) {
          static_cast<uint32_t>(DXIL::NodeIOFlags::Output);
 }
 
-bool IsHLSLNodeRecordArrayType(clang::QualType type) {
-  return ((static_cast<uint32_t>(GetNodeIOType(type)) &
-           static_cast<uint32_t>(DXIL::NodeIOFlags::NodeArray)) ==
-          static_cast<uint32_t>(DXIL::NodeIOFlags::NodeArray));
-}
-
 bool IsHLSLEmptyNodeRecordType(clang::QualType type) {
   return (static_cast<uint32_t>(GetNodeIOType(type)) &
           static_cast<uint32_t>(DXIL::NodeIOFlags::EmptyRecord)) ==

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11796,7 +11796,6 @@ SpirvInstruction *SpirvEmitter::processIntrinsicExtractRecordStruct(
   QualType objType = obj->getType();
   unsigned n = callExpr->getNumArgs();
   assert(hlsl::IsHLSLNodeType(objType));
-  assert(n == 0 || n == 1 && hlsl::IsHLSLNodeRecordArrayType(objType));
 
   QualType recordType = hlsl::GetHLSLNodeIOResultType(astContext, objType);
   SpirvInstruction *res = doExpr(obj);


### PR DESCRIPTION
I misunderstood how this was being used, and now that I understand, the assert makes no sense.

In the SPIRV representation defined in https://github.khronos.org/SPIRV-Registry/extensions/AMD/SPV_AMDX_shader_enqueue.html, as well as in DXIL, the record objects are always arrays. At the source level we differentiate single objects from arrays but the single object is just an array of one element.

For the single object case any function that takes an index defaults to for the index.

This is true in both SPIRV and DXIL. Checking if the type name ends in `s` isn't a meaningful assert. The user either had a single element array, or a multi-element array, and they either didn't provide an index (so it defaults 0) or they did because they were required to at the AST level.

Either way we don't need to check any of this in an assert in the codegen layer.