### PR TITLE
Activate code-owners for ask-mode enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Uncomment the next line in release branches after ask-mode begins
-# * @microsoft/hlsl-release
+* @microsoft/hlsl-release


### PR DESCRIPTION
Uncomment * @microsoft/hlsl-release in .github/CODEOWNERS on the release-1.9.2607 branch to enable ask-mode enforcement: changes to the release branch now require approval from @microsoft/hlsl-release.