### PR TITLE
[HLSL] Add rectangular LinAlg MatVec coverage

### DIFF
--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -349,7 +349,9 @@ public:
 
   // Matrix Vector Arithmetic
   TEST_METHOD(MatVecMul_Thread_16x16_F16);
+  TEST_METHOD(MatVecMul_Thread_4x8_F32);
   TEST_METHOD(MatVecMulAdd_Thread_16x16_F16);
+  TEST_METHOD(MatVecMulAdd_Thread_4x8_F32);
   TEST_METHOD(OuterProduct_Thread_16x16_F16);
 
   // Query Accumulator Layout
@@ -1176,7 +1178,7 @@ static const char MatVecMulShader[] = R"(
       Mat, Input, 0, STRIDE, LAYOUT, 128);
 
     vector<ELEM_TYPE, N_DIM> InVec;
-    for (uint I = 0; I < M_DIM; ++I) {
+    for (uint I = 0; I < N_DIM; ++I) {
       InVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
     }
 
@@ -1248,6 +1250,18 @@ void DxilConf_SM610_LinAlg::MatVecMul_Thread_16x16_F16() {
                /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16);
 }
 
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Scope = MatrixScope::Thread;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 1;
+  runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
+               /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32);
+}
+
 static const char MatVecMulAddShader[] = R"(
   #define USE_A 0
   #define SCOPE_THREAD 0
@@ -1264,7 +1278,7 @@ static const char MatVecMulAddShader[] = R"(
       Mat, Input, 0, STRIDE, LAYOUT, 128);
 
     vector<ELEM_TYPE, N_DIM> InVec;
-    for (uint I = 0; I < M_DIM; ++I) {
+    for (uint I = 0; I < N_DIM; ++I) {
       InVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
     }
 
@@ -1342,6 +1356,19 @@ void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_16x16_F16() {
   runMatVecMulAdd(D3DDevice, DxcSupport, Params, VerboseLogging,
                   /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16,
                   ComponentType::F16);
+}
+
+void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Scope = MatrixScope::Thread;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 1;
+  runMatVecMulAdd(D3DDevice, DxcSupport, Params, VerboseLogging,
+                  /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32,
+                  ComponentType::F32);
 }
 
 // Map a DXIL ComponentType to the D3D12 linear-algebra datatype used by the


### PR DESCRIPTION
Fix rectangular matrix-vector execution coverage for SM6.10 Linear Algebra.

- Initializes MatrixVectorMultiply and MatrixVectorMultiplyAdd input vectors using `N_DIM`, matching the column count of an `M x N` matrix.
- Adds `MatVecMul_Thread_4x8_F32`.
- Adds `MatVecMulAdd_Thread_4x8_F32`.
- Preserves the existing 16x16 F16 behaviour.

For matrix and vector values of 2, the independently hand-derived results are:

- multiply: `[32, 32, 32, 32]`;
- multiply-add with bias 2: `[34, 34, 34, 34]`.

## Validation

- Built the Release `ExecHLSLTests` target successfully.
- Both new 4x8 F32 tests passed using WARP `1.65535.20-preview`, D3D12 Agility SDK `1.721.2-preview` and `ExperimentalShaders=*`.
- Both existing 16x16 F16 MatVec tests passed on the same runtime.
- The change passes the repository's clang-format 17.0.1 check.
- No physical GPU or HLK lab execution is claimed.

## AI assistance and human review

**Human owner:** @JoeCitizen  
**Review completed:** 22 July 2026

The human owner reviewed and approved the changed source, understands the `M x N` input/output dimension rules and expected values, and explicitly authorised the commit, push and maintainer review request. The human owner adopts the rationale above and remains responsible for the contribution.

Substantial AI assistance is disclosed below.

Assisted-by: GitHub Copilot

Refs #8559
Refs #8560