### PR TITLE
[NFC] Update release notes for 1.9.2607

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -93,6 +93,9 @@ line upon naming the release. Refer to previous for appropriate section names.
   [#8246](https://github.com/microsoft/DirectXShaderCompiler/issues/8246).
 - Fixed an ambiguous overloaded `operator+` error with newer Clang
   [#8516](https://github.com/microsoft/DirectXShaderCompiler/pull/8516).
+- Stopped emitting illegal `*.with.overflow` intrinsics for DXIL, which caused
+  validation failures for overflow-check idioms when optimizations were enabled
+  [#8600](https://github.com/microsoft/DirectXShaderCompiler/pull/8600).
 
 #### Other Changes
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,10 @@ The included licenses apply to the following files:
 
 ## Changelog
 
-### Version 1.9.2607
+### Upcoming Release
+
+Place release notes for the upcoming release below this line and remove this
+line upon naming the release. Refer to previous for appropriate section names.
 
 #### HLSL Language
 
@@ -101,6 +104,25 @@ The included licenses apply to the following files:
 - Added `-Fre` support for the Metal backend to emit the Metal Shader Converter
   reflection JSON
   [#8159](https://github.com/microsoft/DirectXShaderCompiler/pull/8159).
+
+### Upcoming Preview Release
+
+These changes apply to experimental preview shader models only and will not be
+part of the next non-preview release.
+
+#### Experimental Shader Model 6.10
+
+These are incremental changes to the experimental Shader Model 6.10 features that
+first shipped in the 1.10.2605 preview.
+
+- Fixed the set of numeric types allowed in LinAlg matrix intrinsics
+  [#8271](https://github.com/microsoft/DirectXShaderCompiler/issues/8271).
+- Corrected the parameter order of `InterlockedAccumulate`
+  [#8459](https://github.com/microsoft/DirectXShaderCompiler/pull/8459).
+- Added validation of LinAlg matrix builtin parameters and result K dimension
+  [#8588](https://github.com/microsoft/DirectXShaderCompiler/pull/8588).
+- Restricted the component types allowed in LinAlg matrices
+  [#8608](https://github.com/microsoft/DirectXShaderCompiler/pull/8608).
 
 ### Version 1.10.2605
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -119,6 +119,10 @@ first shipped in the 1.10.2605 preview.
   [#8271](https://github.com/microsoft/DirectXShaderCompiler/issues/8271).
 - Corrected the parameter order of `InterlockedAccumulate`
   [#8459](https://github.com/microsoft/DirectXShaderCompiler/pull/8459).
+- Added validation of LinAlg matrix builtin parameters and result K dimension
+  [#8588](https://github.com/microsoft/DirectXShaderCompiler/pull/8588).
+- Restricted the component types allowed in LinAlg matrices
+  [#8608](https://github.com/microsoft/DirectXShaderCompiler/pull/8608).
 
 ### Version 1.10.2605
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,10 +17,7 @@ The included licenses apply to the following files:
 
 ## Changelog
 
-### Upcoming Release
-
-Place release notes for the upcoming release below this line and remove this
-line upon naming the release. Refer to previous for appropriate section names.
+### Version 1.9.2607
 
 #### HLSL Language
 
@@ -104,25 +101,6 @@ line upon naming the release. Refer to previous for appropriate section names.
 - Added `-Fre` support for the Metal backend to emit the Metal Shader Converter
   reflection JSON
   [#8159](https://github.com/microsoft/DirectXShaderCompiler/pull/8159).
-
-### Upcoming Preview Release
-
-These changes apply to experimental preview shader models only and will not be
-part of the next non-preview release.
-
-#### Experimental Shader Model 6.10
-
-These are incremental changes to the experimental Shader Model 6.10 features that
-first shipped in the 1.10.2605 preview.
-
-- Fixed the set of numeric types allowed in LinAlg matrix intrinsics
-  [#8271](https://github.com/microsoft/DirectXShaderCompiler/issues/8271).
-- Corrected the parameter order of `InterlockedAccumulate`
-  [#8459](https://github.com/microsoft/DirectXShaderCompiler/pull/8459).
-- Added validation of LinAlg matrix builtin parameters and result K dimension
-  [#8588](https://github.com/microsoft/DirectXShaderCompiler/pull/8588).
-- Restricted the component types allowed in LinAlg matrices
-  [#8608](https://github.com/microsoft/DirectXShaderCompiler/pull/8608).
 
 ### Version 1.10.2605
 


### PR DESCRIPTION
Follow-up pass on the release notes after #8607, covering user-visible changes merged since.
