### PR TITLE
Fix 8601 check for RayQuery user type

### DIFF
--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -753,17 +753,7 @@ clang::RecordDecl *GetRecordDeclFromNodeObjectType(clang::QualType ObjectTy) {
 }
 
 bool IsHLSLRayQueryType(clang::QualType type) {
-  type = type.getCanonicalType();
-  if (const RecordType *RT = dyn_cast<RecordType>(type)) {
-    if (const ClassTemplateSpecializationDecl *templateDecl =
-            dyn_cast<ClassTemplateSpecializationDecl>(
-                RT->getAsCXXRecordDecl())) {
-      StringRef name = templateDecl->getName();
-      if (name == "RayQuery")
-        return true;
-    }
-  }
-  return false;
+  return nullptr != getAttr<HLSLRayQueryObjectAttr>(type);
 }
 
 #ifdef ENABLE_SPIRV_CODEGEN

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1141,12 +1141,16 @@ bool isOpaqueType(QualType type) {
     if (name == "RaytracingAccelerationStructure")
       return true;
 
-    if (name == "RayQuery")
-      return true;
-
     if (name == "SubpassInput")
       return true;
   }
+
+  // Use IsHLSLRayQueryType() rather than a plain name comparison so a
+  // user-defined struct or class named "RayQuery" that shadows the reserved
+  // name is not mistaken for the opaque ray query type.
+  if (hlsl::IsHLSLRayQueryType(type))
+    return true;
+
   return false;
 }
 

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1145,9 +1145,6 @@ bool isOpaqueType(QualType type) {
       return true;
   }
 
-  // Use IsHLSLRayQueryType() rather than a plain name comparison so a
-  // user-defined struct or class named "RayQuery" that shadows the reserved
-  // name is not mistaken for the opaque ray query type.
   if (hlsl::IsHLSLRayQueryType(type))
     return true;
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -965,7 +965,11 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
     return spvContext.getAccelerationStructureTypeNV();
   }
 
-  if (name == "RayQuery")
+  // Use IsHLSLRayQueryType() rather than a plain name comparison: a
+  // user-defined struct or class named "RayQuery" is allowed to shadow the
+  // reserved name and must be lowered as an ordinary struct instead of the
+  // opaque ray query type.
+  if (hlsl::IsHLSLRayQueryType(type))
     return spvContext.getRayQueryTypeKHR();
 
   if (name == "StructuredBuffer" || name == "RWStructuredBuffer" ||

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -965,10 +965,6 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
     return spvContext.getAccelerationStructureTypeNV();
   }
 
-  // Use IsHLSLRayQueryType() rather than a plain name comparison: a
-  // user-defined struct or class named "RayQuery" is allowed to shadow the
-  // reserved name and must be lowered as an ordinary struct instead of the
-  // opaque ray query type.
   if (hlsl::IsHLSLRayQueryType(type))
     return spvContext.getRayQueryTypeKHR();
 

--- a/tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -T cs_6_6 -E MainRayGenShader -fcgl -spirv %s | FileCheck %s
+
+// A user-defined struct named "RayQuery" that shadows the reserved intrinsic
+// name must be lowered as an ordinary struct, not as the opaque ray query
+// type. Previously this crashed the SPIR-V backend.
+// See https://github.com/microsoft/DirectXShaderCompiler/issues/8601
+
+namespace UnifiedRT {
+struct RayQuery {
+  float4 foo;
+};
+} // namespace UnifiedRT
+
+// The shadowing struct is lowered to an ordinary struct with a float4 field,
+// and the local variable uses that struct type in the Function storage class.
+// CHECK: %RayQuery = OpTypeStruct %v4float
+// CHECK: %_ptr_Function_RayQuery = OpTypePointer Function %RayQuery
+// CHECK: %rayQuery = OpVariable %_ptr_Function_RayQuery Function
+
+// It must not be lowered to the opaque ray query type.
+// CHECK-NOT: OpTypeRayQueryKHR
+
+StructuredBuffer<uint> _UnifiedRT_DispatchDims;
+
+[numthreads(128, 1, 1)]
+void MainRayGenShader(in uint3 gidx : SV_DispatchThreadID,
+                      in uint lidx : SV_GroupIndex) {
+  if (gidx.x >= _UnifiedRT_DispatchDims[0] ||
+      gidx.y >= _UnifiedRT_DispatchDims[1] ||
+      gidx.z >= _UnifiedRT_DispatchDims[2])
+    return;
+
+  UnifiedRT::RayQuery rayQuery;
+  rayQuery.foo = float4(1.0, 1.0, 1.0, 1.0);
+}

--- a/tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_6 -E MainRayGenShader -fcgl -spirv %s | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E MainRayGenShader -fcgl -spirv %s | FileCheck %s --implicit-check-not=OpTypeRayQueryKHR
 
 // A user-defined struct named "RayQuery" that shadows the reserved intrinsic
 // name must be lowered as an ordinary struct, not as the opaque ray query
@@ -17,8 +17,9 @@ struct RayQuery {
 // CHECK: %_ptr_Function_RayQuery = OpTypePointer Function %RayQuery
 // CHECK: %rayQuery = OpVariable %_ptr_Function_RayQuery Function
 
-// It must not be lowered to the opaque ray query type.
-// CHECK-NOT: OpTypeRayQueryKHR
+// It must not be lowered to the opaque ray query type. The absence of
+// OpTypeRayQueryKHR anywhere in the module is checked by the
+// --implicit-check-not on the FileCheck invocation above.
 
 StructuredBuffer<uint> _UnifiedRT_DispatchDims;
 

--- a/tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.template.hlsl
@@ -1,0 +1,34 @@
+// RUN: %dxc -T cs_6_6 -E MainRayGenShader -HV 2021 -fcgl -spirv %s | FileCheck %s --implicit-check-not=OpTypeRayQueryKHR
+
+// A user-defined class template named "RayQuery" that shadows the reserved
+// intrinsic name must be lowered as an ordinary struct, not as the opaque ray
+// query type. The intrinsic is itself a class template, so detecting it by
+// name and specialization kind alone also misclassifies this case.
+// See https://github.com/microsoft/DirectXShaderCompiler/issues/8601
+
+namespace UnifiedRT {
+template <typename T> struct RayQuery {
+  T foo;
+};
+} // namespace UnifiedRT
+
+// The shadowing template instance is lowered to an ordinary struct with a
+// float4 field, and the local variable uses that struct type in the Function
+// storage class.
+// CHECK: %RayQuery = OpTypeStruct %v4float
+// CHECK: %_ptr_Function_RayQuery = OpTypePointer Function %RayQuery
+// CHECK: %rayQuery = OpVariable %_ptr_Function_RayQuery Function
+
+StructuredBuffer<uint> _UnifiedRT_DispatchDims;
+
+[numthreads(128, 1, 1)]
+void MainRayGenShader(in uint3 gidx : SV_DispatchThreadID,
+                      in uint lidx : SV_GroupIndex) {
+  if (gidx.x >= _UnifiedRT_DispatchDims[0] ||
+      gidx.y >= _UnifiedRT_DispatchDims[1] ||
+      gidx.z >= _UnifiedRT_DispatchDims[2])
+    return;
+
+  UnifiedRT::RayQuery<float4> rayQuery;
+  rayQuery.foo = float4(1.0, 1.0, 1.0, 1.0);
+}


### PR DESCRIPTION
Fixes #8601

Compiling to SPIR-V crashes when a user-defined struct or class is named
`RayQuery` (a reserved intrinsic name), e.g. a ray-tracing abstraction that
declares its own `RayQuery` type inside a namespace.

HLSL has no rule forbidding this; the local declaration should shadow the
reserved name, and the struct should compile like any other.

Added tools/clang/test/CodeGenSPIRV/type.rayquery.user-defined-shadow.hlsl,
which reproduces the issue and checks that the shadowing struct lowers to a
normal OpTypeStruct and that no OpTypeRayQueryKHR is emitted.

Verified that the intrinsic RayQuery<T> still lowers to OpTypeRayQueryKHR
and that existing rayquery CodeGenSPIRV tests continue to pass.