### PR TITLE
[NFC] Name the 1.9.2607 release in release notes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,10 +17,7 @@ The included licenses apply to the following files:
 
 ## Changelog
 
-### Upcoming Release
-
-Place release notes for the upcoming release below this line and remove this
-line upon naming the release. Refer to previous for appropriate section names.
+### Version 1.9.2607
 
 #### HLSL Language
 
@@ -104,25 +101,6 @@ line upon naming the release. Refer to previous for appropriate section names.
 - Added `-Fre` support for the Metal backend to emit the Metal Shader Converter
   reflection JSON
   [#8159](https://github.com/microsoft/DirectXShaderCompiler/pull/8159).
-
-### Upcoming Preview Release
-
-These changes apply to experimental preview shader models only and will not be
-part of the next non-preview release.
-
-#### Experimental Shader Model 6.10
-
-These are incremental changes to the experimental Shader Model 6.10 features that
-first shipped in the 1.10.2605 preview.
-
-- Fixed the set of numeric types allowed in LinAlg matrix intrinsics
-  [#8271](https://github.com/microsoft/DirectXShaderCompiler/issues/8271).
-- Corrected the parameter order of `InterlockedAccumulate`
-  [#8459](https://github.com/microsoft/DirectXShaderCompiler/pull/8459).
-- Added validation of LinAlg matrix builtin parameters and result K dimension
-  [#8588](https://github.com/microsoft/DirectXShaderCompiler/pull/8588).
-- Restricted the component types allowed in LinAlg matrices
-  [#8608](https://github.com/microsoft/DirectXShaderCompiler/pull/8608).
 
 ### Version 1.10.2605
 


### PR DESCRIPTION
Names the current `Upcoming Release` section as `Version 1.9.2607` and removes the experimental Shader Model 6.10 preview notes, which are not part of this non-preview release branch.