### PR TITLE
[HLK] Guard preview-only GroupSharedLimit tests for non-preview SDK builds

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -210,9 +210,12 @@ public:
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(WaveSizeTest);
   TEST_METHOD(WaveSizeRangeTest);
+  // TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+#if defined(D3D12_PREVIEW_SDK_VERSION)
   TEST_METHOD(GroupSharedLimitTest);
   TEST_METHOD(GroupSharedLimitASTest);
   TEST_METHOD(GroupSharedLimitMSTest);
+#endif // defined(D3D12_PREVIEW_SDK_VERSION)
   TEST_METHOD(GroupWaveIndexTest);
   TEST_METHOD(PartialDerivTest);
   TEST_METHOD(DerivativesTest);
@@ -10624,6 +10627,8 @@ void ExecutionTest::WaveSizeRangeTest() {
                        m_support);
 }
 
+// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+#if defined(D3D12_PREVIEW_SDK_VERSION)
 // Helper: create a SM 6.10 device with HLK-aware skip/fail logic.
 // Returns true if device was created, false if skipped.
 static bool CreateGSMLimitTestDevice(D3D12SDKSelector *D3D12SDK,
@@ -10934,6 +10939,7 @@ void ExecutionTest::GroupSharedLimitMSTest() {
         L"MS Test passed: GroupSharedLimit in mesh shader succeeded.");
   }
 }
+#endif // defined(D3D12_PREVIEW_SDK_VERSION)
 
 void ExecutionTest::GroupWaveIndexTest() {
   WEX::TestExecution::SetVerifyOutput VerifySettings(

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -210,7 +210,7 @@ public:
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(WaveSizeTest);
   TEST_METHOD(WaveSizeRangeTest);
-  // TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+  // TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
   TEST_METHOD(GroupSharedLimitTest);
   TEST_METHOD(GroupSharedLimitASTest);
@@ -10627,7 +10627,7 @@ void ExecutionTest::WaveSizeRangeTest() {
                        m_support);
 }
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
 // Helper: create a SM 6.10 device with HLK-aware skip/fail logic.
 // Returns true if device was created, false if skipped.

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -210,7 +210,8 @@ public:
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(WaveSizeTest);
   TEST_METHOD(WaveSizeRangeTest);
-  // TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
+  // TODO(#8661): Remove me when GroupSharedLimit is available in a released
+  // Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
   TEST_METHOD(GroupSharedLimitTest);
   TEST_METHOD(GroupSharedLimitASTest);
@@ -10627,7 +10628,8 @@ void ExecutionTest::WaveSizeRangeTest() {
                        m_support);
 }
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released
+// Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
 // Helper: create a SM 6.10 device with HLK-aware skip/fail logic.
 // Returns true if device was created, false if skipped.

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -15,7 +15,8 @@
 // D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
 // the released Windows SDK. Define locally so the test can query variable
 // group shared memory capabilities from the Agility SDK runtime.
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released
+// Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION < 720
 
 #ifndef D3D12_FEATURE_D3D12_OPTIONS_PREVIEW
@@ -619,7 +620,8 @@ bool isFallbackPathEnabled() {
   return EnableFallbackValue != 0;
 }
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released
+// Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
   D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -15,7 +15,7 @@
 // D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
 // the released Windows SDK. Define locally so the test can query variable
 // group shared memory capabilities from the Agility SDK runtime.
-// This should be removed once widely supported.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION < 720
 
 #ifndef D3D12_FEATURE_D3D12_OPTIONS_PREVIEW
@@ -619,6 +619,8 @@ bool isFallbackPathEnabled() {
   return EnableFallbackValue != 0;
 }
 
+// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+#if defined(D3D12_PREVIEW_SDK_VERSION)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
   D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
   VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
@@ -639,6 +641,7 @@ UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device) {
       D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupMS;
 }
+#endif // defined(D3D12_PREVIEW_SDK_VERSION)
 
 std::unique_ptr<st::ShaderOp> createComputeOp(const char *Source,
                                               const char *Target,

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -15,7 +15,7 @@
 // D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
 // the released Windows SDK. Define locally so the test can query variable
 // group shared memory capabilities from the Agility SDK runtime.
-// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION < 720
 
 #ifndef D3D12_FEATURE_D3D12_OPTIONS_PREVIEW
@@ -619,7 +619,7 @@ bool isFallbackPathEnabled() {
   return EnableFallbackValue != 0;
 }
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
   D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -74,7 +74,7 @@ bool doesDeviceSupportEnhancedBarriers(ID3D12Device *pDevice);
 bool doesDeviceSupportRelaxedFormatCasting(ID3D12Device *pDevice);
 bool isFallbackPathEnabled();
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device);

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -74,9 +74,12 @@ bool doesDeviceSupportEnhancedBarriers(ID3D12Device *pDevice);
 bool doesDeviceSupportRelaxedFormatCasting(ID3D12Device *pDevice);
 bool isFallbackPathEnabled();
 
+// TODO(#8661): Remove me when GroupSharedLimit is available in a release SDK.
+#if defined(D3D12_PREVIEW_SDK_VERSION)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device);
+#endif // defined(D3D12_PREVIEW_SDK_VERSION)
 
 /// Create a ShaderOp for a compute shader dispatch.
 std::unique_ptr<st::ShaderOp>

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -74,7 +74,8 @@ bool doesDeviceSupportEnhancedBarriers(ID3D12Device *pDevice);
 bool doesDeviceSupportRelaxedFormatCasting(ID3D12Device *pDevice);
 bool isFallbackPathEnabled();
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released Windows SDK.
+// TODO(#8661): Remove me when GroupSharedLimit is available in a released
+// Windows SDK.
 #if defined(D3D12_PREVIEW_SDK_VERSION)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device);


### PR DESCRIPTION
The `GroupSharedLimit` tests and some helpers reference preview-only D3D SDK definitions (`D3D12_FEATURE_D3D12_OPTIONS_PREVIEW` and its data struct). These are provided by a local `#ifdef` fallback, but only when building against a preview SDK. As a result, building the exec/HLK tests against a **non-preview** D3D SDK fails to compile.

Fixed by wrapping the affected tests and helpers in an `#if defined(D3D12_PREVIEW_SDK_VERSION)` guard, so they are only compiled when a preview D3D SDK is present.