### PR TITLE
[HLSL] Add LinAlg group-shared I/O coverage

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -121,8 +121,66 @@ static_assert(
         D3D12_FEATURE_LINEAR_ALGEBRA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT) ==
         static_cast<UINT>(LinearAlgebraOperationSupportFeature),
     "Linear algebra operation feature ID changed");
-static_assert(static_cast<UINT>(D3D12_LINEAR_ALGEBRA_TIER_1_0) == 0x10,
-              "Linear algebra tier ABI changed");
+
+#define ASSERT_RUNTIME_ENUM(RuntimeValue, D3DValue)                            \
+  static_assert(static_cast<UINT>(RuntimeValue) ==                             \
+                    static_cast<UINT>(D3DValue),                               \
+                "Linear algebra runtime enum value changed")
+
+ASSERT_RUNTIME_ENUM(linalg_test::Tier::NotSupported,
+                    D3D12_LINEAR_ALGEBRA_TIER_NOT_SUPPORTED);
+ASSERT_RUNTIME_ENUM(linalg_test::Tier::Tier1_0, D3D12_LINEAR_ALGEBRA_TIER_1_0);
+static_assert(static_cast<UINT>(linalg_test::DataType::None) == 0,
+              "Linear algebra no-bias datatype value changed");
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::SInt16,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_SINT16);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::UInt16,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_UINT16);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::SInt32,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_SINT32);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::UInt32,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_UINT32);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float16,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float32,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::SInt8,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::UInt8,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float8E4M3FN,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT8_E4M3FN);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float8E5M2,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT8_E5M2);
+ASSERT_RUNTIME_ENUM(linalg_test::OperationType::MatrixConstruction,
+                    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_MATRIX_CONSTRUCTION);
+ASSERT_RUNTIME_ENUM(linalg_test::OperationType::WaveMatrixMultiply,
+                    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_WAVE_MATRIX_MULTIPLY);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::OperationType::ThreadGroupMatrixMultiply,
+    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_THREADGROUP_MATRIX_MULTIPLY);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::OperationType::ThreadVectorMatrixMultiply,
+    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_THREAD_VECTOR_MATRIX_MULTIPLY);
+ASSERT_RUNTIME_ENUM(linalg_test::OperationType::ThreadOuterProduct,
+                    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_THREAD_OUTER_PRODUCT);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::OperationType::AtomicAccumulateStore,
+    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_ATOMIC_ACCUMULATE_STORE);
+ASSERT_RUNTIME_ENUM(linalg_test::MultiplicationFlags::None,
+                    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_NONE);
+ASSERT_RUNTIME_ENUM(linalg_test::MultiplicationFlags::Supported,
+                    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_SUPPORTED);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::MultiplicationFlags::EmulatedInputs,
+    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_EMULATED_INPUTS);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::MultiplicationFlags::EmulatedOutputs,
+    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_EMULATED_OUTPUTS);
+ASSERT_RUNTIME_ENUM(linalg_test::MultiplicationFlags::Transpose,
+                    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_TRANSPOSE);
+
+#undef ASSERT_RUNTIME_ENUM
 
 #define ASSERT_RUNTIME_ABI(RuntimeType, D3DType)                               \
   static_assert(sizeof(RuntimeType) == sizeof(D3DType),                        \
@@ -158,43 +216,171 @@ ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraOperationSupport,
                     offsetof(D3DType, D3DField),                               \
                 "Linear algebra runtime ABI field offset changed")
 
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, ComponentType,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
-                      ComponentType);
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, MinN,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT, MinN);
-ASSERT_RUNTIME_OFFSET(RuntimeWaveMatrixMultiplySupport, Shapes,
-                      D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
-                      Shapes);
-ASSERT_RUNTIME_OFFSET(RuntimeThreadGroupMatrixMultiplySupport,
-                      PreferredThreadGroupSize,
-                      D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
-                      PreferredThreadGroupSize);
-ASSERT_RUNTIME_OFFSET(
-    RuntimeThreadVectorMatrixMultiplySupport, SupportFlags,
+#define ASSERT_RUNTIME_OFFSET_SAME(RuntimeType, D3DType, Field)                \
+  ASSERT_RUNTIME_OFFSET(RuntimeType, Field, D3DType, Field)
+
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeLinearAlgebraTierSupport,
+                           D3D12_FEATURE_DATA_LINEAR_ALGEBRA_SUPPORT,
+                           LinearAlgebraTier);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           ComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           WaveSize);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           MinM);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           MinK);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           MinN);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixMultiplyShape,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE, M);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixMultiplyShape,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE, K);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixMultiplyShape,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE, N);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           WaveSize);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           MatrixAComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           MatrixBComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           AccumulatorComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           Inputs);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           SupportFlags);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           NumShapes);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           Shapes);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT, WaveInputs);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT, Shape);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT, SupportFlags);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+    MinThreadGroupSize);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+    MaxThreadGroupSize);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+    PreferredThreadGroupSize);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT,
+    VectorInputType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT,
+    MatrixInputType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT, BiasInputType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT,
+    VectorResultType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
     D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT, SupportFlags);
-ASSERT_RUNTIME_OFFSET(RuntimeThreadOuterProductSupport, Supported,
-                      D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
-                      Supported);
-ASSERT_RUNTIME_OFFSET(RuntimeAtomicAccumulateStoreSupport, GroupSharedSupported,
-                      D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
-                      GroupSharedSupported);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeThreadOuterProductSupport,
+                           D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                           InputComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeThreadOuterProductSupport,
+                           D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                           ResultComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeThreadOuterProductSupport,
+                           D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                           Supported);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeAtomicAccumulateStoreSupport,
+                           D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                           ComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeAtomicAccumulateStoreSupport,
+                           D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                           RWByteAddressBufferSupported);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeAtomicAccumulateStoreSupport,
+                           D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                           GroupSharedSupported);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeLinearAlgebraOperationSupport,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT, OperationType);
 ASSERT_RUNTIME_OFFSET(
     RuntimeLinearAlgebraOperationSupport, MatrixConstruction,
     D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
     MatrixConstruction);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, WaveMatrixMultiply,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    WaveMatrixMultiply);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, ThreadGroupMatrixMultiply,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    ThreadGroupMatrixMultiply);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, ThreadVectorMatrixMultiply,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    ThreadVectorMatrixMultiply);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, ThreadOuterProduct,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    ThreadOuterProductSupport);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, AccumulateStore,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    AccumulateStore);
 
+#undef ASSERT_RUNTIME_OFFSET_SAME
 #undef ASSERT_RUNTIME_OFFSET
 #endif
 
 constexpr UINT KnownMultiplicationFlags = 0xf;
+constexpr UINT MatrixMultiplicationFlags =
+    static_cast<UINT>(linalg_test::MultiplicationFlags::Supported) |
+    static_cast<UINT>(linalg_test::MultiplicationFlags::EmulatedOutputs);
 
-bool isValidMultiplicationFlags(UINT Flags) {
-  if ((Flags & ~KnownMultiplicationFlags) != 0)
+bool isValidMultiplicationFlags(UINT Flags, UINT AllowedFlags) {
+  if ((Flags & ~AllowedFlags) != 0)
     return false;
   return Flags == 0 ||
          (Flags &
           static_cast<UINT>(linalg_test::MultiplicationFlags::Supported)) != 0;
+}
+
+bool isFloat8DataType(linalg_test::DataType Type) {
+  return Type == linalg_test::DataType::Float8E4M3FN ||
+         Type == linalg_test::DataType::Float8E5M2;
+}
+
+bool isValidThreadVectorMultiplicationFlags(
+    UINT Flags, linalg_test::DataType MatrixInputType) {
+  if (!isValidMultiplicationFlags(Flags, KnownMultiplicationFlags))
+    return false;
+  const UINT EmulatedInputs =
+      static_cast<UINT>(linalg_test::MultiplicationFlags::EmulatedInputs);
+  return (Flags & EmulatedInputs) == 0 || isFloat8DataType(MatrixInputType);
 }
 
 LPCWSTR dataTypeName(linalg_test::DataType Type) {
@@ -1009,7 +1195,8 @@ bool hasFlag(MultiplicationFlags Value, MultiplicationFlags Flag) {
 }
 
 bool WaveMatrixMultiplySupport::valid() const {
-  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags),
+                                  MatrixMultiplicationFlags))
     return false;
   if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
     return Shapes.empty();
@@ -1042,7 +1229,8 @@ bool ThreadGroupMatrixMultiplySupport::supported() const {
 }
 
 bool ThreadGroupMatrixMultiplySupport::valid() const {
-  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags),
+                                  MatrixMultiplicationFlags))
     return false;
   if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
     return true;
@@ -1067,7 +1255,8 @@ bool ThreadVectorMatrixMultiplySupport::supported() const {
 }
 
 bool ThreadVectorMatrixMultiplySupport::valid() const {
-  return isValidMultiplicationFlags(static_cast<UINT>(SupportFlags));
+  return isValidThreadVectorMultiplicationFlags(static_cast<UINT>(SupportFlags),
+                                                MatrixInputType);
 }
 
 bool AtomicAccumulateStoreSupport::supports(
@@ -1221,7 +1410,8 @@ HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
   }
 
   if (!isValidMultiplicationFlags(
-          RuntimeSupport.WaveMatrixMultiply.SupportFlags)) {
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags,
+          MatrixMultiplicationFlags)) {
     LogCommentFmt(L"WaveMatrixMultiply query returned invalid flags: 0x%x",
                   RuntimeSupport.WaveMatrixMultiply.SupportFlags);
     return E_UNEXPECTED;
@@ -1275,7 +1465,8 @@ HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
   }
 
   if (!isValidMultiplicationFlags(
-          RuntimeSupport.WaveMatrixMultiply.SupportFlags) ||
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags,
+          MatrixMultiplicationFlags) ||
       (RuntimeSupport.WaveMatrixMultiply.SupportFlags &
        static_cast<UINT>(MultiplicationFlags::Supported)) == 0 ||
       RuntimeSupport.WaveMatrixMultiply.NumShapes == 0 ||
@@ -1352,7 +1543,7 @@ queryThreadGroupMatrixMultiply(ID3D12Device *Device,
   }
 
   const UINT Flags = RuntimeSupport.ThreadGroupMatrixMultiply.SupportFlags;
-  if (!isValidMultiplicationFlags(Flags)) {
+  if (!isValidMultiplicationFlags(Flags, MatrixMultiplicationFlags)) {
     LogCommentFmt(
         L"ThreadGroupMatrixMultiply query returned invalid flags: 0x%x", Flags);
     return E_UNEXPECTED;
@@ -1428,7 +1619,7 @@ queryThreadVectorMatrixMultiply(ID3D12Device *Device,
   }
 
   const UINT Flags = RuntimeSupport.ThreadVectorMatrixMultiply.SupportFlags;
-  if (!isValidMultiplicationFlags(Flags)) {
+  if (!isValidThreadVectorMultiplicationFlags(Flags, Query.MatrixInputType)) {
     LogCommentFmt(
         L"ThreadVectorMatrixMultiply query returned invalid flags: 0x%x",
         Flags);
@@ -1436,6 +1627,7 @@ queryThreadVectorMatrixMultiply(ID3D12Device *Device,
   }
 
   Support.SupportFlags = static_cast<MultiplicationFlags>(Flags);
+  Support.MatrixInputType = Query.MatrixInputType;
   LogCommentFmt(
       L"ThreadVectorMatrixMultiply query: vector=%s, matrix=%s, bias=%s, "
       L"result=%s, flags=0x%x",

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -11,6 +11,7 @@
 #include <d3d12.h>
 #include <dxgi1_4.h>
 #include <filesystem>
+#include <limits>
 #include <optional>
 
 // D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
@@ -1802,6 +1803,76 @@ void addSRVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
   Res.TransitionTo = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
 
   Op->Resources.push_back(Res);
+}
+
+void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
+                                 const char *HeapName,
+                                 std::initializer_list<RawBufferView> Views) {
+  if (!Op || !HeapName || Views.size() == 0 ||
+      Views.size() > (std::numeric_limits<UINT>::max)()) {
+    VERIFY_IS_TRUE(false, "Invalid raw buffer descriptor table");
+    return;
+  }
+
+  st::ShaderOpDescriptorHeap Heap = {};
+  Heap.Name = Op->Strings.insert(HeapName);
+  Heap.Desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+  Heap.Desc.NumDescriptors = static_cast<UINT>(Views.size());
+  Heap.Desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+
+  for (const RawBufferView &View : Views) {
+    st::ShaderOpResource *Resource =
+        View.ResourceName ? Op->GetResourceByName(View.ResourceName) : nullptr;
+    const bool Valid =
+        View.DescriptorName && View.ResourceName && View.NumBytes != 0 &&
+        Resource &&
+        (View.Kind == RawBufferViewKind::SRV ||
+         View.Kind == RawBufferViewKind::UAV) &&
+        View.FirstByte % sizeof(UINT32) == 0 &&
+        View.NumBytes % sizeof(UINT32) == 0 &&
+        View.FirstByte / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
+        View.NumBytes / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
+        View.FirstByte <= Resource->Desc.Width &&
+        View.NumBytes <= Resource->Desc.Width - View.FirstByte;
+    if (!Valid) {
+      VERIFY_IS_TRUE(false, "Invalid raw buffer descriptor");
+      return;
+    }
+
+    st::ShaderOpDescriptor Descriptor = {};
+    Descriptor.Name = Op->Strings.insert(View.DescriptorName);
+    Descriptor.ResName = Op->Strings.insert(View.ResourceName);
+    if (View.Kind == RawBufferViewKind::SRV) {
+      Descriptor.Kind = Op->Strings.insert("SRV");
+      Descriptor.SrvDescPresent = true;
+      Descriptor.SrvDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+      Descriptor.SrvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+      Descriptor.SrvDesc.Shader4ComponentMapping =
+          D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+      Descriptor.SrvDesc.Buffer.FirstElement =
+          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.SrvDesc.Buffer.NumElements =
+          static_cast<UINT>(View.NumBytes / sizeof(UINT32));
+      Descriptor.SrvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
+    } else {
+      Descriptor.Kind = Op->Strings.insert("UAV");
+      Descriptor.UavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+      Descriptor.UavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+      Descriptor.UavDesc.Buffer.FirstElement =
+          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.UavDesc.Buffer.NumElements =
+          static_cast<UINT>(View.NumBytes / sizeof(UINT32));
+      Descriptor.UavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;
+    }
+    Heap.Descriptors.push_back(Descriptor);
+  }
+
+  Op->DescriptorHeaps.push_back(std::move(Heap));
+
+  st::ShaderOpRootValue RootValue = {};
+  RootValue.HeapName = Op->Strings.insert(HeapName);
+  RootValue.Index = RootIndex;
+  Op->RootValues.push_back(RootValue);
 }
 
 void addRootView(st::ShaderOp *Op, UINT Index, const char *ResName) {

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -1809,9 +1809,46 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
                                  const char *HeapName,
                                  std::initializer_list<RawBufferView> Views) {
   if (!Op || !HeapName || Views.size() == 0 ||
-      Views.size() > (std::numeric_limits<UINT>::max)()) {
+      Views.size() > (std::numeric_limits<UINT>::max)() ||
+      Op->RootValues.size() > (std::numeric_limits<UINT>::max)()) {
     VERIFY_IS_TRUE(false, "Invalid raw buffer descriptor table");
     return;
+  }
+
+  for (const st::ShaderOpDescriptorHeap &ExistingHeap : Op->DescriptorHeaps) {
+    const bool DuplicateName =
+        ExistingHeap.Name && _stricmp(ExistingHeap.Name, HeapName) == 0;
+    const bool ConflictingVisibleHeap =
+        ExistingHeap.Desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+        (ExistingHeap.Desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) !=
+            0;
+    if (DuplicateName || ConflictingVisibleHeap) {
+      VERIFY_IS_TRUE(false, "Conflicting raw buffer descriptor table");
+      return;
+    }
+  }
+
+  if (RootIndex == 0 && !Op->RootValues.empty()) {
+    VERIFY_IS_TRUE(false, "Root parameter zero must be the first root value");
+    return;
+  }
+  for (size_t I = 0; I < Op->RootValues.size(); ++I) {
+    const st::ShaderOpRootValue &ExistingRoot = Op->RootValues[I];
+    const UINT ExistingIndex =
+        ExistingRoot.Index == 0 ? static_cast<UINT>(I) : ExistingRoot.Index;
+    if (ExistingIndex == RootIndex) {
+      VERIFY_IS_TRUE(false, "Duplicate root parameter index");
+      return;
+    }
+    for (size_t J = 0; J < I; ++J) {
+      const st::ShaderOpRootValue &PreviousRoot = Op->RootValues[J];
+      const UINT PreviousIndex =
+          PreviousRoot.Index == 0 ? static_cast<UINT>(J) : PreviousRoot.Index;
+      if (ExistingIndex == PreviousIndex) {
+        VERIFY_IS_TRUE(false, "Duplicate root parameter index");
+        return;
+      }
+    }
   }
 
   st::ShaderOpDescriptorHeap Heap = {};
@@ -1826,11 +1863,17 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
     const bool Valid =
         View.DescriptorName && View.ResourceName && View.NumBytes != 0 &&
         Resource &&
+        Resource->Desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
         (View.Kind == RawBufferViewKind::SRV ||
          View.Kind == RawBufferViewKind::UAV) &&
-        View.FirstByte % sizeof(UINT32) == 0 &&
+        (View.Kind != RawBufferViewKind::SRV ||
+         (Resource->Desc.Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE) ==
+             0) &&
+        (View.Kind != RawBufferViewKind::UAV ||
+         (Resource->Desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) !=
+             0) &&
+        View.FirstByte % D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT == 0 &&
         View.NumBytes % sizeof(UINT32) == 0 &&
-        View.FirstByte / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
         View.NumBytes / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
         View.FirstByte <= Resource->Desc.Width &&
         View.NumBytes <= Resource->Desc.Width - View.FirstByte;
@@ -1849,8 +1892,7 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
       Descriptor.SrvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
       Descriptor.SrvDesc.Shader4ComponentMapping =
           D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-      Descriptor.SrvDesc.Buffer.FirstElement =
-          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.SrvDesc.Buffer.FirstElement = View.FirstByte / sizeof(UINT32);
       Descriptor.SrvDesc.Buffer.NumElements =
           static_cast<UINT>(View.NumBytes / sizeof(UINT32));
       Descriptor.SrvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
@@ -1858,8 +1900,7 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
       Descriptor.Kind = Op->Strings.insert("UAV");
       Descriptor.UavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
       Descriptor.UavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-      Descriptor.UavDesc.Buffer.FirstElement =
-          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.UavDesc.Buffer.FirstElement = View.FirstByte / sizeof(UINT32);
       Descriptor.UavDesc.Buffer.NumElements =
           static_cast<UINT>(View.NumBytes / sizeof(UINT32));
       Descriptor.UavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -7,6 +7,7 @@
 
 #include <Verify.h>
 #include <atlcomcli.h>
+#include <cstddef>
 #include <d3d12.h>
 #include <dxgi1_4.h>
 #include <filesystem>
@@ -30,6 +31,213 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
 } D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW;
 
 #endif
+
+namespace {
+
+constexpr D3D12_FEATURE LinearAlgebraSupportFeature =
+    static_cast<D3D12_FEATURE>(77);
+constexpr D3D12_FEATURE LinearAlgebraOperationSupportFeature =
+    static_cast<D3D12_FEATURE>(78);
+
+struct RuntimeLinearAlgebraTierSupport {
+  UINT LinearAlgebraTier;
+};
+
+struct RuntimeMatrixConstructionSupport {
+  UINT ComponentType;
+  UINT WaveSize;
+  UINT MinM;
+  UINT MinK;
+  UINT MinN;
+};
+
+struct RuntimeMatrixMultiplyShape {
+  UINT M;
+  UINT K;
+  UINT N;
+};
+
+struct RuntimeWaveMatrixMultiplyInputs {
+  UINT WaveSize;
+  UINT MatrixAComponentType;
+  UINT MatrixBComponentType;
+  UINT AccumulatorComponentType;
+};
+
+struct RuntimeWaveMatrixMultiplySupport {
+  RuntimeWaveMatrixMultiplyInputs Inputs;
+  UINT SupportFlags;
+  UINT NumShapes;
+  RuntimeMatrixMultiplyShape *Shapes;
+};
+
+struct RuntimeThreadGroupMatrixMultiplySupport {
+  RuntimeWaveMatrixMultiplyInputs WaveInputs;
+  RuntimeMatrixMultiplyShape Shape;
+  UINT SupportFlags;
+  UINT MinThreadGroupSize;
+  UINT MaxThreadGroupSize;
+  UINT PreferredThreadGroupSize;
+};
+
+struct RuntimeThreadVectorMatrixMultiplySupport {
+  UINT VectorInputType;
+  UINT MatrixInputType;
+  UINT BiasInputType;
+  UINT VectorResultType;
+  UINT SupportFlags;
+};
+
+struct RuntimeThreadOuterProductSupport {
+  UINT InputComponentType;
+  UINT ResultComponentType;
+  BOOL Supported;
+};
+
+struct RuntimeAtomicAccumulateStoreSupport {
+  UINT ComponentType;
+  BOOL RWByteAddressBufferSupported;
+  BOOL GroupSharedSupported;
+};
+
+struct RuntimeLinearAlgebraOperationSupport {
+  UINT OperationType;
+  union {
+    RuntimeMatrixConstructionSupport MatrixConstruction;
+    RuntimeWaveMatrixMultiplySupport WaveMatrixMultiply;
+    RuntimeThreadGroupMatrixMultiplySupport ThreadGroupMatrixMultiply;
+    RuntimeThreadVectorMatrixMultiplySupport ThreadVectorMatrixMultiply;
+    RuntimeThreadOuterProductSupport ThreadOuterProduct;
+    RuntimeAtomicAccumulateStoreSupport AccumulateStore;
+  };
+};
+
+#if defined(DIRECT3D_LINEAR_ALGEBRA)
+static_assert(static_cast<UINT>(D3D12_FEATURE_LINEAR_ALGEBRA_SUPPORT) ==
+                  static_cast<UINT>(LinearAlgebraSupportFeature),
+              "Linear algebra tier feature ID changed");
+static_assert(
+    static_cast<UINT>(
+        D3D12_FEATURE_LINEAR_ALGEBRA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT) ==
+        static_cast<UINT>(LinearAlgebraOperationSupportFeature),
+    "Linear algebra operation feature ID changed");
+static_assert(static_cast<UINT>(D3D12_LINEAR_ALGEBRA_TIER_1_0) == 0x10,
+              "Linear algebra tier ABI changed");
+
+#define ASSERT_RUNTIME_ABI(RuntimeType, D3DType)                               \
+  static_assert(sizeof(RuntimeType) == sizeof(D3DType),                        \
+                "Linear algebra runtime ABI size changed");                    \
+  static_assert(alignof(RuntimeType) == alignof(D3DType),                      \
+                "Linear algebra runtime ABI alignment changed")
+
+ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraTierSupport,
+                   D3D12_FEATURE_DATA_LINEAR_ALGEBRA_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeMatrixConstructionSupport,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeMatrixMultiplyShape,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE);
+ASSERT_RUNTIME_ABI(RuntimeWaveMatrixMultiplyInputs,
+                   D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS);
+ASSERT_RUNTIME_ABI(RuntimeWaveMatrixMultiplySupport,
+                   D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeThreadGroupMatrixMultiplySupport,
+                   D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeThreadVectorMatrixMultiplySupport,
+                   D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeThreadOuterProductSupport,
+                   D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeAtomicAccumulateStoreSupport,
+                   D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraOperationSupport,
+                   D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT);
+
+#undef ASSERT_RUNTIME_ABI
+
+#define ASSERT_RUNTIME_OFFSET(RuntimeType, RuntimeField, D3DType, D3DField)    \
+  static_assert(offsetof(RuntimeType, RuntimeField) ==                         \
+                    offsetof(D3DType, D3DField),                               \
+                "Linear algebra runtime ABI field offset changed")
+
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, ComponentType,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                      ComponentType);
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, MinN,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT, MinN);
+ASSERT_RUNTIME_OFFSET(RuntimeWaveMatrixMultiplySupport, Shapes,
+                      D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                      Shapes);
+ASSERT_RUNTIME_OFFSET(RuntimeThreadGroupMatrixMultiplySupport,
+                      PreferredThreadGroupSize,
+                      D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+                      PreferredThreadGroupSize);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeThreadVectorMatrixMultiplySupport, SupportFlags,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT, SupportFlags);
+ASSERT_RUNTIME_OFFSET(RuntimeThreadOuterProductSupport, Supported,
+                      D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                      Supported);
+ASSERT_RUNTIME_OFFSET(RuntimeAtomicAccumulateStoreSupport, GroupSharedSupported,
+                      D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                      GroupSharedSupported);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, MatrixConstruction,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    MatrixConstruction);
+
+#undef ASSERT_RUNTIME_OFFSET
+#endif
+
+constexpr UINT KnownMultiplicationFlags = 0xf;
+
+bool isValidMultiplicationFlags(UINT Flags) {
+  if ((Flags & ~KnownMultiplicationFlags) != 0)
+    return false;
+  return Flags == 0 ||
+         (Flags &
+          static_cast<UINT>(linalg_test::MultiplicationFlags::Supported)) != 0;
+}
+
+LPCWSTR dataTypeName(linalg_test::DataType Type) {
+  using linalg_test::DataType;
+  switch (Type) {
+  case DataType::None:
+    return L"None";
+  case DataType::SInt16:
+    return L"SInt16";
+  case DataType::UInt16:
+    return L"UInt16";
+  case DataType::SInt32:
+    return L"SInt32";
+  case DataType::UInt32:
+    return L"UInt32";
+  case DataType::Float16:
+    return L"Float16";
+  case DataType::Float32:
+    return L"Float32";
+  case DataType::SInt8:
+    return L"SInt8";
+  case DataType::UInt8:
+    return L"UInt8";
+  case DataType::Float8E4M3FN:
+    return L"Float8E4M3FN";
+  case DataType::Float8E5M2:
+    return L"Float8E5M2";
+  }
+  return L"Unknown";
+}
+
+void setWaveInputs(RuntimeWaveMatrixMultiplyInputs &RuntimeInputs,
+                   const linalg_test::WaveMatrixMultiplyQuery &Query) {
+  RuntimeInputs.WaveSize = Query.WaveSize;
+  RuntimeInputs.MatrixAComponentType =
+      static_cast<UINT>(Query.MatrixAComponentType);
+  RuntimeInputs.MatrixBComponentType =
+      static_cast<UINT>(Query.MatrixBComponentType);
+  RuntimeInputs.AccumulatorComponentType =
+      static_cast<UINT>(Query.AccumulatorComponentType);
+}
+
+} // namespace
 
 using namespace hlsl_test;
 
@@ -767,6 +975,543 @@ bool isFallbackPathEnabled() {
                                                      EnableFallbackValue);
   return EnableFallbackValue != 0;
 }
+
+namespace linalg_test {
+
+bool MatrixConstructionSupport::valid() const {
+  const bool AllZero = MinM == 0 && MinK == 0 && MinN == 0;
+  const bool AllNonZero = MinM != 0 && MinK != 0 && MinN != 0;
+  return AllZero || AllNonZero;
+}
+
+bool MatrixConstructionSupport::supported() const {
+  return valid() && MinM != 0;
+}
+
+bool MatrixConstructionSupport::supports(MatrixRole Role, UINT Rows,
+                                         UINT Columns) const {
+  if (!supported())
+    return false;
+
+  switch (Role) {
+  case MatrixRole::A:
+    return Rows >= MinM && Columns >= MinK;
+  case MatrixRole::B:
+    return Rows >= MinK && Columns >= MinN;
+  case MatrixRole::Accumulator:
+    return Rows >= MinM && Columns >= MinN;
+  }
+  return false;
+}
+
+bool hasFlag(MultiplicationFlags Value, MultiplicationFlags Flag) {
+  return (static_cast<UINT>(Value) & static_cast<UINT>(Flag)) != 0;
+}
+
+bool WaveMatrixMultiplySupport::valid() const {
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+    return false;
+  if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
+    return Shapes.empty();
+  if (Shapes.empty())
+    return false;
+  for (const MatrixMultiplyShape &Shape : Shapes) {
+    if (Shape.M == 0 || Shape.K == 0 || Shape.N == 0)
+      return false;
+  }
+  return true;
+}
+
+bool WaveMatrixMultiplySupport::supported() const {
+  return valid() && hasFlag(SupportFlags, MultiplicationFlags::Supported);
+}
+
+bool WaveMatrixMultiplySupport::supportsShape(UINT M, UINT K, UINT N) const {
+  if (!supported())
+    return false;
+  for (const MatrixMultiplyShape &Shape : Shapes) {
+    if (Shape.M != 0 && Shape.K != 0 && Shape.N != 0 && M % Shape.M == 0 &&
+        K % Shape.K == 0 && N % Shape.N == 0)
+      return true;
+  }
+  return false;
+}
+
+bool ThreadGroupMatrixMultiplySupport::supported() const {
+  return valid() && hasFlag(SupportFlags, MultiplicationFlags::Supported);
+}
+
+bool ThreadGroupMatrixMultiplySupport::valid() const {
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+    return false;
+  if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
+    return true;
+  return MinThreadGroupSize != 0 && MaxThreadGroupSize >= MinThreadGroupSize &&
+         MaxThreadGroupSize % MinThreadGroupSize == 0 &&
+         (PreferredThreadGroupSize == 0 ||
+          (PreferredThreadGroupSize >= MinThreadGroupSize &&
+           PreferredThreadGroupSize <= MaxThreadGroupSize &&
+           PreferredThreadGroupSize % MinThreadGroupSize == 0));
+}
+
+bool ThreadGroupMatrixMultiplySupport::supportsThreadGroupSize(
+    UINT ThreadGroupSize) const {
+  return supported() && MinThreadGroupSize != 0 &&
+         ThreadGroupSize >= MinThreadGroupSize &&
+         ThreadGroupSize <= MaxThreadGroupSize &&
+         ThreadGroupSize % MinThreadGroupSize == 0;
+}
+
+bool ThreadVectorMatrixMultiplySupport::supported() const {
+  return valid() && hasFlag(SupportFlags, MultiplicationFlags::Supported);
+}
+
+bool ThreadVectorMatrixMultiplySupport::valid() const {
+  return isValidMultiplicationFlags(static_cast<UINT>(SupportFlags));
+}
+
+bool AtomicAccumulateStoreSupport::supports(
+    AtomicDestination Destination) const {
+  switch (Destination) {
+  case AtomicDestination::RWByteAddressBuffer:
+    return RWByteAddressBufferSupported;
+  case AtomicDestination::GroupShared:
+    return GroupSharedSupported;
+  }
+  return false;
+}
+
+ScopeFlags legalScopes(OperationType Operation) {
+  const ScopeFlags Thread = static_cast<ScopeFlags>(ExecutionScope::Thread);
+  const ScopeFlags Wave = static_cast<ScopeFlags>(ExecutionScope::Wave);
+  const ScopeFlags ThreadGroup =
+      static_cast<ScopeFlags>(ExecutionScope::ThreadGroup);
+  switch (Operation) {
+  case OperationType::MatrixConstruction:
+    return Wave | ThreadGroup;
+  case OperationType::WaveMatrixMultiply:
+    return Wave;
+  case OperationType::ThreadGroupMatrixMultiply:
+    return ThreadGroup;
+  case OperationType::ThreadVectorMatrixMultiply:
+  case OperationType::ThreadOuterProduct:
+    return Thread;
+  case OperationType::AtomicAccumulateStore:
+    // The query category spans thread vector/outer-product accumulation and
+    // Wave/ThreadGroup matrix forms. Individual operations narrow this mask.
+    return Thread | Wave | ThreadGroup;
+  }
+  return 0;
+}
+
+bool isLegalScope(OperationType Operation, ExecutionScope Scope) {
+  return (legalScopes(Operation) & static_cast<ScopeFlags>(Scope)) != 0;
+}
+
+Applicability classifyApplicability(HRESULT QueryResult, bool Supported,
+                                    CapabilityRequirement Requirement) {
+  if (FAILED(QueryResult))
+    return Applicability::Fail;
+  if (Supported)
+    return Applicability::Execute;
+  if (Requirement == CapabilityRequirement::CapabilityGated)
+    return Applicability::NotApplicable;
+  return Applicability::Fail;
+}
+
+HRESULT queryTierSupport(ID3D12Device *Device, TierSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraTierSupport RuntimeSupport = {};
+  const HRESULT HR = Device->CheckFeatureSupport(
+      LinearAlgebraSupportFeature, &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(L"Linear algebra tier query failed: 0x%08x", HR);
+    return HR;
+  }
+
+  if (RuntimeSupport.LinearAlgebraTier !=
+          static_cast<UINT>(Tier::NotSupported) &&
+      RuntimeSupport.LinearAlgebraTier != static_cast<UINT>(Tier::Tier1_0)) {
+    LogCommentFmt(L"Linear algebra tier query returned invalid tier: 0x%x",
+                  RuntimeSupport.LinearAlgebraTier);
+    return E_UNEXPECTED;
+  }
+
+  Support.LinearAlgebraTier =
+      static_cast<Tier>(RuntimeSupport.LinearAlgebraTier);
+  LogCommentFmt(L"Linear algebra tier: 0x%x",
+                static_cast<UINT>(Support.LinearAlgebraTier));
+  return S_OK;
+}
+
+HRESULT queryMatrixConstruction(ID3D12Device *Device,
+                                const MatrixConstructionQuery &Query,
+                                MatrixConstructionSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::MatrixConstruction);
+  RuntimeSupport.MatrixConstruction.ComponentType =
+      static_cast<UINT>(Query.ComponentType);
+  RuntimeSupport.MatrixConstruction.WaveSize = Query.WaveSize;
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"MatrixConstruction query failed: type=%s, wave=%u, hr=0x%08x",
+        dataTypeName(Query.ComponentType), Query.WaveSize, HR);
+    return HR;
+  }
+
+  const UINT MinM = RuntimeSupport.MatrixConstruction.MinM;
+  const UINT MinK = RuntimeSupport.MatrixConstruction.MinK;
+  const UINT MinN = RuntimeSupport.MatrixConstruction.MinN;
+  const bool AllZero = MinM == 0 && MinK == 0 && MinN == 0;
+  const bool AllNonZero = MinM != 0 && MinK != 0 && MinN != 0;
+  if (!AllZero && !AllNonZero) {
+    LogCommentFmt(
+        L"MatrixConstruction query returned malformed minima: type=%s, "
+        L"wave=%u, MinM=%u, MinK=%u, MinN=%u",
+        dataTypeName(Query.ComponentType), Query.WaveSize, MinM, MinK, MinN);
+    return E_UNEXPECTED;
+  }
+
+  Support.MinM = MinM;
+  Support.MinK = MinK;
+  Support.MinN = MinN;
+  LogCommentFmt(
+      L"MatrixConstruction query: type=%s, wave=%u, supported=%u, MinM=%u, "
+      L"MinK=%u, MinN=%u",
+      dataTypeName(Query.ComponentType), Query.WaveSize, Support.supported(),
+      Support.MinM, Support.MinK, Support.MinN);
+  return S_OK;
+}
+
+HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
+                                const WaveMatrixMultiplyQuery &Query,
+                                WaveMatrixMultiplySupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::WaveMatrixMultiply);
+  setWaveInputs(RuntimeSupport.WaveMatrixMultiply.Inputs, Query);
+
+  HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"WaveMatrixMultiply query failed: wave=%u, A=%s, B=%s, Acc=%s, "
+        L"hr=0x%08x",
+        Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+        dataTypeName(Query.MatrixBComponentType),
+        dataTypeName(Query.AccumulatorComponentType), HR);
+    return HR;
+  }
+
+  if (!isValidMultiplicationFlags(
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags)) {
+    LogCommentFmt(L"WaveMatrixMultiply query returned invalid flags: 0x%x",
+                  RuntimeSupport.WaveMatrixMultiply.SupportFlags);
+    return E_UNEXPECTED;
+  }
+
+  const bool Supported =
+      (RuntimeSupport.WaveMatrixMultiply.SupportFlags &
+       static_cast<UINT>(MultiplicationFlags::Supported)) != 0;
+  if (!Supported) {
+    if (RuntimeSupport.WaveMatrixMultiply.NumShapes != 0) {
+      LogCommentFmt(L"Unsupported WaveMatrixMultiply query returned %u shapes",
+                    RuntimeSupport.WaveMatrixMultiply.NumShapes);
+      return E_UNEXPECTED;
+    }
+    Support.SupportFlags = static_cast<MultiplicationFlags>(
+        RuntimeSupport.WaveMatrixMultiply.SupportFlags);
+    LogCommentFmt(L"WaveMatrixMultiply query: wave=%u, A=%s, B=%s, Acc=%s, "
+                  L"flags=0x%x, shapes=0",
+                  Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+                  dataTypeName(Query.MatrixBComponentType),
+                  dataTypeName(Query.AccumulatorComponentType),
+                  static_cast<UINT>(Support.SupportFlags));
+    return S_OK;
+  }
+
+  const UINT RequestedShapes = RuntimeSupport.WaveMatrixMultiply.NumShapes;
+  if (RequestedShapes == 0) {
+    LogCommentFmt(
+        L"Supported WaveMatrixMultiply query returned no native shapes");
+    return E_UNEXPECTED;
+  }
+
+  std::vector<RuntimeMatrixMultiplyShape> RuntimeShapes(RequestedShapes);
+  RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::WaveMatrixMultiply);
+  setWaveInputs(RuntimeSupport.WaveMatrixMultiply.Inputs, Query);
+  RuntimeSupport.WaveMatrixMultiply.NumShapes = RequestedShapes;
+  RuntimeSupport.WaveMatrixMultiply.Shapes = RuntimeShapes.data();
+
+  HR = Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                   &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"WaveMatrixMultiply shape query failed: wave=%u, A=%s, B=%s, "
+        L"Acc=%s, requested=%u, hr=0x%08x",
+        Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+        dataTypeName(Query.MatrixBComponentType),
+        dataTypeName(Query.AccumulatorComponentType), RequestedShapes, HR);
+    return HR;
+  }
+
+  if (!isValidMultiplicationFlags(
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags) ||
+      (RuntimeSupport.WaveMatrixMultiply.SupportFlags &
+       static_cast<UINT>(MultiplicationFlags::Supported)) == 0 ||
+      RuntimeSupport.WaveMatrixMultiply.NumShapes == 0 ||
+      RuntimeSupport.WaveMatrixMultiply.NumShapes > RequestedShapes) {
+    LogCommentFmt(
+        L"WaveMatrixMultiply shape query returned malformed flags/count: "
+        L"flags=0x%x, returned=%u, requested=%u",
+        RuntimeSupport.WaveMatrixMultiply.SupportFlags,
+        RuntimeSupport.WaveMatrixMultiply.NumShapes, RequestedShapes);
+    return E_UNEXPECTED;
+  }
+
+  Support.SupportFlags = static_cast<MultiplicationFlags>(
+      RuntimeSupport.WaveMatrixMultiply.SupportFlags);
+  for (UINT I = 0; I < RuntimeSupport.WaveMatrixMultiply.NumShapes; ++I) {
+    const RuntimeMatrixMultiplyShape &Shape = RuntimeShapes[I];
+    if (Shape.M == 0 || Shape.K == 0 || Shape.N == 0) {
+      LogCommentFmt(
+          L"WaveMatrixMultiply query returned zero native shape at index %u: "
+          L"M=%u, K=%u, N=%u",
+          I, Shape.M, Shape.K, Shape.N);
+      return E_UNEXPECTED;
+    }
+    Support.Shapes.push_back({Shape.M, Shape.K, Shape.N});
+  }
+
+  LogCommentFmt(
+      L"WaveMatrixMultiply query: wave=%u, A=%s, B=%s, Acc=%s, flags=0x%x, "
+      L"shapes=%zu",
+      Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+      dataTypeName(Query.MatrixBComponentType),
+      dataTypeName(Query.AccumulatorComponentType),
+      static_cast<UINT>(Support.SupportFlags), Support.Shapes.size());
+  for (size_t I = 0; I < Support.Shapes.size(); ++I) {
+    const MatrixMultiplyShape &Shape = Support.Shapes[I];
+    LogCommentFmt(L"  Native shape %zu: M=%u, K=%u, N=%u", I, Shape.M, Shape.K,
+                  Shape.N);
+  }
+  return S_OK;
+}
+
+HRESULT
+queryThreadGroupMatrixMultiply(ID3D12Device *Device,
+                               const ThreadGroupMatrixMultiplyQuery &Query,
+                               ThreadGroupMatrixMultiplySupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::ThreadGroupMatrixMultiply);
+  setWaveInputs(RuntimeSupport.ThreadGroupMatrixMultiply.WaveInputs,
+                Query.WaveInputs);
+  RuntimeSupport.ThreadGroupMatrixMultiply.Shape = {
+      Query.Shape.M,
+      Query.Shape.K,
+      Query.Shape.N,
+  };
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"ThreadGroupMatrixMultiply query failed: wave=%u, A=%s, B=%s, "
+        L"Acc=%s, shape=(%u,%u,%u), hr=0x%08x",
+        Query.WaveInputs.WaveSize,
+        dataTypeName(Query.WaveInputs.MatrixAComponentType),
+        dataTypeName(Query.WaveInputs.MatrixBComponentType),
+        dataTypeName(Query.WaveInputs.AccumulatorComponentType), Query.Shape.M,
+        Query.Shape.K, Query.Shape.N, HR);
+    return HR;
+  }
+
+  const UINT Flags = RuntimeSupport.ThreadGroupMatrixMultiply.SupportFlags;
+  if (!isValidMultiplicationFlags(Flags)) {
+    LogCommentFmt(
+        L"ThreadGroupMatrixMultiply query returned invalid flags: 0x%x", Flags);
+    return E_UNEXPECTED;
+  }
+
+  const bool Supported =
+      (Flags & static_cast<UINT>(MultiplicationFlags::Supported)) != 0;
+  const UINT MinSize =
+      RuntimeSupport.ThreadGroupMatrixMultiply.MinThreadGroupSize;
+  const UINT MaxSize =
+      RuntimeSupport.ThreadGroupMatrixMultiply.MaxThreadGroupSize;
+  const UINT PreferredSize =
+      RuntimeSupport.ThreadGroupMatrixMultiply.PreferredThreadGroupSize;
+  if (Supported &&
+      (MinSize == 0 || MaxSize < MinSize || MaxSize % MinSize != 0 ||
+       (PreferredSize != 0 &&
+        (PreferredSize < MinSize || PreferredSize > MaxSize ||
+         PreferredSize % MinSize != 0)))) {
+    LogCommentFmt(
+        L"ThreadGroupMatrixMultiply query returned malformed group sizes: "
+        L"min=%u, max=%u, preferred=%u",
+        MinSize, MaxSize, PreferredSize);
+    return E_UNEXPECTED;
+  }
+
+  Support.SupportFlags = static_cast<MultiplicationFlags>(Flags);
+  Support.MinThreadGroupSize = MinSize;
+  Support.MaxThreadGroupSize = MaxSize;
+  Support.PreferredThreadGroupSize = PreferredSize;
+  LogCommentFmt(
+      L"ThreadGroupMatrixMultiply query: wave=%u, A=%s, B=%s, Acc=%s, "
+      L"shape=(%u,%u,%u), flags=0x%x, minGroup=%u, maxGroup=%u, "
+      L"preferredGroup=%u",
+      Query.WaveInputs.WaveSize,
+      dataTypeName(Query.WaveInputs.MatrixAComponentType),
+      dataTypeName(Query.WaveInputs.MatrixBComponentType),
+      dataTypeName(Query.WaveInputs.AccumulatorComponentType), Query.Shape.M,
+      Query.Shape.K, Query.Shape.N, Flags, MinSize, MaxSize, PreferredSize);
+  return S_OK;
+}
+
+HRESULT
+queryThreadVectorMatrixMultiply(ID3D12Device *Device,
+                                const ThreadVectorMatrixMultiplyQuery &Query,
+                                ThreadVectorMatrixMultiplySupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::ThreadVectorMatrixMultiply);
+  RuntimeSupport.ThreadVectorMatrixMultiply.VectorInputType =
+      static_cast<UINT>(Query.VectorInputType);
+  RuntimeSupport.ThreadVectorMatrixMultiply.MatrixInputType =
+      static_cast<UINT>(Query.MatrixInputType);
+  RuntimeSupport.ThreadVectorMatrixMultiply.BiasInputType =
+      static_cast<UINT>(Query.BiasInputType);
+  RuntimeSupport.ThreadVectorMatrixMultiply.VectorResultType =
+      static_cast<UINT>(Query.VectorResultType);
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"ThreadVectorMatrixMultiply query failed: vector=%s, matrix=%s, "
+        L"bias=%s, result=%s, hr=0x%08x",
+        dataTypeName(Query.VectorInputType),
+        dataTypeName(Query.MatrixInputType), dataTypeName(Query.BiasInputType),
+        dataTypeName(Query.VectorResultType), HR);
+    return HR;
+  }
+
+  const UINT Flags = RuntimeSupport.ThreadVectorMatrixMultiply.SupportFlags;
+  if (!isValidMultiplicationFlags(Flags)) {
+    LogCommentFmt(
+        L"ThreadVectorMatrixMultiply query returned invalid flags: 0x%x",
+        Flags);
+    return E_UNEXPECTED;
+  }
+
+  Support.SupportFlags = static_cast<MultiplicationFlags>(Flags);
+  LogCommentFmt(
+      L"ThreadVectorMatrixMultiply query: vector=%s, matrix=%s, bias=%s, "
+      L"result=%s, flags=0x%x",
+      dataTypeName(Query.VectorInputType), dataTypeName(Query.MatrixInputType),
+      dataTypeName(Query.BiasInputType), dataTypeName(Query.VectorResultType),
+      Flags);
+  return S_OK;
+}
+
+HRESULT queryThreadOuterProduct(ID3D12Device *Device,
+                                const ThreadOuterProductQuery &Query,
+                                ThreadOuterProductSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::ThreadOuterProduct);
+  RuntimeSupport.ThreadOuterProduct.InputComponentType =
+      static_cast<UINT>(Query.InputComponentType);
+  RuntimeSupport.ThreadOuterProduct.ResultComponentType =
+      static_cast<UINT>(Query.ResultComponentType);
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"ThreadOuterProduct query failed: input=%s, result=%s, hr=0x%08x",
+        dataTypeName(Query.InputComponentType),
+        dataTypeName(Query.ResultComponentType), HR);
+    return HR;
+  }
+
+  Support.Supported = RuntimeSupport.ThreadOuterProduct.Supported != FALSE;
+  LogCommentFmt(L"ThreadOuterProduct query: input=%s, result=%s, supported=%u",
+                dataTypeName(Query.InputComponentType),
+                dataTypeName(Query.ResultComponentType), Support.Supported);
+  return S_OK;
+}
+
+HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
+                                   const AtomicAccumulateStoreQuery &Query,
+                                   AtomicAccumulateStoreSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::AtomicAccumulateStore);
+  RuntimeSupport.AccumulateStore.ComponentType =
+      static_cast<UINT>(Query.ComponentType);
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(L"AtomicAccumulateStore query failed: type=%s, hr=0x%08x",
+                  dataTypeName(Query.ComponentType), HR);
+    return HR;
+  }
+
+  Support.RWByteAddressBufferSupported =
+      RuntimeSupport.AccumulateStore.RWByteAddressBufferSupported != FALSE;
+  Support.GroupSharedSupported =
+      RuntimeSupport.AccumulateStore.GroupSharedSupported != FALSE;
+  LogCommentFmt(L"AtomicAccumulateStore query: type=%s, UAV=%u, groupshared=%u",
+                dataTypeName(Query.ComponentType),
+                Support.RWByteAddressBufferSupported,
+                Support.GroupSharedSupported);
+  return S_OK;
+}
+
+} // namespace linalg_test
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 #include <windows.h>
 
 #include "ShaderOpTest.h"
@@ -73,6 +74,199 @@ bool doesDeviceSupportWritableMSAA(ID3D12Device *pDevice);
 bool doesDeviceSupportEnhancedBarriers(ID3D12Device *pDevice);
 bool doesDeviceSupportRelaxedFormatCasting(ID3D12Device *pDevice);
 bool isFallbackPathEnabled();
+
+namespace linalg_test {
+
+enum class Tier : UINT {
+  NotSupported = 0,
+  Tier1_0 = 0x10,
+};
+
+enum class DataType : UINT {
+  None = 0,
+  SInt16 = 2,
+  UInt16 = 3,
+  SInt32 = 4,
+  UInt32 = 5,
+  Float16 = 7,
+  Float32 = 8,
+  SInt8 = 18,
+  UInt8 = 19,
+  Float8E4M3FN = 20,
+  Float8E5M2 = 21,
+};
+
+enum class OperationType : UINT {
+  MatrixConstruction = 0,
+  WaveMatrixMultiply = 1,
+  ThreadGroupMatrixMultiply = 2,
+  ThreadVectorMatrixMultiply = 3,
+  ThreadOuterProduct = 4,
+  AtomicAccumulateStore = 5,
+};
+
+enum class MultiplicationFlags : UINT {
+  None = 0,
+  Supported = 1,
+  EmulatedInputs = 2,
+  EmulatedOutputs = 4,
+  Transpose = 8,
+};
+
+enum class MatrixRole {
+  A,
+  B,
+  Accumulator,
+};
+
+enum class ExecutionScope : UINT {
+  Thread = 1,
+  Wave = 2,
+  ThreadGroup = 4,
+};
+
+using ScopeFlags = UINT;
+
+enum class AtomicDestination {
+  RWByteAddressBuffer,
+  GroupShared,
+};
+
+enum class CapabilityRequirement {
+  Mandatory,
+  CapabilityGated,
+};
+
+enum class Applicability {
+  Execute,
+  NotApplicable,
+  Fail,
+};
+
+struct TierSupport {
+  Tier LinearAlgebraTier = Tier::NotSupported;
+
+  bool supported() const { return LinearAlgebraTier != Tier::NotSupported; }
+};
+
+struct MatrixConstructionQuery {
+  DataType ComponentType;
+  UINT WaveSize;
+};
+
+struct MatrixConstructionSupport {
+  UINT MinM = 0;
+  UINT MinK = 0;
+  UINT MinN = 0;
+
+  bool valid() const;
+  bool supported() const;
+  bool supports(MatrixRole Role, UINT Rows, UINT Columns) const;
+};
+
+struct MatrixMultiplyShape {
+  UINT M;
+  UINT K;
+  UINT N;
+};
+
+struct WaveMatrixMultiplyQuery {
+  UINT WaveSize;
+  DataType MatrixAComponentType;
+  DataType MatrixBComponentType;
+  DataType AccumulatorComponentType;
+};
+
+struct WaveMatrixMultiplySupport {
+  MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+  std::vector<MatrixMultiplyShape> Shapes;
+
+  bool valid() const;
+  bool supported() const;
+  bool supportsShape(UINT M, UINT K, UINT N) const;
+};
+
+struct ThreadGroupMatrixMultiplyQuery {
+  WaveMatrixMultiplyQuery WaveInputs;
+  MatrixMultiplyShape Shape;
+};
+
+struct ThreadGroupMatrixMultiplySupport {
+  MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+  UINT MinThreadGroupSize = 0;
+  UINT MaxThreadGroupSize = 0;
+  UINT PreferredThreadGroupSize = 0;
+
+  bool valid() const;
+  bool supported() const;
+  bool supportsThreadGroupSize(UINT ThreadGroupSize) const;
+};
+
+struct ThreadVectorMatrixMultiplyQuery {
+  DataType VectorInputType;
+  DataType MatrixInputType;
+  DataType BiasInputType;
+  DataType VectorResultType;
+};
+
+struct ThreadVectorMatrixMultiplySupport {
+  MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+
+  bool valid() const;
+  bool supported() const;
+};
+
+struct ThreadOuterProductQuery {
+  DataType InputComponentType;
+  DataType ResultComponentType;
+};
+
+struct ThreadOuterProductSupport {
+  bool Supported = false;
+
+  bool supported() const { return Supported; }
+};
+
+struct AtomicAccumulateStoreQuery {
+  DataType ComponentType;
+};
+
+struct AtomicAccumulateStoreSupport {
+  bool RWByteAddressBufferSupported = false;
+  bool GroupSharedSupported = false;
+
+  bool supports(AtomicDestination Destination) const;
+};
+
+bool hasFlag(MultiplicationFlags Value, MultiplicationFlags Flag);
+ScopeFlags legalScopes(OperationType Operation);
+bool isLegalScope(OperationType Operation, ExecutionScope Scope);
+Applicability classifyApplicability(HRESULT QueryResult, bool Supported,
+                                    CapabilityRequirement Requirement);
+
+HRESULT queryTierSupport(ID3D12Device *Device, TierSupport &Support);
+HRESULT queryMatrixConstruction(ID3D12Device *Device,
+                                const MatrixConstructionQuery &Query,
+                                MatrixConstructionSupport &Support);
+HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
+                                const WaveMatrixMultiplyQuery &Query,
+                                WaveMatrixMultiplySupport &Support);
+HRESULT
+queryThreadGroupMatrixMultiply(ID3D12Device *Device,
+                               const ThreadGroupMatrixMultiplyQuery &Query,
+                               ThreadGroupMatrixMultiplySupport &Support);
+HRESULT
+queryThreadVectorMatrixMultiply(ID3D12Device *Device,
+                                const ThreadVectorMatrixMultiplyQuery &Query,
+                                ThreadVectorMatrixMultiplySupport &Support);
+HRESULT queryThreadOuterProduct(ID3D12Device *Device,
+                                const ThreadOuterProductQuery &Query,
+                                ThreadOuterProductSupport &Support);
+HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
+                                   const AtomicAccumulateStoreQuery &Query,
+                                   AtomicAccumulateStoreSupport &Support);
+
+} // namespace linalg_test
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -211,6 +211,7 @@ struct ThreadVectorMatrixMultiplyQuery {
 
 struct ThreadVectorMatrixMultiplySupport {
   MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+  DataType MatrixInputType = DataType::None;
 
   bool valid() const;
   bool supported() const;

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -3,6 +3,7 @@
 
 #include <atlcomcli.h>
 #include <d3d12.h>
+#include <initializer_list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -290,6 +291,24 @@ void addUAVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
 /// Add a SRV buffer resource to a ShaderOp.
 void addSRVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
                   const char *Init = "zero");
+
+enum class RawBufferViewKind {
+  SRV,
+  UAV,
+};
+
+struct RawBufferView {
+  const char *DescriptorName;
+  const char *ResourceName;
+  RawBufferViewKind Kind;
+  UINT64 FirstByte;
+  UINT64 NumBytes;
+};
+
+/// Add a shader-visible descriptor table containing raw buffer views.
+void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
+                                 const char *HeapName,
+                                 std::initializer_list<RawBufferView> Views);
 
 /// Bind a resource to a root view parameter by index.
 void addRootView(st::ShaderOp *Op, UINT Index, const char *ResName);

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -25,9 +25,13 @@
 #include "HlslTestUtils.h"
 
 #include <climits>
+#include <cstring>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #define STREAM_FLOAT(stream, name, value)                                      \
   stream << std::showpoint << " -D" << name << "=" << value << "F"             \
@@ -92,6 +96,671 @@ struct MatrixParams {
   size_t totalBytes() const { return totalElements() * elementSize(CompType); }
 };
 
+namespace cpu_oracle {
+
+using TypedMatrixValues =
+    std::variant<std::vector<HLSLHalf_t>, std::vector<float>,
+                 std::vector<int32_t>, std::vector<uint32_t>>;
+
+struct TypedMatrix {
+  ComponentType CompType;
+  MatrixDim M;
+  MatrixDim N;
+  TypedMatrixValues Values;
+
+  size_t totalElements() const {
+    return static_cast<size_t>(M) * static_cast<size_t>(N);
+  }
+};
+
+struct MatrixBufferLayout {
+  LinalgMatrixLayout Layout;
+  size_t OffsetBytes;
+  size_t StrideBytes;
+};
+
+enum class ComparisonMode {
+  // Floating-point alternatives allowed by the specification must be listed as
+  // permitted results; Exact compares the encoded component bits.
+  Exact,
+  PermittedResults,
+  Excluded,
+};
+
+// MatrixResultOracle models matrix-valued outputs. Operations whose observable
+// result is a complete destination buffer need a whole-buffer oracle instead.
+struct MatrixResultOracle {
+  ComparisonMode Mode;
+  std::vector<TypedMatrix> Candidates;
+  std::wstring PublicRule;
+};
+
+template <typename T, ComponentType CT> struct NativeComponentTraits {
+  static constexpr ComponentType CompType = CT;
+  static constexpr size_t Size = sizeof(T);
+
+  static void store(BYTE *Dest, const T &Value) {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Component must be trivially copyable");
+    std::memcpy(Dest, &Value, sizeof(Value));
+  }
+
+  static T load(const BYTE *Source) {
+    T Value;
+    std::memcpy(&Value, Source, sizeof(Value));
+    return Value;
+  }
+
+  static bool exactMatch(const T &Actual, const T &Expected) {
+    return std::memcmp(&Actual, &Expected, sizeof(T)) == 0;
+  }
+
+  static std::wstring format(const T &Value) {
+    std::wstringstream Stream;
+    Stream << Value;
+    return Stream.str();
+  }
+};
+
+template <typename T> struct ComponentTraits;
+
+template <>
+struct ComponentTraits<float>
+    : NativeComponentTraits<float, ComponentType::F32> {};
+
+template <>
+struct ComponentTraits<int32_t>
+    : NativeComponentTraits<int32_t, ComponentType::I32> {};
+
+template <>
+struct ComponentTraits<uint32_t>
+    : NativeComponentTraits<uint32_t, ComponentType::U32> {};
+
+template <> struct ComponentTraits<HLSLHalf_t> {
+  static constexpr ComponentType CompType = ComponentType::F16;
+  static constexpr size_t Size = sizeof(uint16_t);
+
+  static void store(BYTE *Dest, const HLSLHalf_t &Value) {
+    std::memcpy(Dest, &Value.Val, sizeof(Value.Val));
+  }
+
+  static HLSLHalf_t load(const BYTE *Source) {
+    uint16_t Bits;
+    std::memcpy(&Bits, Source, sizeof(Bits));
+    return HLSLHalf_t::FromHALF(static_cast<DirectX::PackedVector::HALF>(Bits));
+  }
+
+  static bool exactMatch(const HLSLHalf_t &Actual, const HLSLHalf_t &Expected) {
+    return Actual.Val == Expected.Val;
+  }
+
+  static std::wstring format(const HLSLHalf_t &Value) {
+    std::wstringstream Stream;
+    Stream << static_cast<float>(Value) << L" (bits=0x" << std::hex << Value.Val
+           << L")";
+    return Stream.str();
+  }
+};
+
+static bool checkedMultiply(size_t Left, size_t Right, size_t &Result) {
+  if (Right != 0 && Left > std::numeric_limits<size_t>::max() / Right)
+    return false;
+  Result = Left * Right;
+  return true;
+}
+
+static bool checkedAdd(size_t Left, size_t Right, size_t &Result) {
+  if (Left > std::numeric_limits<size_t>::max() - Right)
+    return false;
+  Result = Left + Right;
+  return true;
+}
+
+static bool isSupportedComponentType(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::F16:
+  case ComponentType::F32:
+  case ComponentType::I32:
+  case ComponentType::U32:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static LPCWSTR componentTypeName(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::F16:
+    return L"F16";
+  case ComponentType::F32:
+    return L"F32";
+  case ComponentType::I32:
+    return L"I32";
+  case ComponentType::U32:
+    return L"U32";
+  default:
+    return L"Unsupported";
+  }
+}
+
+static LPCWSTR comparisonModeName(ComparisonMode Mode) {
+  switch (Mode) {
+  case ComparisonMode::Exact:
+    return L"Exact";
+  case ComparisonMode::PermittedResults:
+    return L"PermittedResults";
+  case ComparisonMode::Excluded:
+    return L"Excluded";
+  }
+  return L"Unknown";
+}
+
+static bool isMatrixValid(const TypedMatrix &Matrix) {
+  size_t ExpectedElements;
+  if (Matrix.M == 0 || Matrix.N == 0 ||
+      !checkedMultiply(static_cast<size_t>(Matrix.M),
+                       static_cast<size_t>(Matrix.N), ExpectedElements))
+    return false;
+
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return std::holds_alternative<std::vector<HLSLHalf_t>>(Matrix.Values) &&
+           std::get<std::vector<HLSLHalf_t>>(Matrix.Values).size() ==
+               ExpectedElements;
+  case ComponentType::F32:
+    return std::holds_alternative<std::vector<float>>(Matrix.Values) &&
+           std::get<std::vector<float>>(Matrix.Values).size() ==
+               ExpectedElements;
+  case ComponentType::I32:
+    return std::holds_alternative<std::vector<int32_t>>(Matrix.Values) &&
+           std::get<std::vector<int32_t>>(Matrix.Values).size() ==
+               ExpectedElements;
+  case ComponentType::U32:
+    return std::holds_alternative<std::vector<uint32_t>>(Matrix.Values) &&
+           std::get<std::vector<uint32_t>>(Matrix.Values).size() ==
+               ExpectedElements;
+  default:
+    return false;
+  }
+}
+
+template <typename T>
+static std::optional<TypedMatrix> makeTypedMatrix(MatrixDim M, MatrixDim N,
+                                                  std::vector<T> Values) {
+  size_t ExpectedElements;
+  if (M == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
+                       ExpectedElements) ||
+      Values.size() != ExpectedElements) {
+    hlsl_test::LogErrorFmt(
+        L"Invalid typed matrix dimensions or element count: M=%u, N=%u, "
+        L"elements=%zu",
+        M, N, Values.size());
+    return std::nullopt;
+  }
+
+  return TypedMatrix{ComponentTraits<T>::CompType, M, N, std::move(Values)};
+}
+
+static std::optional<TypedMatrix>
+makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
+                     uint32_t StartingValue = 1) {
+  size_t NumElements;
+  if (M == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
+                       NumElements)) {
+    hlsl_test::LogErrorFmt(L"Invalid sequential matrix dimensions: M=%u, N=%u",
+                           M, N);
+    return std::nullopt;
+  }
+
+  size_t LastValueSize;
+  if (!checkedAdd(static_cast<size_t>(StartingValue), NumElements - 1,
+                  LastValueSize)) {
+    hlsl_test::LogErrorFmt(L"Sequential matrix value calculation overflowed");
+    return std::nullopt;
+  }
+  const uint64_t LastValue = static_cast<uint64_t>(LastValueSize);
+
+  switch (CompType) {
+  case ComponentType::F16: {
+    if (LastValue > 65504) {
+      hlsl_test::LogErrorFmt(L"F16 sequential value is out of range: %llu",
+                             LastValue);
+      return std::nullopt;
+    }
+    std::vector<HLSLHalf_t> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.emplace_back(static_cast<float>(
+          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  case ComponentType::F32: {
+    if (LastValue > (1u << 24)) {
+      hlsl_test::LogErrorFmt(
+          L"F32 sequential integer cannot be represented exactly: %llu",
+          LastValue);
+      return std::nullopt;
+    }
+    std::vector<float> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.push_back(static_cast<float>(static_cast<uint64_t>(StartingValue) +
+                                          static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  case ComponentType::I32: {
+    if (LastValue >
+        static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+      hlsl_test::LogErrorFmt(L"I32 sequential value is out of range: %llu",
+                             LastValue);
+      return std::nullopt;
+    }
+    std::vector<int32_t> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.push_back(static_cast<int32_t>(
+          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  case ComponentType::U32: {
+    if (LastValue > std::numeric_limits<uint32_t>::max()) {
+      hlsl_test::LogErrorFmt(L"U32 sequential value is out of range: %llu",
+                             LastValue);
+      return std::nullopt;
+    }
+    std::vector<uint32_t> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.push_back(static_cast<uint32_t>(
+          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  default:
+    hlsl_test::LogErrorFmt(L"Unsupported sequential matrix component type: %u",
+                           static_cast<uint32_t>(CompType));
+    return std::nullopt;
+  }
+}
+
+template <typename T>
+static std::optional<TypedMatrix>
+transposeTypedMatrix(const TypedMatrix &Source) {
+  const std::vector<T> &SourceValues = std::get<std::vector<T>>(Source.Values);
+  std::vector<T> Result(Source.totalElements());
+  for (MatrixDim Row = 0; Row < Source.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Source.N; ++Column) {
+      const size_t SourceIndex = static_cast<size_t>(Row) * Source.N + Column;
+      const size_t ResultIndex = static_cast<size_t>(Column) * Source.M + Row;
+      Result[ResultIndex] = SourceValues[SourceIndex];
+    }
+  }
+  return makeTypedMatrix(Source.N, Source.M, std::move(Result));
+}
+
+static std::optional<TypedMatrix> transposeMatrix(const TypedMatrix &Source) {
+  if (!isMatrixValid(Source)) {
+    hlsl_test::LogErrorFmt(L"Cannot transpose an invalid typed matrix");
+    return std::nullopt;
+  }
+
+  switch (Source.CompType) {
+  case ComponentType::F16:
+    return transposeTypedMatrix<HLSLHalf_t>(Source);
+  case ComponentType::F32:
+    return transposeTypedMatrix<float>(Source);
+  case ComponentType::I32:
+    return transposeTypedMatrix<int32_t>(Source);
+  case ComponentType::U32:
+    return transposeTypedMatrix<uint32_t>(Source);
+  default:
+    return std::nullopt;
+  }
+}
+
+static bool isMemoryLayout(LinalgMatrixLayout Layout) {
+  return Layout == LinalgMatrixLayout::RowMajor ||
+         Layout == LinalgMatrixLayout::ColumnMajor;
+}
+
+static std::optional<size_t>
+getMatrixBufferSize(ComponentType CompType, MatrixDim M, MatrixDim N,
+                    const MatrixBufferLayout &Layout) {
+  if (!isSupportedComponentType(CompType) || M == 0 || N == 0 ||
+      !isMemoryLayout(Layout.Layout)) {
+    hlsl_test::LogErrorFmt(
+        L"Invalid matrix buffer description: component=%s, M=%u, N=%u, "
+        L"layout=%u",
+        componentTypeName(CompType), M, N,
+        static_cast<uint32_t>(Layout.Layout));
+    return std::nullopt;
+  }
+
+  const size_t ElementBytes = elementSize(CompType);
+  const size_t MajorCount =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? M : N;
+  const size_t MinorCount =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? N : M;
+  size_t PackedMinorBytes;
+  if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes) ||
+      Layout.StrideBytes < PackedMinorBytes) {
+    hlsl_test::LogErrorFmt(
+        L"Matrix stride is too small: component=%s, M=%u, N=%u, stride=%zu, "
+        L"required=%zu",
+        componentTypeName(CompType), M, N, Layout.StrideBytes,
+        PackedMinorBytes);
+    return std::nullopt;
+  }
+
+  size_t LastMajorOffset;
+  size_t RequiredBytes;
+  if (!checkedMultiply(MajorCount - 1, Layout.StrideBytes, LastMajorOffset) ||
+      !checkedAdd(Layout.OffsetBytes, LastMajorOffset, RequiredBytes) ||
+      !checkedAdd(RequiredBytes, PackedMinorBytes, RequiredBytes)) {
+    hlsl_test::LogErrorFmt(L"Matrix buffer size calculation overflowed");
+    return std::nullopt;
+  }
+  return RequiredBytes;
+}
+
+static std::optional<size_t>
+getMatrixBufferSize(const TypedMatrix &Matrix,
+                    const MatrixBufferLayout &Layout) {
+  if (!isMatrixValid(Matrix)) {
+    hlsl_test::LogErrorFmt(L"Cannot size an invalid typed matrix");
+    return std::nullopt;
+  }
+  return getMatrixBufferSize(Matrix.CompType, Matrix.M, Matrix.N, Layout);
+}
+
+static std::optional<size_t>
+getElementByteOffset(ComponentType CompType, MatrixDim M, MatrixDim N,
+                     MatrixDim Row, MatrixDim Column,
+                     const MatrixBufferLayout &Layout) {
+  if (Row >= M || Column >= N)
+    return std::nullopt;
+
+  const size_t Major =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? Row : Column;
+  const size_t Minor =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? Column : Row;
+  size_t MajorOffset;
+  size_t MinorOffset;
+  size_t ByteOffset;
+  if (!checkedMultiply(Major, Layout.StrideBytes, MajorOffset) ||
+      !checkedMultiply(Minor, elementSize(CompType), MinorOffset) ||
+      !checkedAdd(Layout.OffsetBytes, MajorOffset, ByteOffset) ||
+      !checkedAdd(ByteOffset, MinorOffset, ByteOffset))
+    return std::nullopt;
+  return ByteOffset;
+}
+
+template <typename T>
+static bool writeTypedMatrixBuffer(const TypedMatrix &Matrix,
+                                   const MatrixBufferLayout &Layout,
+                                   std::vector<BYTE> &Buffer) {
+  const std::vector<T> &Values = std::get<std::vector<T>>(Matrix.Values);
+  for (MatrixDim Row = 0; Row < Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Matrix.N; ++Column) {
+      const size_t ValueIndex = static_cast<size_t>(Row) * Matrix.N + Column;
+      std::optional<size_t> ByteOffset = getElementByteOffset(
+          Matrix.CompType, Matrix.M, Matrix.N, Row, Column, Layout);
+      if (!ByteOffset.has_value())
+        return false;
+      ComponentTraits<T>::store(Buffer.data() + *ByteOffset,
+                                Values[ValueIndex]);
+    }
+  }
+  return true;
+}
+
+static bool writeMatrixBuffer(const TypedMatrix &Matrix,
+                              const MatrixBufferLayout &Layout,
+                              std::vector<BYTE> &Buffer) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Matrix, Layout);
+  if (!RequiredBytes.has_value() || Buffer.size() < *RequiredBytes) {
+    hlsl_test::LogErrorFmt(
+        L"Matrix buffer is too small: actual=%zu, required=%zu", Buffer.size(),
+        RequiredBytes.value_or(0));
+    return false;
+  }
+
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return writeTypedMatrixBuffer<HLSLHalf_t>(Matrix, Layout, Buffer);
+  case ComponentType::F32:
+    return writeTypedMatrixBuffer<float>(Matrix, Layout, Buffer);
+  case ComponentType::I32:
+    return writeTypedMatrixBuffer<int32_t>(Matrix, Layout, Buffer);
+  case ComponentType::U32:
+    return writeTypedMatrixBuffer<uint32_t>(Matrix, Layout, Buffer);
+  default:
+    return false;
+  }
+}
+
+template <typename T>
+static std::optional<TypedMatrix>
+decodeTypedMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
+                        const MatrixBufferLayout &Layout, const BYTE *Buffer) {
+  std::vector<T> Values(static_cast<size_t>(M) * N);
+  for (MatrixDim Row = 0; Row < M; ++Row) {
+    for (MatrixDim Column = 0; Column < N; ++Column) {
+      const size_t ValueIndex = static_cast<size_t>(Row) * N + Column;
+      std::optional<size_t> ByteOffset =
+          getElementByteOffset(CompType, M, N, Row, Column, Layout);
+      if (!ByteOffset.has_value())
+        return std::nullopt;
+      Values[ValueIndex] = ComponentTraits<T>::load(Buffer + *ByteOffset);
+    }
+  }
+  return makeTypedMatrix(M, N, std::move(Values));
+}
+
+static std::optional<TypedMatrix>
+decodeMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
+                   const MatrixBufferLayout &Layout, const void *Buffer,
+                   size_t BufferSize) {
+  std::optional<size_t> RequiredBytes =
+      getMatrixBufferSize(CompType, M, N, Layout);
+  if (!Buffer || !RequiredBytes.has_value() || BufferSize < *RequiredBytes) {
+    hlsl_test::LogErrorFmt(
+        L"Cannot decode matrix buffer: actual=%zu, required=%zu", BufferSize,
+        RequiredBytes.value_or(0));
+    return std::nullopt;
+  }
+
+  const BYTE *Bytes = static_cast<const BYTE *>(Buffer);
+  switch (CompType) {
+  case ComponentType::F16:
+    return decodeTypedMatrixBuffer<HLSLHalf_t>(CompType, M, N, Layout, Bytes);
+  case ComponentType::F32:
+    return decodeTypedMatrixBuffer<float>(CompType, M, N, Layout, Bytes);
+  case ComponentType::I32:
+    return decodeTypedMatrixBuffer<int32_t>(CompType, M, N, Layout, Bytes);
+  case ComponentType::U32:
+    return decodeTypedMatrixBuffer<uint32_t>(CompType, M, N, Layout, Bytes);
+  default:
+    return std::nullopt;
+  }
+}
+
+template <typename T>
+static bool exactMatrixMatch(const TypedMatrix &Actual,
+                             const TypedMatrix &Expected,
+                             size_t &FirstMismatch) {
+  const std::vector<T> &ActualValues = std::get<std::vector<T>>(Actual.Values);
+  const std::vector<T> &ExpectedValues =
+      std::get<std::vector<T>>(Expected.Values);
+  for (size_t I = 0; I < ActualValues.size(); ++I) {
+    if (!ComponentTraits<T>::exactMatch(ActualValues[I], ExpectedValues[I])) {
+      FirstMismatch = I;
+      return false;
+    }
+  }
+  FirstMismatch = ActualValues.size();
+  return true;
+}
+
+static bool exactMatrixMatch(const TypedMatrix &Actual,
+                             const TypedMatrix &Expected,
+                             size_t &FirstMismatch) {
+  if (!isMatrixValid(Actual) || !isMatrixValid(Expected) ||
+      Actual.CompType != Expected.CompType || Actual.M != Expected.M ||
+      Actual.N != Expected.N) {
+    FirstMismatch = 0;
+    return false;
+  }
+
+  switch (Actual.CompType) {
+  case ComponentType::F16:
+    return exactMatrixMatch<HLSLHalf_t>(Actual, Expected, FirstMismatch);
+  case ComponentType::F32:
+    return exactMatrixMatch<float>(Actual, Expected, FirstMismatch);
+  case ComponentType::I32:
+    return exactMatrixMatch<int32_t>(Actual, Expected, FirstMismatch);
+  case ComponentType::U32:
+    return exactMatrixMatch<uint32_t>(Actual, Expected, FirstMismatch);
+  default:
+    FirstMismatch = 0;
+    return false;
+  }
+}
+
+static std::wstring matrixValueString(const TypedMatrix &Matrix, size_t Index) {
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return ComponentTraits<HLSLHalf_t>::format(
+        std::get<std::vector<HLSLHalf_t>>(Matrix.Values)[Index]);
+  case ComponentType::F32:
+    return ComponentTraits<float>::format(
+        std::get<std::vector<float>>(Matrix.Values)[Index]);
+  case ComponentType::I32:
+    return ComponentTraits<int32_t>::format(
+        std::get<std::vector<int32_t>>(Matrix.Values)[Index]);
+  case ComponentType::U32:
+    return ComponentTraits<uint32_t>::format(
+        std::get<std::vector<uint32_t>>(Matrix.Values)[Index]);
+  default:
+    return L"unsupported";
+  }
+}
+
+static MatrixResultOracle exactResult(TypedMatrix Expected,
+                                      std::wstring PublicRule) {
+  return MatrixResultOracle{
+      ComparisonMode::Exact, {std::move(Expected)}, std::move(PublicRule)};
+}
+
+static MatrixResultOracle permittedResults(std::vector<TypedMatrix> Candidates,
+                                           std::wstring PublicRule) {
+  return MatrixResultOracle{ComparisonMode::PermittedResults,
+                            std::move(Candidates), std::move(PublicRule)};
+}
+
+static MatrixResultOracle excludedResult(std::wstring PublicRule) {
+  return MatrixResultOracle{
+      ComparisonMode::Excluded, {}, std::move(PublicRule)};
+}
+
+static bool isOracleValid(const MatrixResultOracle &Oracle) {
+  if (Oracle.PublicRule.empty())
+    return false;
+  if (Oracle.Mode == ComparisonMode::Excluded)
+    return Oracle.Candidates.empty();
+  if (Oracle.Mode == ComparisonMode::Exact && Oracle.Candidates.size() != 1)
+    return false;
+  if (Oracle.Mode == ComparisonMode::PermittedResults &&
+      Oracle.Candidates.size() < 2)
+    return false;
+
+  const TypedMatrix &First = Oracle.Candidates.front();
+  if (!isMatrixValid(First))
+    return false;
+  for (const TypedMatrix &Candidate : Oracle.Candidates) {
+    if (!isMatrixValid(Candidate) || Candidate.CompType != First.CompType ||
+        Candidate.M != First.M || Candidate.N != First.N)
+      return false;
+  }
+  return true;
+}
+
+static bool
+matchesAnyCompleteCandidate(const TypedMatrix &Actual,
+                            const MatrixResultOracle &Oracle,
+                            std::vector<size_t> *FirstMismatches = nullptr) {
+  if (!isOracleValid(Oracle) || Oracle.Mode == ComparisonMode::Excluded)
+    return false;
+
+  if (FirstMismatches)
+    FirstMismatches->clear();
+  for (const TypedMatrix &Candidate : Oracle.Candidates) {
+    size_t FirstMismatch;
+    if (exactMatrixMatch(Actual, Candidate, FirstMismatch))
+      return true;
+    if (FirstMismatches)
+      FirstMismatches->push_back(FirstMismatch);
+  }
+  return false;
+}
+
+static bool verifyMatrixBuffer(const void *ActualBuffer,
+                               size_t ActualBufferSize,
+                               const MatrixBufferLayout &Layout,
+                               const MatrixResultOracle &Oracle, bool Verbose) {
+  if (!isOracleValid(Oracle)) {
+    hlsl_test::LogErrorFmt(L"Invalid matrix oracle");
+    return false;
+  }
+  if (Oracle.Mode == ComparisonMode::Excluded) {
+    hlsl_test::LogErrorFmt(
+        L"Excluded matrix result cannot be used as a success fallback: %s",
+        Oracle.PublicRule.c_str());
+    return false;
+  }
+
+  const TypedMatrix &Shape = Oracle.Candidates.front();
+  std::optional<TypedMatrix> Actual = decodeMatrixBuffer(
+      Shape.CompType, Shape.M, Shape.N, Layout, ActualBuffer, ActualBufferSize);
+  if (!Actual.has_value())
+    return false;
+
+  std::vector<size_t> FirstMismatches;
+  if (matchesAnyCompleteCandidate(*Actual, Oracle, &FirstMismatches)) {
+    if (Verbose) {
+      hlsl_test::LogCommentFmt(
+          L"Matrix comparison passed: component=%s, M=%u, N=%u, mode=%s, "
+          L"rule=%s",
+          componentTypeName(Shape.CompType), Shape.M, Shape.N,
+          comparisonModeName(Oracle.Mode), Oracle.PublicRule.c_str());
+    }
+    return true;
+  }
+
+  hlsl_test::LogErrorFmt(
+      L"No complete matrix candidate matched: component=%s, M=%u, N=%u, "
+      L"mode=%s, rule=%s",
+      componentTypeName(Shape.CompType), Shape.M, Shape.N,
+      comparisonModeName(Oracle.Mode), Oracle.PublicRule.c_str());
+  for (size_t CandidateIndex = 0; CandidateIndex < Oracle.Candidates.size();
+       ++CandidateIndex) {
+    const TypedMatrix &Candidate = Oracle.Candidates[CandidateIndex];
+    const size_t Mismatch = FirstMismatches[CandidateIndex];
+    const size_t Row = Mismatch / Shape.N;
+    const size_t Column = Mismatch % Shape.N;
+    hlsl_test::LogErrorFmt(
+        L"Candidate %zu first mismatch at index=%zu, coordinate=(%zu,%zu): "
+        L"actual=%s, expected=%s",
+        CandidateIndex, Mismatch, Row, Column,
+        matrixValueString(*Actual, Mismatch).c_str(),
+        matrixValueString(Candidate, Mismatch).c_str());
+  }
+  return false;
+}
+
+} // namespace cpu_oracle
+
 static std::string buildCompilerArgs(const MatrixParams &Params,
                                      const char *ExtraDefines = nullptr) {
   std::stringstream SS;
@@ -112,8 +781,14 @@ static std::string buildCompilerArgs(const MatrixParams &Params,
   case ComponentType::F32:
     SS << " -DELEM_TYPE=float";
     break;
-  default:
+  case ComponentType::I32:
+    SS << " -DELEM_TYPE=int";
+    break;
+  case ComponentType::U32:
     SS << " -DELEM_TYPE=uint";
+    break;
+  default:
+    VERIFY_IS_TRUE(false, "Unsupported LinAlg component type");
     break;
   }
   if (Params.Enable16Bit)
@@ -303,6 +978,132 @@ static VariantCompType makeExpectedVec(ComponentType CompType,
                                        bool Increment = true) {
   return makeExpectedMat(CompType, 1, NumElements, StartingVal, Increment,
                          false);
+}
+
+class LinAlgCPUOracleTests {
+public:
+  BEGIN_TEST_CLASS(LinAlgCPUOracleTests)
+  TEST_METHOD_PROPERTY(L"Priority", L"0")
+  END_TEST_CLASS()
+
+  TEST_METHOD(TypedMatrixBufferRoundTrip);
+};
+
+void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
+  using namespace cpu_oracle;
+
+  auto VerifyScalarEncoding = [](const std::optional<TypedMatrix> &Matrix,
+                                 const std::vector<BYTE> &ExpectedBytes) {
+    if (!Matrix.has_value())
+      return false;
+    MatrixBufferLayout Layout = {
+        LinalgMatrixLayout::RowMajor,
+        /*OffsetBytes=*/0,
+        /*StrideBytes=*/ExpectedBytes.size(),
+    };
+    std::vector<BYTE> ActualBytes(ExpectedBytes.size(), 0);
+    MatrixResultOracle Oracle =
+        exactResult(*Matrix, L"Host scalar encoding and decoding");
+    return writeMatrixBuffer(*Matrix, Layout, ActualBytes) &&
+           ActualBytes == ExpectedBytes &&
+           verifyMatrixBuffer(ActualBytes.data(), ActualBytes.size(), Layout,
+                              Oracle, /*Verbose=*/false);
+  };
+
+  VERIFY_IS_TRUE(VerifyScalarEncoding(
+      makeTypedMatrix<HLSLHalf_t>(1, 1, {HLSLHalf_t(1.5f)}), {0x00, 0x3e}));
+  VERIFY_IS_TRUE(VerifyScalarEncoding(makeTypedMatrix<float>(1, 1, {-2.5f}),
+                                      {0x00, 0x00, 0x20, 0xc0}));
+  VERIFY_IS_TRUE(VerifyScalarEncoding(makeTypedMatrix<int32_t>(1, 1, {-7}),
+                                      {0xf9, 0xff, 0xff, 0xff}));
+  VERIFY_IS_TRUE(
+      VerifyScalarEncoding(makeTypedMatrix<uint32_t>(1, 1, {0x89abcdefu}),
+                           {0xef, 0xcd, 0xab, 0x89}));
+
+  std::optional<TypedMatrix> Matrix =
+      makeTypedMatrix<uint32_t>(2, 3, {1, 2, 3, 4, 5, 6});
+  VERIFY_IS_TRUE(Matrix.has_value());
+
+  MatrixBufferLayout RowMajor = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/4,
+      /*StrideBytes=*/16,
+  };
+  std::optional<size_t> RowBytes = getMatrixBufferSize(*Matrix, RowMajor);
+  VERIFY_IS_TRUE(RowBytes.has_value());
+  std::vector<BYTE> RowBuffer(*RowBytes, 0xcd);
+  VERIFY_IS_TRUE(writeMatrixBuffer(*Matrix, RowMajor, RowBuffer));
+  const std::vector<BYTE> ExpectedRowBuffer = {
+      0xcd, 0xcd, 0xcd, 0xcd, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+      0x00, 0x03, 0x00, 0x00, 0x00, 0xcd, 0xcd, 0xcd, 0xcd, 0x04, 0x00,
+      0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+  };
+  VERIFY_IS_TRUE(RowBuffer == ExpectedRowBuffer);
+  MatrixResultOracle Exact =
+      exactResult(*Matrix, L"Host exact row-major matrix encoding");
+  VERIFY_IS_TRUE(verifyMatrixBuffer(RowBuffer.data(), RowBuffer.size(),
+                                    RowMajor, Exact, /*Verbose=*/false));
+
+  MatrixBufferLayout ColumnMajor = {
+      LinalgMatrixLayout::ColumnMajor,
+      /*OffsetBytes=*/4,
+      /*StrideBytes=*/12,
+  };
+  std::optional<size_t> ColumnBytes = getMatrixBufferSize(*Matrix, ColumnMajor);
+  VERIFY_IS_TRUE(ColumnBytes.has_value());
+  std::vector<BYTE> ColumnBuffer(*ColumnBytes, 0xcd);
+  VERIFY_IS_TRUE(writeMatrixBuffer(*Matrix, ColumnMajor, ColumnBuffer));
+  const std::vector<BYTE> ExpectedColumnBuffer = {
+      0xcd, 0xcd, 0xcd, 0xcd, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+      0xcd, 0xcd, 0xcd, 0xcd, 0x02, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
+      0xcd, 0xcd, 0xcd, 0xcd, 0x03, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+  };
+  VERIFY_IS_TRUE(ColumnBuffer == ExpectedColumnBuffer);
+  VERIFY_IS_TRUE(verifyMatrixBuffer(ColumnBuffer.data(), ColumnBuffer.size(),
+                                    ColumnMajor, Exact, /*Verbose=*/false));
+
+  std::optional<TypedMatrix> Transposed = transposeMatrix(*Matrix);
+  std::optional<TypedMatrix> ExpectedTranspose =
+      makeTypedMatrix<uint32_t>(3, 2, {1, 4, 2, 5, 3, 6});
+  VERIFY_IS_TRUE(Transposed.has_value());
+  VERIFY_IS_TRUE(ExpectedTranspose.has_value());
+  size_t FirstMismatch;
+  VERIFY_IS_TRUE(
+      exactMatrixMatch(*Transposed, *ExpectedTranspose, FirstMismatch));
+
+  std::optional<TypedMatrix> MixedActual =
+      makeTypedMatrix<uint32_t>(1, 2, {1, 4});
+  std::optional<TypedMatrix> CandidateA =
+      makeTypedMatrix<uint32_t>(1, 2, {1, 2});
+  std::optional<TypedMatrix> CandidateB =
+      makeTypedMatrix<uint32_t>(1, 2, {3, 4});
+  VERIFY_IS_TRUE(MixedActual.has_value());
+  VERIFY_IS_TRUE(CandidateA.has_value());
+  VERIFY_IS_TRUE(CandidateB.has_value());
+  MatrixResultOracle Permitted =
+      permittedResults({*CandidateA, *CandidateB},
+                       L"Host whole-result permitted candidate semantics");
+  VERIFY_IS_FALSE(matchesAnyCompleteCandidate(*MixedActual, Permitted));
+  Permitted.Candidates.push_back(*MixedActual);
+  VERIFY_IS_TRUE(matchesAnyCompleteCandidate(*MixedActual, Permitted));
+
+  MatrixResultOracle Excluded =
+      excludedResult(L"Host excluded-oracle classification");
+  VERIFY_IS_FALSE(matchesAnyCompleteCandidate(*Matrix, Excluded));
+
+  MatrixParams Params = {};
+  Params.M = 2;
+  Params.N = 3;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 4;
+  Params.CompType = ComponentType::I32;
+  VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=int") !=
+                 std::string::npos);
+  Params.CompType = ComponentType::U32;
+  VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=uint") !=
+                 std::string::npos);
 }
 
 class DxilConf_SM610_LinAlg {
@@ -837,8 +1638,6 @@ static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
                            bool Transpose) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
   MatrixParams DstParams = Params;
   if (Transpose) {
     DstParams.M = Params.N;
@@ -856,31 +1655,63 @@ static void runCopyConvert(ID3D12Device *Device,
 
   compileShader(DxcSupport, CopyConvertShader, "cs_6_10", Args, Verbose);
 
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1,
-                                  /*Increment=*/true, Transpose);
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value(),
+                 "Unable to construct typed CopyConvert input");
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      Transpose ? cpu_oracle::transposeMatrix(*Input) : Input;
+  VERIFY_IS_TRUE(Expected.has_value(),
+                 "Unable to construct independent CopyConvert oracle");
+
+  cpu_oracle::MatrixBufferLayout SourceLayout = {
+      Params.Layout,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/Params.strideBytes(),
+  };
+  cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      DstParams.Layout,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/DstParams.strideBytes(),
+  };
+  std::optional<size_t> SourceBufferSize =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  std::optional<size_t> DestinationBufferSize =
+      cpu_oracle::getMatrixBufferSize(*Expected, DestinationLayout);
+  VERIFY_IS_TRUE(SourceBufferSize.has_value(),
+                 "Unable to size typed CopyConvert input");
+  VERIFY_IS_TRUE(DestinationBufferSize.has_value(),
+                 "Unable to size typed CopyConvert output");
+
+  cpu_oracle::TypedMatrix InputMatrix = *Input;
+  cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
+      *Expected,
+      L"HLSL proposal 0035 CopyConvertMatrix transpose and descriptor layout");
 
   // Construct the ShaderOp: two UAV buffers, load from one, store to other.
   auto Op = createComputeOp(CopyConvertShader, "cs_6_10", "UAV(u0), UAV(u1)",
                             Args.c_str());
-  addUAVBuffer(Op.get(), "Input", BufferSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
+  addUAVBuffer(Op.get(), "Input", *SourceBufferSize, false, "byname");
+  addUAVBuffer(Op.get(), "Output", *DestinationBufferSize, true);
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [InputMatrix, SourceLayout](LPCSTR Name, std::vector<BYTE> &Data,
+                                  st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(
+            cpu_oracle::writeMatrixBuffer(InputMatrix, SourceLayout, Data),
+            "Unable to encode typed CopyConvert input");
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
 
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
+      OutData.data(), OutData.size(), DestinationLayout, Oracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16() {

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -26,6 +26,7 @@
 
 #include <climits>
 #include <cstring>
+#include <initializer_list>
 #include <limits>
 #include <optional>
 #include <sstream>
@@ -450,6 +451,33 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
   }
   default:
     hlsl_test::LogErrorFmt(L"Unsupported sequential matrix component type: %u",
+                           static_cast<uint32_t>(CompType));
+    return std::nullopt;
+  }
+}
+
+static std::optional<TypedMatrix> makeZeroMatrix(ComponentType CompType,
+                                                 MatrixDim M, MatrixDim N) {
+  size_t NumElements;
+  if (M == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
+                       NumElements)) {
+    hlsl_test::LogErrorFmt(L"Invalid zero matrix dimensions: M=%u, N=%u", M, N);
+    return std::nullopt;
+  }
+
+  switch (CompType) {
+  case ComponentType::F16:
+    return makeTypedMatrix(
+        M, N, std::vector<HLSLHalf_t>(NumElements, HLSLHalf_t(0.0f)));
+  case ComponentType::F32:
+    return makeTypedMatrix(M, N, std::vector<float>(NumElements, 0.0f));
+  case ComponentType::I32:
+    return makeTypedMatrix(M, N, std::vector<int32_t>(NumElements, 0));
+  case ComponentType::U32:
+    return makeTypedMatrix(M, N, std::vector<uint32_t>(NumElements, 0));
+  default:
+    hlsl_test::LogErrorFmt(L"Unsupported zero matrix component type: %u",
                            static_cast<uint32_t>(CompType));
     return std::nullopt;
   }
@@ -1366,7 +1394,10 @@ public:
 
   // Element access
   TEST_METHOD(ElementAccess_Wave_16x16_F16);
+  TEST_METHOD(ElementAccess_Wave_4x8_F32);
+  TEST_METHOD(ElementGetOOB_Wave_4x8_F32);
   TEST_METHOD(ElementSet_Wave_16x16_F16);
+  TEST_METHOD(ElementSetOOB_Wave_4x8_F32);
 
   // Cast/Convert
   TEST_METHOD(CopyConvert_Wave_16x16_F16);
@@ -1656,17 +1687,129 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging);
 }
 
-static const char ElementAccessShader[] = R"(
-  RWByteAddressBuffer Input : register(u0);
-  RWByteAddressBuffer Output : register(u1);
+struct MatrixConstructionRequirement {
+  linalg_test::MatrixRole Role;
+  MatrixDim Rows;
+  MatrixDim Columns;
+};
 
-  // flatten the 2D index into a 1D index then scale by element size
-  // Always store row-major and work it out in the test runner
-  uint coordToByteOffset(uint2 coord) {
-    return (coord.x * N_DIM + coord.y) * ELEM_SIZE;
+static LPCWSTR matrixRoleName(linalg_test::MatrixRole Role) {
+  switch (Role) {
+  case linalg_test::MatrixRole::A:
+    return L"A";
+  case linalg_test::MatrixRole::B:
+    return L"B";
+  case linalg_test::MatrixRole::Accumulator:
+    return L"Accumulator";
+  }
+  return L"Unknown";
+}
+
+static HRESULT queryMatrixConstructionSupport(
+    ID3D12Device *Device, const MatrixParams &Params,
+    std::initializer_list<MatrixConstructionRequirement> Requirements,
+    LPCWSTR CaseName, bool &Supported, UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!Device || !CaseName || Requirements.size() == 0 ||
+      !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
+                                 toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  for (const MatrixConstructionRequirement &Requirement : Requirements) {
+    if (Requirement.Rows == 0 || Requirement.Columns == 0)
+      return E_INVALIDARG;
   }
 
+  std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
+                                   sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  if (!WaveOptions.WaveOps) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; %s is not applicable", CaseName);
+    return S_OK;
+  }
+
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < WaveOptions.WaveLaneCountMin ||
+        WaveSize > WaveOptions.WaveLaneCountMax)
+      continue;
+
+    linalg_test::MatrixConstructionSupport Construction;
+    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
+                                              Construction);
+    if (FAILED(HR))
+      return HR;
+
+    bool AllSupported = true;
+    for (const MatrixConstructionRequirement &Requirement : Requirements) {
+      if (!Construction.supports(Requirement.Role, Requirement.Rows,
+                                 Requirement.Columns)) {
+        AllSupported = false;
+        break;
+      }
+    }
+    if (!AllSupported)
+      continue;
+
+    hlsl_test::LogCommentFmt(
+        L"MatrixConstruction capability matched wave=%u for %s", WaveSize,
+        CaseName);
+    for (const MatrixConstructionRequirement &Requirement : Requirements) {
+      hlsl_test::LogCommentFmt(L"  role=%s, rows=%u, columns=%u",
+                               matrixRoleName(Requirement.Role),
+                               Requirement.Rows, Requirement.Columns);
+    }
+    Supported = true;
+    SelectedWaveSize = WaveSize;
+    return S_OK;
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No MatrixConstruction query within shader WaveSize(4,64) supports %s",
+      CaseName);
+  return S_OK;
+}
+
+static const char ElementAccessShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Coordinates : register(u1);
+  RWByteAddressBuffer Values : register(u2);
+  RWByteAddressBuffer Lengths : register(u3);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
     if (GetGroupWaveIndex() != 0)
@@ -1678,72 +1821,163 @@ static const char ElementAccessShader[] = R"(
     __builtin_LinAlg_MatrixLoadFromDescriptor(
       Mat, Input, 0, STRIDE, LAYOUT, 128);
 
-    // Copy Matrix values from input to output without assuming order
-    for (uint I = 0; I < __builtin_LinAlg_MatrixLength(Mat); ++I) {
+    uint Len = __builtin_LinAlg_MatrixLength(Mat);
+    Lengths.Store<uint>(threadID * sizeof(uint), Len);
+
+    // Each thread writes to a private slice because implementations may map
+    // multiple threads to the same matrix component.
+    uint SafeLen = min(Len, (uint)(M_DIM * N_DIM));
+    for (uint I = 0; I < SafeLen; ++I) {
       uint2 Coord = __builtin_LinAlg_MatrixGetCoordinate(Mat, I);
-      uint Offset = coordToByteOffset(Coord);
       ELEM_TYPE Elem;
       __builtin_LinAlg_MatrixGetElement(Elem, Mat, I);
-      Output.Store<ELEM_TYPE>(Offset, Elem);
+      uint Slot = threadID * (M_DIM * N_DIM) + I;
+      Coordinates.Store2(Slot * sizeof(uint2), Coord);
+      Values.Store<ELEM_TYPE>(Slot * ELEM_SIZE, Elem);
     }
-
-    // Save the matrix length that this thread saw. The length is written
-    // to the output right after the matrix, offset by the thread index
-    uint LenIdx = (M_DIM * N_DIM * ELEM_SIZE) + (threadID * sizeof(uint));
-    uint Len = __builtin_LinAlg_MatrixLength(Mat);
-    Output.Store<uint>(LenIdx, Len);
   }
 )";
 
 static void runElementAccess(ID3D12Device *Device,
                              dxc::SpecificDllLoader &DxcSupport,
-                             const MatrixParams &Params, bool Verbose) {
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t NumThreads = Params.NumThreads;
   const size_t MatrixSize = Params.totalBytes();
-  // OutputBuf needs to fit the Matrix plus one uint per thread
-  const size_t OutputBufSize = MatrixSize + NumThreads * sizeof(uint32_t);
+  const size_t MaxRecords = NumThreads * NumElements;
+  const size_t CoordinateBufferSize = MaxRecords * 2 * sizeof(uint32_t);
+  const size_t ValueBufferSize = MaxRecords * elementSize(Params.CompType);
+  const size_t LengthBufferSize = NumThreads * sizeof(uint32_t);
 
   std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, ElementAccessShader, "cs_6_10", Args, Verbose);
 
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1);
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Expected.has_value(),
+                 "Unable to construct typed element-access input");
+  const cpu_oracle::MatrixBufferLayout InputLayout = {
+      Params.Layout,
+      0,
+      Params.strideBytes(),
+  };
+  const cpu_oracle::MatrixBufferLayout PackedRowMajor = {
+      LinalgMatrixLayout::RowMajor,
+      0,
+      static_cast<size_t>(Params.N) * elementSize(Params.CompType),
+  };
+  std::vector<BYTE> ExpectedBytes(MatrixSize, 0);
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(*Expected, PackedRowMajor, ExpectedBytes),
+      "Unable to encode typed element-access expectation");
+  const cpu_oracle::TypedMatrix ExpectedMatrix = *Expected;
 
-  auto Op = createComputeOp(ElementAccessShader, "cs_6_10", "UAV(u0), UAV(u1)",
-                            Args.c_str());
+  auto Op = createComputeOp(ElementAccessShader, "cs_6_10",
+                            "UAV(u0), UAV(u1), UAV(u2), UAV(u3)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", OutputBufSize, true);
+  addUAVBuffer(Op.get(), "Coordinates", CoordinateBufferSize, true);
+  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true);
+  addUAVBuffer(Op.get(), "Lengths", LengthBufferSize, true);
   addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
+  addRootView(Op.get(), 1, "Coordinates");
+  addRootView(Op.get(), 2, "Values");
+  addRootView(Op.get(), 3, "Lengths");
 
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [ExpectedMatrix, InputLayout](LPCSTR Name, std::vector<BYTE> &Data,
+                                    st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(
+            cpu_oracle::writeMatrixBuffer(ExpectedMatrix, InputLayout, Data),
+            "Unable to encode element-access input");
+      });
 
-  MappedData OutData;
-  Result->Test->GetReadBackData("Output", &OutData);
+  MappedData CoordinateData;
+  MappedData ValueData;
+  MappedData LengthData;
+  Result->Test->GetReadBackData("Coordinates", &CoordinateData);
+  Result->Test->GetReadBackData("Values", &ValueData);
+  Result->Test->GetReadBackData("Lengths", &LengthData);
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(CoordinateData.size(),
+                                  static_cast<UINT32>(CoordinateBufferSize));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(ValueData.size(),
+                                  static_cast<UINT32>(ValueBufferSize));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(LengthData.size(),
+                                  static_cast<UINT32>(LengthBufferSize));
 
-  // Verify the front of the buffer is a list of elements of the expected type
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  const BYTE *CoordinateBytes =
+      static_cast<const BYTE *>(CoordinateData.data());
+  const BYTE *ValueBytes = static_cast<const BYTE *>(ValueData.data());
+  const BYTE *LengthBytes = static_cast<const BYTE *>(LengthData.data());
+  const size_t ElementBytes = elementSize(Params.CompType);
+  std::vector<bool> Seen(NumElements, false);
+  uint64_t TotalLength = 0;
+  bool RecordsValid = true;
 
-  // Verify the end of the buffer is NumThreads number of lengths, whose
-  // sum is greater than or equal to NumElements
-  const BYTE *Out = static_cast<const BYTE *>(OutData.data());
-  const uint32_t *Lengths =
-      reinterpret_cast<const uint32_t *>(Out + MatrixSize);
-  uint32_t TotalLength = 0;
-  for (size_t I = 0; I < NumThreads; ++I)
-    TotalLength += Lengths[I];
+  for (size_t Thread = 0; Thread < NumThreads && RecordsValid; ++Thread) {
+    uint32_t Length;
+    std::memcpy(&Length, LengthBytes + Thread * sizeof(Length), sizeof(Length));
+    TotalLength += Length;
+    if (Length > NumElements) {
+      hlsl_test::LogErrorFmt(
+          L"MatrixLength returned too many elements: thread=%zu, length=%u, "
+          L"matrixElements=%zu",
+          Thread, Length, NumElements);
+      RecordsValid = false;
+      break;
+    }
+
+    for (size_t LocalIndex = 0; LocalIndex < Length; ++LocalIndex) {
+      const size_t Slot = Thread * NumElements + LocalIndex;
+      uint32_t Coordinate[2];
+      std::memcpy(Coordinate, CoordinateBytes + Slot * 2 * sizeof(uint32_t),
+                  sizeof(Coordinate));
+      const uint32_t Row = Coordinate[0];
+      const uint32_t Column = Coordinate[1];
+      if (Row >= Params.M || Column >= Params.N) {
+        hlsl_test::LogErrorFmt(
+            L"GetCoordinate returned an invalid coordinate: thread=%zu, "
+            L"index=%zu, coordinate=(%u,%u), matrix=(%u,%u)",
+            Thread, LocalIndex, Row, Column, Params.M, Params.N);
+        RecordsValid = false;
+        break;
+      }
+
+      const size_t MatrixIndex = static_cast<size_t>(Row) * Params.N + Column;
+      if (std::memcmp(ValueBytes + Slot * ElementBytes,
+                      ExpectedBytes.data() + MatrixIndex * ElementBytes,
+                      ElementBytes) != 0) {
+        hlsl_test::LogErrorFmt(
+            L"GetElement did not match its reported coordinate: thread=%zu, "
+            L"index=%zu, coordinate=(%u,%u)",
+            Thread, LocalIndex, Row, Column);
+        RecordsValid = false;
+        break;
+      }
+      Seen[MatrixIndex] = true;
+    }
+  }
+
+  VERIFY_IS_TRUE(RecordsValid,
+                 "Matrix Length/GetCoordinate/GetElement records were invalid");
   VERIFY_IS_GREATER_THAN_OR_EQUAL(
-      TotalLength, NumElements, "Sum of all lengths must be gte num elements");
+      TotalLength, static_cast<uint64_t>(NumElements),
+      "Sum of all lengths must cover at least the matrix element count");
+  for (size_t MatrixIndex = 0; MatrixIndex < NumElements; ++MatrixIndex) {
+    if (!Seen[MatrixIndex]) {
+      hlsl_test::LogErrorFmt(
+          L"No thread-local element mapped to matrix coordinate=(%zu,%zu)",
+          MatrixIndex / Params.N, MatrixIndex % Params.N);
+      VERIFY_IS_TRUE(false, "Matrix coordinate was not covered");
+    }
+  }
 }
 
 void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
@@ -1759,11 +1993,178 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
   runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging);
 }
 
+void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}},
+      L"ElementAccess_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"ElementAccess_Wave_4x8_F32"))
+    return;
+
+  runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
+}
+
+static const char ElementGetOOBShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Values : register(u1);
+  RWByteAddressBuffer Executed : register(u2);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, Input, 0, STRIDE, LAYOUT, 128);
+
+    uint OOBIndex = __builtin_LinAlg_MatrixLength(Mat);
+    ELEM_TYPE Elem;
+    __builtin_LinAlg_MatrixGetElement(Elem, Mat, OOBIndex);
+    Values.Store<ELEM_TYPE>(threadID * ELEM_SIZE, Elem);
+    Executed.Store<uint>(threadID * sizeof(uint), 1);
+  }
+)";
+
+static void runElementGetOOB(ID3D12Device *Device,
+                             dxc::SpecificDllLoader &DxcSupport,
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize = 0) {
+  const size_t NumThreads = Params.NumThreads;
+  const size_t MatrixSize = Params.totalBytes();
+  const size_t ValueBufferSize = NumThreads * elementSize(Params.CompType);
+  const size_t ExecutedBufferSize = NumThreads * sizeof(uint32_t);
+  std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+
+  compileShader(DxcSupport, ElementGetOOBShader, "cs_6_10", Args, Verbose);
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> Expected = cpu_oracle::makeZeroMatrix(
+      Params.CompType, 1, static_cast<MatrixDim>(NumThreads));
+  VERIFY_IS_TRUE(Input.has_value() && Expected.has_value(),
+                 "Unable to construct typed GetElement OOB data");
+  const cpu_oracle::MatrixBufferLayout InputLayout = {
+      Params.Layout,
+      0,
+      Params.strideBytes(),
+  };
+  const cpu_oracle::MatrixBufferLayout ValueLayout = {
+      LinalgMatrixLayout::RowMajor,
+      0,
+      ValueBufferSize,
+  };
+  const cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
+      *Expected, L"Matrix::Get returns zero when Index equals Length()");
+  const cpu_oracle::TypedMatrix InputMatrix = *Input;
+
+  auto Op = createComputeOp(ElementGetOOBShader, "cs_6_10",
+                            "UAV(u0), UAV(u1), UAV(u2)", Args.c_str());
+  addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
+  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true);
+  addUAVBuffer(Op.get(), "Executed", ExecutedBufferSize, true);
+  addRootView(Op.get(), 0, "Input");
+  addRootView(Op.get(), 1, "Values");
+  addRootView(Op.get(), 2, "Executed");
+
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [InputMatrix, InputLayout](LPCSTR Name, std::vector<BYTE> &Data,
+                                 st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(
+            cpu_oracle::writeMatrixBuffer(InputMatrix, InputLayout, Data),
+            "Unable to encode GetElement OOB input");
+      });
+
+  MappedData ValueData;
+  MappedData ExecutedData;
+  Result->Test->GetReadBackData("Values", &ValueData);
+  Result->Test->GetReadBackData("Executed", &ExecutedData);
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
+      ValueData.data(), ValueData.size(), ValueLayout, Oracle, Verbose));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(ExecutedData.size(),
+                                  static_cast<UINT32>(ExecutedBufferSize));
+
+  const BYTE *ExecutedBytes = static_cast<const BYTE *>(ExecutedData.data());
+  size_t ExecutedThreads = 0;
+  for (size_t Thread = 0; Thread < NumThreads; ++Thread) {
+    uint32_t Marker;
+    std::memcpy(&Marker, ExecutedBytes + Thread * sizeof(Marker),
+                sizeof(Marker));
+    VERIFY_IS_TRUE(Marker == 0 || Marker == 1,
+                   "GetElement OOB execution marker was invalid");
+    ExecutedThreads += Marker;
+  }
+  VERIFY_IS_GREATER_THAN(ExecutedThreads, static_cast<size_t>(0),
+                         "At least one thread must execute the OOB read");
+}
+
+void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}},
+      L"ElementGetOOB_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"ElementGetOOB_Wave_4x8_F32"))
+    return;
+
+  runElementGetOOB(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
+}
+
 static const char ElementSetShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1788,42 +2189,87 @@ static const char ElementSetShader[] = R"(
   }
 )";
 
+static const char ElementSetOOBShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Output : register(u1);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main() {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, Input, 0, STRIDE, LAYOUT, 128);
+
+    uint OOBIndex = __builtin_LinAlg_MatrixLength(Mat);
+    __builtin_LinAlg_MatrixSetElement(
+      Mat, Mat, OOBIndex, (ELEM_TYPE)123);
+
+    __builtin_LinAlg_MatrixStoreToDescriptor(
+      Mat, Output, 0, STRIDE, LAYOUT, 128);
+  }
+)";
+
 static void runElementSet(ID3D12Device *Device,
                           dxc::SpecificDllLoader &DxcSupport,
-                          const MatrixParams &Params, bool Verbose) {
-  const size_t NumElements = Params.totalElements();
+                          const MatrixParams &Params, const char *Shader,
+                          uint32_t ExpectedStartingValue, LPCWSTR PublicRule,
+                          bool Verbose, UINT ForcedWaveSize = 0) {
   const size_t MatrixSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
-  compileShader(DxcSupport, ElementSetShader, "cs_6_10", Args, Verbose);
+  compileShader(DxcSupport, Shader, "cs_6_10", Args, Verbose);
 
-  // Start counting from 6 since each element was increased by 5
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 6);
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N,
+                                       ExpectedStartingValue);
+  VERIFY_IS_TRUE(Input.has_value() && Expected.has_value(),
+                 "Unable to construct typed SetElement data");
+  const cpu_oracle::MatrixBufferLayout Layout = {
+      Params.Layout,
+      0,
+      Params.strideBytes(),
+  };
+  const cpu_oracle::MatrixResultOracle Oracle =
+      cpu_oracle::exactResult(*Expected, PublicRule);
+  const cpu_oracle::TypedMatrix InputMatrix = *Input;
 
-  auto Op = createComputeOp(ElementSetShader, "cs_6_10", "UAV(u0), UAV(u1)",
-                            Args.c_str());
+  auto Op =
+      createComputeOp(Shader, "cs_6_10", "UAV(u0), UAV(u1)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
   addUAVBuffer(Op.get(), "Output", MatrixSize, true);
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [InputMatrix, Layout](LPCSTR Name, std::vector<BYTE> &Data,
+                            st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(cpu_oracle::writeMatrixBuffer(InputMatrix, Layout, Data),
+                       "Unable to encode SetElement input");
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
 
-  // Verify the front of the buffer is a list of elements of the expected type
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(OutData.data(), OutData.size(),
+                                                Layout, Oracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
@@ -1836,7 +2282,40 @@ void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runElementSet(D3DDevice, DxcSupport, Params, VerboseLogging);
+  runElementSet(D3DDevice, DxcSupport, Params, ElementSetShader,
+                /*ExpectedStartingValue=*/6,
+                L"Matrix::Set updates every in-range thread-local element",
+                VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}},
+      L"ElementSetOOB_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"ElementSetOOB_Wave_4x8_F32"))
+    return;
+
+  runElementSet(D3DDevice, DxcSupport, Params, ElementSetOOBShader,
+                /*ExpectedStartingValue=*/1,
+                L"Matrix::Set is a no-op when Index equals Length()",
+                VerboseLogging, SelectedWaveSize);
 }
 
 static const char CopyConvertShader[] = R"(
@@ -1874,48 +2353,8 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
                                        UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
-  if (!Device || Params.Use != MatrixUse::A ||
-      !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
-                                 toCapabilityScope(Params.Scope)))
+  if (Params.Use != MatrixUse::A)
     return E_INVALIDARG;
-
-  std::optional<linalg_test::DataType> DataType =
-      toCapabilityDataType(Params.CompType);
-  if (!DataType.has_value())
-    return E_INVALIDARG;
-
-  linalg_test::TierSupport Tier;
-  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
-  if (FAILED(HR) || !Tier.supported())
-    return HR;
-
-  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
-  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
-                                   sizeof(WaveOptions));
-  if (FAILED(HR)) {
-    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
-    return HR;
-  }
-  if (!WaveOptions.WaveOps) {
-    hlsl_test::LogCommentFmt(
-        L"Wave operations are unsupported; MatrixConstruction is not "
-        L"applicable");
-    return S_OK;
-  }
-
-  const auto IsPowerOfTwo = [](UINT Value) {
-    return Value != 0 && (Value & (Value - 1)) == 0;
-  };
-  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
-      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
-      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
-    hlsl_test::LogCommentFmt(
-        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
-        L"max=%u",
-        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
-        WaveOptions.WaveLaneCountMax);
-    return E_UNEXPECTED;
-  }
 
   MatrixParams Destination = Params;
   if (Transpose) {
@@ -1923,34 +2362,13 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
     Destination.N = Params.M;
   }
 
-  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < WaveOptions.WaveLaneCountMin ||
-        WaveSize > WaveOptions.WaveLaneCountMax)
-      continue;
-
-    linalg_test::MatrixConstructionSupport Construction;
-    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
-                                              Construction);
-    if (FAILED(HR))
-      return HR;
-    if (Construction.supports(linalg_test::MatrixRole::A, Params.M, Params.N) &&
-        Construction.supports(linalg_test::MatrixRole::A, Destination.M,
-                              Destination.N)) {
-      hlsl_test::LogCommentFmt(
-          L"CopyConvert capability matched wave=%u for source=%ux%u and "
-          L"destination=%ux%u",
-          WaveSize, Params.M, Params.N, Destination.M, Destination.N);
-      Supported = true;
-      SelectedWaveSize = WaveSize;
-      return S_OK;
-    }
-  }
-
-  hlsl_test::LogCommentFmt(
-      L"No MatrixConstruction query within shader WaveSize(4,64) supports "
-      L"CopyConvert source=%ux%u and destination=%ux%u",
-      Params.M, Params.N, Destination.M, Destination.N);
-  return S_OK;
+  return queryMatrixConstructionSupport(
+      Device, Params,
+      {
+          {linalg_test::MatrixRole::A, Params.M, Params.N},
+          {linalg_test::MatrixRole::A, Destination.M, Destination.N},
+      },
+      L"CopyConvert source and destination", Supported, SelectedWaveSize);
 }
 
 static void runCopyConvert(ID3D12Device *Device,

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -96,6 +96,78 @@ struct MatrixParams {
   size_t totalBytes() const { return totalElements() * elementSize(CompType); }
 };
 
+static std::optional<linalg_test::DataType>
+toCapabilityDataType(ComponentType CompType) {
+  using linalg_test::DataType;
+  switch (CompType) {
+  case ComponentType::I16:
+    return DataType::SInt16;
+  case ComponentType::U16:
+    return DataType::UInt16;
+  case ComponentType::I32:
+    return DataType::SInt32;
+  case ComponentType::U32:
+    return DataType::UInt32;
+  case ComponentType::F16:
+    return DataType::Float16;
+  case ComponentType::F32:
+    return DataType::Float32;
+  case ComponentType::I8:
+    return DataType::SInt8;
+  case ComponentType::U8:
+    return DataType::UInt8;
+  case ComponentType::F8_E4M3FN:
+    return DataType::Float8E4M3FN;
+  case ComponentType::F8_E5M2:
+    return DataType::Float8E5M2;
+  default:
+    return std::nullopt;
+  }
+}
+
+static linalg_test::ExecutionScope toCapabilityScope(MatrixScope Scope) {
+  switch (Scope) {
+  case MatrixScope::Thread:
+    return linalg_test::ExecutionScope::Thread;
+  case MatrixScope::Wave:
+    return linalg_test::ExecutionScope::Wave;
+  case MatrixScope::ThreadGroup:
+    return linalg_test::ExecutionScope::ThreadGroup;
+  }
+  VERIFY_IS_TRUE(false, "Unsupported LinAlg matrix scope");
+  return linalg_test::ExecutionScope::Thread;
+}
+
+static bool applyApplicability(linalg_test::Applicability Result,
+                               LPCWSTR CaseName) {
+  using linalg_test::Applicability;
+  switch (Result) {
+  case Applicability::Execute:
+    return true;
+  case Applicability::NotApplicable:
+#ifdef _HLK_CONF
+    hlsl_test::LogErrorFmt(
+        L"Capability-gated case %s reached HLK execution on an unsupported "
+        L"device. Requirement or playlist applicability must exclude it.",
+        CaseName);
+    VERIFY_IS_TRUE(false,
+                   "Unsupported capability-gated case reached HLK execution");
+#else
+    hlsl_test::LogCommentFmt(
+        L"Capability-gated case %s is not applicable on this device", CaseName);
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+#endif
+    return false;
+  case Applicability::Fail:
+    hlsl_test::LogErrorFmt(L"Capability evaluation failed for case %s",
+                           CaseName);
+    VERIFY_IS_TRUE(false, "LinAlg capability evaluation failed");
+    return false;
+  }
+  VERIFY_IS_TRUE(false, "Unknown LinAlg applicability result");
+  return false;
+}
+
 namespace cpu_oracle {
 
 using TypedMatrixValues =
@@ -1123,6 +1195,133 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
                  std::string::npos);
 }
 
+class LinAlgCapabilityTests {
+public:
+  BEGIN_TEST_CLASS(LinAlgCapabilityTests)
+  TEST_METHOD_PROPERTY(L"Priority", L"0")
+  END_TEST_CLASS()
+
+  TEST_METHOD(CapabilityPolicyAndPredicates);
+};
+
+void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
+  using namespace linalg_test;
+
+  VERIFY_IS_TRUE(
+      classifyApplicability(S_OK, true, CapabilityRequirement::Mandatory) ==
+      Applicability::Execute);
+  VERIFY_IS_TRUE(classifyApplicability(
+                     S_OK, false, CapabilityRequirement::CapabilityGated) ==
+                 Applicability::NotApplicable);
+  VERIFY_IS_TRUE(
+      classifyApplicability(S_OK, false, CapabilityRequirement::Mandatory) ==
+      Applicability::Fail);
+  VERIFY_IS_TRUE(
+      classifyApplicability(E_UNEXPECTED, true,
+                            CapabilityRequirement::CapabilityGated) ==
+      Applicability::Fail);
+
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::MatrixConstruction, ExecutionScope::Wave));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::MatrixConstruction,
+                              ExecutionScope::ThreadGroup));
+  VERIFY_IS_FALSE(
+      isLegalScope(OperationType::MatrixConstruction, ExecutionScope::Thread));
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::WaveMatrixMultiply, ExecutionScope::Wave));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::ThreadGroupMatrixMultiply,
+                              ExecutionScope::ThreadGroup));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::ThreadVectorMatrixMultiply,
+                              ExecutionScope::Thread));
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::ThreadOuterProduct, ExecutionScope::Thread));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::AtomicAccumulateStore,
+                              ExecutionScope::Thread));
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::AtomicAccumulateStore, ExecutionScope::Wave));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::AtomicAccumulateStore,
+                              ExecutionScope::ThreadGroup));
+
+  MatrixConstructionSupport Construction = {4, 8, 16};
+  VERIFY_IS_TRUE(Construction.valid());
+  VERIFY_IS_TRUE(Construction.supports(MatrixRole::A, 4, 8));
+  VERIFY_IS_TRUE(Construction.supports(MatrixRole::B, 8, 16));
+  VERIFY_IS_TRUE(Construction.supports(MatrixRole::Accumulator, 4, 16));
+  VERIFY_IS_FALSE(Construction.supports(MatrixRole::A, 3, 8));
+  MatrixConstructionSupport InvalidConstruction = {4, 0, 16};
+  VERIFY_IS_FALSE(InvalidConstruction.valid());
+
+  WaveMatrixMultiplySupport Wave = {
+      MultiplicationFlags::Supported,
+      {{8, 16, 8}, {16, 16, 16}},
+  };
+  VERIFY_IS_TRUE(Wave.valid());
+  VERIFY_IS_TRUE(Wave.supportsShape(32, 32, 16));
+  VERIFY_IS_FALSE(Wave.supportsShape(12, 32, 16));
+  WaveMatrixMultiplySupport InvalidWave = {
+      MultiplicationFlags::EmulatedInputs,
+      {},
+  };
+  VERIFY_IS_FALSE(InvalidWave.valid());
+
+  ThreadGroupMatrixMultiplySupport ThreadGroup = {
+      MultiplicationFlags::Supported,
+      32,
+      128,
+      64,
+  };
+  VERIFY_IS_TRUE(ThreadGroup.valid());
+  VERIFY_IS_TRUE(ThreadGroup.supportsThreadGroupSize(64));
+  VERIFY_IS_FALSE(ThreadGroup.supportsThreadGroupSize(48));
+  ThreadGroup.PreferredThreadGroupSize = 48;
+  VERIFY_IS_FALSE(ThreadGroup.valid());
+
+  ThreadVectorMatrixMultiplySupport ThreadVector = {
+      static_cast<MultiplicationFlags>(
+          static_cast<UINT>(MultiplicationFlags::Supported) |
+          static_cast<UINT>(MultiplicationFlags::EmulatedInputs)),
+  };
+  VERIFY_IS_TRUE(ThreadVector.valid());
+  VERIFY_IS_TRUE(ThreadVector.supported());
+  ThreadVector.SupportFlags = MultiplicationFlags::EmulatedInputs;
+  VERIFY_IS_FALSE(ThreadVector.valid());
+
+  ThreadOuterProductSupport OuterProduct = {true};
+  VERIFY_IS_TRUE(OuterProduct.supported());
+  AtomicAccumulateStoreSupport Atomic = {true, false};
+  VERIFY_IS_TRUE(Atomic.supports(AtomicDestination::RWByteAddressBuffer));
+  VERIFY_IS_FALSE(Atomic.supports(AtomicDestination::GroupShared));
+
+  VERIFY_ARE_EQUAL(0u, static_cast<UINT>(DataType::None));
+  MatrixConstructionQuery ConstructionQuery = {DataType::Float32, 32};
+  WaveMatrixMultiplyQuery WaveQuery = {
+      32,
+      DataType::Float16,
+      DataType::Float16,
+      DataType::Float32,
+  };
+  ThreadGroupMatrixMultiplyQuery ThreadGroupQuery = {
+      WaveQuery,
+      {16, 16, 16},
+  };
+  ThreadVectorMatrixMultiplyQuery ThreadVectorQuery = {
+      DataType::Float16,
+      DataType::Float16,
+      DataType::None,
+      DataType::Float16,
+  };
+  ThreadOuterProductQuery OuterProductQuery = {
+      DataType::Float16,
+      DataType::Float16,
+  };
+  AtomicAccumulateStoreQuery AtomicQuery = {DataType::Float16};
+  VERIFY_ARE_EQUAL(32u, ConstructionQuery.WaveSize);
+  VERIFY_ARE_EQUAL(16u, ThreadGroupQuery.Shape.M);
+  VERIFY_IS_TRUE(ThreadVectorQuery.BiasInputType == DataType::None);
+  VERIFY_IS_TRUE(OuterProductQuery.InputComponentType == DataType::Float16);
+  VERIFY_IS_TRUE(AtomicQuery.ComponentType == DataType::Float16);
+}
+
 class DxilConf_SM610_LinAlg {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM610_LinAlg)
@@ -1651,6 +1850,88 @@ static const char CopyConvertShader[] = R"(
   }
 )";
 
+static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
+                                       const MatrixParams &Params,
+                                       bool Transpose, bool &Supported) {
+  Supported = false;
+  if (!Device || Params.Use != MatrixUse::A ||
+      !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
+                                 toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
+                                   sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  if (!WaveOptions.WaveOps) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; MatrixConstruction is not "
+        L"applicable");
+    return S_OK;
+  }
+
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  MatrixParams Destination = Params;
+  if (Transpose) {
+    Destination.M = Params.N;
+    Destination.N = Params.M;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < WaveOptions.WaveLaneCountMin ||
+        WaveSize > WaveOptions.WaveLaneCountMax)
+      continue;
+
+    linalg_test::MatrixConstructionSupport Construction;
+    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
+                                              Construction);
+    if (FAILED(HR))
+      return HR;
+    if (Construction.supports(linalg_test::MatrixRole::A, Params.M, Params.N) &&
+        Construction.supports(linalg_test::MatrixRole::A, Destination.M,
+                              Destination.N)) {
+      hlsl_test::LogCommentFmt(
+          L"CopyConvert capability matched wave=%u for source=%ux%u and "
+          L"destination=%ux%u",
+          WaveSize, Params.M, Params.N, Destination.M, Destination.N);
+      Supported = true;
+      return S_OK;
+    }
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No MatrixConstruction query within shader WaveSize(4,64) supports "
+      L"CopyConvert source=%ux%u and destination=%ux%u",
+      Params.M, Params.N, Destination.M, Destination.N);
+  return S_OK;
+}
+
 static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
@@ -1769,6 +2050,19 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
+
+  bool Supported;
+  const HRESULT QueryResult =
+      queryCopyConvertSupport(D3DDevice, Params, /*Transpose=*/true, Supported);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"CopyConvert_Wave_4x8_F32_Transpose MatrixConstruction"))
+    return;
+
   // Non-square dimensions make the destination shape and row stride observable.
   runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
                  /*Transpose=*/true);

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1851,7 +1851,7 @@ void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
   const cpu_oracle::MatrixBufferLayout Layout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -1868,7 +1868,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -1888,12 +1888,12 @@ void DxilConf_SM610_LinAlg::
     return;
 
   const cpu_oracle::MatrixBufferLayout Target = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/24,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/16,
   };
@@ -1915,7 +1915,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.Layout = MatrixLayout::ColumnMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -1934,12 +1934,12 @@ void DxilConf_SM610_LinAlg::
     return;
 
   const cpu_oracle::MatrixBufferLayout Target = {
-      LinalgMatrixLayout::ColumnMajor,
+      MatrixLayout::ColumnMajor,
       /*OffsetBytes=*/32,
       /*StrideBytes=*/16,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -1960,7 +1960,7 @@ void DxilConf_SM610_LinAlg::LoadDescriptorBounds_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -1977,12 +1977,12 @@ void DxilConf_SM610_LinAlg::LoadDescriptorBounds_Wave_4x8_F32() {
     return;
 
   const cpu_oracle::MatrixBufferLayout SourceLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout DestinationLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -2035,7 +2035,7 @@ void DxilConf_SM610_LinAlg::StoreDescriptorBounds_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2052,12 +2052,12 @@ void DxilConf_SM610_LinAlg::StoreDescriptorBounds_Wave_4x8_F32() {
     return;
 
   const cpu_oracle::MatrixBufferLayout SourceLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout DestinationLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/32,
   };
@@ -2171,7 +2171,7 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   Params.Enable16Bit = true;
 
   const cpu_oracle::MatrixBufferLayout Layout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -2213,7 +2213,7 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptorBounds_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2231,12 +2231,12 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptorBounds_Wave_4x8_F32() {
     return;
 
   const cpu_oracle::MatrixBufferLayout SourceLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout DestinationLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/32,
   };

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4101,6 +4101,8 @@ struct GroupSharedMemorySpec {
   cpu_oracle::MatrixBufferLayout Layout;
 };
 
+static constexpr size_t GroupSharedTrailingGuardElements = 4;
+
 static const char GroupSharedTransferShader[] = R"(
   ByteAddressBuffer SourceInit : register(t0);
   ByteAddressBuffer DestinationInit : register(t1);
@@ -4162,16 +4164,19 @@ static bool getGroupSharedBufferDescription(const MatrixParams &Params,
                                             size_t &BufferSize,
                                             UINT &NumElements) {
   const size_t ElementBytes = elementSize(Params.CompType);
+  size_t GuardBytes;
   std::optional<size_t> RequiredBytes = cpu_oracle::getMatrixBufferSize(
       Params.CompType, Params.M, Params.N, Spec.Layout);
   if (!RequiredBytes.has_value() ||
       Spec.Layout.OffsetBytes % ElementBytes != 0 ||
       Spec.Layout.StrideBytes % ElementBytes != 0 ||
       *RequiredBytes % ElementBytes != 0 ||
-      *RequiredBytes / ElementBytes > (std::numeric_limits<UINT>::max)())
+      !cpu_oracle::checkedMultiply(GroupSharedTrailingGuardElements,
+                                   ElementBytes, GuardBytes) ||
+      !cpu_oracle::checkedAdd(*RequiredBytes, GuardBytes, BufferSize) ||
+      BufferSize / ElementBytes > (std::numeric_limits<UINT>::max)())
     return false;
 
-  BufferSize = *RequiredBytes;
   NumElements = static_cast<UINT>(BufferSize / ElementBytes);
   return true;
 }

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -24,6 +24,7 @@
 #include "HlslTestDataTypes.h"
 #include "HlslTestUtils.h"
 
+#include <algorithm>
 #include <climits>
 #include <cstring>
 #include <initializer_list>
@@ -2056,19 +2057,30 @@ static void runElementGetOOB(ID3D12Device *Device,
                              UINT ForcedWaveSize = 0) {
   const size_t NumThreads = Params.NumThreads;
   const size_t MatrixSize = Params.totalBytes();
-  const size_t ValueBufferSize = NumThreads * elementSize(Params.CompType);
+  const size_t ElementBytes = elementSize(Params.CompType);
+  const size_t ValueBufferSize = NumThreads * ElementBytes;
   const size_t ExecutedBufferSize = NumThreads * sizeof(uint32_t);
+  constexpr BYTE Sentinel = 0xcd;
+  constexpr uint32_t MarkerSentinel = 0xcdcdcdcd;
+  if (ForcedWaveSize == 0 || ForcedWaveSize > NumThreads) {
+    hlsl_test::LogErrorFmt(
+        L"GetElement OOB requires a concrete wave size within the dispatch: "
+        L"wave=%u, threads=%zu",
+        ForcedWaveSize, NumThreads);
+    VERIFY_IS_TRUE(false, "Invalid GetElement OOB wave size");
+    return;
+  }
+
   std::stringstream ExtraDefs;
-  if (ForcedWaveSize != 0)
-    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, ElementGetOOBShader, "cs_6_10", Args, Verbose);
 
   std::optional<cpu_oracle::TypedMatrix> Input =
       cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
-  std::optional<cpu_oracle::TypedMatrix> Expected = cpu_oracle::makeZeroMatrix(
-      Params.CompType, 1, static_cast<MatrixDim>(NumThreads));
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeZeroMatrix(Params.CompType, 1, 1);
   VERIFY_IS_TRUE(Input.has_value() && Expected.has_value(),
                  "Unable to construct typed GetElement OOB data");
   const cpu_oracle::MatrixBufferLayout InputLayout = {
@@ -2076,56 +2088,90 @@ static void runElementGetOOB(ID3D12Device *Device,
       0,
       Params.strideBytes(),
   };
-  const cpu_oracle::MatrixBufferLayout ValueLayout = {
+  const cpu_oracle::MatrixBufferLayout ExpectedLayout = {
       LinalgMatrixLayout::RowMajor,
       0,
-      ValueBufferSize,
+      ElementBytes,
   };
-  const cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
-      *Expected, L"Matrix::Get returns zero when Index equals Length()");
+  std::vector<BYTE> ExpectedValue(ElementBytes, Sentinel);
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(*Expected, ExpectedLayout, ExpectedValue),
+      "Unable to encode GetElement OOB zero expectation");
   const cpu_oracle::TypedMatrix InputMatrix = *Input;
 
   auto Op = createComputeOp(ElementGetOOBShader, "cs_6_10",
                             "UAV(u0), UAV(u1), UAV(u2)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
-  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true);
-  addUAVBuffer(Op.get(), "Executed", ExecutedBufferSize, true);
+  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true, "byname");
+  addUAVBuffer(Op.get(), "Executed", ExecutedBufferSize, true, "byname");
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Values");
   addRootView(Op.get(), 2, "Executed");
 
   auto Result = runShaderOp(
       Device, DxcSupport, std::move(Op),
-      [InputMatrix, InputLayout](LPCSTR Name, std::vector<BYTE> &Data,
-                                 st::ShaderOp *) {
-        if (_stricmp(Name, "Input") != 0)
+      [InputMatrix, InputLayout, Sentinel](LPCSTR Name, std::vector<BYTE> &Data,
+                                           st::ShaderOp *) {
+        if (_stricmp(Name, "Input") == 0) {
+          VERIFY_IS_TRUE(
+              cpu_oracle::writeMatrixBuffer(InputMatrix, InputLayout, Data),
+              "Unable to encode GetElement OOB input");
           return;
-        VERIFY_IS_TRUE(
-            cpu_oracle::writeMatrixBuffer(InputMatrix, InputLayout, Data),
-            "Unable to encode GetElement OOB input");
+        }
+        if (_stricmp(Name, "Values") == 0 || _stricmp(Name, "Executed") == 0)
+          std::fill(Data.begin(), Data.end(), Sentinel);
       });
 
   MappedData ValueData;
   MappedData ExecutedData;
   Result->Test->GetReadBackData("Values", &ValueData);
   Result->Test->GetReadBackData("Executed", &ExecutedData);
-  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
-      ValueData.data(), ValueData.size(), ValueLayout, Oracle, Verbose));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(ValueData.size(),
+                                  static_cast<UINT32>(ValueBufferSize));
   VERIFY_IS_GREATER_THAN_OR_EQUAL(ExecutedData.size(),
                                   static_cast<UINT32>(ExecutedBufferSize));
 
+  const BYTE *ValueBytes = static_cast<const BYTE *>(ValueData.data());
   const BYTE *ExecutedBytes = static_cast<const BYTE *>(ExecutedData.data());
   size_t ExecutedThreads = 0;
+  bool OutputsValid = true;
   for (size_t Thread = 0; Thread < NumThreads; ++Thread) {
     uint32_t Marker;
     std::memcpy(&Marker, ExecutedBytes + Thread * sizeof(Marker),
                 sizeof(Marker));
-    VERIFY_IS_TRUE(Marker == 0 || Marker == 1,
-                   "GetElement OOB execution marker was invalid");
-    ExecutedThreads += Marker;
+    const BYTE *Value = ValueBytes + Thread * ElementBytes;
+    if (Marker == 1) {
+      ++ExecutedThreads;
+      if (std::memcmp(Value, ExpectedValue.data(), ElementBytes) != 0) {
+        hlsl_test::LogErrorFmt(
+            L"GetElement OOB returned a non-zero value: thread=%zu", Thread);
+        OutputsValid = false;
+      }
+      continue;
+    }
+
+    if (Marker != MarkerSentinel) {
+      hlsl_test::LogErrorFmt(
+          L"GetElement OOB execution marker was invalid: thread=%zu, "
+          L"marker=0x%08x",
+          Thread, Marker);
+      OutputsValid = false;
+      continue;
+    }
+    for (size_t Byte = 0; Byte < ElementBytes; ++Byte) {
+      if (Value[Byte] != Sentinel) {
+        hlsl_test::LogErrorFmt(
+            L"An unexecuted GetElement OOB lane modified its value: "
+            L"thread=%zu",
+            Thread);
+        OutputsValid = false;
+        break;
+      }
+    }
   }
-  VERIFY_IS_GREATER_THAN(ExecutedThreads, static_cast<size_t>(0),
-                         "At least one thread must execute the OOB read");
+  VERIFY_IS_TRUE(OutputsValid, "GetElement OOB outputs were invalid");
+  VERIFY_ARE_EQUAL(static_cast<size_t>(ForcedWaveSize), ExecutedThreads,
+                   "Every lane in the selected first wave must execute");
 }
 
 void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -114,7 +114,7 @@ struct TypedMatrix {
 };
 
 struct MatrixBufferLayout {
-  LinalgMatrixLayout Layout;
+  MatrixLayout Layout;
   size_t OffsetBytes;
   size_t StrideBytes;
 };
@@ -427,9 +427,9 @@ static std::optional<TypedMatrix> transposeMatrix(const TypedMatrix &Source) {
   }
 }
 
-static bool isMemoryLayout(LinalgMatrixLayout Layout) {
-  return Layout == LinalgMatrixLayout::RowMajor ||
-         Layout == LinalgMatrixLayout::ColumnMajor;
+static bool isMemoryLayout(MatrixLayout Layout) {
+  return Layout == MatrixLayout::RowMajor ||
+         Layout == MatrixLayout::ColumnMajor;
 }
 
 static std::optional<size_t>
@@ -446,10 +446,8 @@ getMatrixBufferSize(ComponentType CompType, MatrixDim M, MatrixDim N,
   }
 
   const size_t ElementBytes = elementSize(CompType);
-  const size_t MajorCount =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? M : N;
-  const size_t MinorCount =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? N : M;
+  const size_t MajorCount = Layout.Layout == MatrixLayout::RowMajor ? M : N;
+  const size_t MinorCount = Layout.Layout == MatrixLayout::RowMajor ? N : M;
   size_t PackedMinorBytes;
   if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes)) {
     hlsl_test::LogErrorFmt(
@@ -495,10 +493,8 @@ getElementByteOffset(ComponentType CompType, MatrixDim M, MatrixDim N,
   if (Row >= M || Column >= N)
     return std::nullopt;
 
-  const size_t Major =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? Row : Column;
-  const size_t Minor =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? Column : Row;
+  const size_t Major = Layout.Layout == MatrixLayout::RowMajor ? Row : Column;
+  const size_t Minor = Layout.Layout == MatrixLayout::RowMajor ? Column : Row;
   size_t MajorOffset;
   size_t MinorOffset;
   size_t ByteOffset;
@@ -1011,7 +1007,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
     if (!Matrix.has_value())
       return false;
     MatrixBufferLayout Layout = {
-        LinalgMatrixLayout::RowMajor,
+        MatrixLayout::RowMajor,
         /*OffsetBytes=*/0,
         /*StrideBytes=*/ExpectedBytes.size(),
     };
@@ -1046,7 +1042,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   VERIFY_IS_TRUE(Matrix.has_value());
 
   MatrixBufferLayout RowMajor = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/4,
       /*StrideBytes=*/16,
   };
@@ -1066,7 +1062,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
                                     RowMajor, Exact, /*Verbose=*/false));
 
   MatrixBufferLayout ColumnMajor = {
-      LinalgMatrixLayout::ColumnMajor,
+      MatrixLayout::ColumnMajor,
       /*OffsetBytes=*/4,
       /*StrideBytes=*/12,
   };
@@ -1117,7 +1113,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   Params.N = 3;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 4;
   Params.CompType = ComponentType::I32;
   VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=int") !=

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -166,7 +166,15 @@ template <typename T> struct ComponentTraits;
 
 template <>
 struct ComponentTraits<float>
-    : NativeComponentTraits<float, ComponentType::F32> {};
+    : NativeComponentTraits<float, ComponentType::F32> {
+  static std::wstring format(const float &Value) {
+    uint32_t Bits;
+    std::memcpy(&Bits, &Value, sizeof(Bits));
+    std::wstringstream Stream;
+    Stream << Value << L" (bits=0x" << std::hex << Bits << L")";
+    return Stream.str();
+  }
+};
 
 template <>
 struct ComponentTraits<int32_t>
@@ -443,8 +451,14 @@ getMatrixBufferSize(ComponentType CompType, MatrixDim M, MatrixDim N,
   const size_t MinorCount =
       Layout.Layout == LinalgMatrixLayout::RowMajor ? N : M;
   size_t PackedMinorBytes;
-  if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes) ||
-      Layout.StrideBytes < PackedMinorBytes) {
+  if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes)) {
+    hlsl_test::LogErrorFmt(
+        L"Matrix packed row or column byte calculation overflowed: "
+        L"component=%s, M=%u, N=%u",
+        componentTypeName(CompType), M, N);
+    return std::nullopt;
+  }
+  if (Layout.StrideBytes < PackedMinorBytes) {
     hlsl_test::LogErrorFmt(
         L"Matrix stride is too small: component=%s, M=%u, N=%u, stride=%zu, "
         L"required=%zu",
@@ -1019,6 +1033,13 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   VERIFY_IS_TRUE(
       VerifyScalarEncoding(makeTypedMatrix<uint32_t>(1, 1, {0x89abcdefu}),
                            {0xef, 0xcd, 0xab, 0x89}));
+
+  const uint32_t AdjacentFloatBits = 0x3f800001;
+  float AdjacentFloat;
+  std::memcpy(&AdjacentFloat, &AdjacentFloatBits, sizeof(AdjacentFloat));
+  VERIFY_IS_TRUE(
+      ComponentTraits<float>::format(AdjacentFloat).find(L"3f800001") !=
+      std::wstring::npos);
 
   std::optional<TypedMatrix> Matrix =
       makeTypedMatrix<uint32_t>(2, 3, {1, 2, 3, 4, 5, 6});

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1868,7 +1868,7 @@ static void runElementAccess(ID3D12Device *Device,
       Params.strideBytes(),
   };
   const cpu_oracle::MatrixBufferLayout PackedRowMajor = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       0,
       static_cast<size_t>(Params.N) * elementSize(Params.CompType),
   };
@@ -2001,7 +2001,7 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2089,7 +2089,7 @@ static void runElementGetOOB(ID3D12Device *Device,
       Params.strideBytes(),
   };
   const cpu_oracle::MatrixBufferLayout ExpectedLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       0,
       ElementBytes,
   };
@@ -2181,7 +2181,7 @@ void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2341,7 +2341,7 @@ void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -145,18 +145,9 @@ static bool applyApplicability(linalg_test::Applicability Result,
   case Applicability::Execute:
     return true;
   case Applicability::NotApplicable:
-#ifdef _HLK_CONF
-    hlsl_test::LogErrorFmt(
-        L"Capability-gated case %s reached HLK execution on an unsupported "
-        L"device. Requirement or playlist applicability must exclude it.",
-        CaseName);
-    VERIFY_IS_TRUE(false,
-                   "Unsupported capability-gated case reached HLK execution");
-#else
     hlsl_test::LogCommentFmt(
         L"Capability-gated case %s is not applicable on this device", CaseName);
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-#endif
     return false;
   case Applicability::Fail:
     hlsl_test::LogErrorFmt(L"Capability evaluation failed for case %s",
@@ -1263,6 +1254,13 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
       {},
   };
   VERIFY_IS_FALSE(InvalidWave.valid());
+  InvalidWave = {
+      static_cast<MultiplicationFlags>(
+          static_cast<UINT>(MultiplicationFlags::Supported) |
+          static_cast<UINT>(MultiplicationFlags::EmulatedInputs)),
+      {{8, 16, 8}},
+  };
+  VERIFY_IS_FALSE(InvalidWave.valid());
 
   ThreadGroupMatrixMultiplySupport ThreadGroup = {
       MultiplicationFlags::Supported,
@@ -1275,14 +1273,30 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
   VERIFY_IS_FALSE(ThreadGroup.supportsThreadGroupSize(48));
   ThreadGroup.PreferredThreadGroupSize = 48;
   VERIFY_IS_FALSE(ThreadGroup.valid());
+  ThreadGroup = {
+      static_cast<MultiplicationFlags>(
+          static_cast<UINT>(MultiplicationFlags::Supported) |
+          static_cast<UINT>(MultiplicationFlags::Transpose)),
+      32,
+      128,
+      64,
+  };
+  VERIFY_IS_FALSE(ThreadGroup.valid());
 
   ThreadVectorMatrixMultiplySupport ThreadVector = {
       static_cast<MultiplicationFlags>(
           static_cast<UINT>(MultiplicationFlags::Supported) |
-          static_cast<UINT>(MultiplicationFlags::EmulatedInputs)),
+          static_cast<UINT>(MultiplicationFlags::Transpose)),
+      DataType::Float32,
   };
   VERIFY_IS_TRUE(ThreadVector.valid());
   VERIFY_IS_TRUE(ThreadVector.supported());
+  ThreadVector.SupportFlags = static_cast<MultiplicationFlags>(
+      static_cast<UINT>(MultiplicationFlags::Supported) |
+      static_cast<UINT>(MultiplicationFlags::EmulatedInputs));
+  VERIFY_IS_FALSE(ThreadVector.valid());
+  ThreadVector.MatrixInputType = DataType::Float8E4M3FN;
+  VERIFY_IS_TRUE(ThreadVector.valid());
   ThreadVector.SupportFlags = MultiplicationFlags::EmulatedInputs;
   VERIFY_IS_FALSE(ThreadVector.valid());
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1829,7 +1829,11 @@ static const char CopyConvertShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1852,8 +1856,10 @@ static const char CopyConvertShader[] = R"(
 
 static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
                                        const MatrixParams &Params,
-                                       bool Transpose, bool &Supported) {
+                                       bool Transpose, bool &Supported,
+                                       UINT &SelectedWaveSize) {
   Supported = false;
+  SelectedWaveSize = 0;
   if (!Device || Params.Use != MatrixUse::A ||
       !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
                                  toCapabilityScope(Params.Scope)))
@@ -1921,6 +1927,7 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
           L"destination=%ux%u",
           WaveSize, Params.M, Params.N, Destination.M, Destination.N);
       Supported = true;
+      SelectedWaveSize = WaveSize;
       return S_OK;
     }
   }
@@ -1935,7 +1942,7 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
 static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
-                           bool Transpose) {
+                           bool Transpose, UINT ForcedWaveSize = 0) {
   MatrixParams DstParams = Params;
   if (Transpose) {
     DstParams.M = Params.N;
@@ -1948,6 +1955,8 @@ static void runCopyConvert(ID3D12Device *Device,
   ExtraDefs << " -DDST_N_DIM=" << DstParams.N;
   ExtraDefs << " -DSRC_STRIDE=" << Params.strideBytes();
   ExtraDefs << " -DDST_STRIDE=" << DstParams.strideBytes();
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -2052,8 +2061,9 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
   Params.Enable16Bit = false;
 
   bool Supported;
-  const HRESULT QueryResult =
-      queryCopyConvertSupport(D3DDevice, Params, /*Transpose=*/true, Supported);
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryCopyConvertSupport(
+      D3DDevice, Params, /*Transpose=*/true, Supported, SelectedWaveSize);
   const linalg_test::Applicability Applicability =
       linalg_test::classifyApplicability(
           QueryResult, Supported,
@@ -2065,7 +2075,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
 
   // Non-square dimensions make the destination shape and row stride observable.
   runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
-                 /*Transpose=*/true);
+                 /*Transpose=*/true, SelectedWaveSize);
 }
 
 static const char MatMatMulShader[] = R"(

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -322,6 +322,21 @@ static LPCWSTR componentTypeName(ComponentType CompType) {
   }
 }
 
+static const char *hlslElementTypeName(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::F16:
+    return "half";
+  case ComponentType::F32:
+    return "float";
+  case ComponentType::I32:
+    return "int";
+  case ComponentType::U32:
+    return "uint";
+  default:
+    return nullptr;
+  }
+}
+
 static LPCWSTR comparisonModeName(ComparisonMode Mode) {
   switch (Mode) {
   case ComparisonMode::Exact:
@@ -720,6 +735,27 @@ encodeMatrixBuffer(const TypedMatrix &Matrix, const MatrixBufferLayout &Layout,
   return Buffer;
 }
 
+static std::optional<std::vector<BYTE>>
+makeFilledComponentBuffer(ComponentType CompType, size_t BufferSize,
+                          uint32_t FillValue) {
+  const size_t ElementBytes = elementSize(CompType);
+  if (!isSupportedComponentType(CompType) || BufferSize == 0 ||
+      BufferSize % ElementBytes != 0 ||
+      BufferSize / ElementBytes > (std::numeric_limits<MatrixDim>::max)())
+    return std::nullopt;
+
+  const MatrixDim NumElements =
+      static_cast<MatrixDim>(BufferSize / ElementBytes);
+  std::optional<TypedMatrix> Fill =
+      makeSequentialMatrix(CompType, 1, NumElements, FillValue,
+                           /*Increment=*/false);
+  if (!Fill.has_value())
+    return std::nullopt;
+
+  return encodeMatrixBuffer(*Fill,
+                            {LinalgMatrixLayout::RowMajor, 0, BufferSize});
+}
+
 template <typename T>
 static std::optional<TypedMatrix>
 decodeTypedMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
@@ -1071,22 +1107,11 @@ static std::string buildCompilerArgs(const MatrixParams &Params,
   SS << " -DLAYOUT=" << static_cast<int>(Params.Layout);
   SS << " -DELEM_SIZE=" << static_cast<int>(elementSize(Params.CompType));
   SS << " -DNUMTHREADS=" << Params.NumThreads;
-  switch (Params.CompType) {
-  case ComponentType::F16:
-    SS << " -DELEM_TYPE=half";
-    break;
-  case ComponentType::F32:
-    SS << " -DELEM_TYPE=float";
-    break;
-  case ComponentType::I32:
-    SS << " -DELEM_TYPE=int";
-    break;
-  case ComponentType::U32:
-    SS << " -DELEM_TYPE=uint";
-    break;
-  default:
+  const char *ElementType = cpu_oracle::hlslElementTypeName(Params.CompType);
+  if (!ElementType) {
     VERIFY_IS_TRUE(false, "Unsupported LinAlg component type");
-    break;
+  } else {
+    SS << " -DELEM_TYPE=" << ElementType;
   }
   if (Params.Enable16Bit)
     SS << " -enable-16bit-types";
@@ -1589,6 +1614,12 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
                                                 bool &Supported,
                                                 UINT &SelectedWaveSize);
 
+static HRESULT
+queryAtomicAccumulateSupport(ID3D12Device *Device, const MatrixParams &Params,
+                             linalg_test::AtomicDestination Destination,
+                             LPCWSTR CaseName, bool &Supported,
+                             UINT &SelectedWaveSize);
+
 class DxilConf_SM610_LinAlg {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM610_LinAlg)
@@ -1621,6 +1652,10 @@ public:
   TEST_METHOD(LoadMemory_Wave_16x16_F16);
   TEST_METHOD(StoreMemory_Wave_16x16_F16);
   TEST_METHOD(AccumulateMemory_Wave_16x16_F16);
+  TEST_METHOD(LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded);
+  TEST_METHOD(LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded);
+  TEST_METHOD(LoadStoreMemory_ThreadGroup_4x8_F16);
+  TEST_METHOD(AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded);
 
   // Element access
   TEST_METHOD(ElementAccess_Wave_16x16_F16);
@@ -2387,11 +2422,24 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
                                                 LPCWSTR CaseName,
                                                 bool &Supported,
                                                 UINT &SelectedWaveSize) {
+  return queryAtomicAccumulateSupport(
+      Device, Params, linalg_test::AtomicDestination::RWByteAddressBuffer,
+      CaseName, Supported, SelectedWaveSize);
+}
+
+static HRESULT
+queryAtomicAccumulateSupport(ID3D12Device *Device, const MatrixParams &Params,
+                             linalg_test::AtomicDestination Destination,
+                             LPCWSTR CaseName, bool &Supported,
+                             UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
-  if (!CaseName || !linalg_test::isLegalScope(
-                       linalg_test::OperationType::AtomicAccumulateStore,
-                       toCapabilityScope(Params.Scope)))
+  if (!CaseName ||
+      (Destination != linalg_test::AtomicDestination::RWByteAddressBuffer &&
+       Destination != linalg_test::AtomicDestination::GroupShared) ||
+      !linalg_test::isLegalScope(
+          linalg_test::OperationType::AtomicAccumulateStore,
+          toCapabilityScope(Params.Scope)))
     return E_INVALIDARG;
 
   bool ConstructionSupported;
@@ -2413,12 +2461,15 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
   if (FAILED(HR))
     return HR;
 
-  Supported = AtomicSupport.supports(
-      linalg_test::AtomicDestination::RWByteAddressBuffer);
+  Supported = AtomicSupport.supports(Destination);
   if (!Supported) {
     SelectedWaveSize = 0;
     hlsl_test::LogCommentFmt(
-        L"Atomic descriptor accumulation is unsupported for %s", CaseName);
+        L"Atomic %s accumulation is unsupported for %s",
+        Destination == linalg_test::AtomicDestination::RWByteAddressBuffer
+            ? L"descriptor"
+            : L"group-shared",
+        CaseName);
   }
   return S_OK;
 }
@@ -3821,13 +3872,11 @@ static const char LoadMemoryShader[] = R"(
   RWByteAddressBuffer Output : register(u1);
   groupshared ELEM_TYPE GsData[M_DIM * N_DIM];
 
-  #define ELEM_PER_THREAD (M_DIM * N_DIM / NUMTHREADS)
-
   [WaveSize(4, 64)]
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
-    for (uint I = 0; I < ELEM_PER_THREAD; ++I) {
-      uint Index = threadID * ELEM_PER_THREAD + I;
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
       GsData[Index] = Input.Load<ELEM_TYPE>(Index * ELEM_SIZE);
     }
 
@@ -3903,20 +3952,22 @@ static const char StoreMemoryShader[] = R"(
 
   [WaveSize(4, 64)]
   [numthreads(NUMTHREADS, 1, 1)]
-  void main() {
-    if (GetGroupWaveIndex() != 0)
-      return;
+  void main(uint threadID : SV_GroupIndex) {
+    if (GetGroupWaveIndex() == 0) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+        Mat;
+      __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
 
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
-      Mat;
-    __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
+      __builtin_LinAlg_MatrixStoreToMemory(
+        Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    }
 
-    __builtin_LinAlg_MatrixStoreToMemory(
-      Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    GroupMemoryBarrierWithGroupSync();
 
-    for (uint I = 0; I < M_DIM*N_DIM; ++I) {
-      Output.Store<ELEM_TYPE>(I*ELEM_SIZE, GsData[I]);
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, GsData[Index]);
     }
   }
 )";
@@ -3971,32 +4022,31 @@ static const char AccumulateMemoryShader[] = R"(
   RWByteAddressBuffer Output : register(u0);
   groupshared ELEM_TYPE GsData[M_DIM * N_DIM];
 
-  #define ELEM_PER_THREAD (M_DIM * N_DIM / NUMTHREADS)
-
   [WaveSize(4, 64)]
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
-    ELEM_TYPE fill = FILL_VALUE;
-    for (uint I = 0; I < ELEM_PER_THREAD; ++I) {
-      uint Index = threadID * ELEM_PER_THREAD + I;
-      GsData[Index] = fill;
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
+      GsData[Index] = FILL_VALUE;
     }
 
     GroupMemoryBarrierWithGroupSync();
 
-    if (GetGroupWaveIndex() != 0)
-      return;
+    if (GetGroupWaveIndex() == 0) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+        Mat;
+      __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
 
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
-      Mat;
-    __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
+      __builtin_LinAlg_MatrixAccumulateToMemory(
+        Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    }
 
-    __builtin_LinAlg_MatrixAccumulateToMemory(
-      Mat, GsData, COMP_TYPE, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    GroupMemoryBarrierWithGroupSync();
 
-    for (uint I = 0; I < M_DIM*N_DIM; ++I) {
-      Output.Store<ELEM_TYPE>(I*ELEM_SIZE, GsData[I]);
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, GsData[Index]);
     }
   }
 )";
@@ -4045,6 +4095,465 @@ void DxilConf_SM610_LinAlg::AccumulateMemory_Wave_16x16_F16() {
   Params.Enable16Bit = true;
   runAccumulateMemory(D3DDevice, DxcSupport, Params, VerboseLogging,
                       /*FillValue=*/7.0f);
+}
+
+struct GroupSharedMemorySpec {
+  cpu_oracle::MatrixBufferLayout Layout;
+};
+
+static const char GroupSharedTransferShader[] = R"(
+  ByteAddressBuffer SourceInit : register(t0);
+  ByteAddressBuffer DestinationInit : register(t1);
+  RWByteAddressBuffer Output : register(u2);
+
+  groupshared ELEM_TYPE SourceData[SRC_ELEMENTS];
+  groupshared ELEM_TYPE DestinationData[DST_ELEMENTS];
+
+  void TransferMatrix() {
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromMemory(
+      Mat, SourceData, SRC_OFFSET, SRC_STRIDE, SRC_LAYOUT);
+    __builtin_LinAlg_MatrixStoreToMemory(
+      Mat, DestinationData, DST_OFFSET, DST_STRIDE, DST_LAYOUT);
+  }
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    for (uint Index = threadID; Index < SRC_ELEMENTS;
+         Index += NUMTHREADS) {
+      SourceData[Index] =
+        SourceInit.Load<ELEM_TYPE>(Index * ELEM_SIZE);
+    }
+    for (uint Index = threadID; Index < DST_ELEMENTS;
+         Index += NUMTHREADS) {
+      DestinationData[Index] =
+        DestinationInit.Load<ELEM_TYPE>(Index * ELEM_SIZE);
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    #if SCOPE == 1
+    if (GetGroupWaveIndex() == 0)
+      TransferMatrix();
+    #elif SCOPE == 2
+    TransferMatrix();
+    #else
+    #error Group-shared matrix transfer requires Wave or ThreadGroup scope
+    #endif
+
+    GroupMemoryBarrierWithGroupSync();
+
+    for (uint Index = threadID; Index < DST_ELEMENTS;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, DestinationData[Index]);
+    }
+  }
+)";
+
+static bool getGroupSharedBufferDescription(const MatrixParams &Params,
+                                            const GroupSharedMemorySpec &Spec,
+                                            size_t &BufferSize,
+                                            UINT &NumElements) {
+  const size_t ElementBytes = elementSize(Params.CompType);
+  std::optional<size_t> RequiredBytes = cpu_oracle::getMatrixBufferSize(
+      Params.CompType, Params.M, Params.N, Spec.Layout);
+  if (!RequiredBytes.has_value() ||
+      Spec.Layout.OffsetBytes % ElementBytes != 0 ||
+      Spec.Layout.StrideBytes % ElementBytes != 0 ||
+      *RequiredBytes % ElementBytes != 0 ||
+      *RequiredBytes / ElementBytes > (std::numeric_limits<UINT>::max)())
+    return false;
+
+  BufferSize = *RequiredBytes;
+  NumElements = static_cast<UINT>(BufferSize / ElementBytes);
+  return true;
+}
+
+static void
+runGroupSharedTransfer(ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+                       const MatrixParams &Params,
+                       const GroupSharedMemorySpec &Source,
+                       const GroupSharedMemorySpec &Destination, bool Verbose,
+                       std::optional<UINT> ForcedWaveSize = std::nullopt) {
+  using namespace cpu_oracle;
+
+  if (!Device ||
+      (Params.Scope != MatrixScope::Wave &&
+       Params.Scope != MatrixScope::ThreadGroup) ||
+      Params.Use != MatrixUse::A) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared transfer parameters");
+    return;
+  }
+
+  size_t SourceBufferSize;
+  UINT SourceElements;
+  size_t DestinationBufferSize;
+  UINT DestinationElements;
+  if (!getGroupSharedBufferDescription(Params, Source, SourceBufferSize,
+                                       SourceElements) ||
+      !getGroupSharedBufferDescription(
+          Params, Destination, DestinationBufferSize, DestinationElements)) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared buffer description");
+    return;
+  }
+
+  std::optional<TypedMatrix> SourceValues = makeSequentialMatrix(
+      Params.CompType, Params.M, Params.N, /*StartingValue=*/1);
+  std::optional<TypedMatrix> DestinationValues = makeSequentialMatrix(
+      Params.CompType, Params.M, Params.N, /*StartingValue=*/1);
+  std::optional<std::vector<BYTE>> SourceBuffer =
+      makeFilledComponentBuffer(Params.CompType, SourceBufferSize, 91);
+  std::optional<std::vector<BYTE>> DestinationInitial =
+      makeFilledComponentBuffer(Params.CompType, DestinationBufferSize, 90);
+  if (!SourceValues.has_value() || !DestinationValues.has_value() ||
+      !SourceBuffer.has_value() || !DestinationInitial.has_value() ||
+      !writeMatrixBuffer(*SourceValues, Source.Layout, *SourceBuffer)) {
+    VERIFY_IS_TRUE(false, "Failed to build group-shared transfer inputs");
+    return;
+  }
+
+  std::vector<BYTE> Expected = *DestinationInitial;
+  if (!writeMatrixBuffer(*DestinationValues, Destination.Layout, Expected)) {
+    VERIFY_IS_TRUE(false, "Failed to build group-shared transfer expectation");
+    return;
+  }
+
+  std::stringstream ExtraDefs;
+  ExtraDefs << " -DSRC_ELEMENTS=" << SourceElements;
+  ExtraDefs << " -DSRC_OFFSET="
+            << Source.Layout.OffsetBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DSRC_STRIDE="
+            << Source.Layout.StrideBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DSRC_LAYOUT=" << static_cast<UINT>(Source.Layout.Layout);
+  ExtraDefs << " -DDST_ELEMENTS=" << DestinationElements;
+  ExtraDefs << " -DDST_OFFSET="
+            << Destination.Layout.OffsetBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DDST_STRIDE="
+            << Destination.Layout.StrideBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DDST_LAYOUT=" << static_cast<UINT>(Destination.Layout.Layout);
+  if (ForcedWaveSize.has_value())
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << *ForcedWaveSize;
+
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+  compileShader(DxcSupport, GroupSharedTransferShader, "cs_6_10", Args,
+                Verbose);
+
+  auto Op = createComputeOp(GroupSharedTransferShader, "cs_6_10",
+                            "SRV(t0), SRV(t1), UAV(u2)", Args.c_str());
+  addSRVBuffer(Op.get(), "SourceInit", SourceBuffer->size(), "byname");
+  addSRVBuffer(Op.get(), "DestinationInit", DestinationInitial->size(),
+               "byname");
+  addUAVBuffer(Op.get(), "Output", Expected.size(), true);
+  addRootView(Op.get(), 0, "SourceInit");
+  addRootView(Op.get(), 1, "DestinationInit");
+  addRootView(Op.get(), 2, "Output");
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+                    if (strcmp(Name, "SourceInit") == 0)
+                      Data = *SourceBuffer;
+                    else if (strcmp(Name, "DestinationInit") == 0)
+                      Data = *DestinationInitial;
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  BufferResultOracle Oracle =
+      exactBufferResult(std::move(Expected),
+                        L"Exact group-shared load/store layout and addressing");
+  VERIFY_IS_TRUE(
+      verifyBufferResult(OutData.data(), OutData.size(), Oracle, Verbose));
+}
+
+static void runBidirectionalGroupSharedTransfer(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params, const GroupSharedMemorySpec &Target,
+    const GroupSharedMemorySpec &Canonical, bool Verbose,
+    std::optional<UINT> ForcedWaveSize = std::nullopt) {
+  hlsl_test::LogCommentFmt(L"Group-shared transfer: target to canonical");
+  runGroupSharedTransfer(Device, DxcSupport, Params, Target, Canonical, Verbose,
+                         ForcedWaveSize);
+  hlsl_test::LogCommentFmt(L"Group-shared transfer: canonical to target");
+  runGroupSharedTransfer(Device, DxcSupport, Params, Canonical, Target, Verbose,
+                         ForcedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded "
+                          L"MatrixConstruction"))
+    return;
+
+  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::RowMajor,
+                                         /*OffsetBytes=*/8,
+                                         /*StrideBytes=*/24}};
+  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+                                            /*OffsetBytes=*/0,
+                                            /*StrideBytes=*/16}};
+  runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
+                                      Canonical, VerboseLogging,
+                                      SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded "
+          L"MatrixConstruction"))
+    return;
+
+  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+                                         /*OffsetBytes=*/16,
+                                         /*StrideBytes=*/24}};
+  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+                                            /*OffsetBytes=*/0,
+                                            /*StrideBytes=*/32}};
+  runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
+                                      Canonical, VerboseLogging,
+                                      SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::ThreadGroup;
+  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreMemory_ThreadGroup_4x8_F16", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"LoadStoreMemory_ThreadGroup_4x8_F16 MatrixConstruction"))
+    return;
+
+  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+                                         /*OffsetBytes=*/8,
+                                         /*StrideBytes=*/12}};
+  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+                                            /*OffsetBytes=*/0,
+                                            /*StrideBytes=*/16}};
+  runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
+                                      Canonical, VerboseLogging,
+                                      SelectedWaveSize);
+}
+
+static const char GroupSharedAccumulateShader[] = R"(
+  ByteAddressBuffer Initial : register(t0);
+  RWByteAddressBuffer Output : register(u1);
+  groupshared ELEM_TYPE GsData[MEM_ELEMENTS];
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    for (uint Index = threadID; Index < MEM_ELEMENTS;
+         Index += NUMTHREADS) {
+      GsData[Index] = Initial.Load<ELEM_TYPE>(Index * ELEM_SIZE);
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    if (GetGroupWaveIndex() == 0) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+        Mat;
+      __builtin_LinAlg_FillMatrix(Mat, 0);
+      for (uint I = 0; I < __builtin_LinAlg_MatrixLength(Mat); ++I) {
+        uint2 Coord = __builtin_LinAlg_MatrixGetCoordinate(Mat, I);
+        __builtin_LinAlg_MatrixSetElement(
+          Mat, Mat, I,
+          (ELEM_TYPE)(ACCUMULATE_START + Coord.x * N_DIM + Coord.y));
+      }
+      __builtin_LinAlg_MatrixAccumulateToMemory(
+        Mat, GsData, MEM_OFFSET, MEM_STRIDE, MEM_LAYOUT);
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    for (uint Index = threadID; Index < MEM_ELEMENTS;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, GsData[Index]);
+    }
+  }
+)";
+
+static void runGroupSharedAccumulate(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params, const GroupSharedMemorySpec &Memory,
+    uint32_t InitialValue, uint32_t AccumulateStartingValue, bool Verbose,
+    std::optional<UINT> ForcedWaveSize = std::nullopt) {
+  using namespace cpu_oracle;
+
+  if (!Device || Params.Scope != MatrixScope::Wave ||
+      Params.Use != MatrixUse::Accumulator ||
+      InitialValue >
+          (std::numeric_limits<uint32_t>::max)() - AccumulateStartingValue) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared accumulate parameters");
+    return;
+  }
+
+  size_t BufferSize;
+  UINT NumElements;
+  if (!getGroupSharedBufferDescription(Params, Memory, BufferSize,
+                                       NumElements)) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared accumulate buffer");
+    return;
+  }
+
+  std::optional<TypedMatrix> InitialMatrix =
+      makeSequentialMatrix(Params.CompType, Params.M, Params.N, InitialValue,
+                           /*Increment=*/false);
+  std::optional<TypedMatrix> ExpectedMatrix = makeSequentialMatrix(
+      Params.CompType, Params.M, Params.N,
+      InitialValue + AccumulateStartingValue, /*Increment=*/true);
+  std::optional<std::vector<BYTE>> Initial =
+      makeFilledComponentBuffer(Params.CompType, BufferSize, 90);
+  std::optional<std::vector<BYTE>> Expected =
+      makeFilledComponentBuffer(Params.CompType, BufferSize, 90);
+  if (!InitialMatrix.has_value() || !ExpectedMatrix.has_value() ||
+      !Initial.has_value() || !Expected.has_value() ||
+      !writeMatrixBuffer(*InitialMatrix, Memory.Layout, *Initial) ||
+      !writeMatrixBuffer(*ExpectedMatrix, Memory.Layout, *Expected)) {
+    VERIFY_IS_TRUE(false, "Failed to build group-shared accumulate oracle");
+    return;
+  }
+
+  std::stringstream ExtraDefs;
+  ExtraDefs << " -DMEM_ELEMENTS=" << NumElements;
+  ExtraDefs << " -DMEM_OFFSET="
+            << Memory.Layout.OffsetBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DMEM_STRIDE="
+            << Memory.Layout.StrideBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DMEM_LAYOUT=" << static_cast<UINT>(Memory.Layout.Layout);
+  ExtraDefs << " -DACCUMULATE_START=" << AccumulateStartingValue;
+  if (ForcedWaveSize.has_value())
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << *ForcedWaveSize;
+
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+  compileShader(DxcSupport, GroupSharedAccumulateShader, "cs_6_10", Args,
+                Verbose);
+
+  auto Op = createComputeOp(GroupSharedAccumulateShader, "cs_6_10",
+                            "SRV(t0), UAV(u1)", Args.c_str());
+  addSRVBuffer(Op.get(), "Initial", Initial->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", Expected->size(), true);
+  addRootView(Op.get(), 0, "Initial");
+  addRootView(Op.get(), 1, "Output");
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+                    if (strcmp(Name, "Initial") == 0)
+                      Data = *Initial;
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  BufferResultOracle Oracle = exactBufferResult(
+      std::move(*Expected), L"Exact Wave group-shared atomic accumulation");
+  VERIFY_IS_TRUE(
+      verifyBufferResult(OutData.data(), OutData.size(), Oracle, Verbose));
+}
+
+void DxilConf_SM610_LinAlg::
+    AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryAtomicAccumulateSupport(
+      D3DDevice, Params, linalg_test::AtomicDestination::GroupShared,
+      L"AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded "
+                          L"AtomicAccumulateStore"))
+    return;
+
+  const GroupSharedMemorySpec Memory = {{LinalgMatrixLayout::RowMajor,
+                                         /*OffsetBytes=*/8,
+                                         /*StrideBytes=*/24}};
+  runGroupSharedAccumulate(D3DDevice, DxcSupport, Params, Memory,
+                           /*InitialValue=*/12,
+                           /*AccumulateStartingValue=*/1, VerboseLogging,
+                           SelectedWaveSize);
 }
 
 static const char ConvertShader[] = R"(

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -200,6 +200,12 @@ struct MatrixResultOracle {
   std::wstring PublicRule;
 };
 
+struct BufferResultOracle {
+  ComparisonMode Mode;
+  std::vector<std::vector<BYTE>> Candidates;
+  std::wstring PublicRule;
+};
+
 template <typename T, ComponentType CT> struct NativeComponentTraits {
   static constexpr ComponentType CompType = CT;
   static constexpr size_t Size = sizeof(T);
@@ -377,7 +383,7 @@ static std::optional<TypedMatrix> makeTypedMatrix(MatrixDim M, MatrixDim N,
 
 static std::optional<TypedMatrix>
 makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
-                     uint32_t StartingValue = 1) {
+                     uint32_t StartingValue = 1, bool Increment = true) {
   size_t NumElements;
   if (M == 0 || N == 0 ||
       !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
@@ -388,7 +394,8 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
   }
 
   size_t LastValueSize;
-  if (!checkedAdd(static_cast<size_t>(StartingValue), NumElements - 1,
+  const size_t ValueSpan = Increment ? NumElements - 1 : 0;
+  if (!checkedAdd(static_cast<size_t>(StartingValue), ValueSpan,
                   LastValueSize)) {
     hlsl_test::LogErrorFmt(L"Sequential matrix value calculation overflowed");
     return std::nullopt;
@@ -405,8 +412,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<HLSLHalf_t> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.emplace_back(static_cast<float>(
-          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+      Values.emplace_back(
+          static_cast<float>(static_cast<uint64_t>(StartingValue) +
+                             static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   case ComponentType::F32: {
@@ -419,8 +427,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<float> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.push_back(static_cast<float>(static_cast<uint64_t>(StartingValue) +
-                                          static_cast<uint64_t>(I)));
+      Values.push_back(
+          static_cast<float>(static_cast<uint64_t>(StartingValue) +
+                             static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   case ComponentType::I32: {
@@ -433,8 +442,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<int32_t> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.push_back(static_cast<int32_t>(
-          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+      Values.push_back(
+          static_cast<int32_t>(static_cast<uint64_t>(StartingValue) +
+                               static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   case ComponentType::U32: {
@@ -446,8 +456,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<uint32_t> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.push_back(static_cast<uint32_t>(
-          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+      Values.push_back(
+          static_cast<uint32_t>(static_cast<uint64_t>(StartingValue) +
+                                static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   default:
@@ -643,6 +654,73 @@ static bool writeMatrixBuffer(const TypedMatrix &Matrix,
 }
 
 template <typename T>
+static bool writeTypedMatrixBufferWithinBounds(const TypedMatrix &Matrix,
+                                               const MatrixBufferLayout &Layout,
+                                               size_t AccessibleBytes,
+                                               std::vector<BYTE> &Buffer) {
+  const std::vector<T> &Values = std::get<std::vector<T>>(Matrix.Values);
+  for (MatrixDim Row = 0; Row < Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Matrix.N; ++Column) {
+      const size_t ValueIndex = static_cast<size_t>(Row) * Matrix.N + Column;
+      std::optional<size_t> ByteOffset = getElementByteOffset(
+          Matrix.CompType, Matrix.M, Matrix.N, Row, Column, Layout);
+      size_t EndOffset;
+      if (!ByteOffset.has_value() ||
+          !checkedAdd(*ByteOffset, ComponentTraits<T>::Size, EndOffset))
+        return false;
+      if (EndOffset > AccessibleBytes)
+        continue;
+      ComponentTraits<T>::store(Buffer.data() + *ByteOffset,
+                                Values[ValueIndex]);
+    }
+  }
+  return true;
+}
+
+static bool writeMatrixBufferWithinBounds(const TypedMatrix &Matrix,
+                                          const MatrixBufferLayout &Layout,
+                                          size_t AccessibleBytes,
+                                          std::vector<BYTE> &Buffer) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Matrix, Layout);
+  if (!RequiredBytes.has_value() || Buffer.size() < *RequiredBytes ||
+      AccessibleBytes > Buffer.size()) {
+    hlsl_test::LogErrorFmt(
+        L"Invalid bounded matrix buffer: actual=%zu, required=%zu, bound=%zu",
+        Buffer.size(), RequiredBytes.value_or(0), AccessibleBytes);
+    return false;
+  }
+
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return writeTypedMatrixBufferWithinBounds<HLSLHalf_t>(
+        Matrix, Layout, AccessibleBytes, Buffer);
+  case ComponentType::F32:
+    return writeTypedMatrixBufferWithinBounds<float>(Matrix, Layout,
+                                                     AccessibleBytes, Buffer);
+  case ComponentType::I32:
+    return writeTypedMatrixBufferWithinBounds<int32_t>(Matrix, Layout,
+                                                       AccessibleBytes, Buffer);
+  case ComponentType::U32:
+    return writeTypedMatrixBufferWithinBounds<uint32_t>(
+        Matrix, Layout, AccessibleBytes, Buffer);
+  default:
+    return false;
+  }
+}
+
+static std::optional<std::vector<BYTE>>
+encodeMatrixBuffer(const TypedMatrix &Matrix, const MatrixBufferLayout &Layout,
+                   BYTE FillByte = 0) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Matrix, Layout);
+  if (!RequiredBytes.has_value())
+    return std::nullopt;
+  std::vector<BYTE> Buffer(*RequiredBytes, FillByte);
+  if (!writeMatrixBuffer(Matrix, Layout, Buffer))
+    return std::nullopt;
+  return Buffer;
+}
+
+template <typename T>
 static std::optional<TypedMatrix>
 decodeTypedMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
                         const MatrixBufferLayout &Layout, const BYTE *Buffer) {
@@ -686,6 +764,21 @@ decodeMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
   default:
     return std::nullopt;
   }
+}
+
+static std::optional<TypedMatrix>
+makeBoundedReadResult(const TypedMatrix &Source,
+                      const MatrixBufferLayout &Layout,
+                      size_t AccessibleBytes) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Source, Layout);
+  if (!RequiredBytes.has_value() || AccessibleBytes > *RequiredBytes)
+    return std::nullopt;
+
+  std::vector<BYTE> Buffer(*RequiredBytes, 0);
+  if (!writeMatrixBufferWithinBounds(Source, Layout, AccessibleBytes, Buffer))
+    return std::nullopt;
+  return decodeMatrixBuffer(Source.CompType, Source.M, Source.N, Layout,
+                            Buffer.data(), Buffer.size());
 }
 
 template <typename T>
@@ -764,6 +857,19 @@ static MatrixResultOracle permittedResults(std::vector<TypedMatrix> Candidates,
 static MatrixResultOracle excludedResult(std::wstring PublicRule) {
   return MatrixResultOracle{
       ComparisonMode::Excluded, {}, std::move(PublicRule)};
+}
+
+static BufferResultOracle exactBufferResult(std::vector<BYTE> Expected,
+                                            std::wstring PublicRule) {
+  return BufferResultOracle{
+      ComparisonMode::Exact, {std::move(Expected)}, std::move(PublicRule)};
+}
+
+static BufferResultOracle
+permittedBufferResults(std::vector<std::vector<BYTE>> Candidates,
+                       std::wstring PublicRule) {
+  return BufferResultOracle{ComparisonMode::PermittedResults,
+                            std::move(Candidates), std::move(PublicRule)};
 }
 
 static bool isOracleValid(const MatrixResultOracle &Oracle) {
@@ -857,6 +963,95 @@ static bool verifyMatrixBuffer(const void *ActualBuffer,
         CandidateIndex, Mismatch, Row, Column,
         matrixValueString(*Actual, Mismatch).c_str(),
         matrixValueString(Candidate, Mismatch).c_str());
+  }
+  return false;
+}
+
+static bool isBufferOracleValid(const BufferResultOracle &Oracle) {
+  if (Oracle.PublicRule.empty() || Oracle.Candidates.empty())
+    return false;
+  if (Oracle.Mode == ComparisonMode::Excluded)
+    return false;
+  if (Oracle.Mode == ComparisonMode::Exact && Oracle.Candidates.size() != 1)
+    return false;
+  if (Oracle.Mode == ComparisonMode::PermittedResults &&
+      Oracle.Candidates.size() < 2)
+    return false;
+
+  const size_t ExpectedSize = Oracle.Candidates.front().size();
+  if (ExpectedSize == 0)
+    return false;
+  for (const std::vector<BYTE> &Candidate : Oracle.Candidates) {
+    if (Candidate.size() != ExpectedSize)
+      return false;
+  }
+  return true;
+}
+
+static bool matchesAnyCompleteBufferCandidate(
+    const std::vector<BYTE> &Actual, const BufferResultOracle &Oracle,
+    std::vector<size_t> *FirstMismatches = nullptr) {
+  if (!isBufferOracleValid(Oracle) ||
+      Actual.size() != Oracle.Candidates.front().size())
+    return false;
+
+  if (FirstMismatches)
+    FirstMismatches->clear();
+  for (const std::vector<BYTE> &Candidate : Oracle.Candidates) {
+    const auto Mismatch =
+        std::mismatch(Actual.begin(), Actual.end(), Candidate.begin());
+    const size_t FirstMismatch =
+        static_cast<size_t>(std::distance(Actual.begin(), Mismatch.first));
+    if (FirstMismatch == Actual.size())
+      return true;
+    if (FirstMismatches)
+      FirstMismatches->push_back(FirstMismatch);
+  }
+  return false;
+}
+
+static bool verifyBufferResult(const void *ActualBuffer,
+                               size_t ActualBufferSize,
+                               const BufferResultOracle &Oracle, bool Verbose) {
+  if (!ActualBuffer || !isBufferOracleValid(Oracle)) {
+    hlsl_test::LogErrorFmt(L"Invalid whole-buffer result or oracle");
+    return false;
+  }
+
+  const size_t ExpectedSize = Oracle.Candidates.front().size();
+  if (ActualBufferSize != ExpectedSize) {
+    hlsl_test::LogErrorFmt(
+        L"Whole-buffer size mismatch: actual=%zu, expected=%zu, rule=%s",
+        ActualBufferSize, ExpectedSize, Oracle.PublicRule.c_str());
+    return false;
+  }
+
+  const BYTE *ActualBytes = static_cast<const BYTE *>(ActualBuffer);
+  std::vector<BYTE> Actual(ActualBytes, ActualBytes + ActualBufferSize);
+  std::vector<size_t> FirstMismatches;
+  if (matchesAnyCompleteBufferCandidate(Actual, Oracle, &FirstMismatches)) {
+    if (Verbose) {
+      hlsl_test::LogCommentFmt(
+          L"Whole-buffer comparison passed: bytes=%zu, mode=%s, rule=%s",
+          ActualBufferSize, comparisonModeName(Oracle.Mode),
+          Oracle.PublicRule.c_str());
+    }
+    return true;
+  }
+
+  hlsl_test::LogErrorFmt(
+      L"No complete whole-buffer candidate matched: bytes=%zu, mode=%s, "
+      L"rule=%s",
+      ActualBufferSize, comparisonModeName(Oracle.Mode),
+      Oracle.PublicRule.c_str());
+  for (size_t CandidateIndex = 0; CandidateIndex < Oracle.Candidates.size();
+       ++CandidateIndex) {
+    const size_t Mismatch = FirstMismatches[CandidateIndex];
+    hlsl_test::LogErrorFmt(
+        L"Candidate %zu first mismatch at byte=%zu: actual=0x%02x, "
+        L"expected=0x%02x",
+        CandidateIndex, Mismatch, Actual[Mismatch],
+        Oracle.Candidates[CandidateIndex][Mismatch]);
   }
   return false;
 }
@@ -1200,6 +1395,18 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
       excludedResult(L"Host excluded-oracle classification");
   VERIFY_IS_FALSE(matchesAnyCompleteCandidate(*Matrix, Excluded));
 
+  const std::vector<BYTE> BufferCandidateA = {1, 2, 3, 4};
+  const std::vector<BYTE> BufferCandidateB = {5, 6, 7, 8};
+  const std::vector<BYTE> MixedBuffer = {1, 2, 7, 8};
+  BufferResultOracle BufferPermitted = permittedBufferResults(
+      {BufferCandidateA, BufferCandidateB},
+      L"Host whole-buffer permitted candidate semantics");
+  VERIFY_IS_FALSE(
+      matchesAnyCompleteBufferCandidate(MixedBuffer, BufferPermitted));
+  BufferPermitted.Candidates.push_back(MixedBuffer);
+  VERIFY_IS_TRUE(
+      matchesAnyCompleteBufferCandidate(MixedBuffer, BufferPermitted));
+
   MatrixParams Params = {};
   Params.M = 2;
   Params.N = 3;
@@ -1365,6 +1572,23 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
   VERIFY_IS_TRUE(AtomicQuery.ComponentType == DataType::Float16);
 }
 
+struct MatrixConstructionRequirement {
+  linalg_test::MatrixRole Role;
+  MatrixDim Rows;
+  MatrixDim Columns;
+};
+
+static HRESULT queryMatrixConstructionSupport(
+    ID3D12Device *Device, const MatrixParams &Params,
+    std::initializer_list<MatrixConstructionRequirement> Requirements,
+    LPCWSTR CaseName, bool &Supported, UINT &SelectedWaveSize);
+
+static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
+                                                const MatrixParams &Params,
+                                                LPCWSTR CaseName,
+                                                bool &Supported,
+                                                UINT &SelectedWaveSize);
+
 class DxilConf_SM610_LinAlg {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM610_LinAlg)
@@ -1385,8 +1609,13 @@ public:
 
   // Load/Store/Accumulate Descriptor
   TEST_METHOD(LoadStoreDescriptor_Wave_16x16_F16);
+  TEST_METHOD(LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded);
+  TEST_METHOD(LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset);
+  TEST_METHOD(LoadDescriptorBounds_Wave_4x8_F32);
+  TEST_METHOD(StoreDescriptorBounds_Wave_4x8_F32);
   TEST_METHOD(SplatStore_Wave_16x16_F16);
   TEST_METHOD(AccumulateDescriptor_Wave_16x16_F16);
+  TEST_METHOD(AccumulateDescriptorBounds_Wave_4x8_F32);
 
   // Load/Store/Accumulate Memory
   TEST_METHOD(LoadMemory_Wave_16x16_F16);
@@ -1476,11 +1705,15 @@ bool DxilConf_SM610_LinAlg::setupMethod() {
   return D3D12SDK->createDevice(&D3DDevice, D3D_SHADER_MODEL_6_10, false);
 }
 
-static const char LoadStoreDescriptorShader[] = R"(
-  RWByteAddressBuffer Input : register(u0);
+static const char DescriptorIOShader[] = R"(
+  ByteAddressBuffer Input : register(t0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1490,51 +1723,121 @@ static const char LoadStoreDescriptorShader[] = R"(
       [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
       Mat;
     __builtin_LinAlg_MatrixLoadFromDescriptor(
-      Mat, Input, OFFSET, STRIDE, LAYOUT, 128);
+      Mat, Input, SRC_OFFSET, SRC_STRIDE, SRC_LAYOUT, SRC_ALIGNMENT);
+  #ifdef ACCUMULATE_COUNT
+    for (uint I = 0; I < ACCUMULATE_COUNT; ++I) {
+      __builtin_LinAlg_MatrixAccumulateToDescriptor(
+        Mat, Output, DST_OFFSET, DST_STRIDE, DST_LAYOUT, DST_ALIGNMENT);
+    }
+  #else
     __builtin_LinAlg_MatrixStoreToDescriptor(
-      Mat, Output, OFFSET, STRIDE, LAYOUT, 128);
+      Mat, Output, DST_OFFSET, DST_STRIDE, DST_LAYOUT, DST_ALIGNMENT);
+  #endif
   }
 )";
 
-static void runLoadStoreDescriptor(ID3D12Device *Device,
-                                   dxc::SpecificDllLoader &DxcSupport,
-                                   const MatrixParams &Params, bool Verbose) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
+static void runDescriptorIO(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params, const cpu_oracle::TypedMatrix &InputMatrix,
+    const cpu_oracle::MatrixBufferLayout &SourceLayout,
+    const cpu_oracle::MatrixBufferLayout &DestinationLayout,
+    UINT SourceAlignment, UINT DestinationAlignment, size_t SourceViewBytes,
+    size_t DestinationViewBytes, std::vector<BYTE> InitialOutput,
+    const cpu_oracle::BufferResultOracle &Oracle, bool Verbose,
+    UINT ForcedWaveSize = 0, UINT AccumulateCount = 0) {
+  std::optional<std::vector<BYTE>> SourceBuffer =
+      cpu_oracle::encodeMatrixBuffer(InputMatrix, SourceLayout, 0xcd);
+  VERIFY_IS_TRUE(SourceBuffer.has_value(),
+                 "Unable to encode descriptor input matrix");
+  VERIFY_IS_TRUE(SourceViewBytes <= SourceBuffer->size() &&
+                     DestinationViewBytes <= InitialOutput.size(),
+                 "Descriptor view exceeds its backing resource");
 
-  // TODO: these should be varied by test to ensure full coverage
   std::stringstream ExtraDefs;
-  ExtraDefs << " -DOFFSET=" << 0;
+  ExtraDefs << " -DSRC_OFFSET=" << SourceLayout.OffsetBytes;
+  ExtraDefs << " -DSRC_STRIDE=" << SourceLayout.StrideBytes;
+  ExtraDefs << " -DSRC_LAYOUT=" << static_cast<UINT>(SourceLayout.Layout);
+  ExtraDefs << " -DSRC_ALIGNMENT=" << SourceAlignment;
+  ExtraDefs << " -DDST_OFFSET=" << DestinationLayout.OffsetBytes;
+  ExtraDefs << " -DDST_STRIDE=" << DestinationLayout.StrideBytes;
+  ExtraDefs << " -DDST_LAYOUT=" << static_cast<UINT>(DestinationLayout.Layout);
+  ExtraDefs << " -DDST_ALIGNMENT=" << DestinationAlignment;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  if (AccumulateCount != 0)
+    ExtraDefs << " -DACCUMULATE_COUNT=" << AccumulateCount;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
-  compileShader(DxcSupport, LoadStoreDescriptorShader, "cs_6_10", Args,
-                Verbose);
+  compileShader(DxcSupport, DescriptorIOShader, "cs_6_10", Args, Verbose);
 
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1);
+  auto Op = createComputeOp(DescriptorIOShader, "cs_6_10",
+                            "DescriptorTable(SRV(t0), UAV(u1))", Args.c_str());
+  addSRVBuffer(Op.get(), "Input", SourceBuffer->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", InitialOutput.size(), true, "byname");
+  addRawBufferDescriptorTable(
+      Op.get(), 0, "DescriptorHeap",
+      {
+          {"InputView", "Input", RawBufferViewKind::SRV, 0, SourceViewBytes},
+          {"OutputView", "Output", RawBufferViewKind::UAV, 0,
+           DestinationViewBytes},
+      });
 
-  // Construct the ShaderOp: two UAV buffers, load from one, store to other.
-  auto Op = createComputeOp(LoadStoreDescriptorShader, "cs_6_10",
-                            "UAV(u0), UAV(u1)", Args.c_str());
-  addUAVBuffer(Op.get(), "Input", BufferSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
-
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  const std::vector<BYTE> SourceData = *SourceBuffer;
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [SourceData, InitialOutput](LPCSTR Name, std::vector<BYTE> &Data,
+                                  st::ShaderOp *) {
+        const std::vector<BYTE> *ExpectedData = nullptr;
+        if (_stricmp(Name, "Input") == 0)
+          ExpectedData = &SourceData;
+        else if (_stricmp(Name, "Output") == 0)
+          ExpectedData = &InitialOutput;
+        if (!ExpectedData)
+          return;
+        VERIFY_IS_TRUE(Data.size() == ExpectedData->size(),
+                       "Descriptor resource initializer size mismatch");
+        std::copy(ExpectedData->begin(), ExpectedData->end(), Data.begin());
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
 
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
+static void runExactDescriptorRoundTrip(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params,
+    const cpu_oracle::MatrixBufferLayout &SourceLayout,
+    const cpu_oracle::MatrixBufferLayout &DestinationLayout,
+    UINT SourceAlignment, UINT DestinationAlignment, bool Verbose,
+    UINT ForcedWaveSize = 0) {
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value(),
+                 "Unable to construct descriptor round-trip input");
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  std::optional<size_t> DestinationBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, DestinationLayout);
+  VERIFY_IS_TRUE(SourceBytes.has_value() && DestinationBytes.has_value(),
+                 "Unable to size descriptor round-trip buffers");
+
+  std::vector<BYTE> InitialOutput(*DestinationBytes, 0xcd);
+  std::vector<BYTE> Expected = InitialOutput;
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(*Input, DestinationLayout, Expected),
+      "Unable to encode descriptor round-trip expectation");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::exactBufferResult(
+      std::move(Expected), L"Descriptor load/store preserves logical values, "
+                           L"addressing and padding");
+
+  runDescriptorIO(Device, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, SourceAlignment, DestinationAlignment,
+                  *SourceBytes, *DestinationBytes, std::move(InitialOutput),
+                  Oracle, Verbose, ForcedWaveSize);
 }
 
 void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
@@ -1547,7 +1850,251 @@ void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runLoadStoreDescriptor(D3DDevice, DxcSupport, Params, VerboseLogging);
+  const cpu_oracle::MatrixBufferLayout Layout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Layout, Layout,
+                              /*SourceAlignment=*/128,
+                              /*DestinationAlignment=*/128, VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout Target = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/24,
+  };
+  const cpu_oracle::MatrixBufferLayout Canonical = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/16,
+  };
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Target, Canonical,
+                              /*SourceAlignment=*/16,
+                              /*DestinationAlignment=*/128, VerboseLogging,
+                              SelectedWaveSize);
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Canonical, Target,
+                              /*SourceAlignment=*/128,
+                              /*DestinationAlignment=*/16, VerboseLogging,
+                              SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability, L"LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout Target = {
+      LinalgMatrixLayout::ColumnMajor,
+      /*OffsetBytes=*/32,
+      /*StrideBytes=*/16,
+  };
+  const cpu_oracle::MatrixBufferLayout Canonical = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Target, Canonical,
+                              /*SourceAlignment=*/32,
+                              /*DestinationAlignment=*/128, VerboseLogging,
+                              SelectedWaveSize);
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Canonical, Target,
+                              /*SourceAlignment=*/128,
+                              /*DestinationAlignment=*/32, VerboseLogging,
+                              SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::LoadDescriptorBounds_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadDescriptorBounds_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"LoadDescriptorBounds_Wave_4x8_F32"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout SourceLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/32,
+  };
+  const cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  constexpr size_t SourceViewBytes = 128;
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> WholeLoadZero =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> PerElementLoad =
+      Input ? cpu_oracle::makeBoundedReadResult(*Input, SourceLayout,
+                                                SourceViewBytes)
+            : std::nullopt;
+  VERIFY_IS_TRUE(Input.has_value() && WholeLoadZero.has_value() &&
+                     PerElementLoad.has_value(),
+                 "Unable to construct bounded descriptor load expectations");
+
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  std::optional<size_t> DestinationBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, DestinationLayout);
+  VERIFY_IS_TRUE(SourceBytes.has_value() && DestinationBytes.has_value() &&
+                     SourceViewBytes < *SourceBytes,
+                 "Bounded descriptor load must cross the source view end");
+
+  std::vector<BYTE> InitialOutput(*DestinationBytes, 0xcd);
+  std::vector<BYTE> WholeZero = InitialOutput;
+  std::vector<BYTE> PerElement = InitialOutput;
+  VERIFY_IS_TRUE(cpu_oracle::writeMatrixBuffer(*WholeLoadZero,
+                                               DestinationLayout, WholeZero) &&
+                     cpu_oracle::writeMatrixBuffer(
+                         *PerElementLoad, DestinationLayout, PerElement),
+                 "Unable to encode bounded descriptor load candidates");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::permittedBufferResults(
+      {std::move(WholeZero), std::move(PerElement)},
+      L"Descriptor load may zero the whole matrix or only out-of-bounds "
+      L"elements");
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, /*SourceAlignment=*/16,
+                  /*DestinationAlignment=*/128, SourceViewBytes,
+                  *DestinationBytes, std::move(InitialOutput), Oracle,
+                  VerboseLogging, SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::StoreDescriptorBounds_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"StoreDescriptorBounds_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"StoreDescriptorBounds_Wave_4x8_F32"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout SourceLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  const cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/32,
+  };
+  constexpr size_t DestinationViewBytes = 128;
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> InitialMatrix =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value() && InitialMatrix.has_value(),
+                 "Unable to construct bounded descriptor store data");
+  std::optional<std::vector<BYTE>> InitialOutput =
+      cpu_oracle::encodeMatrixBuffer(*InitialMatrix, DestinationLayout, 0xcd);
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  VERIFY_IS_TRUE(
+      InitialOutput.has_value() && SourceBytes.has_value() &&
+          DestinationViewBytes < InitialOutput->size(),
+      "Bounded descriptor store must cross the destination view end");
+
+  std::vector<BYTE> WholeNoOp = *InitialOutput;
+  std::vector<BYTE> PerElementNoOp = *InitialOutput;
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBufferWithinBounds(
+          *Input, DestinationLayout, DestinationViewBytes, PerElementNoOp),
+      "Unable to encode bounded descriptor store candidate");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::permittedBufferResults(
+      {std::move(WholeNoOp), std::move(PerElementNoOp)},
+      L"Descriptor store may suppress the whole operation or only "
+      L"out-of-bounds "
+      L"elements");
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, /*SourceAlignment=*/128,
+                  /*DestinationAlignment=*/16, *SourceBytes,
+                  DestinationViewBytes, std::move(*InitialOutput), Oracle,
+                  VerboseLogging, SelectedWaveSize);
 }
 
 static const char SplatStoreShader[] = R"(
@@ -1612,69 +2159,6 @@ void DxilConf_SM610_LinAlg::SplatStore_Wave_16x16_F16() {
   runSplatStore(D3DDevice, DxcSupport, Params, 42.0f, VerboseLogging);
 }
 
-static const char AccumulateDescriptorShader[] = R"(
-  #define USE_ACC 2
-
-  ByteAddressBuffer Input : register(t0);
-  RWByteAddressBuffer Output : register(u1);
-
-  [WaveSize(4, 64)]
-  [numthreads(NUMTHREADS, 1, 1)]
-  void main() {
-    if (GetGroupWaveIndex() != 0)
-      return;
-
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE)]]
-      Mat;
-    __builtin_LinAlg_MatrixLoadFromDescriptor(
-      Mat, Input, 0, STRIDE, LAYOUT, 128);
-    __builtin_LinAlg_MatrixAccumulateToDescriptor(
-      Mat, Output, 0, STRIDE, LAYOUT, 128);
-    __builtin_LinAlg_MatrixAccumulateToDescriptor(
-      Mat, Output, 0, STRIDE, LAYOUT, 128);
-  }
-)";
-
-static void runAccumulateDescriptor(ID3D12Device *Device,
-                                    dxc::SpecificDllLoader &DxcSupport,
-                                    const MatrixParams &Params, int FillValue,
-                                    bool Verbose) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
-
-  std::string Args = buildCompilerArgs(Params);
-
-  compileShader(DxcSupport, AccumulateDescriptorShader, "cs_6_10", Args,
-                Verbose);
-
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N,
-                                  static_cast<float>(FillValue) * 2, false);
-
-  auto Op = createComputeOp(AccumulateDescriptorShader, "cs_6_10",
-                            "SRV(t0), UAV(u1)", Args.c_str());
-  addSRVBuffer(Op.get(), "Input", BufferSize, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
-
-  auto Result = runShaderOp(
-      Device, DxcSupport, std::move(Op),
-      [NumElements, Params, FillValue](LPCSTR Name, std::vector<BYTE> &Data,
-                                       st::ShaderOp *) {
-        VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType, NumElements,
-                                       /*StartingVal=*/FillValue,
-                                       /*Increment=*/false),
-                       "Saw unsupported component type");
-      });
-
-  MappedData OutData;
-  Result->Test->GetReadBackData("Output", &OutData);
-
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
-}
-
 void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   MatrixParams Params = {};
   Params.CompType = ComponentType::F16;
@@ -1685,14 +2169,112 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging);
+
+  const cpu_oracle::MatrixBufferLayout Layout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N,
+                                       /*StartingValue=*/12,
+                                       /*Increment=*/false);
+  std::optional<cpu_oracle::TypedMatrix> InitialMatrix =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> ExpectedMatrix =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N,
+                                       /*StartingValue=*/24,
+                                       /*Increment=*/false);
+  VERIFY_IS_TRUE(Input.has_value() && InitialMatrix.has_value() &&
+                     ExpectedMatrix.has_value(),
+                 "Unable to construct descriptor accumulation data");
+  std::optional<std::vector<BYTE>> InitialOutput =
+      cpu_oracle::encodeMatrixBuffer(*InitialMatrix, Layout);
+  std::optional<std::vector<BYTE>> Expected =
+      cpu_oracle::encodeMatrixBuffer(*ExpectedMatrix, Layout);
+  VERIFY_IS_TRUE(InitialOutput.has_value() && Expected.has_value(),
+                 "Unable to encode descriptor accumulation buffers");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::exactBufferResult(
+      std::move(*Expected), L"Two descriptor accumulations add the matrix to "
+                            L"each destination element");
+  const size_t BufferSize = InitialOutput->size();
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, Layout, Layout,
+                  /*SourceAlignment=*/128, /*DestinationAlignment=*/128,
+                  BufferSize, BufferSize, std::move(*InitialOutput), Oracle,
+                  VerboseLogging,
+                  /*ForcedWaveSize=*/0, /*AccumulateCount=*/2);
 }
 
-struct MatrixConstructionRequirement {
-  linalg_test::MatrixRole Role;
-  MatrixDim Rows;
-  MatrixDim Columns;
-};
+void DxilConf_SM610_LinAlg::AccumulateDescriptorBounds_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryDescriptorAccumulateSupport(
+      D3DDevice, Params, L"AccumulateDescriptorBounds_Wave_4x8_F32", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"AccumulateDescriptorBounds_Wave_4x8_F32"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout SourceLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  const cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/32,
+  };
+  constexpr size_t DestinationViewBytes = 128;
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> InitialMatrix =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value() && InitialMatrix.has_value(),
+                 "Unable to construct bounded descriptor accumulation data");
+  std::optional<std::vector<BYTE>> InitialOutput =
+      cpu_oracle::encodeMatrixBuffer(*InitialMatrix, DestinationLayout, 0xcd);
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  VERIFY_IS_TRUE(
+      InitialOutput.has_value() && SourceBytes.has_value() &&
+          DestinationViewBytes < InitialOutput->size(),
+      "Bounded descriptor accumulation must cross the destination view end");
+
+  std::vector<BYTE> WholeNoOp = *InitialOutput;
+  std::vector<BYTE> PerElementNoOp = *InitialOutput;
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBufferWithinBounds(
+          *Input, DestinationLayout, DestinationViewBytes, PerElementNoOp),
+      "Unable to encode bounded descriptor accumulation candidate");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::permittedBufferResults(
+      {std::move(WholeNoOp), std::move(PerElementNoOp)},
+      L"Descriptor accumulation may suppress the whole operation or only "
+      L"out-of-bounds elements");
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, /*SourceAlignment=*/128,
+                  /*DestinationAlignment=*/16, *SourceBytes,
+                  DestinationViewBytes, std::move(*InitialOutput), Oracle,
+                  VerboseLogging, SelectedWaveSize,
+                  /*AccumulateCount=*/1);
+}
 
 static LPCWSTR matrixRoleName(linalg_test::MatrixRole Role) {
   switch (Role) {
@@ -1797,6 +2379,47 @@ static HRESULT queryMatrixConstructionSupport(
   hlsl_test::LogCommentFmt(
       L"No MatrixConstruction query within shader WaveSize(4,64) supports %s",
       CaseName);
+  return S_OK;
+}
+
+static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
+                                                const MatrixParams &Params,
+                                                LPCWSTR CaseName,
+                                                bool &Supported,
+                                                UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!CaseName || !linalg_test::isLegalScope(
+                       linalg_test::OperationType::AtomicAccumulateStore,
+                       toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  bool ConstructionSupported;
+  HRESULT HR = queryMatrixConstructionSupport(
+      Device, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}}, CaseName,
+      ConstructionSupported, SelectedWaveSize);
+  if (FAILED(HR) || !ConstructionSupported)
+    return HR;
+
+  std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::AtomicAccumulateStoreSupport AtomicSupport;
+  HR = linalg_test::queryAtomicAccumulateStore(Device, {*DataType},
+                                               AtomicSupport);
+  if (FAILED(HR))
+    return HR;
+
+  Supported = AtomicSupport.supports(
+      linalg_test::AtomicDestination::RWByteAddressBuffer);
+  if (!Supported) {
+    SelectedWaveSize = 0;
+    hlsl_test::LogCommentFmt(
+        L"Atomic descriptor accumulation is unsupported for %s", CaseName);
+  }
   return S_OK;
 }
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4038,7 +4038,7 @@ static const char AccumulateMemoryShader[] = R"(
       __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
 
       __builtin_LinAlg_MatrixAccumulateToMemory(
-        Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+        Mat, GsData, COMP_TYPE, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
     }
 
     GroupMemoryBarrierWithGroupSync();
@@ -4434,7 +4434,7 @@ static const char GroupSharedAccumulateShader[] = R"(
           (ELEM_TYPE)(ACCUMULATE_START + Coord.x * N_DIM + Coord.y));
       }
       __builtin_LinAlg_MatrixAccumulateToMemory(
-        Mat, GsData, MEM_OFFSET, MEM_STRIDE, MEM_LAYOUT);
+        Mat, GsData, COMP_TYPE, MEM_OFFSET, MEM_STRIDE, MEM_LAYOUT);
     }
 
     GroupMemoryBarrierWithGroupSync();

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -752,8 +752,7 @@ makeFilledComponentBuffer(ComponentType CompType, size_t BufferSize,
   if (!Fill.has_value())
     return std::nullopt;
 
-  return encodeMatrixBuffer(*Fill,
-                            {LinalgMatrixLayout::RowMajor, 0, BufferSize});
+  return encodeMatrixBuffer(*Fill, {MatrixLayout::RowMajor, 0, BufferSize});
 }
 
 template <typename T>
@@ -4299,7 +4298,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4318,10 +4317,10 @@ void DxilConf_SM610_LinAlg::
                           L"MatrixConstruction"))
     return;
 
-  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Target = {{MatrixLayout::RowMajor,
                                          /*OffsetBytes=*/8,
                                          /*StrideBytes=*/24}};
-  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Canonical = {{MatrixLayout::RowMajor,
                                             /*OffsetBytes=*/0,
                                             /*StrideBytes=*/16}};
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
@@ -4337,7 +4336,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.Layout = MatrixLayout::ColumnMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -4357,10 +4356,10 @@ void DxilConf_SM610_LinAlg::
           L"MatrixConstruction"))
     return;
 
-  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+  const GroupSharedMemorySpec Target = {{MatrixLayout::ColumnMajor,
                                          /*OffsetBytes=*/16,
                                          /*StrideBytes=*/24}};
-  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Canonical = {{MatrixLayout::RowMajor,
                                             /*OffsetBytes=*/0,
                                             /*StrideBytes=*/32}};
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
@@ -4375,7 +4374,7 @@ void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::ThreadGroup;
-  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.Layout = MatrixLayout::ColumnMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4393,10 +4392,10 @@ void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
           L"LoadStoreMemory_ThreadGroup_4x8_F16 MatrixConstruction"))
     return;
 
-  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+  const GroupSharedMemorySpec Target = {{MatrixLayout::ColumnMajor,
                                          /*OffsetBytes=*/8,
                                          /*StrideBytes=*/12}};
-  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Canonical = {{MatrixLayout::RowMajor,
                                             /*OffsetBytes=*/0,
                                             /*StrideBytes=*/16}};
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
@@ -4533,7 +4532,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4552,7 +4551,7 @@ void DxilConf_SM610_LinAlg::
                           L"AtomicAccumulateStore"))
     return;
 
-  const GroupSharedMemorySpec Memory = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Memory = {{MatrixLayout::RowMajor,
                                          /*OffsetBytes=*/8,
                                          /*StrideBytes=*/24}};
   runGroupSharedAccumulate(D3DDevice, DxcSupport, Params, Memory,


### PR DESCRIPTION
## Summary

- fix the existing group-shared load/store/accumulate shaders so all threads participate in required group barriers and readback writes are race-free
- add exact-wave Wave F16 RowMajor and Wave F32 ColumnMajor transfer coverage with non-zero offsets, padded strides, and full-buffer guards
- add ThreadGroup F16 transfer coverage and capability-gated Wave F16 atomic accumulation with coordinate-derived values
- preserve four typed trailing sentinel elements after every tested matrix extent so over-writes cannot hide at the end of a backing array

Transfer cases run in both directions through a canonical packed RowMajor representation. The accumulation case adds logical values 1..32 to an independently initialized destination and verifies the exact 13..44 result plus untouched offset, padding, and trailing guards.

This PR intentionally covers matching matrix and group-shared component types only. Cross-component conversion remains separate pending runtime triage; expectations were not widened to accept the preview WARP behaviour.

## Validation

- built the Release `ExecHLSLTests` target
- passed all seven group-shared methods, including the three corrected baselines
- passed 18 dependency regressions covering capability policy, the typed CPU oracle, descriptor paths, element access, and CopyConvert
- propagated the correction through the complete stack and reran all 66 LinAlg methods: 61 passed, 0 failed, and the same 5 capability-backed cases skipped
- ran on WARP `1.65535.20-preview`, Agility SDK `1.721.2-preview`, and `ExperimentalShaders=*`
- compiled the changed `LinAlgTests.cpp` directly against the preview D3D12 headers
- clang-format 17.0.1 and `git diff --check` pass

No physical GPU or HLK lab execution is claimed.

## Stack

This draft is stacked on PR #8669, which is stacked on PR #8668, PR #8667, PR #8666, PR #8665, and PR #8662. Until those ancestors land, this diff contains their commits as well.

- implementation: `adf05b09f`
- review correction: `4e1f8844a`

This remains a draft for named human review. The reviewer should verify the barrier uniformity, bidirectional layout oracle, exact-wave applicability, coordinate-derived atomic expectation, and explicit trailing guards before requesting maintainer review.

Refs #7841
Refs #8651
Refs #8652
Refs #8654
Refs #8548
Refs #8554
Refs #8562

Assisted-by: GitHub Copilot

Closes #8689
