### PR TITLE
[HLSL] Correct ShaderOp SRV resource states

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -860,9 +860,10 @@ void addSRVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
   Res.Desc.MipLevels = 1;
   Res.Desc.SampleDesc.Count = 1;
   Res.Desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-  Res.Desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+  Res.Desc.Flags = D3D12_RESOURCE_FLAG_NONE;
   Res.InitialResourceState = D3D12_RESOURCE_STATE_COPY_DEST;
-  Res.TransitionTo = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+  Res.TransitionTo = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE |
+                     D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 
   Op->Resources.push_back(Res);
 }

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
@@ -587,7 +587,8 @@ void ShaderOpTest::CreatePipelineState() {
 
 void ShaderOpTest::CreateResources() {
   CommandListRefs ResCommandList;
-  ResCommandList.CreateForDevice(m_pDevice, true);
+  // Graphics-only transition states require a DIRECT list.
+  ResCommandList.CreateForDevice(m_pDevice, /*compute*/ false);
   ResCommandList.Allocator->SetName(
       L"ShaderOpTest Resource Creation Allocation");
   ResCommandList.Queue->SetName(L"ShaderOpTest Resource Creation Queue");


### PR DESCRIPTION
## Summary

- create ShaderOp SRV buffers without the unordered-access resource flag
- add `PIXEL_SHADER_RESOURCE` to their transition state
- initialize resources on a DIRECT command list, so that state is legal

## Why

The framework follow-up @tex3d asked for when approving #8366, tracked by #8378:

> We'll probably want to avoid setting the UAV flag from `Res.Desc.Flags` in `addSRVBuffer`, and OR in the `D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE` flag to `Res.TransitionTo`, but since that one requires a `ShaderOpTest.cpp` infrastructure update, we can punt these to a follow-up.

`addSRVBuffer` creates read-only buffers, so the UAV flag over-declares them and costs the debug layer its ability to catch a genuine SRV/UAV mismatch. The helper has no knowledge of the consuming stage, so it should advertise the full shader-resource read state.

That widening is what pulls in the infrastructure change: `PIXEL_SHADER_RESOURCE` is not legal on a COMPUTE list, and `CreateResources` was the only one of four `CreateForDevice` call sites not deriving its list type from the ShaderOp. Test dispatch and draw are unaffected.

## Validation

Local Release `ExecHLSLTests` on WARP, version-matched D3D12Core and d3d12SDKLayers, `ExperimentalShaders=*`, debug layer enabled. Differential against unmodified `main` on identical binaries and runtime, compared per test rather than by totals:

| Selection | This PR | `main` |
| --- | --- | --- |
| `LinAlg::DxilConf_SM610_LinAlg::*` | 22 total, 17 passed, 4 failed, 1 skipped | identical |
| `*BasicTriangleOpTest*` | 2 total, 2 passed | identical |

No individual result differs. The four failures and one skip are pre-existing runtime gaps that reproduce unchanged on `main`. `BasicTriangleOpTest` exercises the DIRECT-list change on a graphics ShaderOp. No debug layer errors were emitted, and no physical GPU or HLK lab execution is claimed.

Refs #7841
Refs #8378
Closes #8684

Assisted-by: GitHub Copilot
