### PR TITLE
[HLSL] Add LinAlg OuterProduct and VectorAccumulate coverage

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -121,8 +121,66 @@ static_assert(
         D3D12_FEATURE_LINEAR_ALGEBRA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT) ==
         static_cast<UINT>(LinearAlgebraOperationSupportFeature),
     "Linear algebra operation feature ID changed");
-static_assert(static_cast<UINT>(D3D12_LINEAR_ALGEBRA_TIER_1_0) == 0x10,
-              "Linear algebra tier ABI changed");
+
+#define ASSERT_RUNTIME_ENUM(RuntimeValue, D3DValue)                            \
+  static_assert(static_cast<UINT>(RuntimeValue) ==                             \
+                    static_cast<UINT>(D3DValue),                               \
+                "Linear algebra runtime enum value changed")
+
+ASSERT_RUNTIME_ENUM(linalg_test::Tier::NotSupported,
+                    D3D12_LINEAR_ALGEBRA_TIER_NOT_SUPPORTED);
+ASSERT_RUNTIME_ENUM(linalg_test::Tier::Tier1_0, D3D12_LINEAR_ALGEBRA_TIER_1_0);
+static_assert(static_cast<UINT>(linalg_test::DataType::None) == 0,
+              "Linear algebra no-bias datatype value changed");
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::SInt16,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_SINT16);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::UInt16,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_UINT16);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::SInt32,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_SINT32);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::UInt32,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_UINT32);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float16,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float32,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::SInt8,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_SINT8);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::UInt8,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_UINT8);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float8E4M3FN,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT8_E4M3FN);
+ASSERT_RUNTIME_ENUM(linalg_test::DataType::Float8E5M2,
+                    D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT8_E5M2);
+ASSERT_RUNTIME_ENUM(linalg_test::OperationType::MatrixConstruction,
+                    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_MATRIX_CONSTRUCTION);
+ASSERT_RUNTIME_ENUM(linalg_test::OperationType::WaveMatrixMultiply,
+                    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_WAVE_MATRIX_MULTIPLY);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::OperationType::ThreadGroupMatrixMultiply,
+    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_THREADGROUP_MATRIX_MULTIPLY);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::OperationType::ThreadVectorMatrixMultiply,
+    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_THREAD_VECTOR_MATRIX_MULTIPLY);
+ASSERT_RUNTIME_ENUM(linalg_test::OperationType::ThreadOuterProduct,
+                    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_THREAD_OUTER_PRODUCT);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::OperationType::AtomicAccumulateStore,
+    D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_ATOMIC_ACCUMULATE_STORE);
+ASSERT_RUNTIME_ENUM(linalg_test::MultiplicationFlags::None,
+                    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_NONE);
+ASSERT_RUNTIME_ENUM(linalg_test::MultiplicationFlags::Supported,
+                    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_SUPPORTED);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::MultiplicationFlags::EmulatedInputs,
+    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_EMULATED_INPUTS);
+ASSERT_RUNTIME_ENUM(
+    linalg_test::MultiplicationFlags::EmulatedOutputs,
+    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_EMULATED_OUTPUTS);
+ASSERT_RUNTIME_ENUM(linalg_test::MultiplicationFlags::Transpose,
+                    D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_TRANSPOSE);
+
+#undef ASSERT_RUNTIME_ENUM
 
 #define ASSERT_RUNTIME_ABI(RuntimeType, D3DType)                               \
   static_assert(sizeof(RuntimeType) == sizeof(D3DType),                        \
@@ -158,43 +216,171 @@ ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraOperationSupport,
                     offsetof(D3DType, D3DField),                               \
                 "Linear algebra runtime ABI field offset changed")
 
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, ComponentType,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
-                      ComponentType);
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, MinN,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT, MinN);
-ASSERT_RUNTIME_OFFSET(RuntimeWaveMatrixMultiplySupport, Shapes,
-                      D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
-                      Shapes);
-ASSERT_RUNTIME_OFFSET(RuntimeThreadGroupMatrixMultiplySupport,
-                      PreferredThreadGroupSize,
-                      D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
-                      PreferredThreadGroupSize);
-ASSERT_RUNTIME_OFFSET(
-    RuntimeThreadVectorMatrixMultiplySupport, SupportFlags,
+#define ASSERT_RUNTIME_OFFSET_SAME(RuntimeType, D3DType, Field)                \
+  ASSERT_RUNTIME_OFFSET(RuntimeType, Field, D3DType, Field)
+
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeLinearAlgebraTierSupport,
+                           D3D12_FEATURE_DATA_LINEAR_ALGEBRA_SUPPORT,
+                           LinearAlgebraTier);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           ComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           WaveSize);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           MinM);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           MinK);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConstructionSupport,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                           MinN);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixMultiplyShape,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE, M);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixMultiplyShape,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE, K);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixMultiplyShape,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE, N);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           WaveSize);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           MatrixAComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           MatrixBComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplyInputs,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS,
+                           AccumulatorComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           Inputs);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           SupportFlags);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           NumShapes);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeWaveMatrixMultiplySupport,
+                           D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                           Shapes);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT, WaveInputs);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT, Shape);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT, SupportFlags);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+    MinThreadGroupSize);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+    MaxThreadGroupSize);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadGroupMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+    PreferredThreadGroupSize);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT,
+    VectorInputType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT,
+    MatrixInputType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT, BiasInputType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT,
+    VectorResultType);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeThreadVectorMatrixMultiplySupport,
     D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT, SupportFlags);
-ASSERT_RUNTIME_OFFSET(RuntimeThreadOuterProductSupport, Supported,
-                      D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
-                      Supported);
-ASSERT_RUNTIME_OFFSET(RuntimeAtomicAccumulateStoreSupport, GroupSharedSupported,
-                      D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
-                      GroupSharedSupported);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeThreadOuterProductSupport,
+                           D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                           InputComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeThreadOuterProductSupport,
+                           D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                           ResultComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeThreadOuterProductSupport,
+                           D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                           Supported);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeAtomicAccumulateStoreSupport,
+                           D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                           ComponentType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeAtomicAccumulateStoreSupport,
+                           D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                           RWByteAddressBufferSupported);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeAtomicAccumulateStoreSupport,
+                           D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                           GroupSharedSupported);
+ASSERT_RUNTIME_OFFSET_SAME(
+    RuntimeLinearAlgebraOperationSupport,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT, OperationType);
 ASSERT_RUNTIME_OFFSET(
     RuntimeLinearAlgebraOperationSupport, MatrixConstruction,
     D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
     MatrixConstruction);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, WaveMatrixMultiply,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    WaveMatrixMultiply);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, ThreadGroupMatrixMultiply,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    ThreadGroupMatrixMultiply);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, ThreadVectorMatrixMultiply,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    ThreadVectorMatrixMultiply);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, ThreadOuterProduct,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    ThreadOuterProductSupport);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, AccumulateStore,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    AccumulateStore);
 
+#undef ASSERT_RUNTIME_OFFSET_SAME
 #undef ASSERT_RUNTIME_OFFSET
 #endif
 
 constexpr UINT KnownMultiplicationFlags = 0xf;
+constexpr UINT MatrixMultiplicationFlags =
+    static_cast<UINT>(linalg_test::MultiplicationFlags::Supported) |
+    static_cast<UINT>(linalg_test::MultiplicationFlags::EmulatedOutputs);
 
-bool isValidMultiplicationFlags(UINT Flags) {
-  if ((Flags & ~KnownMultiplicationFlags) != 0)
+bool isValidMultiplicationFlags(UINT Flags, UINT AllowedFlags) {
+  if ((Flags & ~AllowedFlags) != 0)
     return false;
   return Flags == 0 ||
          (Flags &
           static_cast<UINT>(linalg_test::MultiplicationFlags::Supported)) != 0;
+}
+
+bool isFloat8DataType(linalg_test::DataType Type) {
+  return Type == linalg_test::DataType::Float8E4M3FN ||
+         Type == linalg_test::DataType::Float8E5M2;
+}
+
+bool isValidThreadVectorMultiplicationFlags(
+    UINT Flags, linalg_test::DataType MatrixInputType) {
+  if (!isValidMultiplicationFlags(Flags, KnownMultiplicationFlags))
+    return false;
+  const UINT EmulatedInputs =
+      static_cast<UINT>(linalg_test::MultiplicationFlags::EmulatedInputs);
+  return (Flags & EmulatedInputs) == 0 || isFloat8DataType(MatrixInputType);
 }
 
 LPCWSTR dataTypeName(linalg_test::DataType Type) {
@@ -1009,7 +1195,8 @@ bool hasFlag(MultiplicationFlags Value, MultiplicationFlags Flag) {
 }
 
 bool WaveMatrixMultiplySupport::valid() const {
-  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags),
+                                  MatrixMultiplicationFlags))
     return false;
   if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
     return Shapes.empty();
@@ -1042,7 +1229,8 @@ bool ThreadGroupMatrixMultiplySupport::supported() const {
 }
 
 bool ThreadGroupMatrixMultiplySupport::valid() const {
-  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags),
+                                  MatrixMultiplicationFlags))
     return false;
   if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
     return true;
@@ -1067,7 +1255,8 @@ bool ThreadVectorMatrixMultiplySupport::supported() const {
 }
 
 bool ThreadVectorMatrixMultiplySupport::valid() const {
-  return isValidMultiplicationFlags(static_cast<UINT>(SupportFlags));
+  return isValidThreadVectorMultiplicationFlags(static_cast<UINT>(SupportFlags),
+                                                MatrixInputType);
 }
 
 bool AtomicAccumulateStoreSupport::supports(
@@ -1221,7 +1410,8 @@ HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
   }
 
   if (!isValidMultiplicationFlags(
-          RuntimeSupport.WaveMatrixMultiply.SupportFlags)) {
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags,
+          MatrixMultiplicationFlags)) {
     LogCommentFmt(L"WaveMatrixMultiply query returned invalid flags: 0x%x",
                   RuntimeSupport.WaveMatrixMultiply.SupportFlags);
     return E_UNEXPECTED;
@@ -1275,7 +1465,8 @@ HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
   }
 
   if (!isValidMultiplicationFlags(
-          RuntimeSupport.WaveMatrixMultiply.SupportFlags) ||
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags,
+          MatrixMultiplicationFlags) ||
       (RuntimeSupport.WaveMatrixMultiply.SupportFlags &
        static_cast<UINT>(MultiplicationFlags::Supported)) == 0 ||
       RuntimeSupport.WaveMatrixMultiply.NumShapes == 0 ||
@@ -1352,7 +1543,7 @@ queryThreadGroupMatrixMultiply(ID3D12Device *Device,
   }
 
   const UINT Flags = RuntimeSupport.ThreadGroupMatrixMultiply.SupportFlags;
-  if (!isValidMultiplicationFlags(Flags)) {
+  if (!isValidMultiplicationFlags(Flags, MatrixMultiplicationFlags)) {
     LogCommentFmt(
         L"ThreadGroupMatrixMultiply query returned invalid flags: 0x%x", Flags);
     return E_UNEXPECTED;
@@ -1428,7 +1619,7 @@ queryThreadVectorMatrixMultiply(ID3D12Device *Device,
   }
 
   const UINT Flags = RuntimeSupport.ThreadVectorMatrixMultiply.SupportFlags;
-  if (!isValidMultiplicationFlags(Flags)) {
+  if (!isValidThreadVectorMultiplicationFlags(Flags, Query.MatrixInputType)) {
     LogCommentFmt(
         L"ThreadVectorMatrixMultiply query returned invalid flags: 0x%x",
         Flags);
@@ -1436,6 +1627,7 @@ queryThreadVectorMatrixMultiply(ID3D12Device *Device,
   }
 
   Support.SupportFlags = static_cast<MultiplicationFlags>(Flags);
+  Support.MatrixInputType = Query.MatrixInputType;
   LogCommentFmt(
       L"ThreadVectorMatrixMultiply query: vector=%s, matrix=%s, bias=%s, "
       L"result=%s, flags=0x%x",

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -411,14 +411,49 @@ ASSERT_RUNTIME_OFFSET(
     RuntimeLinearAlgebraOperationSupport, AccumulateStore,
     D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
     AccumulateStore);
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConversionDestInfo, DestDataType,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
-                      DestDataType);
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConversionSrcInfo, SrcStride,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO,
-                      SrcStride);
-ASSERT_RUNTIME_OFFSET(RuntimeMatrixConversionInfo, DataDesc,
-                      D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO, DataDesc);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionDestInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                           DestSize);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionDestInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                           DestLayout);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionDestInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                           DestStride);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionDestInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                           NumRows);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionDestInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                           NumColumns);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionDestInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                           DestDataType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionData,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DATA, DestVA);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionData,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DATA, SrcVA);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionSrcInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO,
+                           SrcSize);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionSrcInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO,
+                           SrcDataType);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionSrcInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO,
+                           SrcLayout);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionSrcInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO,
+                           SrcStride);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO,
+                           DestInfo);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO,
+                           SrcInfo);
+ASSERT_RUNTIME_OFFSET_SAME(RuntimeMatrixConversionInfo,
+                           D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO,
+                           DataDesc);
 
 #undef ASSERT_RUNTIME_OFFSET_SAME
 #undef ASSERT_RUNTIME_OFFSET

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -11,6 +11,7 @@
 #include <d3d12.h>
 #include <dxgi1_4.h>
 #include <filesystem>
+#include <limits>
 #include <optional>
 
 // D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
@@ -1802,6 +1803,76 @@ void addSRVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
   Res.TransitionTo = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
 
   Op->Resources.push_back(Res);
+}
+
+void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
+                                 const char *HeapName,
+                                 std::initializer_list<RawBufferView> Views) {
+  if (!Op || !HeapName || Views.size() == 0 ||
+      Views.size() > (std::numeric_limits<UINT>::max)()) {
+    VERIFY_IS_TRUE(false, "Invalid raw buffer descriptor table");
+    return;
+  }
+
+  st::ShaderOpDescriptorHeap Heap = {};
+  Heap.Name = Op->Strings.insert(HeapName);
+  Heap.Desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+  Heap.Desc.NumDescriptors = static_cast<UINT>(Views.size());
+  Heap.Desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+
+  for (const RawBufferView &View : Views) {
+    st::ShaderOpResource *Resource =
+        View.ResourceName ? Op->GetResourceByName(View.ResourceName) : nullptr;
+    const bool Valid =
+        View.DescriptorName && View.ResourceName && View.NumBytes != 0 &&
+        Resource &&
+        (View.Kind == RawBufferViewKind::SRV ||
+         View.Kind == RawBufferViewKind::UAV) &&
+        View.FirstByte % sizeof(UINT32) == 0 &&
+        View.NumBytes % sizeof(UINT32) == 0 &&
+        View.FirstByte / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
+        View.NumBytes / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
+        View.FirstByte <= Resource->Desc.Width &&
+        View.NumBytes <= Resource->Desc.Width - View.FirstByte;
+    if (!Valid) {
+      VERIFY_IS_TRUE(false, "Invalid raw buffer descriptor");
+      return;
+    }
+
+    st::ShaderOpDescriptor Descriptor = {};
+    Descriptor.Name = Op->Strings.insert(View.DescriptorName);
+    Descriptor.ResName = Op->Strings.insert(View.ResourceName);
+    if (View.Kind == RawBufferViewKind::SRV) {
+      Descriptor.Kind = Op->Strings.insert("SRV");
+      Descriptor.SrvDescPresent = true;
+      Descriptor.SrvDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+      Descriptor.SrvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+      Descriptor.SrvDesc.Shader4ComponentMapping =
+          D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+      Descriptor.SrvDesc.Buffer.FirstElement =
+          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.SrvDesc.Buffer.NumElements =
+          static_cast<UINT>(View.NumBytes / sizeof(UINT32));
+      Descriptor.SrvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
+    } else {
+      Descriptor.Kind = Op->Strings.insert("UAV");
+      Descriptor.UavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+      Descriptor.UavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+      Descriptor.UavDesc.Buffer.FirstElement =
+          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.UavDesc.Buffer.NumElements =
+          static_cast<UINT>(View.NumBytes / sizeof(UINT32));
+      Descriptor.UavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;
+    }
+    Heap.Descriptors.push_back(Descriptor);
+  }
+
+  Op->DescriptorHeaps.push_back(std::move(Heap));
+
+  st::ShaderOpRootValue RootValue = {};
+  RootValue.HeapName = Op->Strings.insert(HeapName);
+  RootValue.Index = RootIndex;
+  Op->RootValues.push_back(RootValue);
 }
 
 void addRootView(st::ShaderOp *Op, UINT Index, const char *ResName) {

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -1809,9 +1809,46 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
                                  const char *HeapName,
                                  std::initializer_list<RawBufferView> Views) {
   if (!Op || !HeapName || Views.size() == 0 ||
-      Views.size() > (std::numeric_limits<UINT>::max)()) {
+      Views.size() > (std::numeric_limits<UINT>::max)() ||
+      Op->RootValues.size() > (std::numeric_limits<UINT>::max)()) {
     VERIFY_IS_TRUE(false, "Invalid raw buffer descriptor table");
     return;
+  }
+
+  for (const st::ShaderOpDescriptorHeap &ExistingHeap : Op->DescriptorHeaps) {
+    const bool DuplicateName =
+        ExistingHeap.Name && _stricmp(ExistingHeap.Name, HeapName) == 0;
+    const bool ConflictingVisibleHeap =
+        ExistingHeap.Desc.Type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV &&
+        (ExistingHeap.Desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) !=
+            0;
+    if (DuplicateName || ConflictingVisibleHeap) {
+      VERIFY_IS_TRUE(false, "Conflicting raw buffer descriptor table");
+      return;
+    }
+  }
+
+  if (RootIndex == 0 && !Op->RootValues.empty()) {
+    VERIFY_IS_TRUE(false, "Root parameter zero must be the first root value");
+    return;
+  }
+  for (size_t I = 0; I < Op->RootValues.size(); ++I) {
+    const st::ShaderOpRootValue &ExistingRoot = Op->RootValues[I];
+    const UINT ExistingIndex =
+        ExistingRoot.Index == 0 ? static_cast<UINT>(I) : ExistingRoot.Index;
+    if (ExistingIndex == RootIndex) {
+      VERIFY_IS_TRUE(false, "Duplicate root parameter index");
+      return;
+    }
+    for (size_t J = 0; J < I; ++J) {
+      const st::ShaderOpRootValue &PreviousRoot = Op->RootValues[J];
+      const UINT PreviousIndex =
+          PreviousRoot.Index == 0 ? static_cast<UINT>(J) : PreviousRoot.Index;
+      if (ExistingIndex == PreviousIndex) {
+        VERIFY_IS_TRUE(false, "Duplicate root parameter index");
+        return;
+      }
+    }
   }
 
   st::ShaderOpDescriptorHeap Heap = {};
@@ -1826,11 +1863,17 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
     const bool Valid =
         View.DescriptorName && View.ResourceName && View.NumBytes != 0 &&
         Resource &&
+        Resource->Desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
         (View.Kind == RawBufferViewKind::SRV ||
          View.Kind == RawBufferViewKind::UAV) &&
-        View.FirstByte % sizeof(UINT32) == 0 &&
+        (View.Kind != RawBufferViewKind::SRV ||
+         (Resource->Desc.Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE) ==
+             0) &&
+        (View.Kind != RawBufferViewKind::UAV ||
+         (Resource->Desc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) !=
+             0) &&
+        View.FirstByte % D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT == 0 &&
         View.NumBytes % sizeof(UINT32) == 0 &&
-        View.FirstByte / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
         View.NumBytes / sizeof(UINT32) <= (std::numeric_limits<UINT>::max)() &&
         View.FirstByte <= Resource->Desc.Width &&
         View.NumBytes <= Resource->Desc.Width - View.FirstByte;
@@ -1849,8 +1892,7 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
       Descriptor.SrvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
       Descriptor.SrvDesc.Shader4ComponentMapping =
           D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-      Descriptor.SrvDesc.Buffer.FirstElement =
-          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.SrvDesc.Buffer.FirstElement = View.FirstByte / sizeof(UINT32);
       Descriptor.SrvDesc.Buffer.NumElements =
           static_cast<UINT>(View.NumBytes / sizeof(UINT32));
       Descriptor.SrvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
@@ -1858,8 +1900,7 @@ void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
       Descriptor.Kind = Op->Strings.insert("UAV");
       Descriptor.UavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
       Descriptor.UavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-      Descriptor.UavDesc.Buffer.FirstElement =
-          static_cast<UINT>(View.FirstByte / sizeof(UINT32));
+      Descriptor.UavDesc.Buffer.FirstElement = View.FirstByte / sizeof(UINT32);
       Descriptor.UavDesc.Buffer.NumElements =
           static_cast<UINT>(View.NumBytes / sizeof(UINT32));
       Descriptor.UavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -113,6 +113,57 @@ struct RuntimeLinearAlgebraOperationSupport {
   };
 };
 
+struct RuntimeMatrixConversionDestInfo {
+  UINT DestSize;
+  UINT DestLayout;
+  UINT DestStride;
+  UINT NumRows;
+  UINT NumColumns;
+  UINT DestDataType;
+};
+
+struct RuntimeMatrixConversionData {
+  D3D12_GPU_VIRTUAL_ADDRESS DestVA;
+  D3D12_GPU_VIRTUAL_ADDRESS SrcVA;
+};
+
+struct RuntimeMatrixConversionSrcInfo {
+  UINT SrcSize;
+  UINT SrcDataType;
+  UINT SrcLayout;
+  UINT SrcStride;
+};
+
+struct RuntimeMatrixConversionInfo {
+  RuntimeMatrixConversionDestInfo DestInfo;
+  RuntimeMatrixConversionSrcInfo SrcInfo;
+  RuntimeMatrixConversionData DataDesc;
+};
+
+MIDL_INTERFACE("8f0856ad-e37c-4d75-be18-fbb3d8c04ced")
+RuntimeD3D12DevicePreview : public IUnknown {
+public:
+  virtual void STDMETHODCALLTYPE
+      GetLinearAlgebraMatrixConversionDestinationInfo(
+          RuntimeMatrixConversionDestInfo * Desc) = 0;
+};
+
+MIDL_INTERFACE("447e915c-c6f9-47e8-84d9-dc4f4495d230")
+RuntimeD3D12GraphicsCommandListPreview : public ID3D12GraphicsCommandList10 {
+public:
+  virtual void STDMETHODCALLTYPE WaitBarrier(
+      UINT NumBarrierGroups, const D3D12_BARRIER_GROUP *BarrierGroups,
+      UINT NumFences, ID3D12Fence *const *Fences,
+      const UINT64 *FenceValues) = 0;
+  virtual void STDMETHODCALLTYPE SignalBarrier(
+      UINT NumBarrierGroups, const D3D12_BARRIER_GROUP *BarrierGroups,
+      ID3D12Fence *Fence, UINT64 FenceValue) = 0;
+  virtual void STDMETHODCALLTYPE SetWorkGraphMaximumGPUInputRecords(
+      UINT MaxRecords, UINT MaxNodeInputs) = 0;
+  virtual void STDMETHODCALLTYPE ConvertLinearAlgebraMatrix(
+      const RuntimeMatrixConversionInfo *Desc, UINT DescCount) = 0;
+};
+
 #if defined(DIRECT3D_LINEAR_ALGEBRA)
 static_assert(static_cast<UINT>(D3D12_FEATURE_LINEAR_ALGEBRA_SUPPORT) ==
                   static_cast<UINT>(LinearAlgebraSupportFeature),
@@ -209,6 +260,14 @@ ASSERT_RUNTIME_ABI(RuntimeAtomicAccumulateStoreSupport,
                    D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT);
 ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraOperationSupport,
                    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeMatrixConversionDestInfo,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO);
+ASSERT_RUNTIME_ABI(RuntimeMatrixConversionData,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DATA);
+ASSERT_RUNTIME_ABI(RuntimeMatrixConversionSrcInfo,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO);
+ASSERT_RUNTIME_ABI(RuntimeMatrixConversionInfo,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO);
 
 #undef ASSERT_RUNTIME_ABI
 
@@ -352,9 +411,34 @@ ASSERT_RUNTIME_OFFSET(
     RuntimeLinearAlgebraOperationSupport, AccumulateStore,
     D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
     AccumulateStore);
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConversionDestInfo, DestDataType,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO,
+                      DestDataType);
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConversionSrcInfo, SrcStride,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_SRC_INFO,
+                      SrcStride);
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConversionInfo, DataDesc,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO, DataDesc);
 
 #undef ASSERT_RUNTIME_OFFSET_SAME
 #undef ASSERT_RUNTIME_OFFSET
+
+static_assert(static_cast<UINT>(D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR) ==
+                  static_cast<UINT>(linalg_test::MatrixLayout::RowMajor),
+              "Linear algebra RowMajor layout ABI changed");
+static_assert(
+    static_cast<UINT>(D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_COLUMN_MAJOR) ==
+        static_cast<UINT>(linalg_test::MatrixLayout::ColumnMajor),
+    "Linear algebra ColumnMajor layout ABI changed");
+static_assert(
+    static_cast<UINT>(D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_MUL_OPTIMAL) ==
+        static_cast<UINT>(linalg_test::MatrixLayout::MulOptimal),
+    "Linear algebra MulOptimal layout ABI changed");
+static_assert(
+    static_cast<UINT>(
+        D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL) ==
+        static_cast<UINT>(linalg_test::MatrixLayout::OuterProductOptimal),
+    "Linear algebra OuterProductOptimal layout ABI changed");
 #endif
 
 constexpr UINT KnownMultiplicationFlags = 0xf;
@@ -2002,22 +2086,19 @@ void compileShader(dxc::SpecificDllLoader &DxcSupport, const char *Source,
   }
 }
 
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
 UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
-                             UINT NumColumns,
-                             D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
-                             D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT Layout,
-                             UINT Stride) {
-  CComPtr<ID3D12DevicePreview> DevicePreview;
+                             UINT NumColumns, linalg_test::DataType DataType,
+                             linalg_test::MatrixLayout Layout, UINT Stride) {
+  CComPtr<RuntimeD3D12DevicePreview> DevicePreview;
   VERIFY_SUCCEEDED(Device->QueryInterface(IID_PPV_ARGS(&DevicePreview)));
 
-  D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO Info = {};
+  RuntimeMatrixConversionDestInfo Info = {};
   Info.DestSize = 0;
-  Info.DestLayout = Layout;
+  Info.DestLayout = static_cast<UINT>(Layout);
   Info.DestStride = Stride;
   Info.NumRows = NumRows;
   Info.NumColumns = NumColumns;
-  Info.DestDataType = DataType;
+  Info.DestDataType = static_cast<UINT>(DataType);
   DevicePreview->GetLinearAlgebraMatrixConversionDestinationInfo(&Info);
   return Info.DestSize;
 }
@@ -2025,10 +2106,9 @@ UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
 void recordLinAlgMatrixConversion(
     ID3D12GraphicsCommandList *List, ID3D12Resource *SrcBuffer, UINT SrcSize,
     ID3D12Resource *DestBuffer, UINT DestSize, UINT NumRows, UINT NumColumns,
-    D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
-    D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT SrcLayout, UINT SrcStride,
-    D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT DestLayout, UINT DestStride) {
-  CComPtr<ID3D12GraphicsCommandListPreview> PreviewList;
+    linalg_test::DataType DataType, linalg_test::MatrixLayout SrcLayout,
+    UINT SrcStride, linalg_test::MatrixLayout DestLayout, UINT DestStride) {
+  CComPtr<RuntimeD3D12GraphicsCommandListPreview> PreviewList;
   VERIFY_SUCCEEDED(List->QueryInterface(IID_PPV_ARGS(&PreviewList)));
 
   // Per the linear-algebra spec, ConvertLinearAlgebraMatrix (legacy barriers)
@@ -2045,19 +2125,18 @@ void recordLinAlgMatrixConversion(
       D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
   List->ResourceBarrier(1, &Barrier);
 
-  D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_INFO Info = {};
+  RuntimeMatrixConversionInfo Info = {};
   Info.DestInfo.DestSize = DestSize;
-  Info.DestInfo.DestLayout = DestLayout;
+  Info.DestInfo.DestLayout = static_cast<UINT>(DestLayout);
   Info.DestInfo.DestStride = DestStride;
   Info.DestInfo.NumRows = NumRows;
   Info.DestInfo.NumColumns = NumColumns;
-  Info.DestInfo.DestDataType = DataType;
+  Info.DestInfo.DestDataType = static_cast<UINT>(DataType);
   Info.SrcInfo.SrcSize = SrcSize;
-  Info.SrcInfo.SrcDataType = DataType;
-  Info.SrcInfo.SrcLayout = SrcLayout;
+  Info.SrcInfo.SrcDataType = static_cast<UINT>(DataType);
+  Info.SrcInfo.SrcLayout = static_cast<UINT>(SrcLayout);
   Info.SrcInfo.SrcStride = SrcStride;
   Info.DataDesc.DestVA = DestBuffer->GetGPUVirtualAddress();
   Info.DataDesc.SrcVA = SrcBuffer->GetGPUVirtualAddress();
   PreviewList->ConvertLinearAlgebraMatrix(&Info, 1);
 }
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -7,6 +7,7 @@
 
 #include <Verify.h>
 #include <atlcomcli.h>
+#include <cstddef>
 #include <d3d12.h>
 #include <dxgi1_4.h>
 #include <filesystem>
@@ -30,6 +31,213 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
 } D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW;
 
 #endif
+
+namespace {
+
+constexpr D3D12_FEATURE LinearAlgebraSupportFeature =
+    static_cast<D3D12_FEATURE>(77);
+constexpr D3D12_FEATURE LinearAlgebraOperationSupportFeature =
+    static_cast<D3D12_FEATURE>(78);
+
+struct RuntimeLinearAlgebraTierSupport {
+  UINT LinearAlgebraTier;
+};
+
+struct RuntimeMatrixConstructionSupport {
+  UINT ComponentType;
+  UINT WaveSize;
+  UINT MinM;
+  UINT MinK;
+  UINT MinN;
+};
+
+struct RuntimeMatrixMultiplyShape {
+  UINT M;
+  UINT K;
+  UINT N;
+};
+
+struct RuntimeWaveMatrixMultiplyInputs {
+  UINT WaveSize;
+  UINT MatrixAComponentType;
+  UINT MatrixBComponentType;
+  UINT AccumulatorComponentType;
+};
+
+struct RuntimeWaveMatrixMultiplySupport {
+  RuntimeWaveMatrixMultiplyInputs Inputs;
+  UINT SupportFlags;
+  UINT NumShapes;
+  RuntimeMatrixMultiplyShape *Shapes;
+};
+
+struct RuntimeThreadGroupMatrixMultiplySupport {
+  RuntimeWaveMatrixMultiplyInputs WaveInputs;
+  RuntimeMatrixMultiplyShape Shape;
+  UINT SupportFlags;
+  UINT MinThreadGroupSize;
+  UINT MaxThreadGroupSize;
+  UINT PreferredThreadGroupSize;
+};
+
+struct RuntimeThreadVectorMatrixMultiplySupport {
+  UINT VectorInputType;
+  UINT MatrixInputType;
+  UINT BiasInputType;
+  UINT VectorResultType;
+  UINT SupportFlags;
+};
+
+struct RuntimeThreadOuterProductSupport {
+  UINT InputComponentType;
+  UINT ResultComponentType;
+  BOOL Supported;
+};
+
+struct RuntimeAtomicAccumulateStoreSupport {
+  UINT ComponentType;
+  BOOL RWByteAddressBufferSupported;
+  BOOL GroupSharedSupported;
+};
+
+struct RuntimeLinearAlgebraOperationSupport {
+  UINT OperationType;
+  union {
+    RuntimeMatrixConstructionSupport MatrixConstruction;
+    RuntimeWaveMatrixMultiplySupport WaveMatrixMultiply;
+    RuntimeThreadGroupMatrixMultiplySupport ThreadGroupMatrixMultiply;
+    RuntimeThreadVectorMatrixMultiplySupport ThreadVectorMatrixMultiply;
+    RuntimeThreadOuterProductSupport ThreadOuterProduct;
+    RuntimeAtomicAccumulateStoreSupport AccumulateStore;
+  };
+};
+
+#if defined(DIRECT3D_LINEAR_ALGEBRA)
+static_assert(static_cast<UINT>(D3D12_FEATURE_LINEAR_ALGEBRA_SUPPORT) ==
+                  static_cast<UINT>(LinearAlgebraSupportFeature),
+              "Linear algebra tier feature ID changed");
+static_assert(
+    static_cast<UINT>(
+        D3D12_FEATURE_LINEAR_ALGEBRA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT) ==
+        static_cast<UINT>(LinearAlgebraOperationSupportFeature),
+    "Linear algebra operation feature ID changed");
+static_assert(static_cast<UINT>(D3D12_LINEAR_ALGEBRA_TIER_1_0) == 0x10,
+              "Linear algebra tier ABI changed");
+
+#define ASSERT_RUNTIME_ABI(RuntimeType, D3DType)                               \
+  static_assert(sizeof(RuntimeType) == sizeof(D3DType),                        \
+                "Linear algebra runtime ABI size changed");                    \
+  static_assert(alignof(RuntimeType) == alignof(D3DType),                      \
+                "Linear algebra runtime ABI alignment changed")
+
+ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraTierSupport,
+                   D3D12_FEATURE_DATA_LINEAR_ALGEBRA_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeMatrixConstructionSupport,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeMatrixMultiplyShape,
+                   D3D12_LINEAR_ALGEBRA_MATRIX_MULTIPLY_SHAPE);
+ASSERT_RUNTIME_ABI(RuntimeWaveMatrixMultiplyInputs,
+                   D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS);
+ASSERT_RUNTIME_ABI(RuntimeWaveMatrixMultiplySupport,
+                   D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeThreadGroupMatrixMultiplySupport,
+                   D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeThreadVectorMatrixMultiplySupport,
+                   D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeThreadOuterProductSupport,
+                   D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeAtomicAccumulateStoreSupport,
+                   D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT);
+ASSERT_RUNTIME_ABI(RuntimeLinearAlgebraOperationSupport,
+                   D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT);
+
+#undef ASSERT_RUNTIME_ABI
+
+#define ASSERT_RUNTIME_OFFSET(RuntimeType, RuntimeField, D3DType, D3DField)    \
+  static_assert(offsetof(RuntimeType, RuntimeField) ==                         \
+                    offsetof(D3DType, D3DField),                               \
+                "Linear algebra runtime ABI field offset changed")
+
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, ComponentType,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT,
+                      ComponentType);
+ASSERT_RUNTIME_OFFSET(RuntimeMatrixConstructionSupport, MinN,
+                      D3D12_LINEAR_ALGEBRA_MATRIX_CONSTRUCTION_SUPPORT, MinN);
+ASSERT_RUNTIME_OFFSET(RuntimeWaveMatrixMultiplySupport, Shapes,
+                      D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_SUPPORT,
+                      Shapes);
+ASSERT_RUNTIME_OFFSET(RuntimeThreadGroupMatrixMultiplySupport,
+                      PreferredThreadGroupSize,
+                      D3D12_LINEAR_ALGEBRA_THREADGROUP_MATRIX_MULTIPLY_SUPPORT,
+                      PreferredThreadGroupSize);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeThreadVectorMatrixMultiplySupport, SupportFlags,
+    D3D12_LINEAR_ALGEBRA_THREAD_VECTOR_MATRIX_MULTIPLY_SUPPORT, SupportFlags);
+ASSERT_RUNTIME_OFFSET(RuntimeThreadOuterProductSupport, Supported,
+                      D3D12_LINEAR_ALGEBRA_THREAD_OUTER_PRODUCT_SUPPORT,
+                      Supported);
+ASSERT_RUNTIME_OFFSET(RuntimeAtomicAccumulateStoreSupport, GroupSharedSupported,
+                      D3D12_LINEAR_ALGEBRA_ATOMIC_ACCUMULATE_STORE_SUPPORT,
+                      GroupSharedSupported);
+ASSERT_RUNTIME_OFFSET(
+    RuntimeLinearAlgebraOperationSupport, MatrixConstruction,
+    D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT,
+    MatrixConstruction);
+
+#undef ASSERT_RUNTIME_OFFSET
+#endif
+
+constexpr UINT KnownMultiplicationFlags = 0xf;
+
+bool isValidMultiplicationFlags(UINT Flags) {
+  if ((Flags & ~KnownMultiplicationFlags) != 0)
+    return false;
+  return Flags == 0 ||
+         (Flags &
+          static_cast<UINT>(linalg_test::MultiplicationFlags::Supported)) != 0;
+}
+
+LPCWSTR dataTypeName(linalg_test::DataType Type) {
+  using linalg_test::DataType;
+  switch (Type) {
+  case DataType::None:
+    return L"None";
+  case DataType::SInt16:
+    return L"SInt16";
+  case DataType::UInt16:
+    return L"UInt16";
+  case DataType::SInt32:
+    return L"SInt32";
+  case DataType::UInt32:
+    return L"UInt32";
+  case DataType::Float16:
+    return L"Float16";
+  case DataType::Float32:
+    return L"Float32";
+  case DataType::SInt8:
+    return L"SInt8";
+  case DataType::UInt8:
+    return L"UInt8";
+  case DataType::Float8E4M3FN:
+    return L"Float8E4M3FN";
+  case DataType::Float8E5M2:
+    return L"Float8E5M2";
+  }
+  return L"Unknown";
+}
+
+void setWaveInputs(RuntimeWaveMatrixMultiplyInputs &RuntimeInputs,
+                   const linalg_test::WaveMatrixMultiplyQuery &Query) {
+  RuntimeInputs.WaveSize = Query.WaveSize;
+  RuntimeInputs.MatrixAComponentType =
+      static_cast<UINT>(Query.MatrixAComponentType);
+  RuntimeInputs.MatrixBComponentType =
+      static_cast<UINT>(Query.MatrixBComponentType);
+  RuntimeInputs.AccumulatorComponentType =
+      static_cast<UINT>(Query.AccumulatorComponentType);
+}
+
+} // namespace
 
 using namespace hlsl_test;
 
@@ -767,6 +975,543 @@ bool isFallbackPathEnabled() {
                                                      EnableFallbackValue);
   return EnableFallbackValue != 0;
 }
+
+namespace linalg_test {
+
+bool MatrixConstructionSupport::valid() const {
+  const bool AllZero = MinM == 0 && MinK == 0 && MinN == 0;
+  const bool AllNonZero = MinM != 0 && MinK != 0 && MinN != 0;
+  return AllZero || AllNonZero;
+}
+
+bool MatrixConstructionSupport::supported() const {
+  return valid() && MinM != 0;
+}
+
+bool MatrixConstructionSupport::supports(MatrixRole Role, UINT Rows,
+                                         UINT Columns) const {
+  if (!supported())
+    return false;
+
+  switch (Role) {
+  case MatrixRole::A:
+    return Rows >= MinM && Columns >= MinK;
+  case MatrixRole::B:
+    return Rows >= MinK && Columns >= MinN;
+  case MatrixRole::Accumulator:
+    return Rows >= MinM && Columns >= MinN;
+  }
+  return false;
+}
+
+bool hasFlag(MultiplicationFlags Value, MultiplicationFlags Flag) {
+  return (static_cast<UINT>(Value) & static_cast<UINT>(Flag)) != 0;
+}
+
+bool WaveMatrixMultiplySupport::valid() const {
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+    return false;
+  if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
+    return Shapes.empty();
+  if (Shapes.empty())
+    return false;
+  for (const MatrixMultiplyShape &Shape : Shapes) {
+    if (Shape.M == 0 || Shape.K == 0 || Shape.N == 0)
+      return false;
+  }
+  return true;
+}
+
+bool WaveMatrixMultiplySupport::supported() const {
+  return valid() && hasFlag(SupportFlags, MultiplicationFlags::Supported);
+}
+
+bool WaveMatrixMultiplySupport::supportsShape(UINT M, UINT K, UINT N) const {
+  if (!supported())
+    return false;
+  for (const MatrixMultiplyShape &Shape : Shapes) {
+    if (Shape.M != 0 && Shape.K != 0 && Shape.N != 0 && M % Shape.M == 0 &&
+        K % Shape.K == 0 && N % Shape.N == 0)
+      return true;
+  }
+  return false;
+}
+
+bool ThreadGroupMatrixMultiplySupport::supported() const {
+  return valid() && hasFlag(SupportFlags, MultiplicationFlags::Supported);
+}
+
+bool ThreadGroupMatrixMultiplySupport::valid() const {
+  if (!isValidMultiplicationFlags(static_cast<UINT>(SupportFlags)))
+    return false;
+  if (!hasFlag(SupportFlags, MultiplicationFlags::Supported))
+    return true;
+  return MinThreadGroupSize != 0 && MaxThreadGroupSize >= MinThreadGroupSize &&
+         MaxThreadGroupSize % MinThreadGroupSize == 0 &&
+         (PreferredThreadGroupSize == 0 ||
+          (PreferredThreadGroupSize >= MinThreadGroupSize &&
+           PreferredThreadGroupSize <= MaxThreadGroupSize &&
+           PreferredThreadGroupSize % MinThreadGroupSize == 0));
+}
+
+bool ThreadGroupMatrixMultiplySupport::supportsThreadGroupSize(
+    UINT ThreadGroupSize) const {
+  return supported() && MinThreadGroupSize != 0 &&
+         ThreadGroupSize >= MinThreadGroupSize &&
+         ThreadGroupSize <= MaxThreadGroupSize &&
+         ThreadGroupSize % MinThreadGroupSize == 0;
+}
+
+bool ThreadVectorMatrixMultiplySupport::supported() const {
+  return valid() && hasFlag(SupportFlags, MultiplicationFlags::Supported);
+}
+
+bool ThreadVectorMatrixMultiplySupport::valid() const {
+  return isValidMultiplicationFlags(static_cast<UINT>(SupportFlags));
+}
+
+bool AtomicAccumulateStoreSupport::supports(
+    AtomicDestination Destination) const {
+  switch (Destination) {
+  case AtomicDestination::RWByteAddressBuffer:
+    return RWByteAddressBufferSupported;
+  case AtomicDestination::GroupShared:
+    return GroupSharedSupported;
+  }
+  return false;
+}
+
+ScopeFlags legalScopes(OperationType Operation) {
+  const ScopeFlags Thread = static_cast<ScopeFlags>(ExecutionScope::Thread);
+  const ScopeFlags Wave = static_cast<ScopeFlags>(ExecutionScope::Wave);
+  const ScopeFlags ThreadGroup =
+      static_cast<ScopeFlags>(ExecutionScope::ThreadGroup);
+  switch (Operation) {
+  case OperationType::MatrixConstruction:
+    return Wave | ThreadGroup;
+  case OperationType::WaveMatrixMultiply:
+    return Wave;
+  case OperationType::ThreadGroupMatrixMultiply:
+    return ThreadGroup;
+  case OperationType::ThreadVectorMatrixMultiply:
+  case OperationType::ThreadOuterProduct:
+    return Thread;
+  case OperationType::AtomicAccumulateStore:
+    // The query category spans thread vector/outer-product accumulation and
+    // Wave/ThreadGroup matrix forms. Individual operations narrow this mask.
+    return Thread | Wave | ThreadGroup;
+  }
+  return 0;
+}
+
+bool isLegalScope(OperationType Operation, ExecutionScope Scope) {
+  return (legalScopes(Operation) & static_cast<ScopeFlags>(Scope)) != 0;
+}
+
+Applicability classifyApplicability(HRESULT QueryResult, bool Supported,
+                                    CapabilityRequirement Requirement) {
+  if (FAILED(QueryResult))
+    return Applicability::Fail;
+  if (Supported)
+    return Applicability::Execute;
+  if (Requirement == CapabilityRequirement::CapabilityGated)
+    return Applicability::NotApplicable;
+  return Applicability::Fail;
+}
+
+HRESULT queryTierSupport(ID3D12Device *Device, TierSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraTierSupport RuntimeSupport = {};
+  const HRESULT HR = Device->CheckFeatureSupport(
+      LinearAlgebraSupportFeature, &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(L"Linear algebra tier query failed: 0x%08x", HR);
+    return HR;
+  }
+
+  if (RuntimeSupport.LinearAlgebraTier !=
+          static_cast<UINT>(Tier::NotSupported) &&
+      RuntimeSupport.LinearAlgebraTier != static_cast<UINT>(Tier::Tier1_0)) {
+    LogCommentFmt(L"Linear algebra tier query returned invalid tier: 0x%x",
+                  RuntimeSupport.LinearAlgebraTier);
+    return E_UNEXPECTED;
+  }
+
+  Support.LinearAlgebraTier =
+      static_cast<Tier>(RuntimeSupport.LinearAlgebraTier);
+  LogCommentFmt(L"Linear algebra tier: 0x%x",
+                static_cast<UINT>(Support.LinearAlgebraTier));
+  return S_OK;
+}
+
+HRESULT queryMatrixConstruction(ID3D12Device *Device,
+                                const MatrixConstructionQuery &Query,
+                                MatrixConstructionSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::MatrixConstruction);
+  RuntimeSupport.MatrixConstruction.ComponentType =
+      static_cast<UINT>(Query.ComponentType);
+  RuntimeSupport.MatrixConstruction.WaveSize = Query.WaveSize;
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"MatrixConstruction query failed: type=%s, wave=%u, hr=0x%08x",
+        dataTypeName(Query.ComponentType), Query.WaveSize, HR);
+    return HR;
+  }
+
+  const UINT MinM = RuntimeSupport.MatrixConstruction.MinM;
+  const UINT MinK = RuntimeSupport.MatrixConstruction.MinK;
+  const UINT MinN = RuntimeSupport.MatrixConstruction.MinN;
+  const bool AllZero = MinM == 0 && MinK == 0 && MinN == 0;
+  const bool AllNonZero = MinM != 0 && MinK != 0 && MinN != 0;
+  if (!AllZero && !AllNonZero) {
+    LogCommentFmt(
+        L"MatrixConstruction query returned malformed minima: type=%s, "
+        L"wave=%u, MinM=%u, MinK=%u, MinN=%u",
+        dataTypeName(Query.ComponentType), Query.WaveSize, MinM, MinK, MinN);
+    return E_UNEXPECTED;
+  }
+
+  Support.MinM = MinM;
+  Support.MinK = MinK;
+  Support.MinN = MinN;
+  LogCommentFmt(
+      L"MatrixConstruction query: type=%s, wave=%u, supported=%u, MinM=%u, "
+      L"MinK=%u, MinN=%u",
+      dataTypeName(Query.ComponentType), Query.WaveSize, Support.supported(),
+      Support.MinM, Support.MinK, Support.MinN);
+  return S_OK;
+}
+
+HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
+                                const WaveMatrixMultiplyQuery &Query,
+                                WaveMatrixMultiplySupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::WaveMatrixMultiply);
+  setWaveInputs(RuntimeSupport.WaveMatrixMultiply.Inputs, Query);
+
+  HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"WaveMatrixMultiply query failed: wave=%u, A=%s, B=%s, Acc=%s, "
+        L"hr=0x%08x",
+        Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+        dataTypeName(Query.MatrixBComponentType),
+        dataTypeName(Query.AccumulatorComponentType), HR);
+    return HR;
+  }
+
+  if (!isValidMultiplicationFlags(
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags)) {
+    LogCommentFmt(L"WaveMatrixMultiply query returned invalid flags: 0x%x",
+                  RuntimeSupport.WaveMatrixMultiply.SupportFlags);
+    return E_UNEXPECTED;
+  }
+
+  const bool Supported =
+      (RuntimeSupport.WaveMatrixMultiply.SupportFlags &
+       static_cast<UINT>(MultiplicationFlags::Supported)) != 0;
+  if (!Supported) {
+    if (RuntimeSupport.WaveMatrixMultiply.NumShapes != 0) {
+      LogCommentFmt(L"Unsupported WaveMatrixMultiply query returned %u shapes",
+                    RuntimeSupport.WaveMatrixMultiply.NumShapes);
+      return E_UNEXPECTED;
+    }
+    Support.SupportFlags = static_cast<MultiplicationFlags>(
+        RuntimeSupport.WaveMatrixMultiply.SupportFlags);
+    LogCommentFmt(L"WaveMatrixMultiply query: wave=%u, A=%s, B=%s, Acc=%s, "
+                  L"flags=0x%x, shapes=0",
+                  Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+                  dataTypeName(Query.MatrixBComponentType),
+                  dataTypeName(Query.AccumulatorComponentType),
+                  static_cast<UINT>(Support.SupportFlags));
+    return S_OK;
+  }
+
+  const UINT RequestedShapes = RuntimeSupport.WaveMatrixMultiply.NumShapes;
+  if (RequestedShapes == 0) {
+    LogCommentFmt(
+        L"Supported WaveMatrixMultiply query returned no native shapes");
+    return E_UNEXPECTED;
+  }
+
+  std::vector<RuntimeMatrixMultiplyShape> RuntimeShapes(RequestedShapes);
+  RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::WaveMatrixMultiply);
+  setWaveInputs(RuntimeSupport.WaveMatrixMultiply.Inputs, Query);
+  RuntimeSupport.WaveMatrixMultiply.NumShapes = RequestedShapes;
+  RuntimeSupport.WaveMatrixMultiply.Shapes = RuntimeShapes.data();
+
+  HR = Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                   &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"WaveMatrixMultiply shape query failed: wave=%u, A=%s, B=%s, "
+        L"Acc=%s, requested=%u, hr=0x%08x",
+        Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+        dataTypeName(Query.MatrixBComponentType),
+        dataTypeName(Query.AccumulatorComponentType), RequestedShapes, HR);
+    return HR;
+  }
+
+  if (!isValidMultiplicationFlags(
+          RuntimeSupport.WaveMatrixMultiply.SupportFlags) ||
+      (RuntimeSupport.WaveMatrixMultiply.SupportFlags &
+       static_cast<UINT>(MultiplicationFlags::Supported)) == 0 ||
+      RuntimeSupport.WaveMatrixMultiply.NumShapes == 0 ||
+      RuntimeSupport.WaveMatrixMultiply.NumShapes > RequestedShapes) {
+    LogCommentFmt(
+        L"WaveMatrixMultiply shape query returned malformed flags/count: "
+        L"flags=0x%x, returned=%u, requested=%u",
+        RuntimeSupport.WaveMatrixMultiply.SupportFlags,
+        RuntimeSupport.WaveMatrixMultiply.NumShapes, RequestedShapes);
+    return E_UNEXPECTED;
+  }
+
+  Support.SupportFlags = static_cast<MultiplicationFlags>(
+      RuntimeSupport.WaveMatrixMultiply.SupportFlags);
+  for (UINT I = 0; I < RuntimeSupport.WaveMatrixMultiply.NumShapes; ++I) {
+    const RuntimeMatrixMultiplyShape &Shape = RuntimeShapes[I];
+    if (Shape.M == 0 || Shape.K == 0 || Shape.N == 0) {
+      LogCommentFmt(
+          L"WaveMatrixMultiply query returned zero native shape at index %u: "
+          L"M=%u, K=%u, N=%u",
+          I, Shape.M, Shape.K, Shape.N);
+      return E_UNEXPECTED;
+    }
+    Support.Shapes.push_back({Shape.M, Shape.K, Shape.N});
+  }
+
+  LogCommentFmt(
+      L"WaveMatrixMultiply query: wave=%u, A=%s, B=%s, Acc=%s, flags=0x%x, "
+      L"shapes=%zu",
+      Query.WaveSize, dataTypeName(Query.MatrixAComponentType),
+      dataTypeName(Query.MatrixBComponentType),
+      dataTypeName(Query.AccumulatorComponentType),
+      static_cast<UINT>(Support.SupportFlags), Support.Shapes.size());
+  for (size_t I = 0; I < Support.Shapes.size(); ++I) {
+    const MatrixMultiplyShape &Shape = Support.Shapes[I];
+    LogCommentFmt(L"  Native shape %zu: M=%u, K=%u, N=%u", I, Shape.M, Shape.K,
+                  Shape.N);
+  }
+  return S_OK;
+}
+
+HRESULT
+queryThreadGroupMatrixMultiply(ID3D12Device *Device,
+                               const ThreadGroupMatrixMultiplyQuery &Query,
+                               ThreadGroupMatrixMultiplySupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::ThreadGroupMatrixMultiply);
+  setWaveInputs(RuntimeSupport.ThreadGroupMatrixMultiply.WaveInputs,
+                Query.WaveInputs);
+  RuntimeSupport.ThreadGroupMatrixMultiply.Shape = {
+      Query.Shape.M,
+      Query.Shape.K,
+      Query.Shape.N,
+  };
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"ThreadGroupMatrixMultiply query failed: wave=%u, A=%s, B=%s, "
+        L"Acc=%s, shape=(%u,%u,%u), hr=0x%08x",
+        Query.WaveInputs.WaveSize,
+        dataTypeName(Query.WaveInputs.MatrixAComponentType),
+        dataTypeName(Query.WaveInputs.MatrixBComponentType),
+        dataTypeName(Query.WaveInputs.AccumulatorComponentType), Query.Shape.M,
+        Query.Shape.K, Query.Shape.N, HR);
+    return HR;
+  }
+
+  const UINT Flags = RuntimeSupport.ThreadGroupMatrixMultiply.SupportFlags;
+  if (!isValidMultiplicationFlags(Flags)) {
+    LogCommentFmt(
+        L"ThreadGroupMatrixMultiply query returned invalid flags: 0x%x", Flags);
+    return E_UNEXPECTED;
+  }
+
+  const bool Supported =
+      (Flags & static_cast<UINT>(MultiplicationFlags::Supported)) != 0;
+  const UINT MinSize =
+      RuntimeSupport.ThreadGroupMatrixMultiply.MinThreadGroupSize;
+  const UINT MaxSize =
+      RuntimeSupport.ThreadGroupMatrixMultiply.MaxThreadGroupSize;
+  const UINT PreferredSize =
+      RuntimeSupport.ThreadGroupMatrixMultiply.PreferredThreadGroupSize;
+  if (Supported &&
+      (MinSize == 0 || MaxSize < MinSize || MaxSize % MinSize != 0 ||
+       (PreferredSize != 0 &&
+        (PreferredSize < MinSize || PreferredSize > MaxSize ||
+         PreferredSize % MinSize != 0)))) {
+    LogCommentFmt(
+        L"ThreadGroupMatrixMultiply query returned malformed group sizes: "
+        L"min=%u, max=%u, preferred=%u",
+        MinSize, MaxSize, PreferredSize);
+    return E_UNEXPECTED;
+  }
+
+  Support.SupportFlags = static_cast<MultiplicationFlags>(Flags);
+  Support.MinThreadGroupSize = MinSize;
+  Support.MaxThreadGroupSize = MaxSize;
+  Support.PreferredThreadGroupSize = PreferredSize;
+  LogCommentFmt(
+      L"ThreadGroupMatrixMultiply query: wave=%u, A=%s, B=%s, Acc=%s, "
+      L"shape=(%u,%u,%u), flags=0x%x, minGroup=%u, maxGroup=%u, "
+      L"preferredGroup=%u",
+      Query.WaveInputs.WaveSize,
+      dataTypeName(Query.WaveInputs.MatrixAComponentType),
+      dataTypeName(Query.WaveInputs.MatrixBComponentType),
+      dataTypeName(Query.WaveInputs.AccumulatorComponentType), Query.Shape.M,
+      Query.Shape.K, Query.Shape.N, Flags, MinSize, MaxSize, PreferredSize);
+  return S_OK;
+}
+
+HRESULT
+queryThreadVectorMatrixMultiply(ID3D12Device *Device,
+                                const ThreadVectorMatrixMultiplyQuery &Query,
+                                ThreadVectorMatrixMultiplySupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::ThreadVectorMatrixMultiply);
+  RuntimeSupport.ThreadVectorMatrixMultiply.VectorInputType =
+      static_cast<UINT>(Query.VectorInputType);
+  RuntimeSupport.ThreadVectorMatrixMultiply.MatrixInputType =
+      static_cast<UINT>(Query.MatrixInputType);
+  RuntimeSupport.ThreadVectorMatrixMultiply.BiasInputType =
+      static_cast<UINT>(Query.BiasInputType);
+  RuntimeSupport.ThreadVectorMatrixMultiply.VectorResultType =
+      static_cast<UINT>(Query.VectorResultType);
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"ThreadVectorMatrixMultiply query failed: vector=%s, matrix=%s, "
+        L"bias=%s, result=%s, hr=0x%08x",
+        dataTypeName(Query.VectorInputType),
+        dataTypeName(Query.MatrixInputType), dataTypeName(Query.BiasInputType),
+        dataTypeName(Query.VectorResultType), HR);
+    return HR;
+  }
+
+  const UINT Flags = RuntimeSupport.ThreadVectorMatrixMultiply.SupportFlags;
+  if (!isValidMultiplicationFlags(Flags)) {
+    LogCommentFmt(
+        L"ThreadVectorMatrixMultiply query returned invalid flags: 0x%x",
+        Flags);
+    return E_UNEXPECTED;
+  }
+
+  Support.SupportFlags = static_cast<MultiplicationFlags>(Flags);
+  LogCommentFmt(
+      L"ThreadVectorMatrixMultiply query: vector=%s, matrix=%s, bias=%s, "
+      L"result=%s, flags=0x%x",
+      dataTypeName(Query.VectorInputType), dataTypeName(Query.MatrixInputType),
+      dataTypeName(Query.BiasInputType), dataTypeName(Query.VectorResultType),
+      Flags);
+  return S_OK;
+}
+
+HRESULT queryThreadOuterProduct(ID3D12Device *Device,
+                                const ThreadOuterProductQuery &Query,
+                                ThreadOuterProductSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::ThreadOuterProduct);
+  RuntimeSupport.ThreadOuterProduct.InputComponentType =
+      static_cast<UINT>(Query.InputComponentType);
+  RuntimeSupport.ThreadOuterProduct.ResultComponentType =
+      static_cast<UINT>(Query.ResultComponentType);
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(
+        L"ThreadOuterProduct query failed: input=%s, result=%s, hr=0x%08x",
+        dataTypeName(Query.InputComponentType),
+        dataTypeName(Query.ResultComponentType), HR);
+    return HR;
+  }
+
+  Support.Supported = RuntimeSupport.ThreadOuterProduct.Supported != FALSE;
+  LogCommentFmt(L"ThreadOuterProduct query: input=%s, result=%s, supported=%u",
+                dataTypeName(Query.InputComponentType),
+                dataTypeName(Query.ResultComponentType), Support.Supported);
+  return S_OK;
+}
+
+HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
+                                   const AtomicAccumulateStoreQuery &Query,
+                                   AtomicAccumulateStoreSupport &Support) {
+  Support = {};
+  if (!Device)
+    return E_INVALIDARG;
+
+  RuntimeLinearAlgebraOperationSupport RuntimeSupport = {};
+  RuntimeSupport.OperationType =
+      static_cast<UINT>(OperationType::AtomicAccumulateStore);
+  RuntimeSupport.AccumulateStore.ComponentType =
+      static_cast<UINT>(Query.ComponentType);
+
+  const HRESULT HR =
+      Device->CheckFeatureSupport(LinearAlgebraOperationSupportFeature,
+                                  &RuntimeSupport, sizeof(RuntimeSupport));
+  if (FAILED(HR)) {
+    LogCommentFmt(L"AtomicAccumulateStore query failed: type=%s, hr=0x%08x",
+                  dataTypeName(Query.ComponentType), HR);
+    return HR;
+  }
+
+  Support.RWByteAddressBufferSupported =
+      RuntimeSupport.AccumulateStore.RWByteAddressBufferSupported != FALSE;
+  Support.GroupSharedSupported =
+      RuntimeSupport.AccumulateStore.GroupSharedSupported != FALSE;
+  LogCommentFmt(L"AtomicAccumulateStore query: type=%s, UAV=%u, groupshared=%u",
+                dataTypeName(Query.ComponentType),
+                Support.RWByteAddressBufferSupported,
+                Support.GroupSharedSupported);
+  return S_OK;
+}
+
+} // namespace linalg_test
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -97,6 +97,13 @@ enum class DataType : UINT {
   Float8E5M2 = 21,
 };
 
+enum class MatrixLayout : UINT {
+  RowMajor = 0,
+  ColumnMajor = 1,
+  MulOptimal = 2,
+  OuterProductOptimal = 3,
+};
+
 enum class OperationType : UINT {
   MatrixConstruction = 0,
   WaveMatrixMultiply = 1,
@@ -326,20 +333,14 @@ void compileShader(dxc::SpecificDllLoader &DxcSupport, const char *Source,
                    const char *Target, const std::string &Args,
                    bool VerboseLogging = false);
 
-// Host-side linear-algebra matrix-conversion helpers. These need the D3D12
-// linear-algebra API (the D3D12_LINEAR_ALGEBRA_* types and the conversion
-// methods on ID3D12DevicePreview / ID3D12GraphicsCommandListPreview), which is
-// gated behind the preview SDK's DIRECT3D_LINEAR_ALGEBRA feature macro. When
-// absent, these helpers and the tests using them are compiled out (they Skip at
-// runtime).
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+// Host-side linear-algebra matrix-conversion helpers. The implementation uses
+// SDK-neutral ABI mirrors for the preview D3D12 interfaces so these remain
+// available when the tests are built against released Windows SDK headers.
 /// Query the number of bytes required to store an NumRows x NumColumns matrix
 /// of the given datatype in the specified device layout.
 UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
-                             UINT NumColumns,
-                             D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
-                             D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT Layout,
-                             UINT Stride);
+                             UINT NumColumns, linalg_test::DataType DataType,
+                             linalg_test::MatrixLayout Layout, UINT Stride);
 
 /// Record a GPU matrix layout conversion onto \p List using
 /// ID3D12GraphicsCommandListPreview::ConvertLinearAlgebraMatrix. Both
@@ -352,9 +353,7 @@ UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
 void recordLinAlgMatrixConversion(
     ID3D12GraphicsCommandList *List, ID3D12Resource *SrcBuffer, UINT SrcSize,
     ID3D12Resource *DestBuffer, UINT DestSize, UINT NumRows, UINT NumColumns,
-    D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
-    D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT SrcLayout, UINT SrcStride,
-    D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT DestLayout, UINT DestStride);
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+    linalg_test::DataType DataType, linalg_test::MatrixLayout SrcLayout,
+    UINT SrcStride, linalg_test::MatrixLayout DestLayout, UINT DestStride);
 
 #endif // HLSLEXECTESTUTILS_H

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 #include <windows.h>
 
 #include "ShaderOpTest.h"
@@ -73,6 +74,199 @@ bool doesDeviceSupportWritableMSAA(ID3D12Device *pDevice);
 bool doesDeviceSupportEnhancedBarriers(ID3D12Device *pDevice);
 bool doesDeviceSupportRelaxedFormatCasting(ID3D12Device *pDevice);
 bool isFallbackPathEnabled();
+
+namespace linalg_test {
+
+enum class Tier : UINT {
+  NotSupported = 0,
+  Tier1_0 = 0x10,
+};
+
+enum class DataType : UINT {
+  None = 0,
+  SInt16 = 2,
+  UInt16 = 3,
+  SInt32 = 4,
+  UInt32 = 5,
+  Float16 = 7,
+  Float32 = 8,
+  SInt8 = 18,
+  UInt8 = 19,
+  Float8E4M3FN = 20,
+  Float8E5M2 = 21,
+};
+
+enum class OperationType : UINT {
+  MatrixConstruction = 0,
+  WaveMatrixMultiply = 1,
+  ThreadGroupMatrixMultiply = 2,
+  ThreadVectorMatrixMultiply = 3,
+  ThreadOuterProduct = 4,
+  AtomicAccumulateStore = 5,
+};
+
+enum class MultiplicationFlags : UINT {
+  None = 0,
+  Supported = 1,
+  EmulatedInputs = 2,
+  EmulatedOutputs = 4,
+  Transpose = 8,
+};
+
+enum class MatrixRole {
+  A,
+  B,
+  Accumulator,
+};
+
+enum class ExecutionScope : UINT {
+  Thread = 1,
+  Wave = 2,
+  ThreadGroup = 4,
+};
+
+using ScopeFlags = UINT;
+
+enum class AtomicDestination {
+  RWByteAddressBuffer,
+  GroupShared,
+};
+
+enum class CapabilityRequirement {
+  Mandatory,
+  CapabilityGated,
+};
+
+enum class Applicability {
+  Execute,
+  NotApplicable,
+  Fail,
+};
+
+struct TierSupport {
+  Tier LinearAlgebraTier = Tier::NotSupported;
+
+  bool supported() const { return LinearAlgebraTier != Tier::NotSupported; }
+};
+
+struct MatrixConstructionQuery {
+  DataType ComponentType;
+  UINT WaveSize;
+};
+
+struct MatrixConstructionSupport {
+  UINT MinM = 0;
+  UINT MinK = 0;
+  UINT MinN = 0;
+
+  bool valid() const;
+  bool supported() const;
+  bool supports(MatrixRole Role, UINT Rows, UINT Columns) const;
+};
+
+struct MatrixMultiplyShape {
+  UINT M;
+  UINT K;
+  UINT N;
+};
+
+struct WaveMatrixMultiplyQuery {
+  UINT WaveSize;
+  DataType MatrixAComponentType;
+  DataType MatrixBComponentType;
+  DataType AccumulatorComponentType;
+};
+
+struct WaveMatrixMultiplySupport {
+  MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+  std::vector<MatrixMultiplyShape> Shapes;
+
+  bool valid() const;
+  bool supported() const;
+  bool supportsShape(UINT M, UINT K, UINT N) const;
+};
+
+struct ThreadGroupMatrixMultiplyQuery {
+  WaveMatrixMultiplyQuery WaveInputs;
+  MatrixMultiplyShape Shape;
+};
+
+struct ThreadGroupMatrixMultiplySupport {
+  MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+  UINT MinThreadGroupSize = 0;
+  UINT MaxThreadGroupSize = 0;
+  UINT PreferredThreadGroupSize = 0;
+
+  bool valid() const;
+  bool supported() const;
+  bool supportsThreadGroupSize(UINT ThreadGroupSize) const;
+};
+
+struct ThreadVectorMatrixMultiplyQuery {
+  DataType VectorInputType;
+  DataType MatrixInputType;
+  DataType BiasInputType;
+  DataType VectorResultType;
+};
+
+struct ThreadVectorMatrixMultiplySupport {
+  MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+
+  bool valid() const;
+  bool supported() const;
+};
+
+struct ThreadOuterProductQuery {
+  DataType InputComponentType;
+  DataType ResultComponentType;
+};
+
+struct ThreadOuterProductSupport {
+  bool Supported = false;
+
+  bool supported() const { return Supported; }
+};
+
+struct AtomicAccumulateStoreQuery {
+  DataType ComponentType;
+};
+
+struct AtomicAccumulateStoreSupport {
+  bool RWByteAddressBufferSupported = false;
+  bool GroupSharedSupported = false;
+
+  bool supports(AtomicDestination Destination) const;
+};
+
+bool hasFlag(MultiplicationFlags Value, MultiplicationFlags Flag);
+ScopeFlags legalScopes(OperationType Operation);
+bool isLegalScope(OperationType Operation, ExecutionScope Scope);
+Applicability classifyApplicability(HRESULT QueryResult, bool Supported,
+                                    CapabilityRequirement Requirement);
+
+HRESULT queryTierSupport(ID3D12Device *Device, TierSupport &Support);
+HRESULT queryMatrixConstruction(ID3D12Device *Device,
+                                const MatrixConstructionQuery &Query,
+                                MatrixConstructionSupport &Support);
+HRESULT queryWaveMatrixMultiply(ID3D12Device *Device,
+                                const WaveMatrixMultiplyQuery &Query,
+                                WaveMatrixMultiplySupport &Support);
+HRESULT
+queryThreadGroupMatrixMultiply(ID3D12Device *Device,
+                               const ThreadGroupMatrixMultiplyQuery &Query,
+                               ThreadGroupMatrixMultiplySupport &Support);
+HRESULT
+queryThreadVectorMatrixMultiply(ID3D12Device *Device,
+                                const ThreadVectorMatrixMultiplyQuery &Query,
+                                ThreadVectorMatrixMultiplySupport &Support);
+HRESULT queryThreadOuterProduct(ID3D12Device *Device,
+                                const ThreadOuterProductQuery &Query,
+                                ThreadOuterProductSupport &Support);
+HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
+                                   const AtomicAccumulateStoreQuery &Query,
+                                   AtomicAccumulateStoreSupport &Support);
+
+} // namespace linalg_test
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -211,6 +211,7 @@ struct ThreadVectorMatrixMultiplyQuery {
 
 struct ThreadVectorMatrixMultiplySupport {
   MultiplicationFlags SupportFlags = MultiplicationFlags::None;
+  DataType MatrixInputType = DataType::None;
 
   bool valid() const;
   bool supported() const;

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -3,6 +3,7 @@
 
 #include <atlcomcli.h>
 #include <d3d12.h>
+#include <initializer_list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -290,6 +291,24 @@ void addUAVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
 /// Add a SRV buffer resource to a ShaderOp.
 void addSRVBuffer(st::ShaderOp *Op, const char *Name, UINT64 Width,
                   const char *Init = "zero");
+
+enum class RawBufferViewKind {
+  SRV,
+  UAV,
+};
+
+struct RawBufferView {
+  const char *DescriptorName;
+  const char *ResourceName;
+  RawBufferViewKind Kind;
+  UINT64 FirstByte;
+  UINT64 NumBytes;
+};
+
+/// Add a shader-visible descriptor table containing raw buffer views.
+void addRawBufferDescriptorTable(st::ShaderOp *Op, UINT RootIndex,
+                                 const char *HeapName,
+                                 std::initializer_list<RawBufferView> Views);
 
 /// Bind a resource to a root view parameter by index.
 void addRootView(st::ShaderOp *Op, UINT Index, const char *ResName);

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -25,9 +25,13 @@
 #include "HlslTestUtils.h"
 
 #include <climits>
+#include <cstring>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #define STREAM_FLOAT(stream, name, value)                                      \
   stream << std::showpoint << " -D" << name << "=" << value << "F"             \
@@ -92,6 +96,671 @@ struct MatrixParams {
   size_t totalBytes() const { return totalElements() * elementSize(CompType); }
 };
 
+namespace cpu_oracle {
+
+using TypedMatrixValues =
+    std::variant<std::vector<HLSLHalf_t>, std::vector<float>,
+                 std::vector<int32_t>, std::vector<uint32_t>>;
+
+struct TypedMatrix {
+  ComponentType CompType;
+  MatrixDim M;
+  MatrixDim N;
+  TypedMatrixValues Values;
+
+  size_t totalElements() const {
+    return static_cast<size_t>(M) * static_cast<size_t>(N);
+  }
+};
+
+struct MatrixBufferLayout {
+  LinalgMatrixLayout Layout;
+  size_t OffsetBytes;
+  size_t StrideBytes;
+};
+
+enum class ComparisonMode {
+  // Floating-point alternatives allowed by the specification must be listed as
+  // permitted results; Exact compares the encoded component bits.
+  Exact,
+  PermittedResults,
+  Excluded,
+};
+
+// MatrixResultOracle models matrix-valued outputs. Operations whose observable
+// result is a complete destination buffer need a whole-buffer oracle instead.
+struct MatrixResultOracle {
+  ComparisonMode Mode;
+  std::vector<TypedMatrix> Candidates;
+  std::wstring PublicRule;
+};
+
+template <typename T, ComponentType CT> struct NativeComponentTraits {
+  static constexpr ComponentType CompType = CT;
+  static constexpr size_t Size = sizeof(T);
+
+  static void store(BYTE *Dest, const T &Value) {
+    static_assert(std::is_trivially_copyable<T>::value,
+                  "Component must be trivially copyable");
+    std::memcpy(Dest, &Value, sizeof(Value));
+  }
+
+  static T load(const BYTE *Source) {
+    T Value;
+    std::memcpy(&Value, Source, sizeof(Value));
+    return Value;
+  }
+
+  static bool exactMatch(const T &Actual, const T &Expected) {
+    return std::memcmp(&Actual, &Expected, sizeof(T)) == 0;
+  }
+
+  static std::wstring format(const T &Value) {
+    std::wstringstream Stream;
+    Stream << Value;
+    return Stream.str();
+  }
+};
+
+template <typename T> struct ComponentTraits;
+
+template <>
+struct ComponentTraits<float>
+    : NativeComponentTraits<float, ComponentType::F32> {};
+
+template <>
+struct ComponentTraits<int32_t>
+    : NativeComponentTraits<int32_t, ComponentType::I32> {};
+
+template <>
+struct ComponentTraits<uint32_t>
+    : NativeComponentTraits<uint32_t, ComponentType::U32> {};
+
+template <> struct ComponentTraits<HLSLHalf_t> {
+  static constexpr ComponentType CompType = ComponentType::F16;
+  static constexpr size_t Size = sizeof(uint16_t);
+
+  static void store(BYTE *Dest, const HLSLHalf_t &Value) {
+    std::memcpy(Dest, &Value.Val, sizeof(Value.Val));
+  }
+
+  static HLSLHalf_t load(const BYTE *Source) {
+    uint16_t Bits;
+    std::memcpy(&Bits, Source, sizeof(Bits));
+    return HLSLHalf_t::FromHALF(static_cast<DirectX::PackedVector::HALF>(Bits));
+  }
+
+  static bool exactMatch(const HLSLHalf_t &Actual, const HLSLHalf_t &Expected) {
+    return Actual.Val == Expected.Val;
+  }
+
+  static std::wstring format(const HLSLHalf_t &Value) {
+    std::wstringstream Stream;
+    Stream << static_cast<float>(Value) << L" (bits=0x" << std::hex << Value.Val
+           << L")";
+    return Stream.str();
+  }
+};
+
+static bool checkedMultiply(size_t Left, size_t Right, size_t &Result) {
+  if (Right != 0 && Left > std::numeric_limits<size_t>::max() / Right)
+    return false;
+  Result = Left * Right;
+  return true;
+}
+
+static bool checkedAdd(size_t Left, size_t Right, size_t &Result) {
+  if (Left > std::numeric_limits<size_t>::max() - Right)
+    return false;
+  Result = Left + Right;
+  return true;
+}
+
+static bool isSupportedComponentType(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::F16:
+  case ComponentType::F32:
+  case ComponentType::I32:
+  case ComponentType::U32:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static LPCWSTR componentTypeName(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::F16:
+    return L"F16";
+  case ComponentType::F32:
+    return L"F32";
+  case ComponentType::I32:
+    return L"I32";
+  case ComponentType::U32:
+    return L"U32";
+  default:
+    return L"Unsupported";
+  }
+}
+
+static LPCWSTR comparisonModeName(ComparisonMode Mode) {
+  switch (Mode) {
+  case ComparisonMode::Exact:
+    return L"Exact";
+  case ComparisonMode::PermittedResults:
+    return L"PermittedResults";
+  case ComparisonMode::Excluded:
+    return L"Excluded";
+  }
+  return L"Unknown";
+}
+
+static bool isMatrixValid(const TypedMatrix &Matrix) {
+  size_t ExpectedElements;
+  if (Matrix.M == 0 || Matrix.N == 0 ||
+      !checkedMultiply(static_cast<size_t>(Matrix.M),
+                       static_cast<size_t>(Matrix.N), ExpectedElements))
+    return false;
+
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return std::holds_alternative<std::vector<HLSLHalf_t>>(Matrix.Values) &&
+           std::get<std::vector<HLSLHalf_t>>(Matrix.Values).size() ==
+               ExpectedElements;
+  case ComponentType::F32:
+    return std::holds_alternative<std::vector<float>>(Matrix.Values) &&
+           std::get<std::vector<float>>(Matrix.Values).size() ==
+               ExpectedElements;
+  case ComponentType::I32:
+    return std::holds_alternative<std::vector<int32_t>>(Matrix.Values) &&
+           std::get<std::vector<int32_t>>(Matrix.Values).size() ==
+               ExpectedElements;
+  case ComponentType::U32:
+    return std::holds_alternative<std::vector<uint32_t>>(Matrix.Values) &&
+           std::get<std::vector<uint32_t>>(Matrix.Values).size() ==
+               ExpectedElements;
+  default:
+    return false;
+  }
+}
+
+template <typename T>
+static std::optional<TypedMatrix> makeTypedMatrix(MatrixDim M, MatrixDim N,
+                                                  std::vector<T> Values) {
+  size_t ExpectedElements;
+  if (M == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
+                       ExpectedElements) ||
+      Values.size() != ExpectedElements) {
+    hlsl_test::LogErrorFmt(
+        L"Invalid typed matrix dimensions or element count: M=%u, N=%u, "
+        L"elements=%zu",
+        M, N, Values.size());
+    return std::nullopt;
+  }
+
+  return TypedMatrix{ComponentTraits<T>::CompType, M, N, std::move(Values)};
+}
+
+static std::optional<TypedMatrix>
+makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
+                     uint32_t StartingValue = 1) {
+  size_t NumElements;
+  if (M == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
+                       NumElements)) {
+    hlsl_test::LogErrorFmt(L"Invalid sequential matrix dimensions: M=%u, N=%u",
+                           M, N);
+    return std::nullopt;
+  }
+
+  size_t LastValueSize;
+  if (!checkedAdd(static_cast<size_t>(StartingValue), NumElements - 1,
+                  LastValueSize)) {
+    hlsl_test::LogErrorFmt(L"Sequential matrix value calculation overflowed");
+    return std::nullopt;
+  }
+  const uint64_t LastValue = static_cast<uint64_t>(LastValueSize);
+
+  switch (CompType) {
+  case ComponentType::F16: {
+    if (LastValue > 65504) {
+      hlsl_test::LogErrorFmt(L"F16 sequential value is out of range: %llu",
+                             LastValue);
+      return std::nullopt;
+    }
+    std::vector<HLSLHalf_t> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.emplace_back(static_cast<float>(
+          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  case ComponentType::F32: {
+    if (LastValue > (1u << 24)) {
+      hlsl_test::LogErrorFmt(
+          L"F32 sequential integer cannot be represented exactly: %llu",
+          LastValue);
+      return std::nullopt;
+    }
+    std::vector<float> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.push_back(static_cast<float>(static_cast<uint64_t>(StartingValue) +
+                                          static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  case ComponentType::I32: {
+    if (LastValue >
+        static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+      hlsl_test::LogErrorFmt(L"I32 sequential value is out of range: %llu",
+                             LastValue);
+      return std::nullopt;
+    }
+    std::vector<int32_t> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.push_back(static_cast<int32_t>(
+          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  case ComponentType::U32: {
+    if (LastValue > std::numeric_limits<uint32_t>::max()) {
+      hlsl_test::LogErrorFmt(L"U32 sequential value is out of range: %llu",
+                             LastValue);
+      return std::nullopt;
+    }
+    std::vector<uint32_t> Values;
+    Values.reserve(NumElements);
+    for (size_t I = 0; I < NumElements; ++I)
+      Values.push_back(static_cast<uint32_t>(
+          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+    return makeTypedMatrix(M, N, std::move(Values));
+  }
+  default:
+    hlsl_test::LogErrorFmt(L"Unsupported sequential matrix component type: %u",
+                           static_cast<uint32_t>(CompType));
+    return std::nullopt;
+  }
+}
+
+template <typename T>
+static std::optional<TypedMatrix>
+transposeTypedMatrix(const TypedMatrix &Source) {
+  const std::vector<T> &SourceValues = std::get<std::vector<T>>(Source.Values);
+  std::vector<T> Result(Source.totalElements());
+  for (MatrixDim Row = 0; Row < Source.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Source.N; ++Column) {
+      const size_t SourceIndex = static_cast<size_t>(Row) * Source.N + Column;
+      const size_t ResultIndex = static_cast<size_t>(Column) * Source.M + Row;
+      Result[ResultIndex] = SourceValues[SourceIndex];
+    }
+  }
+  return makeTypedMatrix(Source.N, Source.M, std::move(Result));
+}
+
+static std::optional<TypedMatrix> transposeMatrix(const TypedMatrix &Source) {
+  if (!isMatrixValid(Source)) {
+    hlsl_test::LogErrorFmt(L"Cannot transpose an invalid typed matrix");
+    return std::nullopt;
+  }
+
+  switch (Source.CompType) {
+  case ComponentType::F16:
+    return transposeTypedMatrix<HLSLHalf_t>(Source);
+  case ComponentType::F32:
+    return transposeTypedMatrix<float>(Source);
+  case ComponentType::I32:
+    return transposeTypedMatrix<int32_t>(Source);
+  case ComponentType::U32:
+    return transposeTypedMatrix<uint32_t>(Source);
+  default:
+    return std::nullopt;
+  }
+}
+
+static bool isMemoryLayout(LinalgMatrixLayout Layout) {
+  return Layout == LinalgMatrixLayout::RowMajor ||
+         Layout == LinalgMatrixLayout::ColumnMajor;
+}
+
+static std::optional<size_t>
+getMatrixBufferSize(ComponentType CompType, MatrixDim M, MatrixDim N,
+                    const MatrixBufferLayout &Layout) {
+  if (!isSupportedComponentType(CompType) || M == 0 || N == 0 ||
+      !isMemoryLayout(Layout.Layout)) {
+    hlsl_test::LogErrorFmt(
+        L"Invalid matrix buffer description: component=%s, M=%u, N=%u, "
+        L"layout=%u",
+        componentTypeName(CompType), M, N,
+        static_cast<uint32_t>(Layout.Layout));
+    return std::nullopt;
+  }
+
+  const size_t ElementBytes = elementSize(CompType);
+  const size_t MajorCount =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? M : N;
+  const size_t MinorCount =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? N : M;
+  size_t PackedMinorBytes;
+  if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes) ||
+      Layout.StrideBytes < PackedMinorBytes) {
+    hlsl_test::LogErrorFmt(
+        L"Matrix stride is too small: component=%s, M=%u, N=%u, stride=%zu, "
+        L"required=%zu",
+        componentTypeName(CompType), M, N, Layout.StrideBytes,
+        PackedMinorBytes);
+    return std::nullopt;
+  }
+
+  size_t LastMajorOffset;
+  size_t RequiredBytes;
+  if (!checkedMultiply(MajorCount - 1, Layout.StrideBytes, LastMajorOffset) ||
+      !checkedAdd(Layout.OffsetBytes, LastMajorOffset, RequiredBytes) ||
+      !checkedAdd(RequiredBytes, PackedMinorBytes, RequiredBytes)) {
+    hlsl_test::LogErrorFmt(L"Matrix buffer size calculation overflowed");
+    return std::nullopt;
+  }
+  return RequiredBytes;
+}
+
+static std::optional<size_t>
+getMatrixBufferSize(const TypedMatrix &Matrix,
+                    const MatrixBufferLayout &Layout) {
+  if (!isMatrixValid(Matrix)) {
+    hlsl_test::LogErrorFmt(L"Cannot size an invalid typed matrix");
+    return std::nullopt;
+  }
+  return getMatrixBufferSize(Matrix.CompType, Matrix.M, Matrix.N, Layout);
+}
+
+static std::optional<size_t>
+getElementByteOffset(ComponentType CompType, MatrixDim M, MatrixDim N,
+                     MatrixDim Row, MatrixDim Column,
+                     const MatrixBufferLayout &Layout) {
+  if (Row >= M || Column >= N)
+    return std::nullopt;
+
+  const size_t Major =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? Row : Column;
+  const size_t Minor =
+      Layout.Layout == LinalgMatrixLayout::RowMajor ? Column : Row;
+  size_t MajorOffset;
+  size_t MinorOffset;
+  size_t ByteOffset;
+  if (!checkedMultiply(Major, Layout.StrideBytes, MajorOffset) ||
+      !checkedMultiply(Minor, elementSize(CompType), MinorOffset) ||
+      !checkedAdd(Layout.OffsetBytes, MajorOffset, ByteOffset) ||
+      !checkedAdd(ByteOffset, MinorOffset, ByteOffset))
+    return std::nullopt;
+  return ByteOffset;
+}
+
+template <typename T>
+static bool writeTypedMatrixBuffer(const TypedMatrix &Matrix,
+                                   const MatrixBufferLayout &Layout,
+                                   std::vector<BYTE> &Buffer) {
+  const std::vector<T> &Values = std::get<std::vector<T>>(Matrix.Values);
+  for (MatrixDim Row = 0; Row < Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Matrix.N; ++Column) {
+      const size_t ValueIndex = static_cast<size_t>(Row) * Matrix.N + Column;
+      std::optional<size_t> ByteOffset = getElementByteOffset(
+          Matrix.CompType, Matrix.M, Matrix.N, Row, Column, Layout);
+      if (!ByteOffset.has_value())
+        return false;
+      ComponentTraits<T>::store(Buffer.data() + *ByteOffset,
+                                Values[ValueIndex]);
+    }
+  }
+  return true;
+}
+
+static bool writeMatrixBuffer(const TypedMatrix &Matrix,
+                              const MatrixBufferLayout &Layout,
+                              std::vector<BYTE> &Buffer) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Matrix, Layout);
+  if (!RequiredBytes.has_value() || Buffer.size() < *RequiredBytes) {
+    hlsl_test::LogErrorFmt(
+        L"Matrix buffer is too small: actual=%zu, required=%zu", Buffer.size(),
+        RequiredBytes.value_or(0));
+    return false;
+  }
+
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return writeTypedMatrixBuffer<HLSLHalf_t>(Matrix, Layout, Buffer);
+  case ComponentType::F32:
+    return writeTypedMatrixBuffer<float>(Matrix, Layout, Buffer);
+  case ComponentType::I32:
+    return writeTypedMatrixBuffer<int32_t>(Matrix, Layout, Buffer);
+  case ComponentType::U32:
+    return writeTypedMatrixBuffer<uint32_t>(Matrix, Layout, Buffer);
+  default:
+    return false;
+  }
+}
+
+template <typename T>
+static std::optional<TypedMatrix>
+decodeTypedMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
+                        const MatrixBufferLayout &Layout, const BYTE *Buffer) {
+  std::vector<T> Values(static_cast<size_t>(M) * N);
+  for (MatrixDim Row = 0; Row < M; ++Row) {
+    for (MatrixDim Column = 0; Column < N; ++Column) {
+      const size_t ValueIndex = static_cast<size_t>(Row) * N + Column;
+      std::optional<size_t> ByteOffset =
+          getElementByteOffset(CompType, M, N, Row, Column, Layout);
+      if (!ByteOffset.has_value())
+        return std::nullopt;
+      Values[ValueIndex] = ComponentTraits<T>::load(Buffer + *ByteOffset);
+    }
+  }
+  return makeTypedMatrix(M, N, std::move(Values));
+}
+
+static std::optional<TypedMatrix>
+decodeMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
+                   const MatrixBufferLayout &Layout, const void *Buffer,
+                   size_t BufferSize) {
+  std::optional<size_t> RequiredBytes =
+      getMatrixBufferSize(CompType, M, N, Layout);
+  if (!Buffer || !RequiredBytes.has_value() || BufferSize < *RequiredBytes) {
+    hlsl_test::LogErrorFmt(
+        L"Cannot decode matrix buffer: actual=%zu, required=%zu", BufferSize,
+        RequiredBytes.value_or(0));
+    return std::nullopt;
+  }
+
+  const BYTE *Bytes = static_cast<const BYTE *>(Buffer);
+  switch (CompType) {
+  case ComponentType::F16:
+    return decodeTypedMatrixBuffer<HLSLHalf_t>(CompType, M, N, Layout, Bytes);
+  case ComponentType::F32:
+    return decodeTypedMatrixBuffer<float>(CompType, M, N, Layout, Bytes);
+  case ComponentType::I32:
+    return decodeTypedMatrixBuffer<int32_t>(CompType, M, N, Layout, Bytes);
+  case ComponentType::U32:
+    return decodeTypedMatrixBuffer<uint32_t>(CompType, M, N, Layout, Bytes);
+  default:
+    return std::nullopt;
+  }
+}
+
+template <typename T>
+static bool exactMatrixMatch(const TypedMatrix &Actual,
+                             const TypedMatrix &Expected,
+                             size_t &FirstMismatch) {
+  const std::vector<T> &ActualValues = std::get<std::vector<T>>(Actual.Values);
+  const std::vector<T> &ExpectedValues =
+      std::get<std::vector<T>>(Expected.Values);
+  for (size_t I = 0; I < ActualValues.size(); ++I) {
+    if (!ComponentTraits<T>::exactMatch(ActualValues[I], ExpectedValues[I])) {
+      FirstMismatch = I;
+      return false;
+    }
+  }
+  FirstMismatch = ActualValues.size();
+  return true;
+}
+
+static bool exactMatrixMatch(const TypedMatrix &Actual,
+                             const TypedMatrix &Expected,
+                             size_t &FirstMismatch) {
+  if (!isMatrixValid(Actual) || !isMatrixValid(Expected) ||
+      Actual.CompType != Expected.CompType || Actual.M != Expected.M ||
+      Actual.N != Expected.N) {
+    FirstMismatch = 0;
+    return false;
+  }
+
+  switch (Actual.CompType) {
+  case ComponentType::F16:
+    return exactMatrixMatch<HLSLHalf_t>(Actual, Expected, FirstMismatch);
+  case ComponentType::F32:
+    return exactMatrixMatch<float>(Actual, Expected, FirstMismatch);
+  case ComponentType::I32:
+    return exactMatrixMatch<int32_t>(Actual, Expected, FirstMismatch);
+  case ComponentType::U32:
+    return exactMatrixMatch<uint32_t>(Actual, Expected, FirstMismatch);
+  default:
+    FirstMismatch = 0;
+    return false;
+  }
+}
+
+static std::wstring matrixValueString(const TypedMatrix &Matrix, size_t Index) {
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return ComponentTraits<HLSLHalf_t>::format(
+        std::get<std::vector<HLSLHalf_t>>(Matrix.Values)[Index]);
+  case ComponentType::F32:
+    return ComponentTraits<float>::format(
+        std::get<std::vector<float>>(Matrix.Values)[Index]);
+  case ComponentType::I32:
+    return ComponentTraits<int32_t>::format(
+        std::get<std::vector<int32_t>>(Matrix.Values)[Index]);
+  case ComponentType::U32:
+    return ComponentTraits<uint32_t>::format(
+        std::get<std::vector<uint32_t>>(Matrix.Values)[Index]);
+  default:
+    return L"unsupported";
+  }
+}
+
+static MatrixResultOracle exactResult(TypedMatrix Expected,
+                                      std::wstring PublicRule) {
+  return MatrixResultOracle{
+      ComparisonMode::Exact, {std::move(Expected)}, std::move(PublicRule)};
+}
+
+static MatrixResultOracle permittedResults(std::vector<TypedMatrix> Candidates,
+                                           std::wstring PublicRule) {
+  return MatrixResultOracle{ComparisonMode::PermittedResults,
+                            std::move(Candidates), std::move(PublicRule)};
+}
+
+static MatrixResultOracle excludedResult(std::wstring PublicRule) {
+  return MatrixResultOracle{
+      ComparisonMode::Excluded, {}, std::move(PublicRule)};
+}
+
+static bool isOracleValid(const MatrixResultOracle &Oracle) {
+  if (Oracle.PublicRule.empty())
+    return false;
+  if (Oracle.Mode == ComparisonMode::Excluded)
+    return Oracle.Candidates.empty();
+  if (Oracle.Mode == ComparisonMode::Exact && Oracle.Candidates.size() != 1)
+    return false;
+  if (Oracle.Mode == ComparisonMode::PermittedResults &&
+      Oracle.Candidates.size() < 2)
+    return false;
+
+  const TypedMatrix &First = Oracle.Candidates.front();
+  if (!isMatrixValid(First))
+    return false;
+  for (const TypedMatrix &Candidate : Oracle.Candidates) {
+    if (!isMatrixValid(Candidate) || Candidate.CompType != First.CompType ||
+        Candidate.M != First.M || Candidate.N != First.N)
+      return false;
+  }
+  return true;
+}
+
+static bool
+matchesAnyCompleteCandidate(const TypedMatrix &Actual,
+                            const MatrixResultOracle &Oracle,
+                            std::vector<size_t> *FirstMismatches = nullptr) {
+  if (!isOracleValid(Oracle) || Oracle.Mode == ComparisonMode::Excluded)
+    return false;
+
+  if (FirstMismatches)
+    FirstMismatches->clear();
+  for (const TypedMatrix &Candidate : Oracle.Candidates) {
+    size_t FirstMismatch;
+    if (exactMatrixMatch(Actual, Candidate, FirstMismatch))
+      return true;
+    if (FirstMismatches)
+      FirstMismatches->push_back(FirstMismatch);
+  }
+  return false;
+}
+
+static bool verifyMatrixBuffer(const void *ActualBuffer,
+                               size_t ActualBufferSize,
+                               const MatrixBufferLayout &Layout,
+                               const MatrixResultOracle &Oracle, bool Verbose) {
+  if (!isOracleValid(Oracle)) {
+    hlsl_test::LogErrorFmt(L"Invalid matrix oracle");
+    return false;
+  }
+  if (Oracle.Mode == ComparisonMode::Excluded) {
+    hlsl_test::LogErrorFmt(
+        L"Excluded matrix result cannot be used as a success fallback: %s",
+        Oracle.PublicRule.c_str());
+    return false;
+  }
+
+  const TypedMatrix &Shape = Oracle.Candidates.front();
+  std::optional<TypedMatrix> Actual = decodeMatrixBuffer(
+      Shape.CompType, Shape.M, Shape.N, Layout, ActualBuffer, ActualBufferSize);
+  if (!Actual.has_value())
+    return false;
+
+  std::vector<size_t> FirstMismatches;
+  if (matchesAnyCompleteCandidate(*Actual, Oracle, &FirstMismatches)) {
+    if (Verbose) {
+      hlsl_test::LogCommentFmt(
+          L"Matrix comparison passed: component=%s, M=%u, N=%u, mode=%s, "
+          L"rule=%s",
+          componentTypeName(Shape.CompType), Shape.M, Shape.N,
+          comparisonModeName(Oracle.Mode), Oracle.PublicRule.c_str());
+    }
+    return true;
+  }
+
+  hlsl_test::LogErrorFmt(
+      L"No complete matrix candidate matched: component=%s, M=%u, N=%u, "
+      L"mode=%s, rule=%s",
+      componentTypeName(Shape.CompType), Shape.M, Shape.N,
+      comparisonModeName(Oracle.Mode), Oracle.PublicRule.c_str());
+  for (size_t CandidateIndex = 0; CandidateIndex < Oracle.Candidates.size();
+       ++CandidateIndex) {
+    const TypedMatrix &Candidate = Oracle.Candidates[CandidateIndex];
+    const size_t Mismatch = FirstMismatches[CandidateIndex];
+    const size_t Row = Mismatch / Shape.N;
+    const size_t Column = Mismatch % Shape.N;
+    hlsl_test::LogErrorFmt(
+        L"Candidate %zu first mismatch at index=%zu, coordinate=(%zu,%zu): "
+        L"actual=%s, expected=%s",
+        CandidateIndex, Mismatch, Row, Column,
+        matrixValueString(*Actual, Mismatch).c_str(),
+        matrixValueString(Candidate, Mismatch).c_str());
+  }
+  return false;
+}
+
+} // namespace cpu_oracle
+
 static std::string buildCompilerArgs(const MatrixParams &Params,
                                      const char *ExtraDefines = nullptr) {
   std::stringstream SS;
@@ -112,8 +781,14 @@ static std::string buildCompilerArgs(const MatrixParams &Params,
   case ComponentType::F32:
     SS << " -DELEM_TYPE=float";
     break;
-  default:
+  case ComponentType::I32:
+    SS << " -DELEM_TYPE=int";
+    break;
+  case ComponentType::U32:
     SS << " -DELEM_TYPE=uint";
+    break;
+  default:
+    VERIFY_IS_TRUE(false, "Unsupported LinAlg component type");
     break;
   }
   if (Params.Enable16Bit)
@@ -303,6 +978,132 @@ static VariantCompType makeExpectedVec(ComponentType CompType,
                                        bool Increment = true) {
   return makeExpectedMat(CompType, 1, NumElements, StartingVal, Increment,
                          false);
+}
+
+class LinAlgCPUOracleTests {
+public:
+  BEGIN_TEST_CLASS(LinAlgCPUOracleTests)
+  TEST_METHOD_PROPERTY(L"Priority", L"0")
+  END_TEST_CLASS()
+
+  TEST_METHOD(TypedMatrixBufferRoundTrip);
+};
+
+void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
+  using namespace cpu_oracle;
+
+  auto VerifyScalarEncoding = [](const std::optional<TypedMatrix> &Matrix,
+                                 const std::vector<BYTE> &ExpectedBytes) {
+    if (!Matrix.has_value())
+      return false;
+    MatrixBufferLayout Layout = {
+        LinalgMatrixLayout::RowMajor,
+        /*OffsetBytes=*/0,
+        /*StrideBytes=*/ExpectedBytes.size(),
+    };
+    std::vector<BYTE> ActualBytes(ExpectedBytes.size(), 0);
+    MatrixResultOracle Oracle =
+        exactResult(*Matrix, L"Host scalar encoding and decoding");
+    return writeMatrixBuffer(*Matrix, Layout, ActualBytes) &&
+           ActualBytes == ExpectedBytes &&
+           verifyMatrixBuffer(ActualBytes.data(), ActualBytes.size(), Layout,
+                              Oracle, /*Verbose=*/false);
+  };
+
+  VERIFY_IS_TRUE(VerifyScalarEncoding(
+      makeTypedMatrix<HLSLHalf_t>(1, 1, {HLSLHalf_t(1.5f)}), {0x00, 0x3e}));
+  VERIFY_IS_TRUE(VerifyScalarEncoding(makeTypedMatrix<float>(1, 1, {-2.5f}),
+                                      {0x00, 0x00, 0x20, 0xc0}));
+  VERIFY_IS_TRUE(VerifyScalarEncoding(makeTypedMatrix<int32_t>(1, 1, {-7}),
+                                      {0xf9, 0xff, 0xff, 0xff}));
+  VERIFY_IS_TRUE(
+      VerifyScalarEncoding(makeTypedMatrix<uint32_t>(1, 1, {0x89abcdefu}),
+                           {0xef, 0xcd, 0xab, 0x89}));
+
+  std::optional<TypedMatrix> Matrix =
+      makeTypedMatrix<uint32_t>(2, 3, {1, 2, 3, 4, 5, 6});
+  VERIFY_IS_TRUE(Matrix.has_value());
+
+  MatrixBufferLayout RowMajor = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/4,
+      /*StrideBytes=*/16,
+  };
+  std::optional<size_t> RowBytes = getMatrixBufferSize(*Matrix, RowMajor);
+  VERIFY_IS_TRUE(RowBytes.has_value());
+  std::vector<BYTE> RowBuffer(*RowBytes, 0xcd);
+  VERIFY_IS_TRUE(writeMatrixBuffer(*Matrix, RowMajor, RowBuffer));
+  const std::vector<BYTE> ExpectedRowBuffer = {
+      0xcd, 0xcd, 0xcd, 0xcd, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+      0x00, 0x03, 0x00, 0x00, 0x00, 0xcd, 0xcd, 0xcd, 0xcd, 0x04, 0x00,
+      0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+  };
+  VERIFY_IS_TRUE(RowBuffer == ExpectedRowBuffer);
+  MatrixResultOracle Exact =
+      exactResult(*Matrix, L"Host exact row-major matrix encoding");
+  VERIFY_IS_TRUE(verifyMatrixBuffer(RowBuffer.data(), RowBuffer.size(),
+                                    RowMajor, Exact, /*Verbose=*/false));
+
+  MatrixBufferLayout ColumnMajor = {
+      LinalgMatrixLayout::ColumnMajor,
+      /*OffsetBytes=*/4,
+      /*StrideBytes=*/12,
+  };
+  std::optional<size_t> ColumnBytes = getMatrixBufferSize(*Matrix, ColumnMajor);
+  VERIFY_IS_TRUE(ColumnBytes.has_value());
+  std::vector<BYTE> ColumnBuffer(*ColumnBytes, 0xcd);
+  VERIFY_IS_TRUE(writeMatrixBuffer(*Matrix, ColumnMajor, ColumnBuffer));
+  const std::vector<BYTE> ExpectedColumnBuffer = {
+      0xcd, 0xcd, 0xcd, 0xcd, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+      0xcd, 0xcd, 0xcd, 0xcd, 0x02, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
+      0xcd, 0xcd, 0xcd, 0xcd, 0x03, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+  };
+  VERIFY_IS_TRUE(ColumnBuffer == ExpectedColumnBuffer);
+  VERIFY_IS_TRUE(verifyMatrixBuffer(ColumnBuffer.data(), ColumnBuffer.size(),
+                                    ColumnMajor, Exact, /*Verbose=*/false));
+
+  std::optional<TypedMatrix> Transposed = transposeMatrix(*Matrix);
+  std::optional<TypedMatrix> ExpectedTranspose =
+      makeTypedMatrix<uint32_t>(3, 2, {1, 4, 2, 5, 3, 6});
+  VERIFY_IS_TRUE(Transposed.has_value());
+  VERIFY_IS_TRUE(ExpectedTranspose.has_value());
+  size_t FirstMismatch;
+  VERIFY_IS_TRUE(
+      exactMatrixMatch(*Transposed, *ExpectedTranspose, FirstMismatch));
+
+  std::optional<TypedMatrix> MixedActual =
+      makeTypedMatrix<uint32_t>(1, 2, {1, 4});
+  std::optional<TypedMatrix> CandidateA =
+      makeTypedMatrix<uint32_t>(1, 2, {1, 2});
+  std::optional<TypedMatrix> CandidateB =
+      makeTypedMatrix<uint32_t>(1, 2, {3, 4});
+  VERIFY_IS_TRUE(MixedActual.has_value());
+  VERIFY_IS_TRUE(CandidateA.has_value());
+  VERIFY_IS_TRUE(CandidateB.has_value());
+  MatrixResultOracle Permitted =
+      permittedResults({*CandidateA, *CandidateB},
+                       L"Host whole-result permitted candidate semantics");
+  VERIFY_IS_FALSE(matchesAnyCompleteCandidate(*MixedActual, Permitted));
+  Permitted.Candidates.push_back(*MixedActual);
+  VERIFY_IS_TRUE(matchesAnyCompleteCandidate(*MixedActual, Permitted));
+
+  MatrixResultOracle Excluded =
+      excludedResult(L"Host excluded-oracle classification");
+  VERIFY_IS_FALSE(matchesAnyCompleteCandidate(*Matrix, Excluded));
+
+  MatrixParams Params = {};
+  Params.M = 2;
+  Params.N = 3;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 4;
+  Params.CompType = ComponentType::I32;
+  VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=int") !=
+                 std::string::npos);
+  Params.CompType = ComponentType::U32;
+  VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=uint") !=
+                 std::string::npos);
 }
 
 class DxilConf_SM610_LinAlg {
@@ -837,8 +1638,6 @@ static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
                            bool Transpose) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
   MatrixParams DstParams = Params;
   if (Transpose) {
     DstParams.M = Params.N;
@@ -856,31 +1655,63 @@ static void runCopyConvert(ID3D12Device *Device,
 
   compileShader(DxcSupport, CopyConvertShader, "cs_6_10", Args, Verbose);
 
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1,
-                                  /*Increment=*/true, Transpose);
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value(),
+                 "Unable to construct typed CopyConvert input");
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      Transpose ? cpu_oracle::transposeMatrix(*Input) : Input;
+  VERIFY_IS_TRUE(Expected.has_value(),
+                 "Unable to construct independent CopyConvert oracle");
+
+  cpu_oracle::MatrixBufferLayout SourceLayout = {
+      Params.Layout,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/Params.strideBytes(),
+  };
+  cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      DstParams.Layout,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/DstParams.strideBytes(),
+  };
+  std::optional<size_t> SourceBufferSize =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  std::optional<size_t> DestinationBufferSize =
+      cpu_oracle::getMatrixBufferSize(*Expected, DestinationLayout);
+  VERIFY_IS_TRUE(SourceBufferSize.has_value(),
+                 "Unable to size typed CopyConvert input");
+  VERIFY_IS_TRUE(DestinationBufferSize.has_value(),
+                 "Unable to size typed CopyConvert output");
+
+  cpu_oracle::TypedMatrix InputMatrix = *Input;
+  cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
+      *Expected,
+      L"HLSL proposal 0035 CopyConvertMatrix transpose and descriptor layout");
 
   // Construct the ShaderOp: two UAV buffers, load from one, store to other.
   auto Op = createComputeOp(CopyConvertShader, "cs_6_10", "UAV(u0), UAV(u1)",
                             Args.c_str());
-  addUAVBuffer(Op.get(), "Input", BufferSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
+  addUAVBuffer(Op.get(), "Input", *SourceBufferSize, false, "byname");
+  addUAVBuffer(Op.get(), "Output", *DestinationBufferSize, true);
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [InputMatrix, SourceLayout](LPCSTR Name, std::vector<BYTE> &Data,
+                                  st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(
+            cpu_oracle::writeMatrixBuffer(InputMatrix, SourceLayout, Data),
+            "Unable to encode typed CopyConvert input");
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
 
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
+      OutData.data(), OutData.size(), DestinationLayout, Oracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16() {

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -26,6 +26,7 @@
 
 #include <climits>
 #include <cstring>
+#include <initializer_list>
 #include <limits>
 #include <optional>
 #include <sstream>
@@ -450,6 +451,33 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
   }
   default:
     hlsl_test::LogErrorFmt(L"Unsupported sequential matrix component type: %u",
+                           static_cast<uint32_t>(CompType));
+    return std::nullopt;
+  }
+}
+
+static std::optional<TypedMatrix> makeZeroMatrix(ComponentType CompType,
+                                                 MatrixDim M, MatrixDim N) {
+  size_t NumElements;
+  if (M == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
+                       NumElements)) {
+    hlsl_test::LogErrorFmt(L"Invalid zero matrix dimensions: M=%u, N=%u", M, N);
+    return std::nullopt;
+  }
+
+  switch (CompType) {
+  case ComponentType::F16:
+    return makeTypedMatrix(
+        M, N, std::vector<HLSLHalf_t>(NumElements, HLSLHalf_t(0.0f)));
+  case ComponentType::F32:
+    return makeTypedMatrix(M, N, std::vector<float>(NumElements, 0.0f));
+  case ComponentType::I32:
+    return makeTypedMatrix(M, N, std::vector<int32_t>(NumElements, 0));
+  case ComponentType::U32:
+    return makeTypedMatrix(M, N, std::vector<uint32_t>(NumElements, 0));
+  default:
+    hlsl_test::LogErrorFmt(L"Unsupported zero matrix component type: %u",
                            static_cast<uint32_t>(CompType));
     return std::nullopt;
   }
@@ -1366,7 +1394,10 @@ public:
 
   // Element access
   TEST_METHOD(ElementAccess_Wave_16x16_F16);
+  TEST_METHOD(ElementAccess_Wave_4x8_F32);
+  TEST_METHOD(ElementGetOOB_Wave_4x8_F32);
   TEST_METHOD(ElementSet_Wave_16x16_F16);
+  TEST_METHOD(ElementSetOOB_Wave_4x8_F32);
 
   // Cast/Convert
   TEST_METHOD(CopyConvert_Wave_16x16_F16);
@@ -1656,17 +1687,129 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging);
 }
 
-static const char ElementAccessShader[] = R"(
-  RWByteAddressBuffer Input : register(u0);
-  RWByteAddressBuffer Output : register(u1);
+struct MatrixConstructionRequirement {
+  linalg_test::MatrixRole Role;
+  MatrixDim Rows;
+  MatrixDim Columns;
+};
 
-  // flatten the 2D index into a 1D index then scale by element size
-  // Always store row-major and work it out in the test runner
-  uint coordToByteOffset(uint2 coord) {
-    return (coord.x * N_DIM + coord.y) * ELEM_SIZE;
+static LPCWSTR matrixRoleName(linalg_test::MatrixRole Role) {
+  switch (Role) {
+  case linalg_test::MatrixRole::A:
+    return L"A";
+  case linalg_test::MatrixRole::B:
+    return L"B";
+  case linalg_test::MatrixRole::Accumulator:
+    return L"Accumulator";
+  }
+  return L"Unknown";
+}
+
+static HRESULT queryMatrixConstructionSupport(
+    ID3D12Device *Device, const MatrixParams &Params,
+    std::initializer_list<MatrixConstructionRequirement> Requirements,
+    LPCWSTR CaseName, bool &Supported, UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!Device || !CaseName || Requirements.size() == 0 ||
+      !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
+                                 toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  for (const MatrixConstructionRequirement &Requirement : Requirements) {
+    if (Requirement.Rows == 0 || Requirement.Columns == 0)
+      return E_INVALIDARG;
   }
 
+  std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
+                                   sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  if (!WaveOptions.WaveOps) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; %s is not applicable", CaseName);
+    return S_OK;
+  }
+
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < WaveOptions.WaveLaneCountMin ||
+        WaveSize > WaveOptions.WaveLaneCountMax)
+      continue;
+
+    linalg_test::MatrixConstructionSupport Construction;
+    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
+                                              Construction);
+    if (FAILED(HR))
+      return HR;
+
+    bool AllSupported = true;
+    for (const MatrixConstructionRequirement &Requirement : Requirements) {
+      if (!Construction.supports(Requirement.Role, Requirement.Rows,
+                                 Requirement.Columns)) {
+        AllSupported = false;
+        break;
+      }
+    }
+    if (!AllSupported)
+      continue;
+
+    hlsl_test::LogCommentFmt(
+        L"MatrixConstruction capability matched wave=%u for %s", WaveSize,
+        CaseName);
+    for (const MatrixConstructionRequirement &Requirement : Requirements) {
+      hlsl_test::LogCommentFmt(L"  role=%s, rows=%u, columns=%u",
+                               matrixRoleName(Requirement.Role),
+                               Requirement.Rows, Requirement.Columns);
+    }
+    Supported = true;
+    SelectedWaveSize = WaveSize;
+    return S_OK;
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No MatrixConstruction query within shader WaveSize(4,64) supports %s",
+      CaseName);
+  return S_OK;
+}
+
+static const char ElementAccessShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Coordinates : register(u1);
+  RWByteAddressBuffer Values : register(u2);
+  RWByteAddressBuffer Lengths : register(u3);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
     if (GetGroupWaveIndex() != 0)
@@ -1678,72 +1821,163 @@ static const char ElementAccessShader[] = R"(
     __builtin_LinAlg_MatrixLoadFromDescriptor(
       Mat, Input, 0, STRIDE, LAYOUT, 128);
 
-    // Copy Matrix values from input to output without assuming order
-    for (uint I = 0; I < __builtin_LinAlg_MatrixLength(Mat); ++I) {
+    uint Len = __builtin_LinAlg_MatrixLength(Mat);
+    Lengths.Store<uint>(threadID * sizeof(uint), Len);
+
+    // Each thread writes to a private slice because implementations may map
+    // multiple threads to the same matrix component.
+    uint SafeLen = min(Len, (uint)(M_DIM * N_DIM));
+    for (uint I = 0; I < SafeLen; ++I) {
       uint2 Coord = __builtin_LinAlg_MatrixGetCoordinate(Mat, I);
-      uint Offset = coordToByteOffset(Coord);
       ELEM_TYPE Elem;
       __builtin_LinAlg_MatrixGetElement(Elem, Mat, I);
-      Output.Store<ELEM_TYPE>(Offset, Elem);
+      uint Slot = threadID * (M_DIM * N_DIM) + I;
+      Coordinates.Store2(Slot * sizeof(uint2), Coord);
+      Values.Store<ELEM_TYPE>(Slot * ELEM_SIZE, Elem);
     }
-
-    // Save the matrix length that this thread saw. The length is written
-    // to the output right after the matrix, offset by the thread index
-    uint LenIdx = (M_DIM * N_DIM * ELEM_SIZE) + (threadID * sizeof(uint));
-    uint Len = __builtin_LinAlg_MatrixLength(Mat);
-    Output.Store<uint>(LenIdx, Len);
   }
 )";
 
 static void runElementAccess(ID3D12Device *Device,
                              dxc::SpecificDllLoader &DxcSupport,
-                             const MatrixParams &Params, bool Verbose) {
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t NumThreads = Params.NumThreads;
   const size_t MatrixSize = Params.totalBytes();
-  // OutputBuf needs to fit the Matrix plus one uint per thread
-  const size_t OutputBufSize = MatrixSize + NumThreads * sizeof(uint32_t);
+  const size_t MaxRecords = NumThreads * NumElements;
+  const size_t CoordinateBufferSize = MaxRecords * 2 * sizeof(uint32_t);
+  const size_t ValueBufferSize = MaxRecords * elementSize(Params.CompType);
+  const size_t LengthBufferSize = NumThreads * sizeof(uint32_t);
 
   std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, ElementAccessShader, "cs_6_10", Args, Verbose);
 
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1);
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Expected.has_value(),
+                 "Unable to construct typed element-access input");
+  const cpu_oracle::MatrixBufferLayout InputLayout = {
+      Params.Layout,
+      0,
+      Params.strideBytes(),
+  };
+  const cpu_oracle::MatrixBufferLayout PackedRowMajor = {
+      LinalgMatrixLayout::RowMajor,
+      0,
+      static_cast<size_t>(Params.N) * elementSize(Params.CompType),
+  };
+  std::vector<BYTE> ExpectedBytes(MatrixSize, 0);
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(*Expected, PackedRowMajor, ExpectedBytes),
+      "Unable to encode typed element-access expectation");
+  const cpu_oracle::TypedMatrix ExpectedMatrix = *Expected;
 
-  auto Op = createComputeOp(ElementAccessShader, "cs_6_10", "UAV(u0), UAV(u1)",
-                            Args.c_str());
+  auto Op = createComputeOp(ElementAccessShader, "cs_6_10",
+                            "UAV(u0), UAV(u1), UAV(u2), UAV(u3)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", OutputBufSize, true);
+  addUAVBuffer(Op.get(), "Coordinates", CoordinateBufferSize, true);
+  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true);
+  addUAVBuffer(Op.get(), "Lengths", LengthBufferSize, true);
   addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
+  addRootView(Op.get(), 1, "Coordinates");
+  addRootView(Op.get(), 2, "Values");
+  addRootView(Op.get(), 3, "Lengths");
 
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [ExpectedMatrix, InputLayout](LPCSTR Name, std::vector<BYTE> &Data,
+                                    st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(
+            cpu_oracle::writeMatrixBuffer(ExpectedMatrix, InputLayout, Data),
+            "Unable to encode element-access input");
+      });
 
-  MappedData OutData;
-  Result->Test->GetReadBackData("Output", &OutData);
+  MappedData CoordinateData;
+  MappedData ValueData;
+  MappedData LengthData;
+  Result->Test->GetReadBackData("Coordinates", &CoordinateData);
+  Result->Test->GetReadBackData("Values", &ValueData);
+  Result->Test->GetReadBackData("Lengths", &LengthData);
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(CoordinateData.size(),
+                                  static_cast<UINT32>(CoordinateBufferSize));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(ValueData.size(),
+                                  static_cast<UINT32>(ValueBufferSize));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(LengthData.size(),
+                                  static_cast<UINT32>(LengthBufferSize));
 
-  // Verify the front of the buffer is a list of elements of the expected type
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  const BYTE *CoordinateBytes =
+      static_cast<const BYTE *>(CoordinateData.data());
+  const BYTE *ValueBytes = static_cast<const BYTE *>(ValueData.data());
+  const BYTE *LengthBytes = static_cast<const BYTE *>(LengthData.data());
+  const size_t ElementBytes = elementSize(Params.CompType);
+  std::vector<bool> Seen(NumElements, false);
+  uint64_t TotalLength = 0;
+  bool RecordsValid = true;
 
-  // Verify the end of the buffer is NumThreads number of lengths, whose
-  // sum is greater than or equal to NumElements
-  const BYTE *Out = static_cast<const BYTE *>(OutData.data());
-  const uint32_t *Lengths =
-      reinterpret_cast<const uint32_t *>(Out + MatrixSize);
-  uint32_t TotalLength = 0;
-  for (size_t I = 0; I < NumThreads; ++I)
-    TotalLength += Lengths[I];
+  for (size_t Thread = 0; Thread < NumThreads && RecordsValid; ++Thread) {
+    uint32_t Length;
+    std::memcpy(&Length, LengthBytes + Thread * sizeof(Length), sizeof(Length));
+    TotalLength += Length;
+    if (Length > NumElements) {
+      hlsl_test::LogErrorFmt(
+          L"MatrixLength returned too many elements: thread=%zu, length=%u, "
+          L"matrixElements=%zu",
+          Thread, Length, NumElements);
+      RecordsValid = false;
+      break;
+    }
+
+    for (size_t LocalIndex = 0; LocalIndex < Length; ++LocalIndex) {
+      const size_t Slot = Thread * NumElements + LocalIndex;
+      uint32_t Coordinate[2];
+      std::memcpy(Coordinate, CoordinateBytes + Slot * 2 * sizeof(uint32_t),
+                  sizeof(Coordinate));
+      const uint32_t Row = Coordinate[0];
+      const uint32_t Column = Coordinate[1];
+      if (Row >= Params.M || Column >= Params.N) {
+        hlsl_test::LogErrorFmt(
+            L"GetCoordinate returned an invalid coordinate: thread=%zu, "
+            L"index=%zu, coordinate=(%u,%u), matrix=(%u,%u)",
+            Thread, LocalIndex, Row, Column, Params.M, Params.N);
+        RecordsValid = false;
+        break;
+      }
+
+      const size_t MatrixIndex = static_cast<size_t>(Row) * Params.N + Column;
+      if (std::memcmp(ValueBytes + Slot * ElementBytes,
+                      ExpectedBytes.data() + MatrixIndex * ElementBytes,
+                      ElementBytes) != 0) {
+        hlsl_test::LogErrorFmt(
+            L"GetElement did not match its reported coordinate: thread=%zu, "
+            L"index=%zu, coordinate=(%u,%u)",
+            Thread, LocalIndex, Row, Column);
+        RecordsValid = false;
+        break;
+      }
+      Seen[MatrixIndex] = true;
+    }
+  }
+
+  VERIFY_IS_TRUE(RecordsValid,
+                 "Matrix Length/GetCoordinate/GetElement records were invalid");
   VERIFY_IS_GREATER_THAN_OR_EQUAL(
-      TotalLength, NumElements, "Sum of all lengths must be gte num elements");
+      TotalLength, static_cast<uint64_t>(NumElements),
+      "Sum of all lengths must cover at least the matrix element count");
+  for (size_t MatrixIndex = 0; MatrixIndex < NumElements; ++MatrixIndex) {
+    if (!Seen[MatrixIndex]) {
+      hlsl_test::LogErrorFmt(
+          L"No thread-local element mapped to matrix coordinate=(%zu,%zu)",
+          MatrixIndex / Params.N, MatrixIndex % Params.N);
+      VERIFY_IS_TRUE(false, "Matrix coordinate was not covered");
+    }
+  }
 }
 
 void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
@@ -1759,11 +1993,178 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
   runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging);
 }
 
+void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}},
+      L"ElementAccess_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"ElementAccess_Wave_4x8_F32"))
+    return;
+
+  runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
+}
+
+static const char ElementGetOOBShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Values : register(u1);
+  RWByteAddressBuffer Executed : register(u2);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, Input, 0, STRIDE, LAYOUT, 128);
+
+    uint OOBIndex = __builtin_LinAlg_MatrixLength(Mat);
+    ELEM_TYPE Elem;
+    __builtin_LinAlg_MatrixGetElement(Elem, Mat, OOBIndex);
+    Values.Store<ELEM_TYPE>(threadID * ELEM_SIZE, Elem);
+    Executed.Store<uint>(threadID * sizeof(uint), 1);
+  }
+)";
+
+static void runElementGetOOB(ID3D12Device *Device,
+                             dxc::SpecificDllLoader &DxcSupport,
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize = 0) {
+  const size_t NumThreads = Params.NumThreads;
+  const size_t MatrixSize = Params.totalBytes();
+  const size_t ValueBufferSize = NumThreads * elementSize(Params.CompType);
+  const size_t ExecutedBufferSize = NumThreads * sizeof(uint32_t);
+  std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+
+  compileShader(DxcSupport, ElementGetOOBShader, "cs_6_10", Args, Verbose);
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> Expected = cpu_oracle::makeZeroMatrix(
+      Params.CompType, 1, static_cast<MatrixDim>(NumThreads));
+  VERIFY_IS_TRUE(Input.has_value() && Expected.has_value(),
+                 "Unable to construct typed GetElement OOB data");
+  const cpu_oracle::MatrixBufferLayout InputLayout = {
+      Params.Layout,
+      0,
+      Params.strideBytes(),
+  };
+  const cpu_oracle::MatrixBufferLayout ValueLayout = {
+      LinalgMatrixLayout::RowMajor,
+      0,
+      ValueBufferSize,
+  };
+  const cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
+      *Expected, L"Matrix::Get returns zero when Index equals Length()");
+  const cpu_oracle::TypedMatrix InputMatrix = *Input;
+
+  auto Op = createComputeOp(ElementGetOOBShader, "cs_6_10",
+                            "UAV(u0), UAV(u1), UAV(u2)", Args.c_str());
+  addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
+  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true);
+  addUAVBuffer(Op.get(), "Executed", ExecutedBufferSize, true);
+  addRootView(Op.get(), 0, "Input");
+  addRootView(Op.get(), 1, "Values");
+  addRootView(Op.get(), 2, "Executed");
+
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [InputMatrix, InputLayout](LPCSTR Name, std::vector<BYTE> &Data,
+                                 st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(
+            cpu_oracle::writeMatrixBuffer(InputMatrix, InputLayout, Data),
+            "Unable to encode GetElement OOB input");
+      });
+
+  MappedData ValueData;
+  MappedData ExecutedData;
+  Result->Test->GetReadBackData("Values", &ValueData);
+  Result->Test->GetReadBackData("Executed", &ExecutedData);
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
+      ValueData.data(), ValueData.size(), ValueLayout, Oracle, Verbose));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(ExecutedData.size(),
+                                  static_cast<UINT32>(ExecutedBufferSize));
+
+  const BYTE *ExecutedBytes = static_cast<const BYTE *>(ExecutedData.data());
+  size_t ExecutedThreads = 0;
+  for (size_t Thread = 0; Thread < NumThreads; ++Thread) {
+    uint32_t Marker;
+    std::memcpy(&Marker, ExecutedBytes + Thread * sizeof(Marker),
+                sizeof(Marker));
+    VERIFY_IS_TRUE(Marker == 0 || Marker == 1,
+                   "GetElement OOB execution marker was invalid");
+    ExecutedThreads += Marker;
+  }
+  VERIFY_IS_GREATER_THAN(ExecutedThreads, static_cast<size_t>(0),
+                         "At least one thread must execute the OOB read");
+}
+
+void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}},
+      L"ElementGetOOB_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"ElementGetOOB_Wave_4x8_F32"))
+    return;
+
+  runElementGetOOB(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
+}
+
 static const char ElementSetShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1788,42 +2189,87 @@ static const char ElementSetShader[] = R"(
   }
 )";
 
+static const char ElementSetOOBShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Output : register(u1);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main() {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, Input, 0, STRIDE, LAYOUT, 128);
+
+    uint OOBIndex = __builtin_LinAlg_MatrixLength(Mat);
+    __builtin_LinAlg_MatrixSetElement(
+      Mat, Mat, OOBIndex, (ELEM_TYPE)123);
+
+    __builtin_LinAlg_MatrixStoreToDescriptor(
+      Mat, Output, 0, STRIDE, LAYOUT, 128);
+  }
+)";
+
 static void runElementSet(ID3D12Device *Device,
                           dxc::SpecificDllLoader &DxcSupport,
-                          const MatrixParams &Params, bool Verbose) {
-  const size_t NumElements = Params.totalElements();
+                          const MatrixParams &Params, const char *Shader,
+                          uint32_t ExpectedStartingValue, LPCWSTR PublicRule,
+                          bool Verbose, UINT ForcedWaveSize = 0) {
   const size_t MatrixSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
-  compileShader(DxcSupport, ElementSetShader, "cs_6_10", Args, Verbose);
+  compileShader(DxcSupport, Shader, "cs_6_10", Args, Verbose);
 
-  // Start counting from 6 since each element was increased by 5
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 6);
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N,
+                                       ExpectedStartingValue);
+  VERIFY_IS_TRUE(Input.has_value() && Expected.has_value(),
+                 "Unable to construct typed SetElement data");
+  const cpu_oracle::MatrixBufferLayout Layout = {
+      Params.Layout,
+      0,
+      Params.strideBytes(),
+  };
+  const cpu_oracle::MatrixResultOracle Oracle =
+      cpu_oracle::exactResult(*Expected, PublicRule);
+  const cpu_oracle::TypedMatrix InputMatrix = *Input;
 
-  auto Op = createComputeOp(ElementSetShader, "cs_6_10", "UAV(u0), UAV(u1)",
-                            Args.c_str());
+  auto Op =
+      createComputeOp(Shader, "cs_6_10", "UAV(u0), UAV(u1)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
   addUAVBuffer(Op.get(), "Output", MatrixSize, true);
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [InputMatrix, Layout](LPCSTR Name, std::vector<BYTE> &Data,
+                            st::ShaderOp *) {
+        if (_stricmp(Name, "Input") != 0)
+          return;
+        VERIFY_IS_TRUE(cpu_oracle::writeMatrixBuffer(InputMatrix, Layout, Data),
+                       "Unable to encode SetElement input");
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
 
-  // Verify the front of the buffer is a list of elements of the expected type
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(OutData.data(), OutData.size(),
+                                                Layout, Oracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
@@ -1836,7 +2282,40 @@ void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runElementSet(D3DDevice, DxcSupport, Params, VerboseLogging);
+  runElementSet(D3DDevice, DxcSupport, Params, ElementSetShader,
+                /*ExpectedStartingValue=*/6,
+                L"Matrix::Set updates every in-range thread-local element",
+                VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}},
+      L"ElementSetOOB_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"ElementSetOOB_Wave_4x8_F32"))
+    return;
+
+  runElementSet(D3DDevice, DxcSupport, Params, ElementSetOOBShader,
+                /*ExpectedStartingValue=*/1,
+                L"Matrix::Set is a no-op when Index equals Length()",
+                VerboseLogging, SelectedWaveSize);
 }
 
 static const char CopyConvertShader[] = R"(
@@ -1874,48 +2353,8 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
                                        UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
-  if (!Device || Params.Use != MatrixUse::A ||
-      !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
-                                 toCapabilityScope(Params.Scope)))
+  if (Params.Use != MatrixUse::A)
     return E_INVALIDARG;
-
-  std::optional<linalg_test::DataType> DataType =
-      toCapabilityDataType(Params.CompType);
-  if (!DataType.has_value())
-    return E_INVALIDARG;
-
-  linalg_test::TierSupport Tier;
-  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
-  if (FAILED(HR) || !Tier.supported())
-    return HR;
-
-  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
-  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
-                                   sizeof(WaveOptions));
-  if (FAILED(HR)) {
-    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
-    return HR;
-  }
-  if (!WaveOptions.WaveOps) {
-    hlsl_test::LogCommentFmt(
-        L"Wave operations are unsupported; MatrixConstruction is not "
-        L"applicable");
-    return S_OK;
-  }
-
-  const auto IsPowerOfTwo = [](UINT Value) {
-    return Value != 0 && (Value & (Value - 1)) == 0;
-  };
-  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
-      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
-      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
-    hlsl_test::LogCommentFmt(
-        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
-        L"max=%u",
-        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
-        WaveOptions.WaveLaneCountMax);
-    return E_UNEXPECTED;
-  }
 
   MatrixParams Destination = Params;
   if (Transpose) {
@@ -1923,34 +2362,13 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
     Destination.N = Params.M;
   }
 
-  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < WaveOptions.WaveLaneCountMin ||
-        WaveSize > WaveOptions.WaveLaneCountMax)
-      continue;
-
-    linalg_test::MatrixConstructionSupport Construction;
-    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
-                                              Construction);
-    if (FAILED(HR))
-      return HR;
-    if (Construction.supports(linalg_test::MatrixRole::A, Params.M, Params.N) &&
-        Construction.supports(linalg_test::MatrixRole::A, Destination.M,
-                              Destination.N)) {
-      hlsl_test::LogCommentFmt(
-          L"CopyConvert capability matched wave=%u for source=%ux%u and "
-          L"destination=%ux%u",
-          WaveSize, Params.M, Params.N, Destination.M, Destination.N);
-      Supported = true;
-      SelectedWaveSize = WaveSize;
-      return S_OK;
-    }
-  }
-
-  hlsl_test::LogCommentFmt(
-      L"No MatrixConstruction query within shader WaveSize(4,64) supports "
-      L"CopyConvert source=%ux%u and destination=%ux%u",
-      Params.M, Params.N, Destination.M, Destination.N);
-  return S_OK;
+  return queryMatrixConstructionSupport(
+      Device, Params,
+      {
+          {linalg_test::MatrixRole::A, Params.M, Params.N},
+          {linalg_test::MatrixRole::A, Destination.M, Destination.N},
+      },
+      L"CopyConvert source and destination", Supported, SelectedWaveSize);
 }
 
 static void runCopyConvert(ID3D12Device *Device,

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3413,7 +3413,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F16_ToF32() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -3441,7 +3441,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_ToF16_Transpose() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4972,7 +4972,7 @@ void DxilConf_SM610_LinAlg::Convert_F16_FP8_RoundTrip() {
   Params.N = 1;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -96,6 +96,78 @@ struct MatrixParams {
   size_t totalBytes() const { return totalElements() * elementSize(CompType); }
 };
 
+static std::optional<linalg_test::DataType>
+toCapabilityDataType(ComponentType CompType) {
+  using linalg_test::DataType;
+  switch (CompType) {
+  case ComponentType::I16:
+    return DataType::SInt16;
+  case ComponentType::U16:
+    return DataType::UInt16;
+  case ComponentType::I32:
+    return DataType::SInt32;
+  case ComponentType::U32:
+    return DataType::UInt32;
+  case ComponentType::F16:
+    return DataType::Float16;
+  case ComponentType::F32:
+    return DataType::Float32;
+  case ComponentType::I8:
+    return DataType::SInt8;
+  case ComponentType::U8:
+    return DataType::UInt8;
+  case ComponentType::F8_E4M3FN:
+    return DataType::Float8E4M3FN;
+  case ComponentType::F8_E5M2:
+    return DataType::Float8E5M2;
+  default:
+    return std::nullopt;
+  }
+}
+
+static linalg_test::ExecutionScope toCapabilityScope(MatrixScope Scope) {
+  switch (Scope) {
+  case MatrixScope::Thread:
+    return linalg_test::ExecutionScope::Thread;
+  case MatrixScope::Wave:
+    return linalg_test::ExecutionScope::Wave;
+  case MatrixScope::ThreadGroup:
+    return linalg_test::ExecutionScope::ThreadGroup;
+  }
+  VERIFY_IS_TRUE(false, "Unsupported LinAlg matrix scope");
+  return linalg_test::ExecutionScope::Thread;
+}
+
+static bool applyApplicability(linalg_test::Applicability Result,
+                               LPCWSTR CaseName) {
+  using linalg_test::Applicability;
+  switch (Result) {
+  case Applicability::Execute:
+    return true;
+  case Applicability::NotApplicable:
+#ifdef _HLK_CONF
+    hlsl_test::LogErrorFmt(
+        L"Capability-gated case %s reached HLK execution on an unsupported "
+        L"device. Requirement or playlist applicability must exclude it.",
+        CaseName);
+    VERIFY_IS_TRUE(false,
+                   "Unsupported capability-gated case reached HLK execution");
+#else
+    hlsl_test::LogCommentFmt(
+        L"Capability-gated case %s is not applicable on this device", CaseName);
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+#endif
+    return false;
+  case Applicability::Fail:
+    hlsl_test::LogErrorFmt(L"Capability evaluation failed for case %s",
+                           CaseName);
+    VERIFY_IS_TRUE(false, "LinAlg capability evaluation failed");
+    return false;
+  }
+  VERIFY_IS_TRUE(false, "Unknown LinAlg applicability result");
+  return false;
+}
+
 namespace cpu_oracle {
 
 using TypedMatrixValues =
@@ -1123,6 +1195,133 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
                  std::string::npos);
 }
 
+class LinAlgCapabilityTests {
+public:
+  BEGIN_TEST_CLASS(LinAlgCapabilityTests)
+  TEST_METHOD_PROPERTY(L"Priority", L"0")
+  END_TEST_CLASS()
+
+  TEST_METHOD(CapabilityPolicyAndPredicates);
+};
+
+void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
+  using namespace linalg_test;
+
+  VERIFY_IS_TRUE(
+      classifyApplicability(S_OK, true, CapabilityRequirement::Mandatory) ==
+      Applicability::Execute);
+  VERIFY_IS_TRUE(classifyApplicability(
+                     S_OK, false, CapabilityRequirement::CapabilityGated) ==
+                 Applicability::NotApplicable);
+  VERIFY_IS_TRUE(
+      classifyApplicability(S_OK, false, CapabilityRequirement::Mandatory) ==
+      Applicability::Fail);
+  VERIFY_IS_TRUE(
+      classifyApplicability(E_UNEXPECTED, true,
+                            CapabilityRequirement::CapabilityGated) ==
+      Applicability::Fail);
+
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::MatrixConstruction, ExecutionScope::Wave));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::MatrixConstruction,
+                              ExecutionScope::ThreadGroup));
+  VERIFY_IS_FALSE(
+      isLegalScope(OperationType::MatrixConstruction, ExecutionScope::Thread));
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::WaveMatrixMultiply, ExecutionScope::Wave));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::ThreadGroupMatrixMultiply,
+                              ExecutionScope::ThreadGroup));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::ThreadVectorMatrixMultiply,
+                              ExecutionScope::Thread));
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::ThreadOuterProduct, ExecutionScope::Thread));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::AtomicAccumulateStore,
+                              ExecutionScope::Thread));
+  VERIFY_IS_TRUE(
+      isLegalScope(OperationType::AtomicAccumulateStore, ExecutionScope::Wave));
+  VERIFY_IS_TRUE(isLegalScope(OperationType::AtomicAccumulateStore,
+                              ExecutionScope::ThreadGroup));
+
+  MatrixConstructionSupport Construction = {4, 8, 16};
+  VERIFY_IS_TRUE(Construction.valid());
+  VERIFY_IS_TRUE(Construction.supports(MatrixRole::A, 4, 8));
+  VERIFY_IS_TRUE(Construction.supports(MatrixRole::B, 8, 16));
+  VERIFY_IS_TRUE(Construction.supports(MatrixRole::Accumulator, 4, 16));
+  VERIFY_IS_FALSE(Construction.supports(MatrixRole::A, 3, 8));
+  MatrixConstructionSupport InvalidConstruction = {4, 0, 16};
+  VERIFY_IS_FALSE(InvalidConstruction.valid());
+
+  WaveMatrixMultiplySupport Wave = {
+      MultiplicationFlags::Supported,
+      {{8, 16, 8}, {16, 16, 16}},
+  };
+  VERIFY_IS_TRUE(Wave.valid());
+  VERIFY_IS_TRUE(Wave.supportsShape(32, 32, 16));
+  VERIFY_IS_FALSE(Wave.supportsShape(12, 32, 16));
+  WaveMatrixMultiplySupport InvalidWave = {
+      MultiplicationFlags::EmulatedInputs,
+      {},
+  };
+  VERIFY_IS_FALSE(InvalidWave.valid());
+
+  ThreadGroupMatrixMultiplySupport ThreadGroup = {
+      MultiplicationFlags::Supported,
+      32,
+      128,
+      64,
+  };
+  VERIFY_IS_TRUE(ThreadGroup.valid());
+  VERIFY_IS_TRUE(ThreadGroup.supportsThreadGroupSize(64));
+  VERIFY_IS_FALSE(ThreadGroup.supportsThreadGroupSize(48));
+  ThreadGroup.PreferredThreadGroupSize = 48;
+  VERIFY_IS_FALSE(ThreadGroup.valid());
+
+  ThreadVectorMatrixMultiplySupport ThreadVector = {
+      static_cast<MultiplicationFlags>(
+          static_cast<UINT>(MultiplicationFlags::Supported) |
+          static_cast<UINT>(MultiplicationFlags::EmulatedInputs)),
+  };
+  VERIFY_IS_TRUE(ThreadVector.valid());
+  VERIFY_IS_TRUE(ThreadVector.supported());
+  ThreadVector.SupportFlags = MultiplicationFlags::EmulatedInputs;
+  VERIFY_IS_FALSE(ThreadVector.valid());
+
+  ThreadOuterProductSupport OuterProduct = {true};
+  VERIFY_IS_TRUE(OuterProduct.supported());
+  AtomicAccumulateStoreSupport Atomic = {true, false};
+  VERIFY_IS_TRUE(Atomic.supports(AtomicDestination::RWByteAddressBuffer));
+  VERIFY_IS_FALSE(Atomic.supports(AtomicDestination::GroupShared));
+
+  VERIFY_ARE_EQUAL(0u, static_cast<UINT>(DataType::None));
+  MatrixConstructionQuery ConstructionQuery = {DataType::Float32, 32};
+  WaveMatrixMultiplyQuery WaveQuery = {
+      32,
+      DataType::Float16,
+      DataType::Float16,
+      DataType::Float32,
+  };
+  ThreadGroupMatrixMultiplyQuery ThreadGroupQuery = {
+      WaveQuery,
+      {16, 16, 16},
+  };
+  ThreadVectorMatrixMultiplyQuery ThreadVectorQuery = {
+      DataType::Float16,
+      DataType::Float16,
+      DataType::None,
+      DataType::Float16,
+  };
+  ThreadOuterProductQuery OuterProductQuery = {
+      DataType::Float16,
+      DataType::Float16,
+  };
+  AtomicAccumulateStoreQuery AtomicQuery = {DataType::Float16};
+  VERIFY_ARE_EQUAL(32u, ConstructionQuery.WaveSize);
+  VERIFY_ARE_EQUAL(16u, ThreadGroupQuery.Shape.M);
+  VERIFY_IS_TRUE(ThreadVectorQuery.BiasInputType == DataType::None);
+  VERIFY_IS_TRUE(OuterProductQuery.InputComponentType == DataType::Float16);
+  VERIFY_IS_TRUE(AtomicQuery.ComponentType == DataType::Float16);
+}
+
 class DxilConf_SM610_LinAlg {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM610_LinAlg)
@@ -1651,6 +1850,88 @@ static const char CopyConvertShader[] = R"(
   }
 )";
 
+static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
+                                       const MatrixParams &Params,
+                                       bool Transpose, bool &Supported) {
+  Supported = false;
+  if (!Device || Params.Use != MatrixUse::A ||
+      !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
+                                 toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
+                                   sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  if (!WaveOptions.WaveOps) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; MatrixConstruction is not "
+        L"applicable");
+    return S_OK;
+  }
+
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  MatrixParams Destination = Params;
+  if (Transpose) {
+    Destination.M = Params.N;
+    Destination.N = Params.M;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < WaveOptions.WaveLaneCountMin ||
+        WaveSize > WaveOptions.WaveLaneCountMax)
+      continue;
+
+    linalg_test::MatrixConstructionSupport Construction;
+    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
+                                              Construction);
+    if (FAILED(HR))
+      return HR;
+    if (Construction.supports(linalg_test::MatrixRole::A, Params.M, Params.N) &&
+        Construction.supports(linalg_test::MatrixRole::A, Destination.M,
+                              Destination.N)) {
+      hlsl_test::LogCommentFmt(
+          L"CopyConvert capability matched wave=%u for source=%ux%u and "
+          L"destination=%ux%u",
+          WaveSize, Params.M, Params.N, Destination.M, Destination.N);
+      Supported = true;
+      return S_OK;
+    }
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No MatrixConstruction query within shader WaveSize(4,64) supports "
+      L"CopyConvert source=%ux%u and destination=%ux%u",
+      Params.M, Params.N, Destination.M, Destination.N);
+  return S_OK;
+}
+
 static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
@@ -1769,6 +2050,19 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
+
+  bool Supported;
+  const HRESULT QueryResult =
+      queryCopyConvertSupport(D3DDevice, Params, /*Transpose=*/true, Supported);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"CopyConvert_Wave_4x8_F32_Transpose MatrixConstruction"))
+    return;
+
   // Non-square dimensions make the destination shape and row stride observable.
   runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
                  /*Transpose=*/true);

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1300,8 +1300,8 @@ encodeLogicalMatrixBuffer(const MatrixParams &Matrix,
       !checkedMultiply(static_cast<size_t>(Matrix.M), Matrix.N,
                        ExpectedElements) ||
       Values.size() != ExpectedElements ||
-      (Matrix.Layout != LinalgMatrixLayout::RowMajor &&
-       Matrix.Layout != LinalgMatrixLayout::ColumnMajor))
+      (Matrix.Layout != MatrixLayout::RowMajor &&
+       Matrix.Layout != MatrixLayout::ColumnMajor))
     return std::nullopt;
 
   const std::optional<std::vector<BYTE>> LogicalComponents =
@@ -1315,9 +1315,9 @@ encodeLogicalMatrixBuffer(const MatrixParams &Matrix,
     return std::nullopt;
   const size_t Stride = Matrix.strideBytes();
   const size_t MinorCount =
-      Matrix.Layout == LinalgMatrixLayout::RowMajor ? Matrix.N : Matrix.M;
+      Matrix.Layout == MatrixLayout::RowMajor ? Matrix.N : Matrix.M;
   const size_t MajorCount =
-      Matrix.Layout == LinalgMatrixLayout::RowMajor ? Matrix.M : Matrix.N;
+      Matrix.Layout == MatrixLayout::RowMajor ? Matrix.M : Matrix.N;
   size_t MinimumStride;
   if (!checkedMultiply(MinorCount, ComponentSize, MinimumStride) ||
       LogicalComponents->size() < LogicalByteCount || Stride < MinimumStride)
@@ -1332,7 +1332,7 @@ encodeLogicalMatrixBuffer(const MatrixParams &Matrix,
       const size_t SourceOffset =
           (static_cast<size_t>(Row) * Matrix.N + Column) * ComponentSize;
       const size_t DestinationOffset =
-          Matrix.Layout == LinalgMatrixLayout::RowMajor
+          Matrix.Layout == MatrixLayout::RowMajor
               ? static_cast<size_t>(Row) * Stride + Column * ComponentSize
               : static_cast<size_t>(Column) * Stride + Row * ComponentSize;
       std::memcpy(Buffer.data() + DestinationOffset,
@@ -4156,7 +4156,7 @@ static MatrixParams makeWaveArithmeticParams(ComponentType CompType,
   Params.N = N;
   Params.Use = Use;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = static_cast<int>(WaveSize);
   Params.Enable16Bit = needs16BitTypes(CompType);
   return Params;

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1851,7 +1851,7 @@ void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
   const cpu_oracle::MatrixBufferLayout Layout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -1868,7 +1868,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -1888,12 +1888,12 @@ void DxilConf_SM610_LinAlg::
     return;
 
   const cpu_oracle::MatrixBufferLayout Target = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/24,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/16,
   };
@@ -1915,7 +1915,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.Layout = MatrixLayout::ColumnMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -1934,12 +1934,12 @@ void DxilConf_SM610_LinAlg::
     return;
 
   const cpu_oracle::MatrixBufferLayout Target = {
-      LinalgMatrixLayout::ColumnMajor,
+      MatrixLayout::ColumnMajor,
       /*OffsetBytes=*/32,
       /*StrideBytes=*/16,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -1960,7 +1960,7 @@ void DxilConf_SM610_LinAlg::LoadDescriptorBounds_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -1977,12 +1977,12 @@ void DxilConf_SM610_LinAlg::LoadDescriptorBounds_Wave_4x8_F32() {
     return;
 
   const cpu_oracle::MatrixBufferLayout SourceLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout DestinationLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -2035,7 +2035,7 @@ void DxilConf_SM610_LinAlg::StoreDescriptorBounds_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2052,12 +2052,12 @@ void DxilConf_SM610_LinAlg::StoreDescriptorBounds_Wave_4x8_F32() {
     return;
 
   const cpu_oracle::MatrixBufferLayout SourceLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout DestinationLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/32,
   };
@@ -2171,7 +2171,7 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   Params.Enable16Bit = true;
 
   const cpu_oracle::MatrixBufferLayout Layout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
@@ -2213,7 +2213,7 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptorBounds_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2231,12 +2231,12 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptorBounds_Wave_4x8_F32() {
     return;
 
   const cpu_oracle::MatrixBufferLayout SourceLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
       /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout DestinationLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/16,
       /*StrideBytes=*/32,
   };

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4101,6 +4101,8 @@ struct GroupSharedMemorySpec {
   cpu_oracle::MatrixBufferLayout Layout;
 };
 
+static constexpr size_t GroupSharedTrailingGuardElements = 4;
+
 static const char GroupSharedTransferShader[] = R"(
   ByteAddressBuffer SourceInit : register(t0);
   ByteAddressBuffer DestinationInit : register(t1);
@@ -4162,16 +4164,19 @@ static bool getGroupSharedBufferDescription(const MatrixParams &Params,
                                             size_t &BufferSize,
                                             UINT &NumElements) {
   const size_t ElementBytes = elementSize(Params.CompType);
+  size_t GuardBytes;
   std::optional<size_t> RequiredBytes = cpu_oracle::getMatrixBufferSize(
       Params.CompType, Params.M, Params.N, Spec.Layout);
   if (!RequiredBytes.has_value() ||
       Spec.Layout.OffsetBytes % ElementBytes != 0 ||
       Spec.Layout.StrideBytes % ElementBytes != 0 ||
       *RequiredBytes % ElementBytes != 0 ||
-      *RequiredBytes / ElementBytes > (std::numeric_limits<UINT>::max)())
+      !cpu_oracle::checkedMultiply(GroupSharedTrailingGuardElements,
+                                   ElementBytes, GuardBytes) ||
+      !cpu_oracle::checkedAdd(*RequiredBytes, GuardBytes, BufferSize) ||
+      BufferSize / ElementBytes > (std::numeric_limits<UINT>::max)())
     return false;
 
-  BufferSize = *RequiredBytes;
   NumElements = static_cast<UINT>(BufferSize / ElementBytes);
   return true;
 }

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -24,6 +24,7 @@
 #include "HlslTestDataTypes.h"
 #include "HlslTestUtils.h"
 
+#include <algorithm>
 #include <climits>
 #include <cstring>
 #include <initializer_list>
@@ -2056,19 +2057,30 @@ static void runElementGetOOB(ID3D12Device *Device,
                              UINT ForcedWaveSize = 0) {
   const size_t NumThreads = Params.NumThreads;
   const size_t MatrixSize = Params.totalBytes();
-  const size_t ValueBufferSize = NumThreads * elementSize(Params.CompType);
+  const size_t ElementBytes = elementSize(Params.CompType);
+  const size_t ValueBufferSize = NumThreads * ElementBytes;
   const size_t ExecutedBufferSize = NumThreads * sizeof(uint32_t);
+  constexpr BYTE Sentinel = 0xcd;
+  constexpr uint32_t MarkerSentinel = 0xcdcdcdcd;
+  if (ForcedWaveSize == 0 || ForcedWaveSize > NumThreads) {
+    hlsl_test::LogErrorFmt(
+        L"GetElement OOB requires a concrete wave size within the dispatch: "
+        L"wave=%u, threads=%zu",
+        ForcedWaveSize, NumThreads);
+    VERIFY_IS_TRUE(false, "Invalid GetElement OOB wave size");
+    return;
+  }
+
   std::stringstream ExtraDefs;
-  if (ForcedWaveSize != 0)
-    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, ElementGetOOBShader, "cs_6_10", Args, Verbose);
 
   std::optional<cpu_oracle::TypedMatrix> Input =
       cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
-  std::optional<cpu_oracle::TypedMatrix> Expected = cpu_oracle::makeZeroMatrix(
-      Params.CompType, 1, static_cast<MatrixDim>(NumThreads));
+  std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeZeroMatrix(Params.CompType, 1, 1);
   VERIFY_IS_TRUE(Input.has_value() && Expected.has_value(),
                  "Unable to construct typed GetElement OOB data");
   const cpu_oracle::MatrixBufferLayout InputLayout = {
@@ -2076,56 +2088,90 @@ static void runElementGetOOB(ID3D12Device *Device,
       0,
       Params.strideBytes(),
   };
-  const cpu_oracle::MatrixBufferLayout ValueLayout = {
+  const cpu_oracle::MatrixBufferLayout ExpectedLayout = {
       LinalgMatrixLayout::RowMajor,
       0,
-      ValueBufferSize,
+      ElementBytes,
   };
-  const cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
-      *Expected, L"Matrix::Get returns zero when Index equals Length()");
+  std::vector<BYTE> ExpectedValue(ElementBytes, Sentinel);
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(*Expected, ExpectedLayout, ExpectedValue),
+      "Unable to encode GetElement OOB zero expectation");
   const cpu_oracle::TypedMatrix InputMatrix = *Input;
 
   auto Op = createComputeOp(ElementGetOOBShader, "cs_6_10",
                             "UAV(u0), UAV(u1), UAV(u2)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
-  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true);
-  addUAVBuffer(Op.get(), "Executed", ExecutedBufferSize, true);
+  addUAVBuffer(Op.get(), "Values", ValueBufferSize, true, "byname");
+  addUAVBuffer(Op.get(), "Executed", ExecutedBufferSize, true, "byname");
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Values");
   addRootView(Op.get(), 2, "Executed");
 
   auto Result = runShaderOp(
       Device, DxcSupport, std::move(Op),
-      [InputMatrix, InputLayout](LPCSTR Name, std::vector<BYTE> &Data,
-                                 st::ShaderOp *) {
-        if (_stricmp(Name, "Input") != 0)
+      [InputMatrix, InputLayout, Sentinel](LPCSTR Name, std::vector<BYTE> &Data,
+                                           st::ShaderOp *) {
+        if (_stricmp(Name, "Input") == 0) {
+          VERIFY_IS_TRUE(
+              cpu_oracle::writeMatrixBuffer(InputMatrix, InputLayout, Data),
+              "Unable to encode GetElement OOB input");
           return;
-        VERIFY_IS_TRUE(
-            cpu_oracle::writeMatrixBuffer(InputMatrix, InputLayout, Data),
-            "Unable to encode GetElement OOB input");
+        }
+        if (_stricmp(Name, "Values") == 0 || _stricmp(Name, "Executed") == 0)
+          std::fill(Data.begin(), Data.end(), Sentinel);
       });
 
   MappedData ValueData;
   MappedData ExecutedData;
   Result->Test->GetReadBackData("Values", &ValueData);
   Result->Test->GetReadBackData("Executed", &ExecutedData);
-  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
-      ValueData.data(), ValueData.size(), ValueLayout, Oracle, Verbose));
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(ValueData.size(),
+                                  static_cast<UINT32>(ValueBufferSize));
   VERIFY_IS_GREATER_THAN_OR_EQUAL(ExecutedData.size(),
                                   static_cast<UINT32>(ExecutedBufferSize));
 
+  const BYTE *ValueBytes = static_cast<const BYTE *>(ValueData.data());
   const BYTE *ExecutedBytes = static_cast<const BYTE *>(ExecutedData.data());
   size_t ExecutedThreads = 0;
+  bool OutputsValid = true;
   for (size_t Thread = 0; Thread < NumThreads; ++Thread) {
     uint32_t Marker;
     std::memcpy(&Marker, ExecutedBytes + Thread * sizeof(Marker),
                 sizeof(Marker));
-    VERIFY_IS_TRUE(Marker == 0 || Marker == 1,
-                   "GetElement OOB execution marker was invalid");
-    ExecutedThreads += Marker;
+    const BYTE *Value = ValueBytes + Thread * ElementBytes;
+    if (Marker == 1) {
+      ++ExecutedThreads;
+      if (std::memcmp(Value, ExpectedValue.data(), ElementBytes) != 0) {
+        hlsl_test::LogErrorFmt(
+            L"GetElement OOB returned a non-zero value: thread=%zu", Thread);
+        OutputsValid = false;
+      }
+      continue;
+    }
+
+    if (Marker != MarkerSentinel) {
+      hlsl_test::LogErrorFmt(
+          L"GetElement OOB execution marker was invalid: thread=%zu, "
+          L"marker=0x%08x",
+          Thread, Marker);
+      OutputsValid = false;
+      continue;
+    }
+    for (size_t Byte = 0; Byte < ElementBytes; ++Byte) {
+      if (Value[Byte] != Sentinel) {
+        hlsl_test::LogErrorFmt(
+            L"An unexecuted GetElement OOB lane modified its value: "
+            L"thread=%zu",
+            Thread);
+        OutputsValid = false;
+        break;
+      }
+    }
   }
-  VERIFY_IS_GREATER_THAN(ExecutedThreads, static_cast<size_t>(0),
-                         "At least one thread must execute the OOB read");
+  VERIFY_IS_TRUE(OutputsValid, "GetElement OOB outputs were invalid");
+  VERIFY_ARE_EQUAL(static_cast<size_t>(ForcedWaveSize), ExecutedThreads,
+                   "Every lane in the selected first wave must execute");
 }
 
 void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -2768,9 +2768,8 @@ static HRESULT queryThreadVectorMatrixMultiplySupport(
   const bool SupportsTranspose =
       (SupportFlags &
        static_cast<UINT>(linalg_test::MultiplicationFlags::Transpose)) != 0;
-  Supported =
-      Support.supported() &&
-      (Params.Layout != LinalgMatrixLayout::ColumnMajor || SupportsTranspose);
+  Supported = Support.supported() &&
+              (Params.Layout != MatrixLayout::ColumnMajor || SupportsTranspose);
   if (!Supported)
     hlsl_test::LogCommentFmt(
         L"Thread-vector matrix multiplication is unsupported for %s", CaseName);
@@ -3994,8 +3993,8 @@ static bool isMatVecCaseValid(const MatVecCaseData &Case) {
   if (Case.Matrix.M == 0 || Case.Matrix.N == 0 ||
       Case.Matrix.Use != MatrixUse::A ||
       Case.Matrix.Scope != MatrixScope::Thread ||
-      (Case.Matrix.Layout != LinalgMatrixLayout::RowMajor &&
-       Case.Matrix.Layout != LinalgMatrixLayout::ColumnMajor) ||
+      (Case.Matrix.Layout != MatrixLayout::RowMajor &&
+       Case.Matrix.Layout != MatrixLayout::ColumnMajor) ||
       Case.Matrix.NumThreads != 1 ||
       Case.MatrixValues.size() != MatrixElementCount ||
       Case.InterpretedVectorValues.size() != Case.Matrix.N ||
@@ -4051,10 +4050,10 @@ encodeMatVecMatrix(const MatVecCaseData &Case) {
   const size_t LogicalByteCount =
       static_cast<size_t>(Case.Matrix.M) * Case.Matrix.N * ComponentSize;
   const size_t Stride = Case.Matrix.strideBytes();
-  const size_t MinorCount = Case.Matrix.Layout == LinalgMatrixLayout::RowMajor
+  const size_t MinorCount = Case.Matrix.Layout == MatrixLayout::RowMajor
                                 ? Case.Matrix.N
                                 : Case.Matrix.M;
-  const size_t MajorCount = Case.Matrix.Layout == LinalgMatrixLayout::RowMajor
+  const size_t MajorCount = Case.Matrix.Layout == MatrixLayout::RowMajor
                                 ? Case.Matrix.M
                                 : Case.Matrix.N;
   if (LogicalComponents->size() < LogicalByteCount ||
@@ -4070,7 +4069,7 @@ encodeMatVecMatrix(const MatVecCaseData &Case) {
       const size_t SourceOffset =
           (static_cast<size_t>(Row) * Case.Matrix.N + Column) * ComponentSize;
       const size_t DestinationOffset =
-          Case.Matrix.Layout == LinalgMatrixLayout::RowMajor
+          Case.Matrix.Layout == MatrixLayout::RowMajor
               ? static_cast<size_t>(Row) * Stride + Column * ComponentSize
               : static_cast<size_t>(Column) * Stride + Row * ComponentSize;
       std::memcpy(Buffer.data() + DestinationOffset,
@@ -4248,7 +4247,7 @@ static void runCapabilityCheckedMatVec(
 
 static MatrixParams makeThreadMatVecParams(ComponentType MatrixType,
                                            MatrixDim M, MatrixDim N,
-                                           LinalgMatrixLayout Layout) {
+                                           MatrixLayout Layout) {
   MatrixParams Params = {};
   Params.CompType = MatrixType;
   Params.M = M;
@@ -4284,7 +4283,7 @@ makeUniformMatVecCase(const MatrixParams &Params, int FillValue,
   return Case;
 }
 
-static MatVecCaseData makeNonUniformF16MatVecCase(LinalgMatrixLayout Layout) {
+static MatVecCaseData makeNonUniformF16MatVecCase(MatrixLayout Layout) {
   MatVecCaseData Case = {};
   Case.Matrix = makeThreadMatVecParams(ComponentType::F16, 4, 8, Layout);
   Case.VectorInputType = ComponentType::F16;
@@ -4297,7 +4296,7 @@ static MatVecCaseData makeNonUniformF16MatVecCase(LinalgMatrixLayout Layout) {
   };
   Case.InterpretedVectorValues = {1, -2, 3, -1, 2, -3, 1, 2};
   Case.PublicRule =
-      Layout == LinalgMatrixLayout::RowMajor
+      Layout == MatrixLayout::RowMajor
           ? L"Exact non-uniform F16 RowMajor matrix-vector dot products"
           : L"Exact non-uniform F16 ColumnMajor matrix-vector dot products";
   return Case;
@@ -4305,8 +4304,8 @@ static MatVecCaseData makeNonUniformF16MatVecCase(LinalgMatrixLayout Layout) {
 
 static MatVecCaseData makeSInt8MatVecCase(ComponentType VectorInputType) {
   MatVecCaseData Case = {};
-  Case.Matrix = makeThreadMatVecParams(ComponentType::I8, 4, 8,
-                                       LinalgMatrixLayout::RowMajor);
+  Case.Matrix =
+      makeThreadMatVecParams(ComponentType::I8, 4, 8, MatrixLayout::RowMajor);
   Case.VectorInputType = VectorInputType;
   Case.InputInterpretation = ComponentType::I8;
   Case.ResultType = ComponentType::I32;
@@ -4332,8 +4331,8 @@ static MatVecCaseData makeSInt8MatVecCase(ComponentType VectorInputType) {
 
 static MatVecCaseData makeUInt8MatVecCase() {
   MatVecCaseData Case = {};
-  Case.Matrix = makeThreadMatVecParams(ComponentType::U8, 4, 8,
-                                       LinalgMatrixLayout::RowMajor);
+  Case.Matrix =
+      makeThreadMatVecParams(ComponentType::U8, 4, 8, MatrixLayout::RowMajor);
   Case.VectorInputType = ComponentType::U8;
   Case.InputInterpretation = ComponentType::U8;
   Case.ResultType = ComponentType::I32;
@@ -4350,8 +4349,8 @@ static MatVecCaseData makeUInt8MatVecCase() {
 
 static MatVecCaseData makeUInt32MatVecCase() {
   MatVecCaseData Case = {};
-  Case.Matrix = makeThreadMatVecParams(ComponentType::U32, 4, 8,
-                                       LinalgMatrixLayout::RowMajor);
+  Case.Matrix =
+      makeThreadMatVecParams(ComponentType::U32, 4, 8, MatrixLayout::RowMajor);
   Case.VectorInputType = ComponentType::U32;
   Case.InputInterpretation = ComponentType::U32;
   Case.ResultType = ComponentType::U32;
@@ -4391,21 +4390,20 @@ static void runMatVecMulAdd(ID3D12Device *Device,
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_16x16_F16() {
   MatrixParams Params = makeThreadMatVecParams(ComponentType::F16, 16, 16,
-                                               LinalgMatrixLayout::RowMajor);
+                                               MatrixLayout::RowMajor);
   runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
                /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F32() {
-  MatrixParams Params = makeThreadMatVecParams(ComponentType::F32, 4, 8,
-                                               LinalgMatrixLayout::RowMajor);
+  MatrixParams Params =
+      makeThreadMatVecParams(ComponentType::F32, 4, 8, MatrixLayout::RowMajor);
   runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
                /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F16_NonUniform() {
-  MatVecCaseData Case =
-      makeNonUniformF16MatVecCase(LinalgMatrixLayout::RowMajor);
+  MatVecCaseData Case = makeNonUniformF16MatVecCase(MatrixLayout::RowMajor);
   runCapabilityCheckedMatVec(D3DDevice, DxcSupport, Case,
                              linalg_test::CapabilityRequirement::Mandatory,
                              L"MatVecMul_Thread_4x8_F16_NonUniform",
@@ -4413,8 +4411,7 @@ void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F16_NonUniform() {
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F16_ColumnMajor() {
-  MatVecCaseData Case =
-      makeNonUniformF16MatVecCase(LinalgMatrixLayout::ColumnMajor);
+  MatVecCaseData Case = makeNonUniformF16MatVecCase(MatrixLayout::ColumnMajor);
   runCapabilityCheckedMatVec(
       D3DDevice, DxcSupport, Case,
       linalg_test::CapabilityRequirement::CapabilityGated,
@@ -4454,21 +4451,20 @@ void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_U32_UnsignedOutput() {
 
 void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_16x16_F16() {
   MatrixParams Params = makeThreadMatVecParams(ComponentType::F16, 16, 16,
-                                               LinalgMatrixLayout::RowMajor);
+                                               MatrixLayout::RowMajor);
   runMatVecMulAdd(D3DDevice, DxcSupport, Params, VerboseLogging,
                   /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F32() {
-  MatrixParams Params = makeThreadMatVecParams(ComponentType::F32, 4, 8,
-                                               LinalgMatrixLayout::RowMajor);
+  MatrixParams Params =
+      makeThreadMatVecParams(ComponentType::F32, 4, 8, MatrixLayout::RowMajor);
   runMatVecMulAdd(D3DDevice, DxcSupport, Params, VerboseLogging,
                   /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F16_IndependentBias() {
-  MatVecCaseData Case =
-      makeNonUniformF16MatVecCase(LinalgMatrixLayout::RowMajor);
+  MatVecCaseData Case = makeNonUniformF16MatVecCase(MatrixLayout::RowMajor);
   Case.BiasInputType = ComponentType::F16;
   Case.BiasValues = {-5, 7, 3, -9};
   Case.PublicRule =

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4670,7 +4670,7 @@ static MatrixParams makeThreadGroupArithmeticParams(ComponentType CompType,
   Params.N = N;
   Params.Use = Use;
   Params.Scope = MatrixScope::ThreadGroup;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = static_cast<int>(ThreadGroupSize);
   Params.Enable16Bit = needs16BitTypes(CompType);
   return Params;

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4852,6 +4852,7 @@ static const char ConvertF32ToI16Shader[] = R"(
 static const char ConvertF16FP8RoundTripShader[] = R"(
   #define CT_F16 8
 
+  ByteAddressBuffer Input : register(t0);
   RWByteAddressBuffer Output : register(u0);
 
   [numthreads(1, 1, 1)]
@@ -4860,11 +4861,12 @@ static const char ConvertF16FP8RoundTripShader[] = R"(
       0.0, 1.0, -1.0, 1.5, -1.5, 3.0, 6.0, -6.0
     };
     vector<uint, 2> PackedBits;
-    vector<uint, 2> PackedRoundTrip;
+    vector<uint, 2> PackedInput = {
+      Input.Load<uint>(0), Input.Load<uint>(sizeof(uint))
+    };
     vector<half, 8> RoundTrip;
     __builtin_LinAlg_Convert(PackedBits, InVec, CT_F16, FP8_TYPE);
-    __builtin_LinAlg_Convert(PackedRoundTrip, InVec, CT_F16, FP8_TYPE);
-    __builtin_LinAlg_Convert(RoundTrip, PackedRoundTrip, FP8_TYPE, CT_F16);
+    __builtin_LinAlg_Convert(RoundTrip, PackedInput, FP8_TYPE, CT_F16);
 
     Output.Store<uint>(0, PackedBits.x);
     Output.Store<uint>(4, PackedBits.y);
@@ -4877,15 +4879,32 @@ static void runExactConvertShader(ID3D12Device *Device,
                                   dxc::SpecificDllLoader &DxcSupport,
                                   const char *Shader, const std::string &Args,
                                   std::vector<BYTE> Expected,
-                                  const std::wstring &PublicRule,
-                                  bool Verbose) {
+                                  const std::wstring &PublicRule, bool Verbose,
+                                  const std::vector<BYTE> *Input = nullptr) {
+  if (Input && Input->empty()) {
+    VERIFY_IS_TRUE(false, "Convert input must not be empty");
+    return;
+  }
+
   compileShader(DxcSupport, Shader, "cs_6_10", Args, Verbose);
 
-  auto Op = createComputeOp(Shader, "cs_6_10", "UAV(u0)", Args.c_str());
+  auto Op = createComputeOp(
+      Shader, "cs_6_10", Input ? "SRV(t0), UAV(u0)" : "UAV(u0)", Args.c_str());
+  UINT OutputRootIndex = 0;
+  if (Input) {
+    addSRVBuffer(Op.get(), "Input", Input->size(), "byname");
+    addRootView(Op.get(), 0, "Input");
+    OutputRootIndex = 1;
+  }
   addUAVBuffer(Op.get(), "Output", Expected.size(), true);
-  addRootView(Op.get(), 0, "Output");
+  addRootView(Op.get(), OutputRootIndex, "Output");
 
-  auto Result = runShaderOp(Device, DxcSupport, std::move(Op));
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [Input](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        if (Input && _stricmp(Name, "Input") == 0)
+          Data = *Input;
+      });
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
   if (Verbose) {
@@ -4996,12 +5015,14 @@ void DxilConf_SM610_LinAlg::Convert_F16_FP8_RoundTrip() {
     if (!Expected.has_value())
       return false;
 
+    const std::vector<BYTE> PackedInput(Expected->begin(),
+                                        Expected->begin() + Values.size());
     ++ExecutedFormats;
     runExactConvertShader(D3DDevice, DxcSupport, ConvertF16FP8RoundTripShader,
                           CompilerArgs, std::move(*Expected),
                           std::wstring(CaseName) +
                               L" exact packed encoding and F16 round trip",
-                          VerboseLogging);
+                          VerboseLogging, &PackedInput);
     return true;
   };
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -114,7 +114,7 @@ struct TypedMatrix {
 };
 
 struct MatrixBufferLayout {
-  LinalgMatrixLayout Layout;
+  MatrixLayout Layout;
   size_t OffsetBytes;
   size_t StrideBytes;
 };
@@ -427,9 +427,9 @@ static std::optional<TypedMatrix> transposeMatrix(const TypedMatrix &Source) {
   }
 }
 
-static bool isMemoryLayout(LinalgMatrixLayout Layout) {
-  return Layout == LinalgMatrixLayout::RowMajor ||
-         Layout == LinalgMatrixLayout::ColumnMajor;
+static bool isMemoryLayout(MatrixLayout Layout) {
+  return Layout == MatrixLayout::RowMajor ||
+         Layout == MatrixLayout::ColumnMajor;
 }
 
 static std::optional<size_t>
@@ -446,10 +446,8 @@ getMatrixBufferSize(ComponentType CompType, MatrixDim M, MatrixDim N,
   }
 
   const size_t ElementBytes = elementSize(CompType);
-  const size_t MajorCount =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? M : N;
-  const size_t MinorCount =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? N : M;
+  const size_t MajorCount = Layout.Layout == MatrixLayout::RowMajor ? M : N;
+  const size_t MinorCount = Layout.Layout == MatrixLayout::RowMajor ? N : M;
   size_t PackedMinorBytes;
   if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes)) {
     hlsl_test::LogErrorFmt(
@@ -495,10 +493,8 @@ getElementByteOffset(ComponentType CompType, MatrixDim M, MatrixDim N,
   if (Row >= M || Column >= N)
     return std::nullopt;
 
-  const size_t Major =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? Row : Column;
-  const size_t Minor =
-      Layout.Layout == LinalgMatrixLayout::RowMajor ? Column : Row;
+  const size_t Major = Layout.Layout == MatrixLayout::RowMajor ? Row : Column;
+  const size_t Minor = Layout.Layout == MatrixLayout::RowMajor ? Column : Row;
   size_t MajorOffset;
   size_t MinorOffset;
   size_t ByteOffset;
@@ -1011,7 +1007,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
     if (!Matrix.has_value())
       return false;
     MatrixBufferLayout Layout = {
-        LinalgMatrixLayout::RowMajor,
+        MatrixLayout::RowMajor,
         /*OffsetBytes=*/0,
         /*StrideBytes=*/ExpectedBytes.size(),
     };
@@ -1046,7 +1042,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   VERIFY_IS_TRUE(Matrix.has_value());
 
   MatrixBufferLayout RowMajor = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       /*OffsetBytes=*/4,
       /*StrideBytes=*/16,
   };
@@ -1066,7 +1062,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
                                     RowMajor, Exact, /*Verbose=*/false));
 
   MatrixBufferLayout ColumnMajor = {
-      LinalgMatrixLayout::ColumnMajor,
+      MatrixLayout::ColumnMajor,
       /*OffsetBytes=*/4,
       /*StrideBytes=*/12,
   };
@@ -1117,7 +1113,7 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   Params.N = 3;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 4;
   Params.CompType = ComponentType::I32;
   VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=int") !=

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -166,7 +166,15 @@ template <typename T> struct ComponentTraits;
 
 template <>
 struct ComponentTraits<float>
-    : NativeComponentTraits<float, ComponentType::F32> {};
+    : NativeComponentTraits<float, ComponentType::F32> {
+  static std::wstring format(const float &Value) {
+    uint32_t Bits;
+    std::memcpy(&Bits, &Value, sizeof(Bits));
+    std::wstringstream Stream;
+    Stream << Value << L" (bits=0x" << std::hex << Bits << L")";
+    return Stream.str();
+  }
+};
 
 template <>
 struct ComponentTraits<int32_t>
@@ -443,8 +451,14 @@ getMatrixBufferSize(ComponentType CompType, MatrixDim M, MatrixDim N,
   const size_t MinorCount =
       Layout.Layout == LinalgMatrixLayout::RowMajor ? N : M;
   size_t PackedMinorBytes;
-  if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes) ||
-      Layout.StrideBytes < PackedMinorBytes) {
+  if (!checkedMultiply(MinorCount, ElementBytes, PackedMinorBytes)) {
+    hlsl_test::LogErrorFmt(
+        L"Matrix packed row or column byte calculation overflowed: "
+        L"component=%s, M=%u, N=%u",
+        componentTypeName(CompType), M, N);
+    return std::nullopt;
+  }
+  if (Layout.StrideBytes < PackedMinorBytes) {
     hlsl_test::LogErrorFmt(
         L"Matrix stride is too small: component=%s, M=%u, N=%u, stride=%zu, "
         L"required=%zu",
@@ -1019,6 +1033,13 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   VERIFY_IS_TRUE(
       VerifyScalarEncoding(makeTypedMatrix<uint32_t>(1, 1, {0x89abcdefu}),
                            {0xef, 0xcd, 0xab, 0x89}));
+
+  const uint32_t AdjacentFloatBits = 0x3f800001;
+  float AdjacentFloat;
+  std::memcpy(&AdjacentFloat, &AdjacentFloatBits, sizeof(AdjacentFloat));
+  VERIFY_IS_TRUE(
+      ComponentTraits<float>::format(AdjacentFloat).find(L"3f800001") !=
+      std::wstring::npos);
 
   std::optional<TypedMatrix> Matrix =
       makeTypedMatrix<uint32_t>(2, 3, {1, 2, 3, 4, 5, 6});

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1868,7 +1868,7 @@ static void runElementAccess(ID3D12Device *Device,
       Params.strideBytes(),
   };
   const cpu_oracle::MatrixBufferLayout PackedRowMajor = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       0,
       static_cast<size_t>(Params.N) * elementSize(Params.CompType),
   };
@@ -2001,7 +2001,7 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2089,7 +2089,7 @@ static void runElementGetOOB(ID3D12Device *Device,
       Params.strideBytes(),
   };
   const cpu_oracle::MatrixBufferLayout ExpectedLayout = {
-      LinalgMatrixLayout::RowMajor,
+      MatrixLayout::RowMajor,
       0,
       ElementBytes,
   };
@@ -2181,7 +2181,7 @@ void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -2341,7 +2341,7 @@ void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3215,9 +3215,23 @@ static HRESULT queryThreadOuterProductSupport(ID3D12Device *Device,
     return HR;
 
   Supported = Support.supported();
-  if (!Supported)
+  if (!Supported) {
     hlsl_test::LogCommentFmt(L"Thread OuterProduct is unsupported for %s",
                              CaseName);
+    return S_OK;
+  }
+
+  linalg_test::AtomicAccumulateStoreSupport AccumulateSupport;
+  HR = linalg_test::queryAtomicAccumulateStore(Device, {*ResultDataType},
+                                               AccumulateSupport);
+  if (FAILED(HR))
+    return HR;
+  Supported = AccumulateSupport.supports(
+      linalg_test::AtomicDestination::RWByteAddressBuffer);
+  if (!Supported)
+    hlsl_test::LogCommentFmt(
+        L"OuterProduct descriptor accumulation is unsupported for %s",
+        CaseName);
   return S_OK;
 }
 
@@ -7147,12 +7161,14 @@ struct VectorAccumulateCaseData {
   ComponentType CompType = ComponentType::Invalid;
   std::vector<int64_t> InputValues;
   std::vector<int64_t> InitialValues;
+  std::vector<int64_t> OutputGuardValues;
   std::wstring PublicRule;
 };
 
 static bool isVectorAccumulateCaseValid(const VectorAccumulateCaseData &Case) {
   return !Case.InputValues.empty() &&
          Case.InputValues.size() == Case.InitialValues.size() &&
+         !Case.OutputGuardValues.empty() &&
          toCapabilityDataType(Case.CompType).has_value() &&
          cpu_oracle::hlslElementTypeName(Case.CompType) &&
          !Case.PublicRule.empty();
@@ -7204,14 +7220,23 @@ static void runVectorAccumulateDescriptor(ID3D12Device *Device,
 
   const std::optional<std::vector<BYTE>> Input =
       cpu_oracle::encodeExactComponents(Case.CompType, Case.InputValues);
-  const std::optional<std::vector<BYTE>> Initial =
-      cpu_oracle::encodeExactComponents(Case.CompType, Case.InitialValues);
   const std::optional<std::vector<int64_t>> ExpectedValues =
       calculateVectorAccumulateExpected(Case);
+  std::vector<int64_t> InitialBufferValues = Case.InitialValues;
+  InitialBufferValues.insert(InitialBufferValues.end(),
+                             Case.OutputGuardValues.begin(),
+                             Case.OutputGuardValues.end());
+  std::vector<int64_t> ExpectedBufferValues =
+      ExpectedValues.value_or(std::vector<int64_t>());
+  ExpectedBufferValues.insert(ExpectedBufferValues.end(),
+                              Case.OutputGuardValues.begin(),
+                              Case.OutputGuardValues.end());
+  const std::optional<std::vector<BYTE>> Initial =
+      cpu_oracle::encodeExactComponents(Case.CompType, InitialBufferValues);
   const std::optional<std::vector<BYTE>> Expected =
-      ExpectedValues.has_value()
-          ? cpu_oracle::encodeExactComponents(Case.CompType, *ExpectedValues)
-          : std::optional<std::vector<BYTE>>();
+      ExpectedValues.has_value() ? cpu_oracle::encodeExactComponents(
+                                       Case.CompType, ExpectedBufferValues)
+                                 : std::optional<std::vector<BYTE>>();
   const std::optional<std::string> Args =
       buildVectorAccumulateCompilerArgs(Case);
   VERIFY_IS_TRUE(Input.has_value());
@@ -7259,6 +7284,7 @@ void DxilConf_SM610_LinAlg::VectorAccumulateDescriptor_Thread_F16() {
   Case.CompType = ComponentType::F16;
   Case.InputValues = {1, 2, 3, 4};
   Case.InitialValues = {0, 0, 0, 0};
+  Case.OutputGuardValues = {37, -91};
   Case.PublicRule = L"Exact F16 vector descriptor accumulation";
   runVectorAccumulateDescriptor(D3DDevice, DxcSupport, Case,
                                 L"VectorAccumulateDescriptor_Thread_F16",
@@ -7271,6 +7297,7 @@ void DxilConf_SM610_LinAlg::
   Case.CompType = ComponentType::F16;
   Case.InputValues = {-3, 2, 5, -1, 4, 0, -2, 6};
   Case.InitialValues = {10, 11, 12, 13, 14, 15, 16, 17};
+  Case.OutputGuardValues = {123, -321};
   Case.PublicRule =
       L"Exact non-contended F16 vector accumulation onto non-zero values";
   runVectorAccumulateDescriptor(
@@ -7284,6 +7311,7 @@ void DxilConf_SM610_LinAlg::
   Case.CompType = ComponentType::F32;
   Case.InputValues = {6, -2, 0, 3, -5, 4, 1, -1};
   Case.InitialValues = {20, 21, 22, 23, 24, 25, 26, 27};
+  Case.OutputGuardValues = {123456, -654321};
   Case.PublicRule =
       L"Exact non-contended F32 vector accumulation onto non-zero values";
   runVectorAccumulateDescriptor(

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -166,6 +166,35 @@ static bool applyApplicability(linalg_test::Applicability Result,
   return false;
 }
 
+static UINT selectThreadGroupMatrixMultiplySize(
+    const linalg_test::ThreadGroupMatrixMultiplySupport &Support, UINT WaveSize,
+    UINT MaxThreadsPerGroup) {
+  if (!Support.supported() || WaveSize == 0 || MaxThreadsPerGroup == 0)
+    return 0;
+
+  UINT Selected = Support.PreferredThreadGroupSize;
+  if (!Support.supportsThreadGroupSize(Selected) ||
+      Selected > MaxThreadsPerGroup)
+    Selected = Support.MinThreadGroupSize;
+  if (!Support.supportsThreadGroupSize(Selected) ||
+      Selected > MaxThreadsPerGroup)
+    return 0;
+  if (Selected > WaveSize)
+    return Selected;
+
+  const UINT MaxExecutable =
+      std::min(Support.MaxThreadGroupSize, MaxThreadsPerGroup);
+  for (UINT Candidate = Support.MinThreadGroupSize;
+       Candidate <= MaxExecutable;) {
+    if (Candidate > WaveSize)
+      return Candidate;
+    if (Candidate > MaxExecutable - Support.MinThreadGroupSize)
+      break;
+    Candidate += Support.MinThreadGroupSize;
+  }
+  return Selected;
+}
+
 namespace cpu_oracle {
 
 using TypedMatrixValues =
@@ -1916,6 +1945,15 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
   VERIFY_IS_TRUE(ThreadGroup.valid());
   VERIFY_IS_TRUE(ThreadGroup.supportsThreadGroupSize(64));
   VERIFY_IS_FALSE(ThreadGroup.supportsThreadGroupSize(48));
+  VERIFY_ARE_EQUAL(64u,
+                   selectThreadGroupMatrixMultiplySize(ThreadGroup, 32, 1024));
+  ThreadGroup.PreferredThreadGroupSize = 32;
+  VERIFY_ARE_EQUAL(64u,
+                   selectThreadGroupMatrixMultiplySize(ThreadGroup, 32, 1024));
+  ThreadGroup.MaxThreadGroupSize = 32;
+  VERIFY_ARE_EQUAL(32u,
+                   selectThreadGroupMatrixMultiplySize(ThreadGroup, 32, 1024));
+  ThreadGroup.MaxThreadGroupSize = 128;
   ThreadGroup.PreferredThreadGroupSize = 48;
   VERIFY_IS_FALSE(ThreadGroup.valid());
   ThreadGroup = {
@@ -3045,11 +3083,9 @@ static HRESULT queryThreadGroupMatrixMultiplyCaseSupport(
     if (!MultiplySupport.supported())
       continue;
 
-    UINT ThreadGroupSize = MultiplySupport.PreferredThreadGroupSize;
-    if (ThreadGroupSize == 0 || ThreadGroupSize > MaxThreadsPerGroup)
-      ThreadGroupSize = MultiplySupport.MinThreadGroupSize;
-    if (!MultiplySupport.supportsThreadGroupSize(ThreadGroupSize) ||
-        ThreadGroupSize > MaxThreadsPerGroup) {
+    const UINT ThreadGroupSize = selectThreadGroupMatrixMultiplySize(
+        MultiplySupport, WaveSize, MaxThreadsPerGroup);
+    if (ThreadGroupSize == 0) {
       hlsl_test::LogCommentFmt(
           L"ThreadGroupMatrixMultiply returned no executable group size for "
           L"%s: min=%u, max=%u, preferred=%u",
@@ -4640,6 +4676,10 @@ static MatrixParams makeThreadGroupArithmeticParams(ComponentType CompType,
   return Params;
 }
 
+static constexpr size_t ThreadGroupArithmeticTrailingGuardElements = 4;
+static constexpr int64_t ThreadGroupArithmeticResultSentinel = -4096;
+static constexpr int64_t ThreadGroupArithmeticGuardSentinel = -2048;
+
 static const char ThreadGroupMultiplyShader[] = R"(
   #define USE_A 0
   #define USE_B 1
@@ -4661,7 +4701,8 @@ static const char ThreadGroupMultiplyShader[] = R"(
   #if DO_ACCUMULATE
   groupshared ACCUMULATOR_ELEM_TYPE AccumulatorData[ACCUMULATOR_ELEMENTS];
   #endif
-  groupshared ACCUMULATOR_ELEM_TYPE ResultData[ACCUMULATOR_ELEMENTS];
+  groupshared ACCUMULATOR_ELEM_TYPE
+    ResultData[ACCUMULATOR_ELEMENTS + RESULT_GUARD_ELEMENTS];
 
   [WaveSize(FORCED_WAVE_SIZE)]
   [numthreads(THREADGROUP_SIZE, 1, 1)]
@@ -4684,9 +4725,12 @@ static const char ThreadGroupMultiplyShader[] = R"(
           Index * ACCUMULATOR_ELEM_SIZE);
     }
     #endif
-    for (uint Index = threadID; Index < ACCUMULATOR_ELEMENTS;
+    for (uint Index = threadID;
+         Index < ACCUMULATOR_ELEMENTS + RESULT_GUARD_ELEMENTS;
          Index += THREADGROUP_SIZE) {
-      ResultData[Index] = (ACCUMULATOR_ELEM_TYPE)-4096;
+      ResultData[Index] = Index < ACCUMULATOR_ELEMENTS
+        ? (ACCUMULATOR_ELEM_TYPE)RESULT_SENTINEL
+        : (ACCUMULATOR_ELEM_TYPE)RESULT_GUARD_SENTINEL;
     }
 
     GroupMemoryBarrierWithGroupSync();
@@ -4727,7 +4771,8 @@ static const char ThreadGroupMultiplyShader[] = R"(
 
     GroupMemoryBarrierWithGroupSync();
 
-    for (uint Index = threadID; Index < ACCUMULATOR_ELEMENTS;
+    for (uint Index = threadID;
+         Index < ACCUMULATOR_ELEMENTS + RESULT_GUARD_ELEMENTS;
          Index += THREADGROUP_SIZE) {
       Output.Store<ACCUMULATOR_ELEM_TYPE>(
         Index * ACCUMULATOR_ELEM_SIZE, ResultData[Index]);
@@ -4772,6 +4817,10 @@ buildThreadGroupMultiplyCompilerArgs(const MatrixMultiplyCaseData &Case,
   SS << " -DMATRIX_A_ELEMENTS=" << MatrixA.totalElements();
   SS << " -DMATRIX_B_ELEMENTS=" << MatrixB.totalElements();
   SS << " -DACCUMULATOR_ELEMENTS=" << Accumulator.totalElements();
+  SS << " -DRESULT_GUARD_ELEMENTS="
+     << ThreadGroupArithmeticTrailingGuardElements;
+  SS << " -DRESULT_SENTINEL=" << ThreadGroupArithmeticResultSentinel;
+  SS << " -DRESULT_GUARD_SENTINEL=" << ThreadGroupArithmeticGuardSentinel;
   SS << " -DMATRIX_A_ELEM_SIZE="
      << static_cast<int>(elementSize(Case.MatrixAType));
   SS << " -DMATRIX_B_ELEM_SIZE="
@@ -4812,9 +4861,16 @@ static void runThreadGroupMultiplyCase(ID3D12Device *Device,
                                    : std::optional<std::vector<BYTE>>();
   const std::optional<std::vector<int64_t>> ExpectedValues =
       calculateMatrixMultiplyExpected(Case);
+  std::optional<std::vector<int64_t>> GuardedExpectedValues = ExpectedValues;
+  if (GuardedExpectedValues.has_value()) {
+    GuardedExpectedValues->insert(GuardedExpectedValues->end(),
+                                  ThreadGroupArithmeticTrailingGuardElements,
+                                  ThreadGroupArithmeticGuardSentinel);
+  }
   const std::optional<std::vector<BYTE>> Expected =
-      ExpectedValues.has_value()
-          ? cpu_oracle::encodeLogicalMatrixBuffer(Accumulator, *ExpectedValues)
+      GuardedExpectedValues.has_value()
+          ? cpu_oracle::encodeExactComponents(Case.AccumulatorType,
+                                              *GuardedExpectedValues)
           : std::optional<std::vector<BYTE>>();
   const std::optional<std::string> Args =
       buildThreadGroupMultiplyCompilerArgs(Case, WaveSize, ThreadGroupSize);

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -145,18 +145,9 @@ static bool applyApplicability(linalg_test::Applicability Result,
   case Applicability::Execute:
     return true;
   case Applicability::NotApplicable:
-#ifdef _HLK_CONF
-    hlsl_test::LogErrorFmt(
-        L"Capability-gated case %s reached HLK execution on an unsupported "
-        L"device. Requirement or playlist applicability must exclude it.",
-        CaseName);
-    VERIFY_IS_TRUE(false,
-                   "Unsupported capability-gated case reached HLK execution");
-#else
     hlsl_test::LogCommentFmt(
         L"Capability-gated case %s is not applicable on this device", CaseName);
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-#endif
     return false;
   case Applicability::Fail:
     hlsl_test::LogErrorFmt(L"Capability evaluation failed for case %s",
@@ -1263,6 +1254,13 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
       {},
   };
   VERIFY_IS_FALSE(InvalidWave.valid());
+  InvalidWave = {
+      static_cast<MultiplicationFlags>(
+          static_cast<UINT>(MultiplicationFlags::Supported) |
+          static_cast<UINT>(MultiplicationFlags::EmulatedInputs)),
+      {{8, 16, 8}},
+  };
+  VERIFY_IS_FALSE(InvalidWave.valid());
 
   ThreadGroupMatrixMultiplySupport ThreadGroup = {
       MultiplicationFlags::Supported,
@@ -1275,14 +1273,30 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
   VERIFY_IS_FALSE(ThreadGroup.supportsThreadGroupSize(48));
   ThreadGroup.PreferredThreadGroupSize = 48;
   VERIFY_IS_FALSE(ThreadGroup.valid());
+  ThreadGroup = {
+      static_cast<MultiplicationFlags>(
+          static_cast<UINT>(MultiplicationFlags::Supported) |
+          static_cast<UINT>(MultiplicationFlags::Transpose)),
+      32,
+      128,
+      64,
+  };
+  VERIFY_IS_FALSE(ThreadGroup.valid());
 
   ThreadVectorMatrixMultiplySupport ThreadVector = {
       static_cast<MultiplicationFlags>(
           static_cast<UINT>(MultiplicationFlags::Supported) |
-          static_cast<UINT>(MultiplicationFlags::EmulatedInputs)),
+          static_cast<UINT>(MultiplicationFlags::Transpose)),
+      DataType::Float32,
   };
   VERIFY_IS_TRUE(ThreadVector.valid());
   VERIFY_IS_TRUE(ThreadVector.supported());
+  ThreadVector.SupportFlags = static_cast<MultiplicationFlags>(
+      static_cast<UINT>(MultiplicationFlags::Supported) |
+      static_cast<UINT>(MultiplicationFlags::EmulatedInputs));
+  VERIFY_IS_FALSE(ThreadVector.valid());
+  ThreadVector.MatrixInputType = DataType::Float8E4M3FN;
+  VERIFY_IS_TRUE(ThreadVector.valid());
   ThreadVector.SupportFlags = MultiplicationFlags::EmulatedInputs;
   VERIFY_IS_FALSE(ThreadVector.valid());
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -1829,7 +1829,11 @@ static const char CopyConvertShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1852,8 +1856,10 @@ static const char CopyConvertShader[] = R"(
 
 static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
                                        const MatrixParams &Params,
-                                       bool Transpose, bool &Supported) {
+                                       bool Transpose, bool &Supported,
+                                       UINT &SelectedWaveSize) {
   Supported = false;
+  SelectedWaveSize = 0;
   if (!Device || Params.Use != MatrixUse::A ||
       !linalg_test::isLegalScope(linalg_test::OperationType::MatrixConstruction,
                                  toCapabilityScope(Params.Scope)))
@@ -1921,6 +1927,7 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
           L"destination=%ux%u",
           WaveSize, Params.M, Params.N, Destination.M, Destination.N);
       Supported = true;
+      SelectedWaveSize = WaveSize;
       return S_OK;
     }
   }
@@ -1935,7 +1942,7 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
 static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
-                           bool Transpose) {
+                           bool Transpose, UINT ForcedWaveSize = 0) {
   MatrixParams DstParams = Params;
   if (Transpose) {
     DstParams.M = Params.N;
@@ -1948,6 +1955,8 @@ static void runCopyConvert(ID3D12Device *Device,
   ExtraDefs << " -DDST_N_DIM=" << DstParams.N;
   ExtraDefs << " -DSRC_STRIDE=" << Params.strideBytes();
   ExtraDefs << " -DDST_STRIDE=" << DstParams.strideBytes();
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -2052,8 +2061,9 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
   Params.Enable16Bit = false;
 
   bool Supported;
-  const HRESULT QueryResult =
-      queryCopyConvertSupport(D3DDevice, Params, /*Transpose=*/true, Supported);
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryCopyConvertSupport(
+      D3DDevice, Params, /*Transpose=*/true, Supported, SelectedWaveSize);
   const linalg_test::Applicability Applicability =
       linalg_test::classifyApplicability(
           QueryResult, Supported,
@@ -2065,7 +2075,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
 
   // Non-square dimensions make the destination shape and row stride observable.
   runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
-                 /*Transpose=*/true);
+                 /*Transpose=*/true, SelectedWaveSize);
 }
 
 static const char MatMatMulShader[] = R"(

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3979,7 +3979,9 @@ struct MatVecCaseData {
   ComponentType ResultType = ComponentType::Invalid;
   bool OutputSigned = true;
   std::vector<int64_t> MatrixValues;
-  std::vector<int64_t> VectorValues;
+  // Keep native F32 inputs separate from their hand-derived interpreted values.
+  std::vector<int64_t> InterpretedVectorValues;
+  std::optional<std::vector<float>> NativeF32VectorValues;
   std::vector<int64_t> BiasValues;
   std::wstring PublicRule;
 
@@ -3996,7 +3998,18 @@ static bool isMatVecCaseValid(const MatVecCaseData &Case) {
        Case.Matrix.Layout != LinalgMatrixLayout::ColumnMajor) ||
       Case.Matrix.NumThreads != 1 ||
       Case.MatrixValues.size() != MatrixElementCount ||
-      Case.VectorValues.size() != Case.Matrix.N || Case.PublicRule.empty())
+      Case.InterpretedVectorValues.size() != Case.Matrix.N ||
+      Case.PublicRule.empty())
+    return false;
+
+  if (Case.NativeF32VectorValues.has_value() &&
+      (Case.VectorInputType != ComponentType::F32 ||
+       Case.InputInterpretation == ComponentType::F32 ||
+       Case.NativeF32VectorValues->size() != Case.Matrix.N))
+    return false;
+  if (Case.VectorInputType == ComponentType::F32 &&
+      Case.InputInterpretation != ComponentType::F32 &&
+      !Case.NativeF32VectorValues.has_value())
     return false;
 
   if (Case.hasBias() != !Case.BiasValues.empty() ||
@@ -4010,6 +4023,10 @@ static bool isMatVecCaseValid(const MatVecCaseData &Case) {
     return false;
   if (!cpu_oracle::isPackedVectorComponent(Case.VectorInputType) &&
       Case.InputInterpretation != Case.Matrix.CompType)
+    return false;
+  if (!cpu_oracle::encodeExactComponents(Case.InputInterpretation,
+                                         Case.InterpretedVectorValues)
+           .has_value())
     return false;
 
   const char *ResultTypeName = cpu_oracle::hlslElementTypeName(Case.ResultType);
@@ -4070,7 +4087,7 @@ calculateMatVecExpected(const MatVecCaseData &Case) {
     for (MatrixDim Column = 0; Column < Case.Matrix.N; ++Column) {
       Expected[Row] +=
           Case.MatrixValues[static_cast<size_t>(Row) * Case.Matrix.N + Column] *
-          Case.VectorValues[Column];
+          Case.InterpretedVectorValues[Column];
     }
     if (Case.hasBias())
       Expected[Row] += Case.BiasValues[Row];
@@ -4140,8 +4157,11 @@ static void runMatVecCase(ID3D12Device *Device,
   const std::optional<std::vector<BYTE>> MatrixBuffer =
       encodeMatVecMatrix(Case);
   const std::optional<std::vector<BYTE>> VectorBuffer =
-      cpu_oracle::encodeExactComponents(Case.VectorInputType,
-                                        Case.VectorValues);
+      Case.NativeF32VectorValues.has_value()
+          ? std::optional<std::vector<BYTE>>(
+                cpu_oracle::encodeNativeVector(*Case.NativeF32VectorValues))
+          : cpu_oracle::encodeExactComponents(Case.VectorInputType,
+                                              Case.InterpretedVectorValues);
   const std::optional<std::vector<BYTE>> BiasBuffer =
       Case.hasBias() ? cpu_oracle::encodeExactComponents(Case.BiasInputType,
                                                          Case.BiasValues)
@@ -4254,7 +4274,7 @@ makeUniformMatVecCase(const MatrixParams &Params, int FillValue,
   Case.ResultType = Params.CompType;
   Case.OutputSigned = OutputSigned;
   Case.MatrixValues.assign(static_cast<size_t>(Params.M) * Params.N, FillValue);
-  Case.VectorValues.assign(Params.N, FillValue);
+  Case.InterpretedVectorValues.assign(Params.N, FillValue);
   if (Case.hasBias())
     Case.BiasValues.assign(Params.M, FillValue);
   Case.PublicRule =
@@ -4275,7 +4295,7 @@ static MatVecCaseData makeNonUniformF16MatVecCase(LinalgMatrixLayout Layout) {
       1,  0, -1, 2, -2, 3, -3, 1,  0, 1,  2, -1, 3, -2, 1,  -3,
       -1, 2, 0,  1, -2, 1, 3,  -1, 2, -1, 1, 0,  1, -3, -2, 3,
   };
-  Case.VectorValues = {1, -2, 3, -1, 2, -3, 1, 2};
+  Case.InterpretedVectorValues = {1, -2, 3, -1, 2, -3, 1, 2};
   Case.PublicRule =
       Layout == LinalgMatrixLayout::RowMajor
           ? L"Exact non-uniform F16 RowMajor matrix-vector dot products"
@@ -4295,11 +4315,18 @@ static MatVecCaseData makeSInt8MatVecCase(ComponentType VectorInputType) {
       1, -2, 3, -4, 5, -6, 7, -8, -1, 2,  -3, 4,  -5, 6,  -7, 8,
       1, 1,  1, 1,  1, 1,  1, 1,  -8, -7, -6, -5, -4, -3, -2, -1,
   };
-  Case.VectorValues = {1, -1, 2, -2, 3, -3, 4, -4};
+  if (VectorInputType == ComponentType::F32) {
+    Case.NativeF32VectorValues = std::vector<float>{
+        1.5f, -1.5f, 2.5f, -2.5f, 127.6f, -128.6f, 200.0f, -200.0f};
+    Case.InterpretedVectorValues = {2, -2, 2, -2, 127, -128, 127, -128};
+  } else {
+    Case.InterpretedVectorValues = {1, -1, 2, -2, 3, -3, 4, -4};
+  }
   Case.PublicRule =
       VectorInputType == ComponentType::I8
           ? L"Exact packed SInt8 vector times SInt8 matrix dot products"
-          : L"Exact native F32 vector conversion for SInt8 matrix dot products";
+          : L"Native F32 vector uses RTNE saturating SInt8 conversion before "
+            L"exact matrix dot products";
   return Case;
 }
 
@@ -4315,7 +4342,7 @@ static MatVecCaseData makeUInt8MatVecCase() {
       255, 1, 2,   3, 4,   5, 6,   7, 128, 127, 1, 1,   1, 1,   1, 1,
       200, 0, 200, 0, 200, 0, 200, 0, 0,   200, 0, 200, 0, 200, 0, 200,
   };
-  Case.VectorValues = {1, 2, 3, 4, 5, 6, 7, 8};
+  Case.InterpretedVectorValues = {255, 128, 200, 1, 2, 3, 4, 5};
   Case.PublicRule =
       L"Exact packed UInt8 vector times UInt8 matrix dot products";
   return Case;
@@ -4333,7 +4360,7 @@ static MatVecCaseData makeUInt32MatVecCase() {
       2147483648LL, 0, 0,   0, 0,   0, 0,   0, 1, 2,   3, 4,   5, 6,   7, 8,
       100,          0, 100, 0, 100, 0, 100, 0, 0, 200, 0, 200, 0, 200, 0, 200,
   };
-  Case.VectorValues = {1, 1, 1, 1, 1, 1, 1, 1};
+  Case.InterpretedVectorValues = {1, 1, 1, 1, 1, 1, 1, 1};
   Case.PublicRule =
       L"Exact native UInt32 matrix-vector results with unsigned output";
   return Case;

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3962,7 +3962,7 @@ static const char MatVecMulAddShader[] = R"(
 
     vector<OUTPUT_TYPE, M_DIM> OutVec;
     __builtin_LinAlg_MatrixVectorMultiplyAdd(
-      OutVec, Mat, OUTPUT_SIGNED, InVec, INPUT_INTERP, BiasVec, BIAS_INTERP);
+      OutVec, Mat, OUTPUT_SIGNED, InVec, INPUT_INTERP, BiasVec);
 
     for (uint I = 0; I < M_DIM; ++I) {
       Output.Store<OUTPUT_TYPE>(I * OUTPUT_SIZE, OutVec[I]);
@@ -4140,7 +4140,6 @@ buildMatVecCompilerArgs(const MatVecCaseData &Case) {
        << cpu_oracle::vectorStorageCount(Case.BiasInputType, Case.Matrix.M);
     SS << " -DBIAS_STORAGE_SIZE="
        << cpu_oracle::vectorStorageElementSize(Case.BiasInputType);
-    SS << " -DBIAS_INTERP=" << static_cast<int>(Case.BiasInputType);
   }
 
   if (needs16BitTypes(Case.Matrix.CompType) ||
@@ -4380,11 +4379,10 @@ static void runMatVecMulAdd(ID3D12Device *Device,
                             dxc::SpecificDllLoader &DxcSupport,
                             const MatrixParams &Params, bool Verbose,
                             int FillValue, bool OutputSigned,
-                            ComponentType InputInterp,
-                            ComponentType BiasInterp) {
+                            ComponentType InputInterp) {
   runMatVecCase(Device, DxcSupport,
                 makeUniformMatVecCase(Params, FillValue, OutputSigned,
-                                      InputInterp, BiasInterp),
+                                      InputInterp, Params.CompType),
                 Verbose);
 }
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -59,6 +59,11 @@ using MatrixDim = uint32_t;
 /// Return the byte size of a single element for the given component type.
 static uint8_t elementSize(ComponentType CT) {
   switch (CT) {
+  case ComponentType::I8:
+  case ComponentType::U8:
+  case ComponentType::F8_E4M3FN:
+  case ComponentType::F8_E5M2:
+    return 1;
   case ComponentType::F16:
   case ComponentType::I16:
   case ComponentType::U16:
@@ -339,6 +344,34 @@ static const char *hlslElementTypeName(ComponentType CompType) {
   default:
     return nullptr;
   }
+}
+
+static bool isPackedVectorComponent(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::I8:
+  case ComponentType::U8:
+  case ComponentType::F8_E4M3FN:
+  case ComponentType::F8_E5M2:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static const char *hlslVectorStorageTypeName(ComponentType CompType) {
+  return isPackedVectorComponent(CompType) ? "uint"
+                                           : hlslElementTypeName(CompType);
+}
+
+static MatrixDim vectorStorageCount(ComponentType CompType,
+                                    MatrixDim LogicalCount) {
+  return isPackedVectorComponent(CompType) ? (LogicalCount + 3) / 4
+                                           : LogicalCount;
+}
+
+static size_t vectorStorageElementSize(ComponentType CompType) {
+  return isPackedVectorComponent(CompType) ? sizeof(uint32_t)
+                                           : elementSize(CompType);
 }
 
 static LPCWSTR comparisonModeName(ComparisonMode Mode) {
@@ -1096,13 +1129,92 @@ static bool verifyBufferResult(const void *ActualBuffer,
 }
 
 template <typename T>
-static std::vector<BYTE> encodeNativeVector(std::initializer_list<T> Values) {
+static std::vector<BYTE>
+encodeNativeVector(const std::vector<T> &NativeValues) {
   static_assert(std::is_trivially_copyable<T>::value,
                 "Vector values must be trivially copyable");
-  std::vector<T> NativeValues(Values);
   std::vector<BYTE> Bytes(NativeValues.size() * sizeof(T));
-  std::memcpy(Bytes.data(), NativeValues.data(), Bytes.size());
+  if (!Bytes.empty())
+    std::memcpy(Bytes.data(), NativeValues.data(), Bytes.size());
   return Bytes;
+}
+
+template <typename T>
+static std::vector<BYTE> encodeNativeVector(std::initializer_list<T> Values) {
+  return encodeNativeVector(std::vector<T>(Values));
+}
+
+static std::optional<std::vector<BYTE>>
+encodeExactComponents(ComponentType CompType,
+                      const std::vector<int64_t> &Values) {
+  switch (CompType) {
+  case ComponentType::F16: {
+    std::vector<HLSLHalf_t> NativeValues;
+    NativeValues.reserve(Values.size());
+    for (int64_t Value : Values) {
+      HLSLHalf_t Half(static_cast<float>(Value));
+      if (static_cast<float>(Half) != static_cast<float>(Value))
+        return std::nullopt;
+      NativeValues.push_back(Half);
+    }
+    return encodeNativeVector(NativeValues);
+  }
+  case ComponentType::F32: {
+    std::vector<float> NativeValues;
+    NativeValues.reserve(Values.size());
+    for (int64_t Value : Values) {
+      const float FloatValue = static_cast<float>(Value);
+      if (static_cast<int64_t>(FloatValue) != Value)
+        return std::nullopt;
+      NativeValues.push_back(FloatValue);
+    }
+    return encodeNativeVector(NativeValues);
+  }
+  case ComponentType::I32: {
+    std::vector<int32_t> NativeValues;
+    NativeValues.reserve(Values.size());
+    for (int64_t Value : Values) {
+      if (Value < std::numeric_limits<int32_t>::min() ||
+          Value > std::numeric_limits<int32_t>::max())
+        return std::nullopt;
+      NativeValues.push_back(static_cast<int32_t>(Value));
+    }
+    return encodeNativeVector(NativeValues);
+  }
+  case ComponentType::U32: {
+    std::vector<uint32_t> NativeValues;
+    NativeValues.reserve(Values.size());
+    for (int64_t Value : Values) {
+      if (Value < 0 ||
+          static_cast<uint64_t>(Value) > std::numeric_limits<uint32_t>::max())
+        return std::nullopt;
+      NativeValues.push_back(static_cast<uint32_t>(Value));
+    }
+    return encodeNativeVector(NativeValues);
+  }
+  case ComponentType::I8:
+  case ComponentType::U8: {
+    std::vector<BYTE> Bytes;
+    Bytes.reserve((Values.size() + 3) & ~size_t(3));
+    for (int64_t Value : Values) {
+      if (CompType == ComponentType::I8) {
+        if (Value < std::numeric_limits<int8_t>::min() ||
+            Value > std::numeric_limits<int8_t>::max())
+          return std::nullopt;
+        Bytes.push_back(static_cast<BYTE>(static_cast<int8_t>(Value)));
+      } else {
+        if (Value < 0 || Value > std::numeric_limits<uint8_t>::max())
+          return std::nullopt;
+        Bytes.push_back(static_cast<BYTE>(Value));
+      }
+    }
+    while (Bytes.size() % sizeof(uint32_t) != 0)
+      Bytes.push_back(0);
+    return Bytes;
+  }
+  default:
+    return std::nullopt;
+  }
 }
 
 static std::optional<BYTE> encodeExactFP8(HLSLHalf_t Value,
@@ -1520,6 +1632,20 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   VERIFY_IS_TRUE(
       matchesAnyCompleteBufferCandidate(MixedBuffer, BufferPermitted));
 
+  const std::optional<std::vector<BYTE>> PackedSInt8 =
+      encodeExactComponents(ComponentType::I8, {-1, 2, -3, 4, 5});
+  const std::optional<std::vector<BYTE>> PackedUInt8 =
+      encodeExactComponents(ComponentType::U8, {255, 2, 253, 4, 5});
+  VERIFY_IS_TRUE(PackedSInt8.has_value());
+  VERIFY_IS_TRUE(PackedUInt8.has_value());
+  VERIFY_IS_TRUE(*PackedSInt8 == std::vector<BYTE>({0xff, 0x02, 0xfd, 0x04,
+                                                    0x05, 0x00, 0x00, 0x00}));
+  VERIFY_IS_TRUE(*PackedUInt8 == std::vector<BYTE>({0xff, 0x02, 0xfd, 0x04,
+                                                    0x05, 0x00, 0x00, 0x00}));
+  VERIFY_ARE_EQUAL(1u, static_cast<unsigned>(elementSize(ComponentType::I8)));
+  VERIFY_ARE_EQUAL(2u, vectorStorageCount(ComponentType::I8, 8));
+  VERIFY_ARE_EQUAL(8u, vectorStorageCount(ComponentType::F32, 8));
+
   MatrixParams Params = {};
   Params.M = 2;
   Params.N = 3;
@@ -1728,6 +1854,11 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
                                                 bool &Supported,
                                                 UINT &SelectedWaveSize);
 
+static HRESULT queryThreadVectorMatrixMultiplySupport(
+    ID3D12Device *Device, const MatrixParams &Params,
+    ComponentType VectorInputType, ComponentType BiasInputType,
+    ComponentType ResultType, LPCWSTR CaseName, bool &Supported);
+
 static HRESULT
 queryAtomicAccumulateSupport(ID3D12Device *Device, const MatrixParams &Params,
                              linalg_test::AtomicDestination Destination,
@@ -1793,8 +1924,15 @@ public:
   // Matrix Vector Arithmetic
   TEST_METHOD(MatVecMul_Thread_16x16_F16);
   TEST_METHOD(MatVecMul_Thread_4x8_F32);
+  TEST_METHOD(MatVecMul_Thread_4x8_F16_NonUniform);
+  TEST_METHOD(MatVecMul_Thread_4x8_F16_ColumnMajor);
+  TEST_METHOD(MatVecMul_Thread_4x8_I8_Interpreted);
+  TEST_METHOD(MatVecMul_Thread_4x8_U8_Interpreted);
+  TEST_METHOD(MatVecMul_Thread_4x8_F32_ToI8);
+  TEST_METHOD(MatVecMul_Thread_4x8_U32_UnsignedOutput);
   TEST_METHOD(MatVecMulAdd_Thread_16x16_F16);
   TEST_METHOD(MatVecMulAdd_Thread_4x8_F32);
+  TEST_METHOD(MatVecMulAdd_Thread_4x8_F16_IndependentBias);
   TEST_METHOD(OuterProduct_Thread_16x16_F16);
 
   // Query Accumulator Layout
@@ -2575,6 +2713,68 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
   return queryAtomicAccumulateSupport(
       Device, Params, linalg_test::AtomicDestination::RWByteAddressBuffer,
       CaseName, Supported, SelectedWaveSize);
+}
+
+static HRESULT queryThreadVectorMatrixMultiplySupport(
+    ID3D12Device *Device, const MatrixParams &Params,
+    ComponentType VectorInputType, ComponentType BiasInputType,
+    ComponentType ResultType, LPCWSTR CaseName, bool &Supported) {
+  Supported = false;
+  if (!Device || !CaseName || Params.Use != MatrixUse::A ||
+      !linalg_test::isLegalScope(
+          linalg_test::OperationType::ThreadVectorMatrixMultiply,
+          toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  const std::optional<linalg_test::DataType> VectorType =
+      toCapabilityDataType(VectorInputType);
+  const std::optional<linalg_test::DataType> MatrixType =
+      toCapabilityDataType(Params.CompType);
+  const std::optional<linalg_test::DataType> BiasType =
+      BiasInputType == ComponentType::Invalid
+          ? std::optional<linalg_test::DataType>(linalg_test::DataType::None)
+          : toCapabilityDataType(BiasInputType);
+  const std::optional<linalg_test::DataType> VectorResultType =
+      toCapabilityDataType(ResultType);
+  if (!VectorType.has_value() || !MatrixType.has_value() ||
+      !BiasType.has_value() || !VectorResultType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  linalg_test::ThreadVectorMatrixMultiplySupport Support;
+  HR = linalg_test::queryThreadVectorMatrixMultiply(
+      Device, {*VectorType, *MatrixType, *BiasType, *VectorResultType},
+      Support);
+  if (FAILED(HR))
+    return HR;
+
+  const UINT SupportFlags = static_cast<UINT>(Support.SupportFlags);
+  const bool EmulatedInputs =
+      (SupportFlags &
+       static_cast<UINT>(linalg_test::MultiplicationFlags::EmulatedInputs)) !=
+      0;
+  if (EmulatedInputs && Params.CompType != ComponentType::F8_E4M3FN &&
+      Params.CompType != ComponentType::F8_E5M2) {
+    hlsl_test::LogCommentFmt(
+        L"Thread-vector query returned EMULATED_INPUTS for non-FP8 matrix %s",
+        CaseName);
+    return E_UNEXPECTED;
+  }
+
+  const bool SupportsTranspose =
+      (SupportFlags &
+       static_cast<UINT>(linalg_test::MultiplicationFlags::Transpose)) != 0;
+  Supported =
+      Support.supported() &&
+      (Params.Layout != LinalgMatrixLayout::ColumnMajor || SupportsTranspose);
+  if (!Supported)
+    hlsl_test::LogCommentFmt(
+        L"Thread-vector matrix multiplication is unsupported for %s", CaseName);
+  return S_OK;
 }
 
 static HRESULT
@@ -3703,205 +3903,553 @@ static const char MatVecMulShader[] = R"(
   #define USE_A 0
   #define SCOPE_THREAD 0
 
-  ByteAddressBuffer Input : register(t0);
-  RWByteAddressBuffer Output : register(u1);
+  ByteAddressBuffer MatrixInput : register(t0);
+  ByteAddressBuffer VectorInput : register(t1);
+  RWByteAddressBuffer Output : register(u2);
 
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE_A, SCOPE_THREAD)]]
+      [[__LinAlgMatrix_Attributes(
+        MATRIX_COMP_TYPE, M_DIM, N_DIM, USE_A, SCOPE_THREAD)]]
       Mat;
     __builtin_LinAlg_MatrixLoadFromDescriptor(
-      Mat, Input, 0, STRIDE, LAYOUT, 128);
+      Mat, MatrixInput, 0, MATRIX_STRIDE, MATRIX_LAYOUT, 128);
 
-    vector<ELEM_TYPE, N_DIM> InVec;
-    for (uint I = 0; I < N_DIM; ++I) {
-      InVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
+    vector<INPUT_STORAGE_TYPE, INPUT_STORAGE_COUNT> InVec;
+    for (uint I = 0; I < INPUT_STORAGE_COUNT; ++I) {
+      InVec[I] =
+        VectorInput.Load<INPUT_STORAGE_TYPE>(I * INPUT_STORAGE_SIZE);
     }
 
-    vector<ELEM_TYPE, M_DIM> OutVec;
+    vector<OUTPUT_TYPE, M_DIM> OutVec;
     __builtin_LinAlg_MatrixVectorMultiply(
-      OutVec, Mat, OUTPUT_SIGNED, InVec, IN_INTERP);
+      OutVec, Mat, OUTPUT_SIGNED, InVec, INPUT_INTERP);
 
     for (uint I = 0; I < M_DIM; ++I) {
-      Output.Store<ELEM_TYPE>(I * ELEM_SIZE, OutVec[I]);
+      Output.Store<OUTPUT_TYPE>(I * OUTPUT_SIZE, OutVec[I]);
     }
   }
 )";
+
+static const char MatVecMulAddShader[] = R"(
+  #define USE_A 0
+  #define SCOPE_THREAD 0
+
+  ByteAddressBuffer MatrixInput : register(t0);
+  ByteAddressBuffer VectorInput : register(t1);
+  ByteAddressBuffer BiasInput : register(t2);
+  RWByteAddressBuffer Output : register(u3);
+
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main() {
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        MATRIX_COMP_TYPE, M_DIM, N_DIM, USE_A, SCOPE_THREAD)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, MatrixInput, 0, MATRIX_STRIDE, MATRIX_LAYOUT, 128);
+
+    vector<INPUT_STORAGE_TYPE, INPUT_STORAGE_COUNT> InVec;
+    for (uint I = 0; I < INPUT_STORAGE_COUNT; ++I) {
+      InVec[I] =
+        VectorInput.Load<INPUT_STORAGE_TYPE>(I * INPUT_STORAGE_SIZE);
+    }
+
+    vector<BIAS_STORAGE_TYPE, BIAS_STORAGE_COUNT> BiasVec;
+    for (uint I = 0; I < BIAS_STORAGE_COUNT; ++I) {
+      BiasVec[I] = BiasInput.Load<BIAS_STORAGE_TYPE>(I * BIAS_STORAGE_SIZE);
+    }
+
+    vector<OUTPUT_TYPE, M_DIM> OutVec;
+    __builtin_LinAlg_MatrixVectorMultiplyAdd(
+      OutVec, Mat, OUTPUT_SIGNED, InVec, INPUT_INTERP, BiasVec, BIAS_INTERP);
+
+    for (uint I = 0; I < M_DIM; ++I) {
+      Output.Store<OUTPUT_TYPE>(I * OUTPUT_SIZE, OutVec[I]);
+    }
+  }
+)";
+
+struct MatVecCaseData {
+  MatrixParams Matrix = {};
+  ComponentType VectorInputType = ComponentType::Invalid;
+  ComponentType InputInterpretation = ComponentType::Invalid;
+  ComponentType BiasInputType = ComponentType::Invalid;
+  ComponentType ResultType = ComponentType::Invalid;
+  bool OutputSigned = true;
+  std::vector<int64_t> MatrixValues;
+  std::vector<int64_t> VectorValues;
+  std::vector<int64_t> BiasValues;
+  std::wstring PublicRule;
+
+  bool hasBias() const { return BiasInputType != ComponentType::Invalid; }
+};
+
+static bool isMatVecCaseValid(const MatVecCaseData &Case) {
+  const size_t MatrixElementCount =
+      static_cast<size_t>(Case.Matrix.M) * Case.Matrix.N;
+  if (Case.Matrix.M == 0 || Case.Matrix.N == 0 ||
+      Case.Matrix.Use != MatrixUse::A ||
+      Case.Matrix.Scope != MatrixScope::Thread ||
+      (Case.Matrix.Layout != LinalgMatrixLayout::RowMajor &&
+       Case.Matrix.Layout != LinalgMatrixLayout::ColumnMajor) ||
+      Case.Matrix.NumThreads != 1 ||
+      Case.MatrixValues.size() != MatrixElementCount ||
+      Case.VectorValues.size() != Case.Matrix.N || Case.PublicRule.empty())
+    return false;
+
+  if (Case.hasBias() != !Case.BiasValues.empty() ||
+      (Case.hasBias() && (Case.BiasValues.size() != Case.Matrix.M ||
+                          Case.BiasInputType != Case.ResultType)))
+    return false;
+
+  if (cpu_oracle::isPackedVectorComponent(Case.VectorInputType) &&
+      (Case.VectorInputType != Case.Matrix.CompType ||
+       Case.InputInterpretation != Case.VectorInputType))
+    return false;
+  if (!cpu_oracle::isPackedVectorComponent(Case.VectorInputType) &&
+      Case.InputInterpretation != Case.Matrix.CompType)
+    return false;
+
+  const char *ResultTypeName = cpu_oracle::hlslElementTypeName(Case.ResultType);
+  const bool ExpectedOutputSigned = Case.ResultType != ComponentType::U32;
+  return Case.OutputSigned == ExpectedOutputSigned &&
+         cpu_oracle::hlslVectorStorageTypeName(Case.VectorInputType) !=
+             nullptr &&
+         ResultTypeName != nullptr &&
+         (!Case.hasBias() ||
+          cpu_oracle::hlslVectorStorageTypeName(Case.BiasInputType) != nullptr);
+}
+
+static std::optional<std::vector<BYTE>>
+encodeMatVecMatrix(const MatVecCaseData &Case) {
+  const std::optional<std::vector<BYTE>> LogicalComponents =
+      cpu_oracle::encodeExactComponents(Case.Matrix.CompType,
+                                        Case.MatrixValues);
+  if (!LogicalComponents.has_value())
+    return std::nullopt;
+
+  const size_t ComponentSize = elementSize(Case.Matrix.CompType);
+  const size_t LogicalByteCount =
+      static_cast<size_t>(Case.Matrix.M) * Case.Matrix.N * ComponentSize;
+  const size_t Stride = Case.Matrix.strideBytes();
+  const size_t MinorCount = Case.Matrix.Layout == LinalgMatrixLayout::RowMajor
+                                ? Case.Matrix.N
+                                : Case.Matrix.M;
+  const size_t MajorCount = Case.Matrix.Layout == LinalgMatrixLayout::RowMajor
+                                ? Case.Matrix.M
+                                : Case.Matrix.N;
+  if (LogicalComponents->size() < LogicalByteCount ||
+      Stride < MinorCount * ComponentSize)
+    return std::nullopt;
+
+  size_t BufferSize;
+  if (!cpu_oracle::checkedMultiply(MajorCount, Stride, BufferSize))
+    return std::nullopt;
+  std::vector<BYTE> Buffer(BufferSize, 0);
+  for (MatrixDim Row = 0; Row < Case.Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Case.Matrix.N; ++Column) {
+      const size_t SourceOffset =
+          (static_cast<size_t>(Row) * Case.Matrix.N + Column) * ComponentSize;
+      const size_t DestinationOffset =
+          Case.Matrix.Layout == LinalgMatrixLayout::RowMajor
+              ? static_cast<size_t>(Row) * Stride + Column * ComponentSize
+              : static_cast<size_t>(Column) * Stride + Row * ComponentSize;
+      std::memcpy(Buffer.data() + DestinationOffset,
+                  LogicalComponents->data() + SourceOffset, ComponentSize);
+    }
+  }
+  return Buffer;
+}
+
+static std::vector<int64_t>
+calculateMatVecExpected(const MatVecCaseData &Case) {
+  std::vector<int64_t> Expected(Case.Matrix.M, 0);
+  for (MatrixDim Row = 0; Row < Case.Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Case.Matrix.N; ++Column) {
+      Expected[Row] +=
+          Case.MatrixValues[static_cast<size_t>(Row) * Case.Matrix.N + Column] *
+          Case.VectorValues[Column];
+    }
+    if (Case.hasBias())
+      Expected[Row] += Case.BiasValues[Row];
+  }
+  return Expected;
+}
+
+static bool needs16BitTypes(ComponentType CompType) {
+  return CompType == ComponentType::F16 || CompType == ComponentType::I16 ||
+         CompType == ComponentType::U16;
+}
+
+static std::optional<std::string>
+buildMatVecCompilerArgs(const MatVecCaseData &Case) {
+  if (!isMatVecCaseValid(Case))
+    return std::nullopt;
+
+  const char *InputStorageType =
+      cpu_oracle::hlslVectorStorageTypeName(Case.VectorInputType);
+  const char *OutputType = cpu_oracle::hlslElementTypeName(Case.ResultType);
+  const char *BiasStorageType =
+      Case.hasBias() ? cpu_oracle::hlslVectorStorageTypeName(Case.BiasInputType)
+                     : nullptr;
+  if (!InputStorageType || !OutputType || (Case.hasBias() && !BiasStorageType))
+    return std::nullopt;
+
+  std::stringstream SS;
+  SS << "-HV 202x";
+  SS << " -DMATRIX_COMP_TYPE=" << static_cast<int>(Case.Matrix.CompType);
+  SS << " -DM_DIM=" << Case.Matrix.M;
+  SS << " -DN_DIM=" << Case.Matrix.N;
+  SS << " -DMATRIX_STRIDE=" << Case.Matrix.strideBytes();
+  SS << " -DMATRIX_LAYOUT=" << static_cast<int>(Case.Matrix.Layout);
+  SS << " -DNUMTHREADS=" << Case.Matrix.NumThreads;
+  SS << " -DINPUT_STORAGE_TYPE=" << InputStorageType;
+  SS << " -DINPUT_STORAGE_COUNT="
+     << cpu_oracle::vectorStorageCount(Case.VectorInputType, Case.Matrix.N);
+  SS << " -DINPUT_STORAGE_SIZE="
+     << cpu_oracle::vectorStorageElementSize(Case.VectorInputType);
+  // Native vectors carry their source type in DXIL; the immediate identifies
+  // the matrix-format conversion target. Packed vectors use the same type for
+  // storage interpretation and matrix data.
+  SS << " -DINPUT_INTERP=" << static_cast<int>(Case.InputInterpretation);
+  SS << " -DOUTPUT_TYPE=" << OutputType;
+  SS << " -DOUTPUT_SIZE="
+     << static_cast<unsigned>(elementSize(Case.ResultType));
+  SS << " -DOUTPUT_SIGNED=" << Case.OutputSigned;
+  if (Case.hasBias()) {
+    SS << " -DBIAS_STORAGE_TYPE=" << BiasStorageType;
+    SS << " -DBIAS_STORAGE_COUNT="
+       << cpu_oracle::vectorStorageCount(Case.BiasInputType, Case.Matrix.M);
+    SS << " -DBIAS_STORAGE_SIZE="
+       << cpu_oracle::vectorStorageElementSize(Case.BiasInputType);
+    SS << " -DBIAS_INTERP=" << static_cast<int>(Case.BiasInputType);
+  }
+
+  if (needs16BitTypes(Case.Matrix.CompType) ||
+      needs16BitTypes(Case.VectorInputType) ||
+      needs16BitTypes(Case.BiasInputType) || needs16BitTypes(Case.ResultType))
+    SS << " -enable-16bit-types";
+  return SS.str();
+}
+
+static void runMatVecCase(ID3D12Device *Device,
+                          dxc::SpecificDllLoader &DxcSupport,
+                          const MatVecCaseData &Case, bool Verbose) {
+  const std::optional<std::vector<BYTE>> MatrixBuffer =
+      encodeMatVecMatrix(Case);
+  const std::optional<std::vector<BYTE>> VectorBuffer =
+      cpu_oracle::encodeExactComponents(Case.VectorInputType,
+                                        Case.VectorValues);
+  const std::optional<std::vector<BYTE>> BiasBuffer =
+      Case.hasBias() ? cpu_oracle::encodeExactComponents(Case.BiasInputType,
+                                                         Case.BiasValues)
+                     : std::optional<std::vector<BYTE>>();
+  const std::optional<std::vector<BYTE>> Expected =
+      cpu_oracle::encodeExactComponents(Case.ResultType,
+                                        calculateMatVecExpected(Case));
+  const std::optional<std::string> Args = buildMatVecCompilerArgs(Case);
+  VERIFY_IS_TRUE(MatrixBuffer.has_value());
+  VERIFY_IS_TRUE(VectorBuffer.has_value());
+  VERIFY_IS_TRUE(!Case.hasBias() || BiasBuffer.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  VERIFY_IS_TRUE(Args.has_value());
+  if (!MatrixBuffer.has_value() || !VectorBuffer.has_value() ||
+      (Case.hasBias() && !BiasBuffer.has_value()) || !Expected.has_value() ||
+      !Args.has_value())
+    return;
+
+  const char *Shader = Case.hasBias() ? MatVecMulAddShader : MatVecMulShader;
+  const char *RootSignature = Case.hasBias()
+                                  ? "SRV(t0), SRV(t1), SRV(t2), UAV(u3)"
+                                  : "SRV(t0), SRV(t1), UAV(u2)";
+  compileShader(DxcSupport, Shader, "cs_6_10", *Args, Verbose);
+
+  auto Op = createComputeOp(Shader, "cs_6_10", RootSignature, Args->c_str());
+  addSRVBuffer(Op.get(), "MatrixInput", MatrixBuffer->size(), "byname");
+  addSRVBuffer(Op.get(), "VectorInput", VectorBuffer->size(), "byname");
+  if (Case.hasBias())
+    addSRVBuffer(Op.get(), "BiasInput", BiasBuffer->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", Expected->size(), true);
+  addRootView(Op.get(), 0, "MatrixInput");
+  addRootView(Op.get(), 1, "VectorInput");
+  if (Case.hasBias()) {
+    addRootView(Op.get(), 2, "BiasInput");
+    addRootView(Op.get(), 3, "Output");
+  } else {
+    addRootView(Op.get(), 2, "Output");
+  }
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+                    const std::vector<BYTE> *Source = nullptr;
+                    if (strcmp(Name, "MatrixInput") == 0)
+                      Source = &*MatrixBuffer;
+                    else if (strcmp(Name, "VectorInput") == 0)
+                      Source = &*VectorBuffer;
+                    else if (Case.hasBias() && strcmp(Name, "BiasInput") == 0)
+                      Source = &*BiasBuffer;
+                    if (!Source)
+                      return;
+                    VERIFY_IS_TRUE(Data.size() == Source->size(),
+                                   "MatVec resource initializer size mismatch");
+                    std::copy(Source->begin(), Source->end(), Data.begin());
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  if (Verbose) {
+    const BYTE *Bytes = static_cast<const BYTE *>(OutData.data());
+    for (size_t I = 0; I < OutData.size(); ++I)
+      hlsl_test::LogCommentFmt(L"  MatVec output[%zu]=0x%02x", I, Bytes[I]);
+  }
+  cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(std::move(*Expected), Case.PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
+static void runCapabilityCheckedMatVec(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatVecCaseData &Case, linalg_test::CapabilityRequirement Requirement,
+    LPCWSTR CaseName, bool Verbose) {
+  bool Supported;
+  const HRESULT HR = queryThreadVectorMatrixMultiplySupport(
+      Device, Case.Matrix, Case.VectorInputType, Case.BiasInputType,
+      Case.ResultType, CaseName, Supported);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(HR, Supported, Requirement);
+  if (!applyApplicability(Applicability, CaseName))
+    return;
+  runMatVecCase(Device, DxcSupport, Case, Verbose);
+}
+
+static MatrixParams makeThreadMatVecParams(ComponentType MatrixType,
+                                           MatrixDim M, MatrixDim N,
+                                           LinalgMatrixLayout Layout) {
+  MatrixParams Params = {};
+  Params.CompType = MatrixType;
+  Params.M = M;
+  Params.N = N;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Thread;
+  Params.Layout = Layout;
+  Params.NumThreads = 1;
+  Params.Enable16Bit = needs16BitTypes(MatrixType);
+  return Params;
+}
+
+static MatVecCaseData
+makeUniformMatVecCase(const MatrixParams &Params, int FillValue,
+                      bool OutputSigned, ComponentType InputInterp,
+                      ComponentType BiasInterp = ComponentType::Invalid) {
+  MatVecCaseData Case = {};
+  Case.Matrix = Params;
+  Case.Matrix.Use = MatrixUse::A;
+  Case.VectorInputType = Params.CompType;
+  Case.InputInterpretation = InputInterp;
+  Case.BiasInputType = BiasInterp;
+  Case.ResultType = Params.CompType;
+  Case.OutputSigned = OutputSigned;
+  Case.MatrixValues.assign(static_cast<size_t>(Params.M) * Params.N, FillValue);
+  Case.VectorValues.assign(Params.N, FillValue);
+  if (Case.hasBias())
+    Case.BiasValues.assign(Params.M, FillValue);
+  Case.PublicRule =
+      Case.hasBias()
+          ? L"Exact uniform matrix-vector dot products plus independent bias"
+          : L"Exact uniform matrix-vector dot products";
+  return Case;
+}
+
+static MatVecCaseData makeNonUniformF16MatVecCase(LinalgMatrixLayout Layout) {
+  MatVecCaseData Case = {};
+  Case.Matrix = makeThreadMatVecParams(ComponentType::F16, 4, 8, Layout);
+  Case.VectorInputType = ComponentType::F16;
+  Case.InputInterpretation = ComponentType::F16;
+  Case.ResultType = ComponentType::F16;
+  Case.OutputSigned = true;
+  Case.MatrixValues = {
+      1,  0, -1, 2, -2, 3, -3, 1,  0, 1,  2, -1, 3, -2, 1,  -3,
+      -1, 2, 0,  1, -2, 1, 3,  -1, 2, -1, 1, 0,  1, -3, -2, 3,
+  };
+  Case.VectorValues = {1, -2, 3, -1, 2, -3, 1, 2};
+  Case.PublicRule =
+      Layout == LinalgMatrixLayout::RowMajor
+          ? L"Exact non-uniform F16 RowMajor matrix-vector dot products"
+          : L"Exact non-uniform F16 ColumnMajor matrix-vector dot products";
+  return Case;
+}
+
+static MatVecCaseData makeSInt8MatVecCase(ComponentType VectorInputType) {
+  MatVecCaseData Case = {};
+  Case.Matrix = makeThreadMatVecParams(ComponentType::I8, 4, 8,
+                                       LinalgMatrixLayout::RowMajor);
+  Case.VectorInputType = VectorInputType;
+  Case.InputInterpretation = ComponentType::I8;
+  Case.ResultType = ComponentType::I32;
+  Case.OutputSigned = true;
+  Case.MatrixValues = {
+      1, -2, 3, -4, 5, -6, 7, -8, -1, 2,  -3, 4,  -5, 6,  -7, 8,
+      1, 1,  1, 1,  1, 1,  1, 1,  -8, -7, -6, -5, -4, -3, -2, -1,
+  };
+  Case.VectorValues = {1, -1, 2, -2, 3, -3, 4, -4};
+  Case.PublicRule =
+      VectorInputType == ComponentType::I8
+          ? L"Exact packed SInt8 vector times SInt8 matrix dot products"
+          : L"Exact native F32 vector conversion for SInt8 matrix dot products";
+  return Case;
+}
+
+static MatVecCaseData makeUInt8MatVecCase() {
+  MatVecCaseData Case = {};
+  Case.Matrix = makeThreadMatVecParams(ComponentType::U8, 4, 8,
+                                       LinalgMatrixLayout::RowMajor);
+  Case.VectorInputType = ComponentType::U8;
+  Case.InputInterpretation = ComponentType::U8;
+  Case.ResultType = ComponentType::I32;
+  Case.OutputSigned = true;
+  Case.MatrixValues = {
+      255, 1, 2,   3, 4,   5, 6,   7, 128, 127, 1, 1,   1, 1,   1, 1,
+      200, 0, 200, 0, 200, 0, 200, 0, 0,   200, 0, 200, 0, 200, 0, 200,
+  };
+  Case.VectorValues = {1, 2, 3, 4, 5, 6, 7, 8};
+  Case.PublicRule =
+      L"Exact packed UInt8 vector times UInt8 matrix dot products";
+  return Case;
+}
+
+static MatVecCaseData makeUInt32MatVecCase() {
+  MatVecCaseData Case = {};
+  Case.Matrix = makeThreadMatVecParams(ComponentType::U32, 4, 8,
+                                       LinalgMatrixLayout::RowMajor);
+  Case.VectorInputType = ComponentType::U32;
+  Case.InputInterpretation = ComponentType::U32;
+  Case.ResultType = ComponentType::U32;
+  Case.OutputSigned = false;
+  Case.MatrixValues = {
+      2147483648LL, 0, 0,   0, 0,   0, 0,   0, 1, 2,   3, 4,   5, 6,   7, 8,
+      100,          0, 100, 0, 100, 0, 100, 0, 0, 200, 0, 200, 0, 200, 0, 200,
+  };
+  Case.VectorValues = {1, 1, 1, 1, 1, 1, 1, 1};
+  Case.PublicRule =
+      L"Exact native UInt32 matrix-vector results with unsigned output";
+  return Case;
+}
 
 static void runMatVecMul(ID3D12Device *Device,
                          dxc::SpecificDllLoader &DxcSupport,
                          const MatrixParams &Params, bool Verbose,
                          int FillValue, bool OutputSigned,
                          ComponentType InputInterp) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
-
-  std::stringstream ExtraDefs;
-  ExtraDefs << " -DOUTPUT_SIGNED=" << OutputSigned;
-  ExtraDefs << " -DIN_INTERP=" << static_cast<int>(InputInterp);
-
-  std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
-
-  compileShader(DxcSupport, MatVecMulShader, "cs_6_10", Args, Verbose);
-
-  auto Expected =
-      makeExpectedVec(Params.CompType, Params.M,
-                      static_cast<float>(FillValue * FillValue * Params.N),
-                      /*Increment=*/false);
-
-  auto Op = createComputeOp(MatVecMulShader, "cs_6_10", "SRV(t0), UAV(u1)",
-                            Args.c_str());
-  addSRVBuffer(Op.get(), "Input", BufferSize, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
-
-  auto Result = runShaderOp(
-      Device, DxcSupport, std::move(Op),
-      [NumElements, Params, FillValue](LPCSTR Name, std::vector<BYTE> &Data,
-                                       st::ShaderOp *) {
-        VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType, NumElements,
-                                       /*StartingVal=*/FillValue,
-                                       /*Increment=*/false),
-                       "Saw unsupported component type");
-      });
-
-  MappedData OutData;
-  Result->Test->GetReadBackData("Output", &OutData);
-
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, Params.M, Verbose));
+  runMatVecCase(
+      Device, DxcSupport,
+      makeUniformMatVecCase(Params, FillValue, OutputSigned, InputInterp),
+      Verbose);
 }
-
-void DxilConf_SM610_LinAlg::MatVecMul_Thread_16x16_F16() {
-  MatrixParams Params = {};
-  Params.CompType = ComponentType::F16;
-  Params.M = 16;
-  Params.N = 16;
-  Params.Scope = MatrixScope::Thread;
-  Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 1;
-  Params.Enable16Bit = true;
-  runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
-               /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16);
-}
-
-void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F32() {
-  MatrixParams Params = {};
-  Params.CompType = ComponentType::F32;
-  Params.M = 4;
-  Params.N = 8;
-  Params.Scope = MatrixScope::Thread;
-  Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 1;
-  runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
-               /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32);
-}
-
-static const char MatVecMulAddShader[] = R"(
-  #define USE_A 0
-  #define SCOPE_THREAD 0
-
-  ByteAddressBuffer Input : register(t0);
-  RWByteAddressBuffer Output : register(u1);
-
-  [numthreads(NUMTHREADS, 1, 1)]
-  void main() {
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE_A, SCOPE_THREAD)]]
-      Mat;
-    __builtin_LinAlg_MatrixLoadFromDescriptor(
-      Mat, Input, 0, STRIDE, LAYOUT, 128);
-
-    vector<ELEM_TYPE, N_DIM> InVec;
-    for (uint I = 0; I < N_DIM; ++I) {
-      InVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
-    }
-
-    vector<ELEM_TYPE, M_DIM> BiasVec;
-    for (uint I = 0; I < M_DIM; ++I) {
-      BiasVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
-    }
-
-    vector<ELEM_TYPE, M_DIM> OutVec;
-    __builtin_LinAlg_MatrixVectorMultiplyAdd(
-      OutVec, Mat, OUTPUT_SIGNED, InVec, IN_INTERP, BiasVec);
-
-    for (uint I = 0; I < M_DIM; ++I) {
-      Output.Store<ELEM_TYPE>(I * ELEM_SIZE, OutVec[I]);
-    }
-  }
-)";
 
 static void runMatVecMulAdd(ID3D12Device *Device,
                             dxc::SpecificDllLoader &DxcSupport,
                             const MatrixParams &Params, bool Verbose,
                             int FillValue, bool OutputSigned,
-                            ComponentType InputInterp) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
+                            ComponentType InputInterp,
+                            ComponentType BiasInterp) {
+  runMatVecCase(Device, DxcSupport,
+                makeUniformMatVecCase(Params, FillValue, OutputSigned,
+                                      InputInterp, BiasInterp),
+                Verbose);
+}
 
-  std::stringstream ExtraDefs;
-  ExtraDefs << " -DOUTPUT_SIGNED=" << OutputSigned;
-  ExtraDefs << " -DIN_INTERP=" << static_cast<int>(InputInterp);
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_16x16_F16() {
+  MatrixParams Params = makeThreadMatVecParams(ComponentType::F16, 16, 16,
+                                               LinalgMatrixLayout::RowMajor);
+  runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
+               /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16);
+}
 
-  std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F32() {
+  MatrixParams Params = makeThreadMatVecParams(ComponentType::F32, 4, 8,
+                                               LinalgMatrixLayout::RowMajor);
+  runMatVecMul(D3DDevice, DxcSupport, Params, VerboseLogging,
+               /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32);
+}
 
-  compileShader(DxcSupport, MatVecMulAddShader, "cs_6_10", Args, Verbose);
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F16_NonUniform() {
+  MatVecCaseData Case =
+      makeNonUniformF16MatVecCase(LinalgMatrixLayout::RowMajor);
+  runCapabilityCheckedMatVec(D3DDevice, DxcSupport, Case,
+                             linalg_test::CapabilityRequirement::Mandatory,
+                             L"MatVecMul_Thread_4x8_F16_NonUniform",
+                             VerboseLogging);
+}
 
-  auto Expected = makeExpectedVec(
-      Params.CompType, Params.M,
-      static_cast<float>(FillValue * FillValue * Params.N + FillValue),
-      /*Increment=*/false);
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F16_ColumnMajor() {
+  MatVecCaseData Case =
+      makeNonUniformF16MatVecCase(LinalgMatrixLayout::ColumnMajor);
+  runCapabilityCheckedMatVec(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatVecMul_Thread_4x8_F16_ColumnMajor", VerboseLogging);
+}
 
-  auto Op = createComputeOp(MatVecMulAddShader, "cs_6_10", "SRV(t0), UAV(u1)",
-                            Args.c_str());
-  addSRVBuffer(Op.get(), "Input", BufferSize, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_I8_Interpreted() {
+  MatVecCaseData Case = makeSInt8MatVecCase(ComponentType::I8);
+  runCapabilityCheckedMatVec(D3DDevice, DxcSupport, Case,
+                             linalg_test::CapabilityRequirement::Mandatory,
+                             L"MatVecMul_Thread_4x8_I8_Interpreted",
+                             VerboseLogging);
+}
 
-  auto Result = runShaderOp(
-      Device, DxcSupport, std::move(Op),
-      [NumElements, Params, FillValue](LPCSTR Name, std::vector<BYTE> &Data,
-                                       st::ShaderOp *) {
-        VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType, NumElements,
-                                       /*StartingVal=*/FillValue,
-                                       /*Increment=*/false),
-                       "Saw unsupported component type");
-      });
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_U8_Interpreted() {
+  MatVecCaseData Case = makeUInt8MatVecCase();
+  runCapabilityCheckedMatVec(D3DDevice, DxcSupport, Case,
+                             linalg_test::CapabilityRequirement::Mandatory,
+                             L"MatVecMul_Thread_4x8_U8_Interpreted",
+                             VerboseLogging);
+}
 
-  MappedData OutData;
-  Result->Test->GetReadBackData("Output", &OutData);
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F32_ToI8() {
+  MatVecCaseData Case = makeSInt8MatVecCase(ComponentType::F32);
+  runCapabilityCheckedMatVec(D3DDevice, DxcSupport, Case,
+                             linalg_test::CapabilityRequirement::Mandatory,
+                             L"MatVecMul_Thread_4x8_F32_ToI8", VerboseLogging);
+}
 
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, Params.M, Verbose));
+void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_U32_UnsignedOutput() {
+  MatVecCaseData Case = makeUInt32MatVecCase();
+  runCapabilityCheckedMatVec(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatVecMul_Thread_4x8_U32_UnsignedOutput", VerboseLogging);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_16x16_F16() {
-  MatrixParams Params = {};
-  Params.CompType = ComponentType::F16;
-  Params.M = 16;
-  Params.N = 16;
-  Params.Scope = MatrixScope::Thread;
-  Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 1;
-  Params.Enable16Bit = true;
+  MatrixParams Params = makeThreadMatVecParams(ComponentType::F16, 16, 16,
+                                               LinalgMatrixLayout::RowMajor);
   runMatVecMulAdd(D3DDevice, DxcSupport, Params, VerboseLogging,
                   /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F16);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F32() {
-  MatrixParams Params = {};
-  Params.CompType = ComponentType::F32;
-  Params.M = 4;
-  Params.N = 8;
-  Params.Scope = MatrixScope::Thread;
-  Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 1;
+  MatrixParams Params = makeThreadMatVecParams(ComponentType::F32, 4, 8,
+                                               LinalgMatrixLayout::RowMajor);
   runMatVecMulAdd(D3DDevice, DxcSupport, Params, VerboseLogging,
                   /*FillValue=*/2, /*OutputSigned=*/true, ComponentType::F32);
+}
+
+void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F16_IndependentBias() {
+  MatVecCaseData Case =
+      makeNonUniformF16MatVecCase(LinalgMatrixLayout::RowMajor);
+  Case.BiasInputType = ComponentType::F16;
+  Case.BiasValues = {-5, 7, 3, -9};
+  Case.PublicRule =
+      L"Exact non-uniform F16 matrix-vector dot products plus independent bias";
+  runCapabilityCheckedMatVec(D3DDevice, DxcSupport, Case,
+                             linalg_test::CapabilityRequirement::Mandatory,
+                             L"MatVecMulAdd_Thread_4x8_F16_IndependentBias",
+                             VerboseLogging);
 }
 
 // Map a DXIL ComponentType to the D3D12 linear-algebra datatype used by the

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -322,6 +322,21 @@ static LPCWSTR componentTypeName(ComponentType CompType) {
   }
 }
 
+static const char *hlslElementTypeName(ComponentType CompType) {
+  switch (CompType) {
+  case ComponentType::F16:
+    return "half";
+  case ComponentType::F32:
+    return "float";
+  case ComponentType::I32:
+    return "int";
+  case ComponentType::U32:
+    return "uint";
+  default:
+    return nullptr;
+  }
+}
+
 static LPCWSTR comparisonModeName(ComparisonMode Mode) {
   switch (Mode) {
   case ComparisonMode::Exact:
@@ -720,6 +735,27 @@ encodeMatrixBuffer(const TypedMatrix &Matrix, const MatrixBufferLayout &Layout,
   return Buffer;
 }
 
+static std::optional<std::vector<BYTE>>
+makeFilledComponentBuffer(ComponentType CompType, size_t BufferSize,
+                          uint32_t FillValue) {
+  const size_t ElementBytes = elementSize(CompType);
+  if (!isSupportedComponentType(CompType) || BufferSize == 0 ||
+      BufferSize % ElementBytes != 0 ||
+      BufferSize / ElementBytes > (std::numeric_limits<MatrixDim>::max)())
+    return std::nullopt;
+
+  const MatrixDim NumElements =
+      static_cast<MatrixDim>(BufferSize / ElementBytes);
+  std::optional<TypedMatrix> Fill =
+      makeSequentialMatrix(CompType, 1, NumElements, FillValue,
+                           /*Increment=*/false);
+  if (!Fill.has_value())
+    return std::nullopt;
+
+  return encodeMatrixBuffer(*Fill,
+                            {LinalgMatrixLayout::RowMajor, 0, BufferSize});
+}
+
 template <typename T>
 static std::optional<TypedMatrix>
 decodeTypedMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
@@ -1071,22 +1107,11 @@ static std::string buildCompilerArgs(const MatrixParams &Params,
   SS << " -DLAYOUT=" << static_cast<int>(Params.Layout);
   SS << " -DELEM_SIZE=" << static_cast<int>(elementSize(Params.CompType));
   SS << " -DNUMTHREADS=" << Params.NumThreads;
-  switch (Params.CompType) {
-  case ComponentType::F16:
-    SS << " -DELEM_TYPE=half";
-    break;
-  case ComponentType::F32:
-    SS << " -DELEM_TYPE=float";
-    break;
-  case ComponentType::I32:
-    SS << " -DELEM_TYPE=int";
-    break;
-  case ComponentType::U32:
-    SS << " -DELEM_TYPE=uint";
-    break;
-  default:
+  const char *ElementType = cpu_oracle::hlslElementTypeName(Params.CompType);
+  if (!ElementType) {
     VERIFY_IS_TRUE(false, "Unsupported LinAlg component type");
-    break;
+  } else {
+    SS << " -DELEM_TYPE=" << ElementType;
   }
   if (Params.Enable16Bit)
     SS << " -enable-16bit-types";
@@ -1589,6 +1614,12 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
                                                 bool &Supported,
                                                 UINT &SelectedWaveSize);
 
+static HRESULT
+queryAtomicAccumulateSupport(ID3D12Device *Device, const MatrixParams &Params,
+                             linalg_test::AtomicDestination Destination,
+                             LPCWSTR CaseName, bool &Supported,
+                             UINT &SelectedWaveSize);
+
 class DxilConf_SM610_LinAlg {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM610_LinAlg)
@@ -1621,6 +1652,10 @@ public:
   TEST_METHOD(LoadMemory_Wave_16x16_F16);
   TEST_METHOD(StoreMemory_Wave_16x16_F16);
   TEST_METHOD(AccumulateMemory_Wave_16x16_F16);
+  TEST_METHOD(LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded);
+  TEST_METHOD(LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded);
+  TEST_METHOD(LoadStoreMemory_ThreadGroup_4x8_F16);
+  TEST_METHOD(AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded);
 
   // Element access
   TEST_METHOD(ElementAccess_Wave_16x16_F16);
@@ -2387,11 +2422,24 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
                                                 LPCWSTR CaseName,
                                                 bool &Supported,
                                                 UINT &SelectedWaveSize) {
+  return queryAtomicAccumulateSupport(
+      Device, Params, linalg_test::AtomicDestination::RWByteAddressBuffer,
+      CaseName, Supported, SelectedWaveSize);
+}
+
+static HRESULT
+queryAtomicAccumulateSupport(ID3D12Device *Device, const MatrixParams &Params,
+                             linalg_test::AtomicDestination Destination,
+                             LPCWSTR CaseName, bool &Supported,
+                             UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
-  if (!CaseName || !linalg_test::isLegalScope(
-                       linalg_test::OperationType::AtomicAccumulateStore,
-                       toCapabilityScope(Params.Scope)))
+  if (!CaseName ||
+      (Destination != linalg_test::AtomicDestination::RWByteAddressBuffer &&
+       Destination != linalg_test::AtomicDestination::GroupShared) ||
+      !linalg_test::isLegalScope(
+          linalg_test::OperationType::AtomicAccumulateStore,
+          toCapabilityScope(Params.Scope)))
     return E_INVALIDARG;
 
   bool ConstructionSupported;
@@ -2413,12 +2461,15 @@ static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
   if (FAILED(HR))
     return HR;
 
-  Supported = AtomicSupport.supports(
-      linalg_test::AtomicDestination::RWByteAddressBuffer);
+  Supported = AtomicSupport.supports(Destination);
   if (!Supported) {
     SelectedWaveSize = 0;
     hlsl_test::LogCommentFmt(
-        L"Atomic descriptor accumulation is unsupported for %s", CaseName);
+        L"Atomic %s accumulation is unsupported for %s",
+        Destination == linalg_test::AtomicDestination::RWByteAddressBuffer
+            ? L"descriptor"
+            : L"group-shared",
+        CaseName);
   }
   return S_OK;
 }
@@ -3821,13 +3872,11 @@ static const char LoadMemoryShader[] = R"(
   RWByteAddressBuffer Output : register(u1);
   groupshared ELEM_TYPE GsData[M_DIM * N_DIM];
 
-  #define ELEM_PER_THREAD (M_DIM * N_DIM / NUMTHREADS)
-
   [WaveSize(4, 64)]
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
-    for (uint I = 0; I < ELEM_PER_THREAD; ++I) {
-      uint Index = threadID * ELEM_PER_THREAD + I;
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
       GsData[Index] = Input.Load<ELEM_TYPE>(Index * ELEM_SIZE);
     }
 
@@ -3903,20 +3952,22 @@ static const char StoreMemoryShader[] = R"(
 
   [WaveSize(4, 64)]
   [numthreads(NUMTHREADS, 1, 1)]
-  void main() {
-    if (GetGroupWaveIndex() != 0)
-      return;
+  void main(uint threadID : SV_GroupIndex) {
+    if (GetGroupWaveIndex() == 0) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+        Mat;
+      __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
 
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
-      Mat;
-    __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
+      __builtin_LinAlg_MatrixStoreToMemory(
+        Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    }
 
-    __builtin_LinAlg_MatrixStoreToMemory(
-      Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    GroupMemoryBarrierWithGroupSync();
 
-    for (uint I = 0; I < M_DIM*N_DIM; ++I) {
-      Output.Store<ELEM_TYPE>(I*ELEM_SIZE, GsData[I]);
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, GsData[Index]);
     }
   }
 )";
@@ -3971,32 +4022,31 @@ static const char AccumulateMemoryShader[] = R"(
   RWByteAddressBuffer Output : register(u0);
   groupshared ELEM_TYPE GsData[M_DIM * N_DIM];
 
-  #define ELEM_PER_THREAD (M_DIM * N_DIM / NUMTHREADS)
-
   [WaveSize(4, 64)]
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
-    ELEM_TYPE fill = FILL_VALUE;
-    for (uint I = 0; I < ELEM_PER_THREAD; ++I) {
-      uint Index = threadID * ELEM_PER_THREAD + I;
-      GsData[Index] = fill;
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
+      GsData[Index] = FILL_VALUE;
     }
 
     GroupMemoryBarrierWithGroupSync();
 
-    if (GetGroupWaveIndex() != 0)
-      return;
+    if (GetGroupWaveIndex() == 0) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+        Mat;
+      __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
 
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
-      Mat;
-    __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
+      __builtin_LinAlg_MatrixAccumulateToMemory(
+        Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    }
 
-    __builtin_LinAlg_MatrixAccumulateToMemory(
-      Mat, GsData, COMP_TYPE, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+    GroupMemoryBarrierWithGroupSync();
 
-    for (uint I = 0; I < M_DIM*N_DIM; ++I) {
-      Output.Store<ELEM_TYPE>(I*ELEM_SIZE, GsData[I]);
+    for (uint Index = threadID; Index < M_DIM * N_DIM;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, GsData[Index]);
     }
   }
 )";
@@ -4045,6 +4095,465 @@ void DxilConf_SM610_LinAlg::AccumulateMemory_Wave_16x16_F16() {
   Params.Enable16Bit = true;
   runAccumulateMemory(D3DDevice, DxcSupport, Params, VerboseLogging,
                       /*FillValue=*/7.0f);
+}
+
+struct GroupSharedMemorySpec {
+  cpu_oracle::MatrixBufferLayout Layout;
+};
+
+static const char GroupSharedTransferShader[] = R"(
+  ByteAddressBuffer SourceInit : register(t0);
+  ByteAddressBuffer DestinationInit : register(t1);
+  RWByteAddressBuffer Output : register(u2);
+
+  groupshared ELEM_TYPE SourceData[SRC_ELEMENTS];
+  groupshared ELEM_TYPE DestinationData[DST_ELEMENTS];
+
+  void TransferMatrix() {
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromMemory(
+      Mat, SourceData, SRC_OFFSET, SRC_STRIDE, SRC_LAYOUT);
+    __builtin_LinAlg_MatrixStoreToMemory(
+      Mat, DestinationData, DST_OFFSET, DST_STRIDE, DST_LAYOUT);
+  }
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    for (uint Index = threadID; Index < SRC_ELEMENTS;
+         Index += NUMTHREADS) {
+      SourceData[Index] =
+        SourceInit.Load<ELEM_TYPE>(Index * ELEM_SIZE);
+    }
+    for (uint Index = threadID; Index < DST_ELEMENTS;
+         Index += NUMTHREADS) {
+      DestinationData[Index] =
+        DestinationInit.Load<ELEM_TYPE>(Index * ELEM_SIZE);
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    #if SCOPE == 1
+    if (GetGroupWaveIndex() == 0)
+      TransferMatrix();
+    #elif SCOPE == 2
+    TransferMatrix();
+    #else
+    #error Group-shared matrix transfer requires Wave or ThreadGroup scope
+    #endif
+
+    GroupMemoryBarrierWithGroupSync();
+
+    for (uint Index = threadID; Index < DST_ELEMENTS;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, DestinationData[Index]);
+    }
+  }
+)";
+
+static bool getGroupSharedBufferDescription(const MatrixParams &Params,
+                                            const GroupSharedMemorySpec &Spec,
+                                            size_t &BufferSize,
+                                            UINT &NumElements) {
+  const size_t ElementBytes = elementSize(Params.CompType);
+  std::optional<size_t> RequiredBytes = cpu_oracle::getMatrixBufferSize(
+      Params.CompType, Params.M, Params.N, Spec.Layout);
+  if (!RequiredBytes.has_value() ||
+      Spec.Layout.OffsetBytes % ElementBytes != 0 ||
+      Spec.Layout.StrideBytes % ElementBytes != 0 ||
+      *RequiredBytes % ElementBytes != 0 ||
+      *RequiredBytes / ElementBytes > (std::numeric_limits<UINT>::max)())
+    return false;
+
+  BufferSize = *RequiredBytes;
+  NumElements = static_cast<UINT>(BufferSize / ElementBytes);
+  return true;
+}
+
+static void
+runGroupSharedTransfer(ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+                       const MatrixParams &Params,
+                       const GroupSharedMemorySpec &Source,
+                       const GroupSharedMemorySpec &Destination, bool Verbose,
+                       std::optional<UINT> ForcedWaveSize = std::nullopt) {
+  using namespace cpu_oracle;
+
+  if (!Device ||
+      (Params.Scope != MatrixScope::Wave &&
+       Params.Scope != MatrixScope::ThreadGroup) ||
+      Params.Use != MatrixUse::A) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared transfer parameters");
+    return;
+  }
+
+  size_t SourceBufferSize;
+  UINT SourceElements;
+  size_t DestinationBufferSize;
+  UINT DestinationElements;
+  if (!getGroupSharedBufferDescription(Params, Source, SourceBufferSize,
+                                       SourceElements) ||
+      !getGroupSharedBufferDescription(
+          Params, Destination, DestinationBufferSize, DestinationElements)) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared buffer description");
+    return;
+  }
+
+  std::optional<TypedMatrix> SourceValues = makeSequentialMatrix(
+      Params.CompType, Params.M, Params.N, /*StartingValue=*/1);
+  std::optional<TypedMatrix> DestinationValues = makeSequentialMatrix(
+      Params.CompType, Params.M, Params.N, /*StartingValue=*/1);
+  std::optional<std::vector<BYTE>> SourceBuffer =
+      makeFilledComponentBuffer(Params.CompType, SourceBufferSize, 91);
+  std::optional<std::vector<BYTE>> DestinationInitial =
+      makeFilledComponentBuffer(Params.CompType, DestinationBufferSize, 90);
+  if (!SourceValues.has_value() || !DestinationValues.has_value() ||
+      !SourceBuffer.has_value() || !DestinationInitial.has_value() ||
+      !writeMatrixBuffer(*SourceValues, Source.Layout, *SourceBuffer)) {
+    VERIFY_IS_TRUE(false, "Failed to build group-shared transfer inputs");
+    return;
+  }
+
+  std::vector<BYTE> Expected = *DestinationInitial;
+  if (!writeMatrixBuffer(*DestinationValues, Destination.Layout, Expected)) {
+    VERIFY_IS_TRUE(false, "Failed to build group-shared transfer expectation");
+    return;
+  }
+
+  std::stringstream ExtraDefs;
+  ExtraDefs << " -DSRC_ELEMENTS=" << SourceElements;
+  ExtraDefs << " -DSRC_OFFSET="
+            << Source.Layout.OffsetBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DSRC_STRIDE="
+            << Source.Layout.StrideBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DSRC_LAYOUT=" << static_cast<UINT>(Source.Layout.Layout);
+  ExtraDefs << " -DDST_ELEMENTS=" << DestinationElements;
+  ExtraDefs << " -DDST_OFFSET="
+            << Destination.Layout.OffsetBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DDST_STRIDE="
+            << Destination.Layout.StrideBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DDST_LAYOUT=" << static_cast<UINT>(Destination.Layout.Layout);
+  if (ForcedWaveSize.has_value())
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << *ForcedWaveSize;
+
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+  compileShader(DxcSupport, GroupSharedTransferShader, "cs_6_10", Args,
+                Verbose);
+
+  auto Op = createComputeOp(GroupSharedTransferShader, "cs_6_10",
+                            "SRV(t0), SRV(t1), UAV(u2)", Args.c_str());
+  addSRVBuffer(Op.get(), "SourceInit", SourceBuffer->size(), "byname");
+  addSRVBuffer(Op.get(), "DestinationInit", DestinationInitial->size(),
+               "byname");
+  addUAVBuffer(Op.get(), "Output", Expected.size(), true);
+  addRootView(Op.get(), 0, "SourceInit");
+  addRootView(Op.get(), 1, "DestinationInit");
+  addRootView(Op.get(), 2, "Output");
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+                    if (strcmp(Name, "SourceInit") == 0)
+                      Data = *SourceBuffer;
+                    else if (strcmp(Name, "DestinationInit") == 0)
+                      Data = *DestinationInitial;
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  BufferResultOracle Oracle =
+      exactBufferResult(std::move(Expected),
+                        L"Exact group-shared load/store layout and addressing");
+  VERIFY_IS_TRUE(
+      verifyBufferResult(OutData.data(), OutData.size(), Oracle, Verbose));
+}
+
+static void runBidirectionalGroupSharedTransfer(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params, const GroupSharedMemorySpec &Target,
+    const GroupSharedMemorySpec &Canonical, bool Verbose,
+    std::optional<UINT> ForcedWaveSize = std::nullopt) {
+  hlsl_test::LogCommentFmt(L"Group-shared transfer: target to canonical");
+  runGroupSharedTransfer(Device, DxcSupport, Params, Target, Canonical, Verbose,
+                         ForcedWaveSize);
+  hlsl_test::LogCommentFmt(L"Group-shared transfer: canonical to target");
+  runGroupSharedTransfer(Device, DxcSupport, Params, Canonical, Target, Verbose,
+                         ForcedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"LoadStoreMemory_Wave_4x8_F16_RowMajorOffsetPadded "
+                          L"MatrixConstruction"))
+    return;
+
+  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::RowMajor,
+                                         /*OffsetBytes=*/8,
+                                         /*StrideBytes=*/24}};
+  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+                                            /*OffsetBytes=*/0,
+                                            /*StrideBytes=*/16}};
+  runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
+                                      Canonical, VerboseLogging,
+                                      SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"LoadStoreMemory_Wave_4x8_F32_ColumnMajorOffsetPadded "
+          L"MatrixConstruction"))
+    return;
+
+  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+                                         /*OffsetBytes=*/16,
+                                         /*StrideBytes=*/24}};
+  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+                                            /*OffsetBytes=*/0,
+                                            /*StrideBytes=*/32}};
+  runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
+                                      Canonical, VerboseLogging,
+                                      SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::ThreadGroup;
+  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreMemory_ThreadGroup_4x8_F16", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"LoadStoreMemory_ThreadGroup_4x8_F16 MatrixConstruction"))
+    return;
+
+  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+                                         /*OffsetBytes=*/8,
+                                         /*StrideBytes=*/12}};
+  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+                                            /*OffsetBytes=*/0,
+                                            /*StrideBytes=*/16}};
+  runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
+                                      Canonical, VerboseLogging,
+                                      SelectedWaveSize);
+}
+
+static const char GroupSharedAccumulateShader[] = R"(
+  ByteAddressBuffer Initial : register(t0);
+  RWByteAddressBuffer Output : register(u1);
+  groupshared ELEM_TYPE GsData[MEM_ELEMENTS];
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    for (uint Index = threadID; Index < MEM_ELEMENTS;
+         Index += NUMTHREADS) {
+      GsData[Index] = Initial.Load<ELEM_TYPE>(Index * ELEM_SIZE);
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    if (GetGroupWaveIndex() == 0) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+        Mat;
+      __builtin_LinAlg_FillMatrix(Mat, 0);
+      for (uint I = 0; I < __builtin_LinAlg_MatrixLength(Mat); ++I) {
+        uint2 Coord = __builtin_LinAlg_MatrixGetCoordinate(Mat, I);
+        __builtin_LinAlg_MatrixSetElement(
+          Mat, Mat, I,
+          (ELEM_TYPE)(ACCUMULATE_START + Coord.x * N_DIM + Coord.y));
+      }
+      __builtin_LinAlg_MatrixAccumulateToMemory(
+        Mat, GsData, MEM_OFFSET, MEM_STRIDE, MEM_LAYOUT);
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    for (uint Index = threadID; Index < MEM_ELEMENTS;
+         Index += NUMTHREADS) {
+      Output.Store<ELEM_TYPE>(Index * ELEM_SIZE, GsData[Index]);
+    }
+  }
+)";
+
+static void runGroupSharedAccumulate(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params, const GroupSharedMemorySpec &Memory,
+    uint32_t InitialValue, uint32_t AccumulateStartingValue, bool Verbose,
+    std::optional<UINT> ForcedWaveSize = std::nullopt) {
+  using namespace cpu_oracle;
+
+  if (!Device || Params.Scope != MatrixScope::Wave ||
+      Params.Use != MatrixUse::Accumulator ||
+      InitialValue >
+          (std::numeric_limits<uint32_t>::max)() - AccumulateStartingValue) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared accumulate parameters");
+    return;
+  }
+
+  size_t BufferSize;
+  UINT NumElements;
+  if (!getGroupSharedBufferDescription(Params, Memory, BufferSize,
+                                       NumElements)) {
+    VERIFY_IS_TRUE(false, "Invalid group-shared accumulate buffer");
+    return;
+  }
+
+  std::optional<TypedMatrix> InitialMatrix =
+      makeSequentialMatrix(Params.CompType, Params.M, Params.N, InitialValue,
+                           /*Increment=*/false);
+  std::optional<TypedMatrix> ExpectedMatrix = makeSequentialMatrix(
+      Params.CompType, Params.M, Params.N,
+      InitialValue + AccumulateStartingValue, /*Increment=*/true);
+  std::optional<std::vector<BYTE>> Initial =
+      makeFilledComponentBuffer(Params.CompType, BufferSize, 90);
+  std::optional<std::vector<BYTE>> Expected =
+      makeFilledComponentBuffer(Params.CompType, BufferSize, 90);
+  if (!InitialMatrix.has_value() || !ExpectedMatrix.has_value() ||
+      !Initial.has_value() || !Expected.has_value() ||
+      !writeMatrixBuffer(*InitialMatrix, Memory.Layout, *Initial) ||
+      !writeMatrixBuffer(*ExpectedMatrix, Memory.Layout, *Expected)) {
+    VERIFY_IS_TRUE(false, "Failed to build group-shared accumulate oracle");
+    return;
+  }
+
+  std::stringstream ExtraDefs;
+  ExtraDefs << " -DMEM_ELEMENTS=" << NumElements;
+  ExtraDefs << " -DMEM_OFFSET="
+            << Memory.Layout.OffsetBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DMEM_STRIDE="
+            << Memory.Layout.StrideBytes / elementSize(Params.CompType);
+  ExtraDefs << " -DMEM_LAYOUT=" << static_cast<UINT>(Memory.Layout.Layout);
+  ExtraDefs << " -DACCUMULATE_START=" << AccumulateStartingValue;
+  if (ForcedWaveSize.has_value())
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << *ForcedWaveSize;
+
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+  compileShader(DxcSupport, GroupSharedAccumulateShader, "cs_6_10", Args,
+                Verbose);
+
+  auto Op = createComputeOp(GroupSharedAccumulateShader, "cs_6_10",
+                            "SRV(t0), UAV(u1)", Args.c_str());
+  addSRVBuffer(Op.get(), "Initial", Initial->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", Expected->size(), true);
+  addRootView(Op.get(), 0, "Initial");
+  addRootView(Op.get(), 1, "Output");
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+                    if (strcmp(Name, "Initial") == 0)
+                      Data = *Initial;
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  BufferResultOracle Oracle = exactBufferResult(
+      std::move(*Expected), L"Exact Wave group-shared atomic accumulation");
+  VERIFY_IS_TRUE(
+      verifyBufferResult(OutData.data(), OutData.size(), Oracle, Verbose));
+}
+
+void DxilConf_SM610_LinAlg::
+    AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryAtomicAccumulateSupport(
+      D3DDevice, Params, linalg_test::AtomicDestination::GroupShared,
+      L"AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"AccumulateMemory_Wave_4x8_F16_RowMajorOffsetPadded "
+                          L"AtomicAccumulateStore"))
+    return;
+
+  const GroupSharedMemorySpec Memory = {{LinalgMatrixLayout::RowMajor,
+                                         /*OffsetBytes=*/8,
+                                         /*StrideBytes=*/24}};
+  runGroupSharedAccumulate(D3DDevice, DxcSupport, Params, Memory,
+                           /*InitialValue=*/12,
+                           /*AccumulateStartingValue=*/1, VerboseLogging,
+                           SelectedWaveSize);
 }
 
 static const char ConvertShader[] = R"(

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -200,6 +200,12 @@ struct MatrixResultOracle {
   std::wstring PublicRule;
 };
 
+struct BufferResultOracle {
+  ComparisonMode Mode;
+  std::vector<std::vector<BYTE>> Candidates;
+  std::wstring PublicRule;
+};
+
 template <typename T, ComponentType CT> struct NativeComponentTraits {
   static constexpr ComponentType CompType = CT;
   static constexpr size_t Size = sizeof(T);
@@ -377,7 +383,7 @@ static std::optional<TypedMatrix> makeTypedMatrix(MatrixDim M, MatrixDim N,
 
 static std::optional<TypedMatrix>
 makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
-                     uint32_t StartingValue = 1) {
+                     uint32_t StartingValue = 1, bool Increment = true) {
   size_t NumElements;
   if (M == 0 || N == 0 ||
       !checkedMultiply(static_cast<size_t>(M), static_cast<size_t>(N),
@@ -388,7 +394,8 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
   }
 
   size_t LastValueSize;
-  if (!checkedAdd(static_cast<size_t>(StartingValue), NumElements - 1,
+  const size_t ValueSpan = Increment ? NumElements - 1 : 0;
+  if (!checkedAdd(static_cast<size_t>(StartingValue), ValueSpan,
                   LastValueSize)) {
     hlsl_test::LogErrorFmt(L"Sequential matrix value calculation overflowed");
     return std::nullopt;
@@ -405,8 +412,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<HLSLHalf_t> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.emplace_back(static_cast<float>(
-          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+      Values.emplace_back(
+          static_cast<float>(static_cast<uint64_t>(StartingValue) +
+                             static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   case ComponentType::F32: {
@@ -419,8 +427,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<float> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.push_back(static_cast<float>(static_cast<uint64_t>(StartingValue) +
-                                          static_cast<uint64_t>(I)));
+      Values.push_back(
+          static_cast<float>(static_cast<uint64_t>(StartingValue) +
+                             static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   case ComponentType::I32: {
@@ -433,8 +442,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<int32_t> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.push_back(static_cast<int32_t>(
-          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+      Values.push_back(
+          static_cast<int32_t>(static_cast<uint64_t>(StartingValue) +
+                               static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   case ComponentType::U32: {
@@ -446,8 +456,9 @@ makeSequentialMatrix(ComponentType CompType, MatrixDim M, MatrixDim N,
     std::vector<uint32_t> Values;
     Values.reserve(NumElements);
     for (size_t I = 0; I < NumElements; ++I)
-      Values.push_back(static_cast<uint32_t>(
-          static_cast<uint64_t>(StartingValue) + static_cast<uint64_t>(I)));
+      Values.push_back(
+          static_cast<uint32_t>(static_cast<uint64_t>(StartingValue) +
+                                static_cast<uint64_t>(Increment ? I : 0)));
     return makeTypedMatrix(M, N, std::move(Values));
   }
   default:
@@ -643,6 +654,73 @@ static bool writeMatrixBuffer(const TypedMatrix &Matrix,
 }
 
 template <typename T>
+static bool writeTypedMatrixBufferWithinBounds(const TypedMatrix &Matrix,
+                                               const MatrixBufferLayout &Layout,
+                                               size_t AccessibleBytes,
+                                               std::vector<BYTE> &Buffer) {
+  const std::vector<T> &Values = std::get<std::vector<T>>(Matrix.Values);
+  for (MatrixDim Row = 0; Row < Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Matrix.N; ++Column) {
+      const size_t ValueIndex = static_cast<size_t>(Row) * Matrix.N + Column;
+      std::optional<size_t> ByteOffset = getElementByteOffset(
+          Matrix.CompType, Matrix.M, Matrix.N, Row, Column, Layout);
+      size_t EndOffset;
+      if (!ByteOffset.has_value() ||
+          !checkedAdd(*ByteOffset, ComponentTraits<T>::Size, EndOffset))
+        return false;
+      if (EndOffset > AccessibleBytes)
+        continue;
+      ComponentTraits<T>::store(Buffer.data() + *ByteOffset,
+                                Values[ValueIndex]);
+    }
+  }
+  return true;
+}
+
+static bool writeMatrixBufferWithinBounds(const TypedMatrix &Matrix,
+                                          const MatrixBufferLayout &Layout,
+                                          size_t AccessibleBytes,
+                                          std::vector<BYTE> &Buffer) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Matrix, Layout);
+  if (!RequiredBytes.has_value() || Buffer.size() < *RequiredBytes ||
+      AccessibleBytes > Buffer.size()) {
+    hlsl_test::LogErrorFmt(
+        L"Invalid bounded matrix buffer: actual=%zu, required=%zu, bound=%zu",
+        Buffer.size(), RequiredBytes.value_or(0), AccessibleBytes);
+    return false;
+  }
+
+  switch (Matrix.CompType) {
+  case ComponentType::F16:
+    return writeTypedMatrixBufferWithinBounds<HLSLHalf_t>(
+        Matrix, Layout, AccessibleBytes, Buffer);
+  case ComponentType::F32:
+    return writeTypedMatrixBufferWithinBounds<float>(Matrix, Layout,
+                                                     AccessibleBytes, Buffer);
+  case ComponentType::I32:
+    return writeTypedMatrixBufferWithinBounds<int32_t>(Matrix, Layout,
+                                                       AccessibleBytes, Buffer);
+  case ComponentType::U32:
+    return writeTypedMatrixBufferWithinBounds<uint32_t>(
+        Matrix, Layout, AccessibleBytes, Buffer);
+  default:
+    return false;
+  }
+}
+
+static std::optional<std::vector<BYTE>>
+encodeMatrixBuffer(const TypedMatrix &Matrix, const MatrixBufferLayout &Layout,
+                   BYTE FillByte = 0) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Matrix, Layout);
+  if (!RequiredBytes.has_value())
+    return std::nullopt;
+  std::vector<BYTE> Buffer(*RequiredBytes, FillByte);
+  if (!writeMatrixBuffer(Matrix, Layout, Buffer))
+    return std::nullopt;
+  return Buffer;
+}
+
+template <typename T>
 static std::optional<TypedMatrix>
 decodeTypedMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
                         const MatrixBufferLayout &Layout, const BYTE *Buffer) {
@@ -686,6 +764,21 @@ decodeMatrixBuffer(ComponentType CompType, MatrixDim M, MatrixDim N,
   default:
     return std::nullopt;
   }
+}
+
+static std::optional<TypedMatrix>
+makeBoundedReadResult(const TypedMatrix &Source,
+                      const MatrixBufferLayout &Layout,
+                      size_t AccessibleBytes) {
+  std::optional<size_t> RequiredBytes = getMatrixBufferSize(Source, Layout);
+  if (!RequiredBytes.has_value() || AccessibleBytes > *RequiredBytes)
+    return std::nullopt;
+
+  std::vector<BYTE> Buffer(*RequiredBytes, 0);
+  if (!writeMatrixBufferWithinBounds(Source, Layout, AccessibleBytes, Buffer))
+    return std::nullopt;
+  return decodeMatrixBuffer(Source.CompType, Source.M, Source.N, Layout,
+                            Buffer.data(), Buffer.size());
 }
 
 template <typename T>
@@ -764,6 +857,19 @@ static MatrixResultOracle permittedResults(std::vector<TypedMatrix> Candidates,
 static MatrixResultOracle excludedResult(std::wstring PublicRule) {
   return MatrixResultOracle{
       ComparisonMode::Excluded, {}, std::move(PublicRule)};
+}
+
+static BufferResultOracle exactBufferResult(std::vector<BYTE> Expected,
+                                            std::wstring PublicRule) {
+  return BufferResultOracle{
+      ComparisonMode::Exact, {std::move(Expected)}, std::move(PublicRule)};
+}
+
+static BufferResultOracle
+permittedBufferResults(std::vector<std::vector<BYTE>> Candidates,
+                       std::wstring PublicRule) {
+  return BufferResultOracle{ComparisonMode::PermittedResults,
+                            std::move(Candidates), std::move(PublicRule)};
 }
 
 static bool isOracleValid(const MatrixResultOracle &Oracle) {
@@ -857,6 +963,95 @@ static bool verifyMatrixBuffer(const void *ActualBuffer,
         CandidateIndex, Mismatch, Row, Column,
         matrixValueString(*Actual, Mismatch).c_str(),
         matrixValueString(Candidate, Mismatch).c_str());
+  }
+  return false;
+}
+
+static bool isBufferOracleValid(const BufferResultOracle &Oracle) {
+  if (Oracle.PublicRule.empty() || Oracle.Candidates.empty())
+    return false;
+  if (Oracle.Mode == ComparisonMode::Excluded)
+    return false;
+  if (Oracle.Mode == ComparisonMode::Exact && Oracle.Candidates.size() != 1)
+    return false;
+  if (Oracle.Mode == ComparisonMode::PermittedResults &&
+      Oracle.Candidates.size() < 2)
+    return false;
+
+  const size_t ExpectedSize = Oracle.Candidates.front().size();
+  if (ExpectedSize == 0)
+    return false;
+  for (const std::vector<BYTE> &Candidate : Oracle.Candidates) {
+    if (Candidate.size() != ExpectedSize)
+      return false;
+  }
+  return true;
+}
+
+static bool matchesAnyCompleteBufferCandidate(
+    const std::vector<BYTE> &Actual, const BufferResultOracle &Oracle,
+    std::vector<size_t> *FirstMismatches = nullptr) {
+  if (!isBufferOracleValid(Oracle) ||
+      Actual.size() != Oracle.Candidates.front().size())
+    return false;
+
+  if (FirstMismatches)
+    FirstMismatches->clear();
+  for (const std::vector<BYTE> &Candidate : Oracle.Candidates) {
+    const auto Mismatch =
+        std::mismatch(Actual.begin(), Actual.end(), Candidate.begin());
+    const size_t FirstMismatch =
+        static_cast<size_t>(std::distance(Actual.begin(), Mismatch.first));
+    if (FirstMismatch == Actual.size())
+      return true;
+    if (FirstMismatches)
+      FirstMismatches->push_back(FirstMismatch);
+  }
+  return false;
+}
+
+static bool verifyBufferResult(const void *ActualBuffer,
+                               size_t ActualBufferSize,
+                               const BufferResultOracle &Oracle, bool Verbose) {
+  if (!ActualBuffer || !isBufferOracleValid(Oracle)) {
+    hlsl_test::LogErrorFmt(L"Invalid whole-buffer result or oracle");
+    return false;
+  }
+
+  const size_t ExpectedSize = Oracle.Candidates.front().size();
+  if (ActualBufferSize != ExpectedSize) {
+    hlsl_test::LogErrorFmt(
+        L"Whole-buffer size mismatch: actual=%zu, expected=%zu, rule=%s",
+        ActualBufferSize, ExpectedSize, Oracle.PublicRule.c_str());
+    return false;
+  }
+
+  const BYTE *ActualBytes = static_cast<const BYTE *>(ActualBuffer);
+  std::vector<BYTE> Actual(ActualBytes, ActualBytes + ActualBufferSize);
+  std::vector<size_t> FirstMismatches;
+  if (matchesAnyCompleteBufferCandidate(Actual, Oracle, &FirstMismatches)) {
+    if (Verbose) {
+      hlsl_test::LogCommentFmt(
+          L"Whole-buffer comparison passed: bytes=%zu, mode=%s, rule=%s",
+          ActualBufferSize, comparisonModeName(Oracle.Mode),
+          Oracle.PublicRule.c_str());
+    }
+    return true;
+  }
+
+  hlsl_test::LogErrorFmt(
+      L"No complete whole-buffer candidate matched: bytes=%zu, mode=%s, "
+      L"rule=%s",
+      ActualBufferSize, comparisonModeName(Oracle.Mode),
+      Oracle.PublicRule.c_str());
+  for (size_t CandidateIndex = 0; CandidateIndex < Oracle.Candidates.size();
+       ++CandidateIndex) {
+    const size_t Mismatch = FirstMismatches[CandidateIndex];
+    hlsl_test::LogErrorFmt(
+        L"Candidate %zu first mismatch at byte=%zu: actual=0x%02x, "
+        L"expected=0x%02x",
+        CandidateIndex, Mismatch, Actual[Mismatch],
+        Oracle.Candidates[CandidateIndex][Mismatch]);
   }
   return false;
 }
@@ -1200,6 +1395,18 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
       excludedResult(L"Host excluded-oracle classification");
   VERIFY_IS_FALSE(matchesAnyCompleteCandidate(*Matrix, Excluded));
 
+  const std::vector<BYTE> BufferCandidateA = {1, 2, 3, 4};
+  const std::vector<BYTE> BufferCandidateB = {5, 6, 7, 8};
+  const std::vector<BYTE> MixedBuffer = {1, 2, 7, 8};
+  BufferResultOracle BufferPermitted = permittedBufferResults(
+      {BufferCandidateA, BufferCandidateB},
+      L"Host whole-buffer permitted candidate semantics");
+  VERIFY_IS_FALSE(
+      matchesAnyCompleteBufferCandidate(MixedBuffer, BufferPermitted));
+  BufferPermitted.Candidates.push_back(MixedBuffer);
+  VERIFY_IS_TRUE(
+      matchesAnyCompleteBufferCandidate(MixedBuffer, BufferPermitted));
+
   MatrixParams Params = {};
   Params.M = 2;
   Params.N = 3;
@@ -1365,6 +1572,23 @@ void LinAlgCapabilityTests::CapabilityPolicyAndPredicates() {
   VERIFY_IS_TRUE(AtomicQuery.ComponentType == DataType::Float16);
 }
 
+struct MatrixConstructionRequirement {
+  linalg_test::MatrixRole Role;
+  MatrixDim Rows;
+  MatrixDim Columns;
+};
+
+static HRESULT queryMatrixConstructionSupport(
+    ID3D12Device *Device, const MatrixParams &Params,
+    std::initializer_list<MatrixConstructionRequirement> Requirements,
+    LPCWSTR CaseName, bool &Supported, UINT &SelectedWaveSize);
+
+static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
+                                                const MatrixParams &Params,
+                                                LPCWSTR CaseName,
+                                                bool &Supported,
+                                                UINT &SelectedWaveSize);
+
 class DxilConf_SM610_LinAlg {
 public:
   BEGIN_TEST_CLASS(DxilConf_SM610_LinAlg)
@@ -1385,8 +1609,13 @@ public:
 
   // Load/Store/Accumulate Descriptor
   TEST_METHOD(LoadStoreDescriptor_Wave_16x16_F16);
+  TEST_METHOD(LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded);
+  TEST_METHOD(LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset);
+  TEST_METHOD(LoadDescriptorBounds_Wave_4x8_F32);
+  TEST_METHOD(StoreDescriptorBounds_Wave_4x8_F32);
   TEST_METHOD(SplatStore_Wave_16x16_F16);
   TEST_METHOD(AccumulateDescriptor_Wave_16x16_F16);
+  TEST_METHOD(AccumulateDescriptorBounds_Wave_4x8_F32);
 
   // Load/Store/Accumulate Memory
   TEST_METHOD(LoadMemory_Wave_16x16_F16);
@@ -1476,11 +1705,15 @@ bool DxilConf_SM610_LinAlg::setupMethod() {
   return D3D12SDK->createDevice(&D3DDevice, D3D_SHADER_MODEL_6_10, false);
 }
 
-static const char LoadStoreDescriptorShader[] = R"(
-  RWByteAddressBuffer Input : register(u0);
+static const char DescriptorIOShader[] = R"(
+  ByteAddressBuffer Input : register(t0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1490,51 +1723,121 @@ static const char LoadStoreDescriptorShader[] = R"(
       [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
       Mat;
     __builtin_LinAlg_MatrixLoadFromDescriptor(
-      Mat, Input, OFFSET, STRIDE, LAYOUT, 128);
+      Mat, Input, SRC_OFFSET, SRC_STRIDE, SRC_LAYOUT, SRC_ALIGNMENT);
+  #ifdef ACCUMULATE_COUNT
+    for (uint I = 0; I < ACCUMULATE_COUNT; ++I) {
+      __builtin_LinAlg_MatrixAccumulateToDescriptor(
+        Mat, Output, DST_OFFSET, DST_STRIDE, DST_LAYOUT, DST_ALIGNMENT);
+    }
+  #else
     __builtin_LinAlg_MatrixStoreToDescriptor(
-      Mat, Output, OFFSET, STRIDE, LAYOUT, 128);
+      Mat, Output, DST_OFFSET, DST_STRIDE, DST_LAYOUT, DST_ALIGNMENT);
+  #endif
   }
 )";
 
-static void runLoadStoreDescriptor(ID3D12Device *Device,
-                                   dxc::SpecificDllLoader &DxcSupport,
-                                   const MatrixParams &Params, bool Verbose) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
+static void runDescriptorIO(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params, const cpu_oracle::TypedMatrix &InputMatrix,
+    const cpu_oracle::MatrixBufferLayout &SourceLayout,
+    const cpu_oracle::MatrixBufferLayout &DestinationLayout,
+    UINT SourceAlignment, UINT DestinationAlignment, size_t SourceViewBytes,
+    size_t DestinationViewBytes, std::vector<BYTE> InitialOutput,
+    const cpu_oracle::BufferResultOracle &Oracle, bool Verbose,
+    UINT ForcedWaveSize = 0, UINT AccumulateCount = 0) {
+  std::optional<std::vector<BYTE>> SourceBuffer =
+      cpu_oracle::encodeMatrixBuffer(InputMatrix, SourceLayout, 0xcd);
+  VERIFY_IS_TRUE(SourceBuffer.has_value(),
+                 "Unable to encode descriptor input matrix");
+  VERIFY_IS_TRUE(SourceViewBytes <= SourceBuffer->size() &&
+                     DestinationViewBytes <= InitialOutput.size(),
+                 "Descriptor view exceeds its backing resource");
 
-  // TODO: these should be varied by test to ensure full coverage
   std::stringstream ExtraDefs;
-  ExtraDefs << " -DOFFSET=" << 0;
+  ExtraDefs << " -DSRC_OFFSET=" << SourceLayout.OffsetBytes;
+  ExtraDefs << " -DSRC_STRIDE=" << SourceLayout.StrideBytes;
+  ExtraDefs << " -DSRC_LAYOUT=" << static_cast<UINT>(SourceLayout.Layout);
+  ExtraDefs << " -DSRC_ALIGNMENT=" << SourceAlignment;
+  ExtraDefs << " -DDST_OFFSET=" << DestinationLayout.OffsetBytes;
+  ExtraDefs << " -DDST_STRIDE=" << DestinationLayout.StrideBytes;
+  ExtraDefs << " -DDST_LAYOUT=" << static_cast<UINT>(DestinationLayout.Layout);
+  ExtraDefs << " -DDST_ALIGNMENT=" << DestinationAlignment;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  if (AccumulateCount != 0)
+    ExtraDefs << " -DACCUMULATE_COUNT=" << AccumulateCount;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
-  compileShader(DxcSupport, LoadStoreDescriptorShader, "cs_6_10", Args,
-                Verbose);
+  compileShader(DxcSupport, DescriptorIOShader, "cs_6_10", Args, Verbose);
 
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1);
+  auto Op = createComputeOp(DescriptorIOShader, "cs_6_10",
+                            "DescriptorTable(SRV(t0), UAV(u1))", Args.c_str());
+  addSRVBuffer(Op.get(), "Input", SourceBuffer->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", InitialOutput.size(), true, "byname");
+  addRawBufferDescriptorTable(
+      Op.get(), 0, "DescriptorHeap",
+      {
+          {"InputView", "Input", RawBufferViewKind::SRV, 0, SourceViewBytes},
+          {"OutputView", "Output", RawBufferViewKind::UAV, 0,
+           DestinationViewBytes},
+      });
 
-  // Construct the ShaderOp: two UAV buffers, load from one, store to other.
-  auto Op = createComputeOp(LoadStoreDescriptorShader, "cs_6_10",
-                            "UAV(u0), UAV(u1)", Args.c_str());
-  addUAVBuffer(Op.get(), "Input", BufferSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
-
-  auto Result =
-      runShaderOp(Device, DxcSupport, std::move(Op),
-                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                                        st::ShaderOp *) {
-                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                                   NumElements),
-                                   "Saw unsupported component type");
-                  });
+  const std::vector<BYTE> SourceData = *SourceBuffer;
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [SourceData, InitialOutput](LPCSTR Name, std::vector<BYTE> &Data,
+                                  st::ShaderOp *) {
+        const std::vector<BYTE> *ExpectedData = nullptr;
+        if (_stricmp(Name, "Input") == 0)
+          ExpectedData = &SourceData;
+        else if (_stricmp(Name, "Output") == 0)
+          ExpectedData = &InitialOutput;
+        if (!ExpectedData)
+          return;
+        VERIFY_IS_TRUE(Data.size() == ExpectedData->size(),
+                       "Descriptor resource initializer size mismatch");
+        std::copy(ExpectedData->begin(), ExpectedData->end(), Data.begin());
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
 
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
+static void runExactDescriptorRoundTrip(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixParams &Params,
+    const cpu_oracle::MatrixBufferLayout &SourceLayout,
+    const cpu_oracle::MatrixBufferLayout &DestinationLayout,
+    UINT SourceAlignment, UINT DestinationAlignment, bool Verbose,
+    UINT ForcedWaveSize = 0) {
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value(),
+                 "Unable to construct descriptor round-trip input");
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  std::optional<size_t> DestinationBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, DestinationLayout);
+  VERIFY_IS_TRUE(SourceBytes.has_value() && DestinationBytes.has_value(),
+                 "Unable to size descriptor round-trip buffers");
+
+  std::vector<BYTE> InitialOutput(*DestinationBytes, 0xcd);
+  std::vector<BYTE> Expected = InitialOutput;
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(*Input, DestinationLayout, Expected),
+      "Unable to encode descriptor round-trip expectation");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::exactBufferResult(
+      std::move(Expected), L"Descriptor load/store preserves logical values, "
+                           L"addressing and padding");
+
+  runDescriptorIO(Device, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, SourceAlignment, DestinationAlignment,
+                  *SourceBytes, *DestinationBytes, std::move(InitialOutput),
+                  Oracle, Verbose, ForcedWaveSize);
 }
 
 void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
@@ -1547,7 +1850,251 @@ void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runLoadStoreDescriptor(D3DDevice, DxcSupport, Params, VerboseLogging);
+  const cpu_oracle::MatrixBufferLayout Layout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Layout, Layout,
+                              /*SourceAlignment=*/128,
+                              /*DestinationAlignment=*/128, VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"LoadStoreDescriptor_Wave_4x8_F16_RowMajorOffsetPadded"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout Target = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/24,
+  };
+  const cpu_oracle::MatrixBufferLayout Canonical = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/16,
+  };
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Target, Canonical,
+                              /*SourceAlignment=*/16,
+                              /*DestinationAlignment=*/128, VerboseLogging,
+                              SelectedWaveSize);
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Canonical, Target,
+                              /*SourceAlignment=*/128,
+                              /*DestinationAlignment=*/16, VerboseLogging,
+                              SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::
+    LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability, L"LoadStoreDescriptor_Wave_4x8_F32_ColumnMajorOffset"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout Target = {
+      LinalgMatrixLayout::ColumnMajor,
+      /*OffsetBytes=*/32,
+      /*StrideBytes=*/16,
+  };
+  const cpu_oracle::MatrixBufferLayout Canonical = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Target, Canonical,
+                              /*SourceAlignment=*/32,
+                              /*DestinationAlignment=*/128, VerboseLogging,
+                              SelectedWaveSize);
+  runExactDescriptorRoundTrip(D3DDevice, DxcSupport, Params, Canonical, Target,
+                              /*SourceAlignment=*/128,
+                              /*DestinationAlignment=*/32, VerboseLogging,
+                              SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::LoadDescriptorBounds_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"LoadDescriptorBounds_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"LoadDescriptorBounds_Wave_4x8_F32"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout SourceLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/32,
+  };
+  const cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  constexpr size_t SourceViewBytes = 128;
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> WholeLoadZero =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> PerElementLoad =
+      Input ? cpu_oracle::makeBoundedReadResult(*Input, SourceLayout,
+                                                SourceViewBytes)
+            : std::nullopt;
+  VERIFY_IS_TRUE(Input.has_value() && WholeLoadZero.has_value() &&
+                     PerElementLoad.has_value(),
+                 "Unable to construct bounded descriptor load expectations");
+
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  std::optional<size_t> DestinationBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, DestinationLayout);
+  VERIFY_IS_TRUE(SourceBytes.has_value() && DestinationBytes.has_value() &&
+                     SourceViewBytes < *SourceBytes,
+                 "Bounded descriptor load must cross the source view end");
+
+  std::vector<BYTE> InitialOutput(*DestinationBytes, 0xcd);
+  std::vector<BYTE> WholeZero = InitialOutput;
+  std::vector<BYTE> PerElement = InitialOutput;
+  VERIFY_IS_TRUE(cpu_oracle::writeMatrixBuffer(*WholeLoadZero,
+                                               DestinationLayout, WholeZero) &&
+                     cpu_oracle::writeMatrixBuffer(
+                         *PerElementLoad, DestinationLayout, PerElement),
+                 "Unable to encode bounded descriptor load candidates");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::permittedBufferResults(
+      {std::move(WholeZero), std::move(PerElement)},
+      L"Descriptor load may zero the whole matrix or only out-of-bounds "
+      L"elements");
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, /*SourceAlignment=*/16,
+                  /*DestinationAlignment=*/128, SourceViewBytes,
+                  *DestinationBytes, std::move(InitialOutput), Oracle,
+                  VerboseLogging, SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::StoreDescriptorBounds_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      D3DDevice, Params, {{linalg_test::MatrixRole::A, Params.M, Params.N}},
+      L"StoreDescriptorBounds_Wave_4x8_F32", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"StoreDescriptorBounds_Wave_4x8_F32"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout SourceLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  const cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/32,
+  };
+  constexpr size_t DestinationViewBytes = 128;
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> InitialMatrix =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value() && InitialMatrix.has_value(),
+                 "Unable to construct bounded descriptor store data");
+  std::optional<std::vector<BYTE>> InitialOutput =
+      cpu_oracle::encodeMatrixBuffer(*InitialMatrix, DestinationLayout, 0xcd);
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  VERIFY_IS_TRUE(
+      InitialOutput.has_value() && SourceBytes.has_value() &&
+          DestinationViewBytes < InitialOutput->size(),
+      "Bounded descriptor store must cross the destination view end");
+
+  std::vector<BYTE> WholeNoOp = *InitialOutput;
+  std::vector<BYTE> PerElementNoOp = *InitialOutput;
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBufferWithinBounds(
+          *Input, DestinationLayout, DestinationViewBytes, PerElementNoOp),
+      "Unable to encode bounded descriptor store candidate");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::permittedBufferResults(
+      {std::move(WholeNoOp), std::move(PerElementNoOp)},
+      L"Descriptor store may suppress the whole operation or only "
+      L"out-of-bounds "
+      L"elements");
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, /*SourceAlignment=*/128,
+                  /*DestinationAlignment=*/16, *SourceBytes,
+                  DestinationViewBytes, std::move(*InitialOutput), Oracle,
+                  VerboseLogging, SelectedWaveSize);
 }
 
 static const char SplatStoreShader[] = R"(
@@ -1612,69 +2159,6 @@ void DxilConf_SM610_LinAlg::SplatStore_Wave_16x16_F16() {
   runSplatStore(D3DDevice, DxcSupport, Params, 42.0f, VerboseLogging);
 }
 
-static const char AccumulateDescriptorShader[] = R"(
-  #define USE_ACC 2
-
-  ByteAddressBuffer Input : register(t0);
-  RWByteAddressBuffer Output : register(u1);
-
-  [WaveSize(4, 64)]
-  [numthreads(NUMTHREADS, 1, 1)]
-  void main() {
-    if (GetGroupWaveIndex() != 0)
-      return;
-
-    __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE)]]
-      Mat;
-    __builtin_LinAlg_MatrixLoadFromDescriptor(
-      Mat, Input, 0, STRIDE, LAYOUT, 128);
-    __builtin_LinAlg_MatrixAccumulateToDescriptor(
-      Mat, Output, 0, STRIDE, LAYOUT, 128);
-    __builtin_LinAlg_MatrixAccumulateToDescriptor(
-      Mat, Output, 0, STRIDE, LAYOUT, 128);
-  }
-)";
-
-static void runAccumulateDescriptor(ID3D12Device *Device,
-                                    dxc::SpecificDllLoader &DxcSupport,
-                                    const MatrixParams &Params, int FillValue,
-                                    bool Verbose) {
-  const size_t NumElements = Params.totalElements();
-  const size_t BufferSize = Params.totalBytes();
-
-  std::string Args = buildCompilerArgs(Params);
-
-  compileShader(DxcSupport, AccumulateDescriptorShader, "cs_6_10", Args,
-                Verbose);
-
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N,
-                                  static_cast<float>(FillValue) * 2, false);
-
-  auto Op = createComputeOp(AccumulateDescriptorShader, "cs_6_10",
-                            "SRV(t0), UAV(u1)", Args.c_str());
-  addSRVBuffer(Op.get(), "Input", BufferSize, "byname");
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Input");
-  addRootView(Op.get(), 1, "Output");
-
-  auto Result = runShaderOp(
-      Device, DxcSupport, std::move(Op),
-      [NumElements, Params, FillValue](LPCSTR Name, std::vector<BYTE> &Data,
-                                       st::ShaderOp *) {
-        VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType, NumElements,
-                                       /*StartingVal=*/FillValue,
-                                       /*Increment=*/false),
-                       "Saw unsupported component type");
-      });
-
-  MappedData OutData;
-  Result->Test->GetReadBackData("Output", &OutData);
-
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumElements, Verbose));
-}
-
 void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   MatrixParams Params = {};
   Params.CompType = ComponentType::F16;
@@ -1685,14 +2169,112 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging);
+
+  const cpu_oracle::MatrixBufferLayout Layout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N,
+                                       /*StartingValue=*/12,
+                                       /*Increment=*/false);
+  std::optional<cpu_oracle::TypedMatrix> InitialMatrix =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> ExpectedMatrix =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N,
+                                       /*StartingValue=*/24,
+                                       /*Increment=*/false);
+  VERIFY_IS_TRUE(Input.has_value() && InitialMatrix.has_value() &&
+                     ExpectedMatrix.has_value(),
+                 "Unable to construct descriptor accumulation data");
+  std::optional<std::vector<BYTE>> InitialOutput =
+      cpu_oracle::encodeMatrixBuffer(*InitialMatrix, Layout);
+  std::optional<std::vector<BYTE>> Expected =
+      cpu_oracle::encodeMatrixBuffer(*ExpectedMatrix, Layout);
+  VERIFY_IS_TRUE(InitialOutput.has_value() && Expected.has_value(),
+                 "Unable to encode descriptor accumulation buffers");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::exactBufferResult(
+      std::move(*Expected), L"Two descriptor accumulations add the matrix to "
+                            L"each destination element");
+  const size_t BufferSize = InitialOutput->size();
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, Layout, Layout,
+                  /*SourceAlignment=*/128, /*DestinationAlignment=*/128,
+                  BufferSize, BufferSize, std::move(*InitialOutput), Oracle,
+                  VerboseLogging,
+                  /*ForcedWaveSize=*/0, /*AccumulateCount=*/2);
 }
 
-struct MatrixConstructionRequirement {
-  linalg_test::MatrixRole Role;
-  MatrixDim Rows;
-  MatrixDim Columns;
-};
+void DxilConf_SM610_LinAlg::AccumulateDescriptorBounds_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult = queryDescriptorAccumulateSupport(
+      D3DDevice, Params, L"AccumulateDescriptorBounds_Wave_4x8_F32", Supported,
+      SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"AccumulateDescriptorBounds_Wave_4x8_F32"))
+    return;
+
+  const cpu_oracle::MatrixBufferLayout SourceLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/32,
+  };
+  const cpu_oracle::MatrixBufferLayout DestinationLayout = {
+      LinalgMatrixLayout::RowMajor,
+      /*OffsetBytes=*/16,
+      /*StrideBytes=*/32,
+  };
+  constexpr size_t DestinationViewBytes = 128;
+
+  std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
+  std::optional<cpu_oracle::TypedMatrix> InitialMatrix =
+      cpu_oracle::makeZeroMatrix(Params.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Input.has_value() && InitialMatrix.has_value(),
+                 "Unable to construct bounded descriptor accumulation data");
+  std::optional<std::vector<BYTE>> InitialOutput =
+      cpu_oracle::encodeMatrixBuffer(*InitialMatrix, DestinationLayout, 0xcd);
+  std::optional<size_t> SourceBytes =
+      cpu_oracle::getMatrixBufferSize(*Input, SourceLayout);
+  VERIFY_IS_TRUE(
+      InitialOutput.has_value() && SourceBytes.has_value() &&
+          DestinationViewBytes < InitialOutput->size(),
+      "Bounded descriptor accumulation must cross the destination view end");
+
+  std::vector<BYTE> WholeNoOp = *InitialOutput;
+  std::vector<BYTE> PerElementNoOp = *InitialOutput;
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBufferWithinBounds(
+          *Input, DestinationLayout, DestinationViewBytes, PerElementNoOp),
+      "Unable to encode bounded descriptor accumulation candidate");
+  cpu_oracle::BufferResultOracle Oracle = cpu_oracle::permittedBufferResults(
+      {std::move(WholeNoOp), std::move(PerElementNoOp)},
+      L"Descriptor accumulation may suppress the whole operation or only "
+      L"out-of-bounds elements");
+
+  runDescriptorIO(D3DDevice, DxcSupport, Params, *Input, SourceLayout,
+                  DestinationLayout, /*SourceAlignment=*/128,
+                  /*DestinationAlignment=*/16, *SourceBytes,
+                  DestinationViewBytes, std::move(*InitialOutput), Oracle,
+                  VerboseLogging, SelectedWaveSize,
+                  /*AccumulateCount=*/1);
+}
 
 static LPCWSTR matrixRoleName(linalg_test::MatrixRole Role) {
   switch (Role) {
@@ -1797,6 +2379,47 @@ static HRESULT queryMatrixConstructionSupport(
   hlsl_test::LogCommentFmt(
       L"No MatrixConstruction query within shader WaveSize(4,64) supports %s",
       CaseName);
+  return S_OK;
+}
+
+static HRESULT queryDescriptorAccumulateSupport(ID3D12Device *Device,
+                                                const MatrixParams &Params,
+                                                LPCWSTR CaseName,
+                                                bool &Supported,
+                                                UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!CaseName || !linalg_test::isLegalScope(
+                       linalg_test::OperationType::AtomicAccumulateStore,
+                       toCapabilityScope(Params.Scope)))
+    return E_INVALIDARG;
+
+  bool ConstructionSupported;
+  HRESULT HR = queryMatrixConstructionSupport(
+      Device, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N}}, CaseName,
+      ConstructionSupported, SelectedWaveSize);
+  if (FAILED(HR) || !ConstructionSupported)
+    return HR;
+
+  std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::AtomicAccumulateStoreSupport AtomicSupport;
+  HR = linalg_test::queryAtomicAccumulateStore(Device, {*DataType},
+                                               AtomicSupport);
+  if (FAILED(HR))
+    return HR;
+
+  Supported = AtomicSupport.supports(
+      linalg_test::AtomicDestination::RWByteAddressBuffer);
+  if (!Supported) {
+    SelectedWaveSize = 0;
+    hlsl_test::LogCommentFmt(
+        L"Atomic descriptor accumulation is unsupported for %s", CaseName);
+  }
   return S_OK;
 }
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -317,6 +317,10 @@ static LPCWSTR componentTypeName(ComponentType CompType) {
     return L"I32";
   case ComponentType::U32:
     return L"U32";
+  case ComponentType::F8_E4M3FN:
+    return L"F8_E4M3FN";
+  case ComponentType::F8_E5M2:
+    return L"F8_E5M2";
   default:
     return L"Unsupported";
   }
@@ -1091,6 +1095,91 @@ static bool verifyBufferResult(const void *ActualBuffer,
   return false;
 }
 
+template <typename T>
+static std::vector<BYTE> encodeNativeVector(std::initializer_list<T> Values) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "Vector values must be trivially copyable");
+  std::vector<T> NativeValues(Values);
+  std::vector<BYTE> Bytes(NativeValues.size() * sizeof(T));
+  std::memcpy(Bytes.data(), NativeValues.data(), Bytes.size());
+  return Bytes;
+}
+
+static std::optional<BYTE> encodeExactFP8(HLSLHalf_t Value,
+                                          ComponentType CompType) {
+  unsigned MantissaBits;
+  unsigned ExponentBias;
+  unsigned MaxFiniteExponent;
+  switch (CompType) {
+  case ComponentType::F8_E4M3FN:
+    MantissaBits = 3;
+    ExponentBias = 7;
+    MaxFiniteExponent = 0xf;
+    break;
+  case ComponentType::F8_E5M2:
+    MantissaBits = 2;
+    ExponentBias = 15;
+    MaxFiniteExponent = 0x1e;
+    break;
+  default:
+    return std::nullopt;
+  }
+
+  const unsigned Sign = Value.Val >> 15;
+  const unsigned SourceExponent = (Value.Val >> 10) & 0x1f;
+  const unsigned SourceMantissa = Value.Val & 0x3ff;
+  if (SourceExponent == 0) {
+    if (SourceMantissa != 0)
+      return std::nullopt;
+    return static_cast<BYTE>(Sign << 7);
+  }
+  if (SourceExponent == 0x1f)
+    return std::nullopt;
+
+  const int DestinationExponent =
+      static_cast<int>(SourceExponent) - 15 + static_cast<int>(ExponentBias);
+  if (DestinationExponent <= 0 ||
+      static_cast<unsigned>(DestinationExponent) > MaxFiniteExponent)
+    return std::nullopt;
+
+  const unsigned DiscardedBits = 10 - MantissaBits;
+  const unsigned DiscardedMask = (1u << DiscardedBits) - 1;
+  if ((SourceMantissa & DiscardedMask) != 0)
+    return std::nullopt;
+
+  const unsigned DestinationMantissa = SourceMantissa >> DiscardedBits;
+  if (CompType == ComponentType::F8_E4M3FN && DestinationExponent == 0xf &&
+      DestinationMantissa == 0x7)
+    return std::nullopt;
+
+  return static_cast<BYTE>(
+      (Sign << 7) |
+      (static_cast<unsigned>(DestinationExponent) << MantissaBits) |
+      DestinationMantissa);
+}
+
+static std::optional<std::vector<BYTE>>
+encodeExactFP8RoundTrip(const std::vector<float> &Values,
+                        ComponentType CompType) {
+  if (Values.empty() || Values.size() % 4 != 0)
+    return std::nullopt;
+
+  const size_t PackedBytes = Values.size();
+  std::vector<BYTE> Expected(PackedBytes + Values.size() * sizeof(uint16_t));
+  for (size_t I = 0; I < Values.size(); ++I) {
+    const HLSLHalf_t Half(Values[I]);
+    const std::optional<BYTE> Encoded = encodeExactFP8(Half, CompType);
+    if (!Encoded.has_value())
+      return std::nullopt;
+
+    Expected[I] = *Encoded;
+    const size_t HalfOffset = PackedBytes + I * sizeof(uint16_t);
+    Expected[HalfOffset] = static_cast<BYTE>(Half.Val & 0xff);
+    Expected[HalfOffset + 1] = static_cast<BYTE>(Half.Val >> 8);
+  }
+  return Expected;
+}
+
 } // namespace cpu_oracle
 
 static std::string buildCompilerArgs(const MatrixParams &Params,
@@ -1444,6 +1533,30 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   Params.CompType = ComponentType::U32;
   VERIFY_IS_TRUE(buildCompilerArgs(Params).find(" -DELEM_TYPE=uint") !=
                  std::string::npos);
+
+  const std::vector<float> FP8Values = {
+      0.0f, 1.0f, -1.0f, 1.5f, -1.5f, 3.0f, 6.0f, -6.0f,
+  };
+  const std::optional<std::vector<BYTE>> E4M3 =
+      encodeExactFP8RoundTrip(FP8Values, ComponentType::F8_E4M3FN);
+  const std::optional<std::vector<BYTE>> E5M2 =
+      encodeExactFP8RoundTrip(FP8Values, ComponentType::F8_E5M2);
+  VERIFY_IS_TRUE(E4M3.has_value());
+  VERIFY_IS_TRUE(E5M2.has_value());
+  if (E4M3.has_value()) {
+    const std::vector<BYTE> ExpectedE4M3 = {
+        0x00, 0x38, 0xb8, 0x3c, 0xbc, 0x44, 0x4c, 0xcc, 0x00, 0x00, 0x00, 0x3c,
+        0x00, 0xbc, 0x00, 0x3e, 0x00, 0xbe, 0x00, 0x42, 0x00, 0x46, 0x00, 0xc6,
+    };
+    VERIFY_IS_TRUE(*E4M3 == ExpectedE4M3);
+  }
+  if (E5M2.has_value()) {
+    const std::vector<BYTE> ExpectedE5M2 = {
+        0x00, 0x3c, 0xbc, 0x3e, 0xbe, 0x42, 0x46, 0xc6, 0x00, 0x00, 0x00, 0x3c,
+        0x00, 0xbc, 0x00, 0x3e, 0x00, 0xbe, 0x00, 0x42, 0x00, 0x46, 0x00, 0xc6,
+    };
+    VERIFY_IS_TRUE(*E5M2 == ExpectedE5M2);
+  }
 }
 
 class LinAlgCapabilityTests {
@@ -1600,6 +1713,8 @@ struct MatrixConstructionRequirement {
   linalg_test::MatrixRole Role;
   MatrixDim Rows;
   MatrixDim Columns;
+  ComponentType CompType = ComponentType::Invalid;
+  bool RequireShape = true;
 };
 
 static HRESULT queryMatrixConstructionSupport(
@@ -1667,6 +1782,8 @@ public:
   TEST_METHOD(CopyConvert_Wave_16x16_F16);
   TEST_METHOD(CopyConvert_Wave_16x16_F16_Transpose);
   TEST_METHOD(CopyConvert_Wave_4x8_F32_Transpose);
+  TEST_METHOD(CopyConvert_Wave_4x8_F16_ToF32);
+  TEST_METHOD(CopyConvert_Wave_4x8_F32_ToF16_Transpose);
 
   // Matrix Matrix Arithmetic
   TEST_METHOD(MatMatMul_Wave_16x16x16_F16);
@@ -1685,6 +1802,9 @@ public:
 
   // Convert
   TEST_METHOD(Convert);
+  TEST_METHOD(Convert_I16_ToI32_Exact);
+  TEST_METHOD(Convert_F32_ToI16_RTNE_Saturate);
+  TEST_METHOD(Convert_F16_FP8_RoundTrip);
 
   // Vector Accumulate
   TEST_METHOD(VectorAccumulateDescriptor_Thread_F16);
@@ -2334,14 +2454,18 @@ static HRESULT queryMatrixConstructionSupport(
     return E_INVALIDARG;
 
   for (const MatrixConstructionRequirement &Requirement : Requirements) {
-    if (Requirement.Rows == 0 || Requirement.Columns == 0)
+    if (Requirement.RequireShape &&
+        (Requirement.Rows == 0 || Requirement.Columns == 0))
       return E_INVALIDARG;
   }
 
-  std::optional<linalg_test::DataType> DataType =
-      toCapabilityDataType(Params.CompType);
-  if (!DataType.has_value())
-    return E_INVALIDARG;
+  for (const MatrixConstructionRequirement &Requirement : Requirements) {
+    const ComponentType CompType =
+        Requirement.CompType == ComponentType::Invalid ? Params.CompType
+                                                       : Requirement.CompType;
+    if (!toCapabilityDataType(CompType).has_value())
+      return E_INVALIDARG;
+  }
 
   linalg_test::TierSupport Tier;
   HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
@@ -2380,16 +2504,34 @@ static HRESULT queryMatrixConstructionSupport(
         WaveSize > WaveOptions.WaveLaneCountMax)
       continue;
 
-    linalg_test::MatrixConstructionSupport Construction;
-    HR = linalg_test::queryMatrixConstruction(Device, {*DataType, WaveSize},
-                                              Construction);
-    if (FAILED(HR))
-      return HR;
-
+    std::vector<std::pair<linalg_test::DataType,
+                          linalg_test::MatrixConstructionSupport>>
+        ConstructionByType;
     bool AllSupported = true;
     for (const MatrixConstructionRequirement &Requirement : Requirements) {
-      if (!Construction.supports(Requirement.Role, Requirement.Rows,
-                                 Requirement.Columns)) {
+      const ComponentType CompType =
+          Requirement.CompType == ComponentType::Invalid ? Params.CompType
+                                                         : Requirement.CompType;
+      const linalg_test::DataType DataType =
+          toCapabilityDataType(CompType).value();
+      auto Construction = std::find_if(
+          ConstructionByType.begin(), ConstructionByType.end(),
+          [DataType](const auto &Entry) { return Entry.first == DataType; });
+      if (Construction == ConstructionByType.end()) {
+        linalg_test::MatrixConstructionSupport Support;
+        HR = linalg_test::queryMatrixConstruction(Device, {DataType, WaveSize},
+                                                  Support);
+        if (FAILED(HR))
+          return HR;
+        Construction = ConstructionByType.emplace(ConstructionByType.end(),
+                                                  DataType, Support);
+      }
+      const bool RequirementSupported =
+          Requirement.RequireShape
+              ? Construction->second.supports(
+                    Requirement.Role, Requirement.Rows, Requirement.Columns)
+              : Construction->second.supported();
+      if (!RequirementSupported) {
         AllSupported = false;
         break;
       }
@@ -2401,9 +2543,18 @@ static HRESULT queryMatrixConstructionSupport(
         L"MatrixConstruction capability matched wave=%u for %s", WaveSize,
         CaseName);
     for (const MatrixConstructionRequirement &Requirement : Requirements) {
-      hlsl_test::LogCommentFmt(L"  role=%s, rows=%u, columns=%u",
-                               matrixRoleName(Requirement.Role),
-                               Requirement.Rows, Requirement.Columns);
+      const ComponentType CompType =
+          Requirement.CompType == ComponentType::Invalid ? Params.CompType
+                                                         : Requirement.CompType;
+      if (Requirement.RequireShape) {
+        hlsl_test::LogCommentFmt(L"  type=%s, role=%s, rows=%u, columns=%u",
+                                 cpu_oracle::componentTypeName(CompType),
+                                 matrixRoleName(Requirement.Role),
+                                 Requirement.Rows, Requirement.Columns);
+      } else {
+        hlsl_test::LogCommentFmt(L"  type=%s",
+                                 cpu_oracle::componentTypeName(CompType));
+      }
     }
     Supported = true;
     SelectedWaveSize = WaveSize;
@@ -3040,6 +3191,7 @@ void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
 static const char CopyConvertShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
+  RWByteAddressBuffer SourceAfter : register(u2);
 
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
@@ -3055,7 +3207,7 @@ static const char CopyConvertShader[] = R"(
       [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
       Src;
     __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, DST_M_DIM, DST_N_DIM, USE, SCOPE)]]
+      [[__LinAlgMatrix_Attributes(DST_COMP_TYPE, DST_M_DIM, DST_N_DIM, USE, SCOPE)]]
       Dst;
 
     __builtin_LinAlg_MatrixLoadFromDescriptor(
@@ -3063,19 +3215,24 @@ static const char CopyConvertShader[] = R"(
     __builtin_LinAlg_CopyConvertMatrix(Dst, Src, TRANSPOSE);
     __builtin_LinAlg_MatrixStoreToDescriptor(
       Dst, Output, 0, DST_STRIDE, LAYOUT, 128);
+    __builtin_LinAlg_MatrixStoreToDescriptor(
+      Src, SourceAfter, 0, SRC_STRIDE, LAYOUT, 128);
   }
 )";
 
 static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
                                        const MatrixParams &Params,
+                                       ComponentType DestinationCompType,
                                        bool Transpose, bool &Supported,
                                        UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
-  if (Params.Use != MatrixUse::A)
+  if (Params.Use != MatrixUse::A ||
+      DestinationCompType == ComponentType::Invalid)
     return E_INVALIDARG;
 
   MatrixParams Destination = Params;
+  Destination.CompType = DestinationCompType;
   if (Transpose) {
     Destination.M = Params.N;
     Destination.N = Params.M;
@@ -3084,17 +3241,20 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
   return queryMatrixConstructionSupport(
       Device, Params,
       {
-          {linalg_test::MatrixRole::A, Params.M, Params.N},
-          {linalg_test::MatrixRole::A, Destination.M, Destination.N},
+          {linalg_test::MatrixRole::A, Params.M, Params.N, Params.CompType},
+          {linalg_test::MatrixRole::A, Destination.M, Destination.N,
+           Destination.CompType},
       },
       L"CopyConvert source and destination", Supported, SelectedWaveSize);
 }
 
 static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
-                           const MatrixParams &Params, bool Verbose,
+                           const MatrixParams &Params,
+                           ComponentType DestinationCompType, bool Verbose,
                            bool Transpose, UINT ForcedWaveSize = 0) {
   MatrixParams DstParams = Params;
+  DstParams.CompType = DestinationCompType;
   if (Transpose) {
     DstParams.M = Params.N;
     DstParams.N = Params.M;
@@ -3102,6 +3262,7 @@ static void runCopyConvert(ID3D12Device *Device,
 
   std::stringstream ExtraDefs;
   ExtraDefs << " -DTRANSPOSE=" << Transpose;
+  ExtraDefs << " -DDST_COMP_TYPE=" << static_cast<int>(DstParams.CompType);
   ExtraDefs << " -DDST_M_DIM=" << DstParams.M;
   ExtraDefs << " -DDST_N_DIM=" << DstParams.N;
   ExtraDefs << " -DSRC_STRIDE=" << Params.strideBytes();
@@ -3117,8 +3278,12 @@ static void runCopyConvert(ID3D12Device *Device,
       cpu_oracle::makeSequentialMatrix(Params.CompType, Params.M, Params.N);
   VERIFY_IS_TRUE(Input.has_value(),
                  "Unable to construct typed CopyConvert input");
+  std::optional<cpu_oracle::TypedMatrix> Converted =
+      cpu_oracle::makeSequentialMatrix(DstParams.CompType, Params.M, Params.N);
+  VERIFY_IS_TRUE(Converted.has_value(),
+                 "Unable to construct typed CopyConvert conversion oracle");
   std::optional<cpu_oracle::TypedMatrix> Expected =
-      Transpose ? cpu_oracle::transposeMatrix(*Input) : Input;
+      Transpose ? cpu_oracle::transposeMatrix(*Converted) : Converted;
   VERIFY_IS_TRUE(Expected.has_value(),
                  "Unable to construct independent CopyConvert oracle");
 
@@ -3145,14 +3310,17 @@ static void runCopyConvert(ID3D12Device *Device,
   cpu_oracle::MatrixResultOracle Oracle = cpu_oracle::exactResult(
       *Expected,
       L"HLSL proposal 0035 CopyConvertMatrix transpose and descriptor layout");
+  cpu_oracle::MatrixResultOracle SourceOracle = cpu_oracle::exactResult(
+      *Input, L"CopyConvertMatrix leaves the source matrix unmodified");
 
-  // Construct the ShaderOp: two UAV buffers, load from one, store to other.
-  auto Op = createComputeOp(CopyConvertShader, "cs_6_10", "UAV(u0), UAV(u1)",
-                            Args.c_str());
+  auto Op = createComputeOp(CopyConvertShader, "cs_6_10",
+                            "UAV(u0), UAV(u1), UAV(u2)", Args.c_str());
   addUAVBuffer(Op.get(), "Input", *SourceBufferSize, false, "byname");
   addUAVBuffer(Op.get(), "Output", *DestinationBufferSize, true);
+  addUAVBuffer(Op.get(), "SourceAfter", *SourceBufferSize, true);
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
+  addRootView(Op.get(), 2, "SourceAfter");
 
   auto Result = runShaderOp(
       Device, DxcSupport, std::move(Op),
@@ -3166,10 +3334,15 @@ static void runCopyConvert(ID3D12Device *Device,
       });
 
   MappedData OutData;
+  MappedData SourceAfterData;
   Result->Test->GetReadBackData("Output", &OutData);
+  Result->Test->GetReadBackData("SourceAfter", &SourceAfterData);
 
   VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
       OutData.data(), OutData.size(), DestinationLayout, Oracle, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(
+      SourceAfterData.data(), SourceAfterData.size(), SourceLayout,
+      SourceOracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16() {
@@ -3182,7 +3355,8 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
+  runCopyConvert(D3DDevice, DxcSupport, Params, ComponentType::F16,
+                 VerboseLogging,
                  /*Transpose=*/false);
 }
 
@@ -3196,7 +3370,8 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16_Transpose() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
+  runCopyConvert(D3DDevice, DxcSupport, Params, ComponentType::F16,
+                 VerboseLogging,
                  /*Transpose=*/true);
 }
 
@@ -3213,8 +3388,9 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
 
   bool Supported;
   UINT SelectedWaveSize;
-  const HRESULT QueryResult = queryCopyConvertSupport(
-      D3DDevice, Params, /*Transpose=*/true, Supported, SelectedWaveSize);
+  const HRESULT QueryResult =
+      queryCopyConvertSupport(D3DDevice, Params, ComponentType::F32,
+                              /*Transpose=*/true, Supported, SelectedWaveSize);
   const linalg_test::Applicability Applicability =
       linalg_test::classifyApplicability(
           QueryResult, Supported,
@@ -3225,8 +3401,66 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
     return;
 
   // Non-square dimensions make the destination shape and row stride observable.
-  runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
+  runCopyConvert(D3DDevice, DxcSupport, Params, ComponentType::F32,
+                 VerboseLogging,
                  /*Transpose=*/true, SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F16_ToF32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F16;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult =
+      queryCopyConvertSupport(D3DDevice, Params, ComponentType::F32,
+                              /*Transpose=*/false, Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability,
+                          L"CopyConvert_Wave_4x8_F16_ToF32 MatrixConstruction"))
+    return;
+
+  runCopyConvert(D3DDevice, DxcSupport, Params, ComponentType::F32,
+                 VerboseLogging, /*Transpose=*/false, SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_ToF16_Transpose() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT QueryResult =
+      queryCopyConvertSupport(D3DDevice, Params, ComponentType::F16,
+                              /*Transpose=*/true, Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(
+          Applicability,
+          L"CopyConvert_Wave_4x8_F32_ToF16_Transpose MatrixConstruction"))
+    return;
+
+  runCopyConvert(D3DDevice, DxcSupport, Params, ComponentType::F16,
+                 VerboseLogging, /*Transpose=*/true, SelectedWaveSize);
 }
 
 static const char MatMatMulShader[] = R"(
@@ -4578,6 +4812,94 @@ static const char ConvertShader[] = R"(
   }
 )";
 
+static const char ConvertI16ToI32Shader[] = R"(
+  #define CT_I16 2
+  #define CT_I32 4
+
+  RWByteAddressBuffer Output : register(u0);
+
+  [numthreads(1, 1, 1)]
+  void main() {
+    vector<int16_t, 8> InVec = {
+      -32768, -1024, -1, 0, 1, 1024, 12345, 32767
+    };
+    vector<int, 8> OutVec;
+    __builtin_LinAlg_Convert(OutVec, InVec, CT_I16, CT_I32);
+    for (uint I = 0; I < 8; ++I)
+      Output.Store<int>(I * sizeof(int), OutVec[I]);
+  }
+)";
+
+static const char ConvertF32ToI16Shader[] = R"(
+  #define CT_I16 2
+  #define CT_F32 9
+
+  RWByteAddressBuffer Output : register(u0);
+
+  [numthreads(1, 1, 1)]
+  void main() {
+    vector<float, 8> InVec = {
+      -40000.0F, -32768.5F, -2.5F, -1.5F,
+      1.5F, 2.5F, 32767.5F, 40000.0F
+    };
+    vector<int16_t, 8> OutVec;
+    __builtin_LinAlg_Convert(OutVec, InVec, CT_F32, CT_I16);
+    for (uint I = 0; I < 8; ++I)
+      Output.Store<int16_t>(I * sizeof(int16_t), OutVec[I]);
+  }
+)";
+
+static const char ConvertF16FP8RoundTripShader[] = R"(
+  #define CT_F16 8
+
+  RWByteAddressBuffer Output : register(u0);
+
+  [numthreads(1, 1, 1)]
+  void main() {
+    vector<half, 8> InVec = {
+      0.0, 1.0, -1.0, 1.5, -1.5, 3.0, 6.0, -6.0
+    };
+    vector<uint, 2> PackedBits;
+    vector<uint, 2> PackedRoundTrip;
+    vector<half, 8> RoundTrip;
+    __builtin_LinAlg_Convert(PackedBits, InVec, CT_F16, FP8_TYPE);
+    __builtin_LinAlg_Convert(PackedRoundTrip, InVec, CT_F16, FP8_TYPE);
+    __builtin_LinAlg_Convert(RoundTrip, PackedRoundTrip, FP8_TYPE, CT_F16);
+
+    Output.Store<uint>(0, PackedBits.x);
+    Output.Store<uint>(4, PackedBits.y);
+    for (uint I = 0; I < 8; ++I)
+      Output.Store<half>(8 + I * sizeof(half), RoundTrip[I]);
+  }
+)";
+
+static void runExactConvertShader(ID3D12Device *Device,
+                                  dxc::SpecificDllLoader &DxcSupport,
+                                  const char *Shader, const std::string &Args,
+                                  std::vector<BYTE> Expected,
+                                  const std::wstring &PublicRule,
+                                  bool Verbose) {
+  compileShader(DxcSupport, Shader, "cs_6_10", Args, Verbose);
+
+  auto Op = createComputeOp(Shader, "cs_6_10", "UAV(u0)", Args.c_str());
+  addUAVBuffer(Op.get(), "Output", Expected.size(), true);
+  addRootView(Op.get(), 0, "Output");
+
+  auto Result = runShaderOp(Device, DxcSupport, std::move(Op));
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  if (Verbose) {
+    const BYTE *Bytes = static_cast<const BYTE *>(OutData.data());
+    for (size_t I = 0; I < OutData.size(); ++I)
+      hlsl_test::LogCommentFmt(L"  output[%zu]=0x%02x", I, Bytes[I]);
+  }
+
+  cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(std::move(Expected), PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
 static void runConvert(ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
                        bool Verbose) {
   std::string Args = "-HV 202x -enable-16bit-types";
@@ -4603,6 +4925,96 @@ static void runConvert(ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
 
 void DxilConf_SM610_LinAlg::Convert() {
   runConvert(D3DDevice, DxcSupport, VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::Convert_I16_ToI32_Exact() {
+  runExactConvertShader(
+      D3DDevice, DxcSupport, ConvertI16ToI32Shader,
+      "-HV 202x -enable-16bit-types",
+      cpu_oracle::encodeNativeVector<int32_t>(
+          {-32768, -1024, -1, 0, 1, 1024, 12345, 32767}),
+      L"Integer widening preserves exactly representable values",
+      VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::Convert_F32_ToI16_RTNE_Saturate() {
+  runExactConvertShader(
+      D3DDevice, DxcSupport, ConvertF32ToI16Shader,
+      "-HV 202x -enable-16bit-types",
+      cpu_oracle::encodeNativeVector<int16_t>(
+          {-32768, -32768, -2, -2, 2, 2, 32767, 32767}),
+      L"Floating-to-integer conversion uses RTNE and saturation",
+      VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::Convert_F16_FP8_RoundTrip() {
+  MatrixParams Params = {};
+  Params.M = 1;
+  Params.N = 1;
+  Params.Use = MatrixUse::A;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = true;
+
+  const std::vector<float> Values = {
+      0.0f, 1.0f, -1.0f, 1.5f, -1.5f, 3.0f, 6.0f, -6.0f,
+  };
+
+  size_t ExecutedFormats = 0;
+  auto RunFormat = [&](ComponentType CompType, const char *CompilerArgs,
+                       LPCWSTR CaseName) -> bool {
+    Params.CompType = CompType;
+    bool Supported;
+    UINT SelectedWaveSize;
+    // D3D12 has no Convert query, so use shape-independent construction
+    // support as the closest available component-type capability proxy.
+    const HRESULT QueryResult = queryMatrixConstructionSupport(
+        D3DDevice, Params,
+        {{linalg_test::MatrixRole::A, 0, 0, CompType,
+          /*RequireShape=*/false}},
+        CaseName, Supported, SelectedWaveSize);
+    const linalg_test::Applicability Applicability =
+        linalg_test::classifyApplicability(
+            QueryResult, Supported,
+            linalg_test::CapabilityRequirement::CapabilityGated);
+    if (Applicability == linalg_test::Applicability::Fail)
+      return applyApplicability(Applicability, CaseName);
+    if (Applicability == linalg_test::Applicability::NotApplicable) {
+      // Each format is an optional subcase; the method is not applicable only
+      // when neither format can execute.
+      hlsl_test::LogCommentFmt(
+          L"Skipping %s because the component type is not advertised",
+          CaseName);
+      return true;
+    }
+
+    std::optional<std::vector<BYTE>> Expected =
+        cpu_oracle::encodeExactFP8RoundTrip(Values, CompType);
+    VERIFY_IS_TRUE(Expected.has_value(),
+                   "Unable to derive exact FP8 conversion oracle");
+    if (!Expected.has_value())
+      return false;
+
+    ++ExecutedFormats;
+    runExactConvertShader(D3DDevice, DxcSupport, ConvertF16FP8RoundTripShader,
+                          CompilerArgs, std::move(*Expected),
+                          std::wstring(CaseName) +
+                              L" exact packed encoding and F16 round trip",
+                          VerboseLogging);
+    return true;
+  };
+
+  if (!RunFormat(ComponentType::F8_E4M3FN,
+                 "-HV 202x -enable-16bit-types -DFP8_TYPE=21", L"F8_E4M3FN"))
+    return;
+  if (!RunFormat(ComponentType::F8_E5M2,
+                 "-HV 202x -enable-16bit-types -DFP8_TYPE=22", L"F8_E5M2"))
+    return;
+
+  if (ExecutedFormats == 0)
+    applyApplicability(linalg_test::Applicability::NotApplicable,
+                       L"Convert_F16_FP8_RoundTrip");
 }
 
 static const char VectorAccumulateDescriptorShader[] = R"(

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -300,6 +300,81 @@ static bool checkedAdd(size_t Left, size_t Right, size_t &Result) {
   return true;
 }
 
+static bool checkedAddInt64(int64_t Left, int64_t Right, int64_t &Result) {
+  if ((Right > 0 && Left > std::numeric_limits<int64_t>::max() - Right) ||
+      (Right < 0 && Left < std::numeric_limits<int64_t>::min() - Right))
+    return false;
+  Result = Left + Right;
+  return true;
+}
+
+static bool checkedMultiplyInt64(int64_t Left, int64_t Right, int64_t &Result) {
+  if (Left == 0 || Right == 0) {
+    Result = 0;
+    return true;
+  }
+  if (Left == -1) {
+    if (Right == std::numeric_limits<int64_t>::min())
+      return false;
+    Result = -Right;
+    return true;
+  }
+  if (Right == -1) {
+    if (Left == std::numeric_limits<int64_t>::min())
+      return false;
+    Result = -Left;
+    return true;
+  }
+
+  if ((Left > 0 && Right > 0 &&
+       Left > std::numeric_limits<int64_t>::max() / Right) ||
+      (Left > 0 && Right < 0 &&
+       Right < std::numeric_limits<int64_t>::min() / Left) ||
+      (Left < 0 && Right > 0 &&
+       Left < std::numeric_limits<int64_t>::min() / Right) ||
+      (Left < 0 && Right < 0 &&
+       Left < std::numeric_limits<int64_t>::max() / Right))
+    return false;
+
+  Result = Left * Right;
+  return true;
+}
+
+static std::optional<std::vector<int64_t>>
+multiplyIntegerMatrices(MatrixDim M, MatrixDim K, MatrixDim N,
+                        const std::vector<int64_t> &MatrixA,
+                        const std::vector<int64_t> &MatrixB,
+                        const std::vector<int64_t> *Accumulator = nullptr) {
+  size_t MatrixAElements;
+  size_t MatrixBElements;
+  size_t AccumulatorElements;
+  if (M == 0 || K == 0 || N == 0 ||
+      !checkedMultiply(static_cast<size_t>(M), K, MatrixAElements) ||
+      !checkedMultiply(static_cast<size_t>(K), N, MatrixBElements) ||
+      !checkedMultiply(static_cast<size_t>(M), N, AccumulatorElements) ||
+      MatrixA.size() != MatrixAElements || MatrixB.size() != MatrixBElements ||
+      (Accumulator && Accumulator->size() != AccumulatorElements))
+    return std::nullopt;
+
+  std::vector<int64_t> Result(AccumulatorElements, 0);
+  for (MatrixDim Row = 0; Row < M; ++Row) {
+    for (MatrixDim Column = 0; Column < N; ++Column) {
+      const size_t OutputIndex = static_cast<size_t>(Row) * N + Column;
+      int64_t Sum = Accumulator ? (*Accumulator)[OutputIndex] : 0;
+      for (MatrixDim Inner = 0; Inner < K; ++Inner) {
+        int64_t Product;
+        if (!checkedMultiplyInt64(
+                MatrixA[static_cast<size_t>(Row) * K + Inner],
+                MatrixB[static_cast<size_t>(Inner) * N + Column], Product) ||
+            !checkedAddInt64(Sum, Product, Sum))
+          return std::nullopt;
+      }
+      Result[OutputIndex] = Sum;
+    }
+  }
+  return Result;
+}
+
 static bool isSupportedComponentType(ComponentType CompType) {
   switch (CompType) {
   case ComponentType::F16:
@@ -1217,6 +1292,56 @@ encodeExactComponents(ComponentType CompType,
   }
 }
 
+static std::optional<std::vector<BYTE>>
+encodeLogicalMatrixBuffer(const MatrixParams &Matrix,
+                          const std::vector<int64_t> &Values) {
+  size_t ExpectedElements;
+  if (Matrix.M == 0 || Matrix.N == 0 ||
+      !checkedMultiply(static_cast<size_t>(Matrix.M), Matrix.N,
+                       ExpectedElements) ||
+      Values.size() != ExpectedElements ||
+      (Matrix.Layout != LinalgMatrixLayout::RowMajor &&
+       Matrix.Layout != LinalgMatrixLayout::ColumnMajor))
+    return std::nullopt;
+
+  const std::optional<std::vector<BYTE>> LogicalComponents =
+      encodeExactComponents(Matrix.CompType, Values);
+  if (!LogicalComponents.has_value())
+    return std::nullopt;
+
+  const size_t ComponentSize = elementSize(Matrix.CompType);
+  size_t LogicalByteCount;
+  if (!checkedMultiply(ExpectedElements, ComponentSize, LogicalByteCount))
+    return std::nullopt;
+  const size_t Stride = Matrix.strideBytes();
+  const size_t MinorCount =
+      Matrix.Layout == LinalgMatrixLayout::RowMajor ? Matrix.N : Matrix.M;
+  const size_t MajorCount =
+      Matrix.Layout == LinalgMatrixLayout::RowMajor ? Matrix.M : Matrix.N;
+  size_t MinimumStride;
+  if (!checkedMultiply(MinorCount, ComponentSize, MinimumStride) ||
+      LogicalComponents->size() < LogicalByteCount || Stride < MinimumStride)
+    return std::nullopt;
+
+  size_t BufferSize;
+  if (!checkedMultiply(MajorCount, Stride, BufferSize))
+    return std::nullopt;
+  std::vector<BYTE> Buffer(BufferSize, 0);
+  for (MatrixDim Row = 0; Row < Matrix.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Matrix.N; ++Column) {
+      const size_t SourceOffset =
+          (static_cast<size_t>(Row) * Matrix.N + Column) * ComponentSize;
+      const size_t DestinationOffset =
+          Matrix.Layout == LinalgMatrixLayout::RowMajor
+              ? static_cast<size_t>(Row) * Stride + Column * ComponentSize
+              : static_cast<size_t>(Column) * Stride + Row * ComponentSize;
+      std::memcpy(Buffer.data() + DestinationOffset,
+                  LogicalComponents->data() + SourceOffset, ComponentSize);
+    }
+  }
+  return Buffer;
+}
+
 static std::optional<BYTE> encodeExactFP8(HLSLHalf_t Value,
                                           ComponentType CompType) {
   unsigned MantissaBits;
@@ -1293,6 +1418,11 @@ encodeExactFP8RoundTrip(const std::vector<float> &Values,
 }
 
 } // namespace cpu_oracle
+
+static bool needs16BitTypes(ComponentType CompType) {
+  return CompType == ComponentType::F16 || CompType == ComponentType::I16 ||
+         CompType == ComponentType::U16;
+}
 
 static std::string buildCompilerArgs(const MatrixParams &Params,
                                      const char *ExtraDefines = nullptr) {
@@ -1599,6 +1729,22 @@ void LinAlgCPUOracleTests::TypedMatrixBufferRoundTrip() {
   size_t FirstMismatch;
   VERIFY_IS_TRUE(
       exactMatrixMatch(*Transposed, *ExpectedTranspose, FirstMismatch));
+
+  const std::optional<std::vector<int64_t>> Product =
+      multiplyIntegerMatrices(/*M=*/2, /*K=*/3, /*N=*/2,
+                              /*MatrixA=*/{1, 2, 3, 4, 5, 6},
+                              /*MatrixB=*/{7, 8, 9, 10, 11, 12});
+  VERIFY_IS_TRUE(Product.has_value());
+  VERIFY_IS_TRUE(*Product == std::vector<int64_t>({58, 64, 139, 154}));
+  const std::vector<int64_t> InitialAccumulator = {1, -1, 2, -2};
+  const std::optional<std::vector<int64_t>> ProductAccumulated =
+      multiplyIntegerMatrices(/*M=*/2, /*K=*/3, /*N=*/2,
+                              /*MatrixA=*/{1, 2, 3, 4, 5, 6},
+                              /*MatrixB=*/{7, 8, 9, 10, 11, 12},
+                              &InitialAccumulator);
+  VERIFY_IS_TRUE(ProductAccumulated.has_value());
+  VERIFY_IS_TRUE(*ProductAccumulated ==
+                 std::vector<int64_t>({59, 63, 141, 152}));
 
   std::optional<TypedMatrix> MixedActual =
       makeTypedMatrix<uint32_t>(1, 2, {1, 4});
@@ -1918,8 +2064,13 @@ public:
 
   // Matrix Matrix Arithmetic
   TEST_METHOD(MatMatMul_Wave_16x16x16_F16);
+  TEST_METHOD(MatMatMul_Wave_8x32x16_F16_NonUniform);
+  TEST_METHOD(MatMatMul_Wave_8x32x16_F16_ToF32);
+  TEST_METHOD(MatMatMul_Wave_16x16x16_I32);
   TEST_METHOD(MatMatMulAccum_Wave_16x16x16_F16);
+  TEST_METHOD(MatMatMulAccum_Wave_8x32x16_F16_ToF32_NonUniform);
   TEST_METHOD(MatAccum_Wave_16x16_F16);
+  TEST_METHOD(MatAccum_Wave_8x32_F16_BUse_NonUniform);
 
   // Matrix Vector Arithmetic
   TEST_METHOD(MatVecMul_Thread_16x16_F16);
@@ -2701,6 +2852,104 @@ static HRESULT queryMatrixConstructionSupport(
 
   hlsl_test::LogCommentFmt(
       L"No MatrixConstruction query within shader WaveSize(4,64) supports %s",
+      CaseName);
+  return S_OK;
+}
+
+static HRESULT queryWaveMatrixMultiplyCaseSupport(
+    ID3D12Device *Device, ComponentType MatrixAType, ComponentType MatrixBType,
+    ComponentType AccumulatorType, MatrixDim M, MatrixDim K, MatrixDim N,
+    LPCWSTR CaseName, bool &Supported, UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  const std::optional<linalg_test::DataType> MatrixADataType =
+      toCapabilityDataType(MatrixAType);
+  const std::optional<linalg_test::DataType> MatrixBDataType =
+      toCapabilityDataType(MatrixBType);
+  const std::optional<linalg_test::DataType> AccumulatorDataType =
+      toCapabilityDataType(AccumulatorType);
+  if (!Device || !CaseName || M == 0 || K == 0 || N == 0 ||
+      !MatrixADataType.has_value() || !MatrixBDataType.has_value() ||
+      !AccumulatorDataType.has_value() ||
+      !linalg_test::isLegalScope(linalg_test::OperationType::WaveMatrixMultiply,
+                                 linalg_test::ExecutionScope::Wave))
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
+                                   sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!WaveOptions.WaveOps || !IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    if (!WaveOptions.WaveOps)
+      return S_OK;
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < WaveOptions.WaveLaneCountMin ||
+        WaveSize > WaveOptions.WaveLaneCountMax)
+      continue;
+
+    linalg_test::MatrixConstructionSupport MatrixASupport;
+    linalg_test::MatrixConstructionSupport MatrixBSupport;
+    linalg_test::MatrixConstructionSupport AccumulatorSupport;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*MatrixADataType, WaveSize}, MatrixASupport);
+    if (FAILED(HR))
+      return HR;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*MatrixBDataType, WaveSize}, MatrixBSupport);
+    if (FAILED(HR))
+      return HR;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*AccumulatorDataType, WaveSize}, AccumulatorSupport);
+    if (FAILED(HR))
+      return HR;
+    if (!MatrixASupport.supports(linalg_test::MatrixRole::A, M, K) ||
+        !MatrixBSupport.supports(linalg_test::MatrixRole::B, K, N) ||
+        !AccumulatorSupport.supports(linalg_test::MatrixRole::Accumulator, M,
+                                     N))
+      continue;
+
+    linalg_test::WaveMatrixMultiplySupport MultiplySupport;
+    HR = linalg_test::queryWaveMatrixMultiply(
+        Device,
+        {WaveSize, *MatrixADataType, *MatrixBDataType, *AccumulatorDataType},
+        MultiplySupport);
+    if (FAILED(HR))
+      return HR;
+    if (!MultiplySupport.supportsShape(M, K, N))
+      continue;
+
+    hlsl_test::LogCommentFmt(
+        L"WaveMatrixMultiply capability matched wave=%u, M=%u, K=%u, N=%u "
+        L"for %s",
+        WaveSize, M, K, N, CaseName);
+    Supported = true;
+    SelectedWaveSize = WaveSize;
+    return S_OK;
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No WaveMatrixMultiply query within the device wave range supports %s",
       CaseName);
   return S_OK;
 }
@@ -3898,6 +4147,557 @@ void DxilConf_SM610_LinAlg::MatAccum_Wave_16x16_F16() {
               /*LHSFill=*/2.0f, /*RHSFill=*/3.0f);
 }
 
+static MatrixParams makeWaveArithmeticParams(ComponentType CompType,
+                                             MatrixDim M, MatrixDim N,
+                                             MatrixUse Use, UINT WaveSize) {
+  MatrixParams Params = {};
+  Params.CompType = CompType;
+  Params.M = M;
+  Params.N = N;
+  Params.Use = Use;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = static_cast<int>(WaveSize);
+  Params.Enable16Bit = needs16BitTypes(CompType);
+  return Params;
+}
+
+static std::vector<int64_t> makeWaveArithmeticPattern(MatrixDim M, MatrixDim N,
+                                                      int64_t RowScale,
+                                                      int64_t ColumnScale,
+                                                      int64_t Modulus,
+                                                      int64_t Center) {
+  VERIFY_IS_TRUE(M != 0 && N != 0 && Modulus > 0);
+  if (M == 0 || N == 0 || Modulus <= 0)
+    return {};
+  std::vector<int64_t> Values(static_cast<size_t>(M) * N);
+  for (MatrixDim Row = 0; Row < M; ++Row) {
+    for (MatrixDim Column = 0; Column < N; ++Column) {
+      Values[static_cast<size_t>(Row) * N + Column] =
+          (static_cast<int64_t>(Row) * RowScale +
+           static_cast<int64_t>(Column) * ColumnScale) %
+              Modulus -
+          Center;
+    }
+  }
+  return Values;
+}
+
+enum class WaveMultiplyOperation {
+  Multiply,
+  MultiplyAccumulate,
+};
+
+struct WaveMultiplyCaseData {
+  ComponentType MatrixAType = ComponentType::Invalid;
+  ComponentType MatrixBType = ComponentType::Invalid;
+  ComponentType AccumulatorType = ComponentType::Invalid;
+  MatrixDim M = 0;
+  MatrixDim K = 0;
+  MatrixDim N = 0;
+  WaveMultiplyOperation Operation = WaveMultiplyOperation::Multiply;
+  std::vector<int64_t> MatrixAValues;
+  std::vector<int64_t> MatrixBValues;
+  std::vector<int64_t> AccumulatorValues;
+  std::wstring PublicRule;
+
+  bool hasInitialAccumulator() const {
+    return Operation == WaveMultiplyOperation::MultiplyAccumulate;
+  }
+};
+
+static bool isWaveMultiplyCaseValid(const WaveMultiplyCaseData &Case) {
+  const size_t MatrixAElements = static_cast<size_t>(Case.M) * Case.K;
+  const size_t MatrixBElements = static_cast<size_t>(Case.K) * Case.N;
+  const size_t AccumulatorElements = static_cast<size_t>(Case.M) * Case.N;
+  return Case.M != 0 && Case.K != 0 && Case.N != 0 &&
+         Case.MatrixAValues.size() == MatrixAElements &&
+         Case.MatrixBValues.size() == MatrixBElements &&
+         Case.hasInitialAccumulator() ==
+             (Case.AccumulatorValues.size() == AccumulatorElements) &&
+         toCapabilityDataType(Case.MatrixAType).has_value() &&
+         toCapabilityDataType(Case.MatrixBType).has_value() &&
+         toCapabilityDataType(Case.AccumulatorType).has_value() &&
+         !Case.PublicRule.empty();
+}
+
+static std::optional<std::vector<int64_t>>
+calculateWaveMultiplyExpected(const WaveMultiplyCaseData &Case) {
+  const std::vector<int64_t> *Accumulator =
+      Case.hasInitialAccumulator() ? &Case.AccumulatorValues : nullptr;
+  return cpu_oracle::multiplyIntegerMatrices(Case.M, Case.K, Case.N,
+                                             Case.MatrixAValues,
+                                             Case.MatrixBValues, Accumulator);
+}
+
+static const char WaveMultiplyShader[] = R"(
+  #define USE_A 0
+  #define USE_B 1
+  #define USE_ACC 2
+  #define SCOPE_WAVE 1
+  #define LAYOUT_ROW_MAJOR 0
+
+  ByteAddressBuffer MatrixAInput : register(t0);
+  ByteAddressBuffer MatrixBInput : register(t1);
+#if DO_ACCUMULATE
+  ByteAddressBuffer AccumulatorInput : register(t2);
+  RWByteAddressBuffer Output : register(u3);
+#else
+  RWByteAddressBuffer Output : register(u2);
+#endif
+
+  [WaveSize(FORCED_WAVE_SIZE)]
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main() {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        MATRIX_A_COMP_TYPE, M_DIM, K_DIM, USE_A, SCOPE_WAVE)]]
+      MatA;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      MatA, MatrixAInput, 0, MATRIX_A_STRIDE, LAYOUT_ROW_MAJOR, 128);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        MATRIX_B_COMP_TYPE, K_DIM, N_DIM, USE_B, SCOPE_WAVE)]]
+      MatB;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      MatB, MatrixBInput, 0, MATRIX_B_STRIDE, LAYOUT_ROW_MAJOR, 128);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        ACCUMULATOR_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+      Result;
+#if DO_ACCUMULATE
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        ACCUMULATOR_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+      Accumulator;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Accumulator, AccumulatorInput, 0, ACCUMULATOR_STRIDE,
+      LAYOUT_ROW_MAJOR, 128);
+    __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(
+      Result, MatA, MatB, Accumulator);
+#else
+    __builtin_LinAlg_MatrixMatrixMultiply(Result, MatA, MatB);
+#endif
+
+    __builtin_LinAlg_MatrixStoreToDescriptor(
+      Result, Output, 0, ACCUMULATOR_STRIDE, LAYOUT_ROW_MAJOR, 128);
+  }
+)";
+
+static std::optional<std::string>
+buildWaveMultiplyCompilerArgs(const WaveMultiplyCaseData &Case, UINT WaveSize) {
+  if (!isWaveMultiplyCaseValid(Case) || WaveSize == 0)
+    return std::nullopt;
+
+  const MatrixParams MatrixA = makeWaveArithmeticParams(
+      Case.MatrixAType, Case.M, Case.K, MatrixUse::A, WaveSize);
+  const MatrixParams MatrixB = makeWaveArithmeticParams(
+      Case.MatrixBType, Case.K, Case.N, MatrixUse::B, WaveSize);
+  const MatrixParams Accumulator = makeWaveArithmeticParams(
+      Case.AccumulatorType, Case.M, Case.N, MatrixUse::Accumulator, WaveSize);
+
+  std::stringstream SS;
+  SS << "-HV 202x";
+  SS << " -DMATRIX_A_COMP_TYPE=" << static_cast<int>(Case.MatrixAType);
+  SS << " -DMATRIX_B_COMP_TYPE=" << static_cast<int>(Case.MatrixBType);
+  SS << " -DACCUMULATOR_COMP_TYPE=" << static_cast<int>(Case.AccumulatorType);
+  SS << " -DM_DIM=" << Case.M;
+  SS << " -DK_DIM=" << Case.K;
+  SS << " -DN_DIM=" << Case.N;
+  SS << " -DMATRIX_A_STRIDE=" << MatrixA.strideBytes();
+  SS << " -DMATRIX_B_STRIDE=" << MatrixB.strideBytes();
+  SS << " -DACCUMULATOR_STRIDE=" << Accumulator.strideBytes();
+  SS << " -DNUMTHREADS=" << WaveSize;
+  SS << " -DFORCED_WAVE_SIZE=" << WaveSize;
+  SS << " -DDO_ACCUMULATE=" << Case.hasInitialAccumulator();
+  if (needs16BitTypes(Case.MatrixAType) || needs16BitTypes(Case.MatrixBType) ||
+      needs16BitTypes(Case.AccumulatorType))
+    SS << " -enable-16bit-types";
+  return SS.str();
+}
+
+static void runWaveMultiplyCase(ID3D12Device *Device,
+                                dxc::SpecificDllLoader &DxcSupport,
+                                const WaveMultiplyCaseData &Case, UINT WaveSize,
+                                bool Verbose) {
+  const MatrixParams MatrixA = makeWaveArithmeticParams(
+      Case.MatrixAType, Case.M, Case.K, MatrixUse::A, WaveSize);
+  const MatrixParams MatrixB = makeWaveArithmeticParams(
+      Case.MatrixBType, Case.K, Case.N, MatrixUse::B, WaveSize);
+  const MatrixParams Accumulator = makeWaveArithmeticParams(
+      Case.AccumulatorType, Case.M, Case.N, MatrixUse::Accumulator, WaveSize);
+  const std::optional<std::vector<BYTE>> MatrixABuffer =
+      cpu_oracle::encodeLogicalMatrixBuffer(MatrixA, Case.MatrixAValues);
+  const std::optional<std::vector<BYTE>> MatrixBBuffer =
+      cpu_oracle::encodeLogicalMatrixBuffer(MatrixB, Case.MatrixBValues);
+  const std::optional<std::vector<BYTE>> AccumulatorBuffer =
+      Case.hasInitialAccumulator() ? cpu_oracle::encodeLogicalMatrixBuffer(
+                                         Accumulator, Case.AccumulatorValues)
+                                   : std::optional<std::vector<BYTE>>();
+  const std::optional<std::vector<int64_t>> ExpectedValues =
+      calculateWaveMultiplyExpected(Case);
+  const std::optional<std::vector<BYTE>> Expected =
+      ExpectedValues.has_value()
+          ? cpu_oracle::encodeLogicalMatrixBuffer(Accumulator, *ExpectedValues)
+          : std::optional<std::vector<BYTE>>();
+  const std::optional<std::string> Args =
+      buildWaveMultiplyCompilerArgs(Case, WaveSize);
+  VERIFY_IS_TRUE(MatrixABuffer.has_value());
+  VERIFY_IS_TRUE(MatrixBBuffer.has_value());
+  VERIFY_IS_TRUE(!Case.hasInitialAccumulator() ||
+                 AccumulatorBuffer.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  VERIFY_IS_TRUE(Args.has_value());
+  if (!MatrixABuffer.has_value() || !MatrixBBuffer.has_value() ||
+      (Case.hasInitialAccumulator() && !AccumulatorBuffer.has_value()) ||
+      !Expected.has_value() || !Args.has_value())
+    return;
+
+  const char *RootSignature = Case.hasInitialAccumulator()
+                                  ? "SRV(t0), SRV(t1), SRV(t2), UAV(u3)"
+                                  : "SRV(t0), SRV(t1), UAV(u2)";
+  compileShader(DxcSupport, WaveMultiplyShader, "cs_6_10", *Args, Verbose);
+
+  auto Op = createComputeOp(WaveMultiplyShader, "cs_6_10", RootSignature,
+                            Args->c_str());
+  addSRVBuffer(Op.get(), "MatrixAInput", MatrixABuffer->size(), "byname");
+  addSRVBuffer(Op.get(), "MatrixBInput", MatrixBBuffer->size(), "byname");
+  if (Case.hasInitialAccumulator())
+    addSRVBuffer(Op.get(), "AccumulatorInput", AccumulatorBuffer->size(),
+                 "byname");
+  addUAVBuffer(Op.get(), "Output", Expected->size(), true);
+  addRootView(Op.get(), 0, "MatrixAInput");
+  addRootView(Op.get(), 1, "MatrixBInput");
+  if (Case.hasInitialAccumulator()) {
+    addRootView(Op.get(), 2, "AccumulatorInput");
+    addRootView(Op.get(), 3, "Output");
+  } else {
+    addRootView(Op.get(), 2, "Output");
+  }
+
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        const std::vector<BYTE> *Source = nullptr;
+        if (strcmp(Name, "MatrixAInput") == 0)
+          Source = &*MatrixABuffer;
+        else if (strcmp(Name, "MatrixBInput") == 0)
+          Source = &*MatrixBBuffer;
+        else if (Case.hasInitialAccumulator() &&
+                 strcmp(Name, "AccumulatorInput") == 0)
+          Source = &*AccumulatorBuffer;
+        if (!Source)
+          return;
+        VERIFY_IS_TRUE(Data.size() == Source->size(),
+                       "Wave matrix arithmetic initializer size mismatch");
+        std::copy(Source->begin(), Source->end(), Data.begin());
+      });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  const cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(*Expected, Case.PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
+static void
+runCapabilityCheckedWaveMultiply(ID3D12Device *Device,
+                                 dxc::SpecificDllLoader &DxcSupport,
+                                 const WaveMultiplyCaseData &Case,
+                                 linalg_test::CapabilityRequirement Requirement,
+                                 LPCWSTR CaseName, bool Verbose) {
+  VERIFY_IS_TRUE(isWaveMultiplyCaseValid(Case));
+  if (!isWaveMultiplyCaseValid(Case))
+    return;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT HR = queryWaveMatrixMultiplyCaseSupport(
+      Device, Case.MatrixAType, Case.MatrixBType, Case.AccumulatorType, Case.M,
+      Case.K, Case.N, CaseName, Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(HR, Supported, Requirement);
+  if (!applyApplicability(Applicability, CaseName))
+    return;
+  runWaveMultiplyCase(Device, DxcSupport, Case, SelectedWaveSize, Verbose);
+}
+
+static WaveMultiplyCaseData
+makeRectangularF16WaveMultiplyCase(ComponentType AccumulatorType,
+                                   WaveMultiplyOperation Operation) {
+  WaveMultiplyCaseData Case = {};
+  Case.MatrixAType = ComponentType::F16;
+  Case.MatrixBType = ComponentType::F16;
+  Case.AccumulatorType = AccumulatorType;
+  Case.M = 8;
+  Case.K = 32;
+  Case.N = 16;
+  Case.Operation = Operation;
+  Case.MatrixAValues = makeWaveArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
+  Case.MatrixBValues = makeWaveArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
+  if (Case.hasInitialAccumulator()) {
+    Case.AccumulatorValues =
+        makeWaveArithmeticPattern(Case.M, Case.N, 2, 1, 5, 2);
+    Case.PublicRule =
+        L"Exact non-uniform F16 products plus an independent F32 accumulator";
+  } else if (AccumulatorType == ComponentType::F32) {
+    Case.PublicRule =
+        L"Exact non-uniform F16 matrix product accumulated and stored as F32";
+  } else {
+    Case.PublicRule = L"Exact non-uniform rectangular F16 matrix product";
+  }
+  return Case;
+}
+
+void DxilConf_SM610_LinAlg::MatMatMul_Wave_8x32x16_F16_NonUniform() {
+  const WaveMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
+      ComponentType::F16, WaveMultiplyOperation::Multiply);
+  runCapabilityCheckedWaveMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMul_Wave_8x32x16_F16_NonUniform", VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::MatMatMul_Wave_8x32x16_F16_ToF32() {
+  const WaveMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
+      ComponentType::F32, WaveMultiplyOperation::Multiply);
+  runCapabilityCheckedWaveMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMul_Wave_8x32x16_F16_ToF32", VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::MatMatMulAccum_Wave_8x32x16_F16_ToF32_NonUniform() {
+  const WaveMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
+      ComponentType::F32, WaveMultiplyOperation::MultiplyAccumulate);
+  runCapabilityCheckedWaveMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMulAccum_Wave_8x32x16_F16_ToF32_NonUniform", VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::MatMatMul_Wave_16x16x16_I32() {
+  WaveMultiplyCaseData Case = {};
+  Case.MatrixAType = ComponentType::I32;
+  Case.MatrixBType = ComponentType::I32;
+  Case.AccumulatorType = ComponentType::I32;
+  Case.M = 16;
+  Case.K = 16;
+  Case.N = 16;
+  Case.MatrixAValues = makeWaveArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
+  Case.MatrixBValues = makeWaveArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
+  Case.PublicRule = L"Exact non-uniform I32 matrix product";
+  runCapabilityCheckedWaveMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMul_Wave_16x16x16_I32", VerboseLogging);
+}
+
+struct WaveAccumulateCaseData {
+  ComponentType AccumulatorType = ComponentType::Invalid;
+  ComponentType RHSType = ComponentType::Invalid;
+  MatrixUse RHSUse = MatrixUse::A;
+  MatrixDim M = 0;
+  MatrixDim N = 0;
+  std::vector<int64_t> AccumulatorValues;
+  std::vector<int64_t> RHSValues;
+  std::wstring PublicRule;
+};
+
+static bool isWaveAccumulateCaseValid(const WaveAccumulateCaseData &Case) {
+  const size_t Elements = static_cast<size_t>(Case.M) * Case.N;
+  return Case.M != 0 && Case.N != 0 &&
+         (Case.RHSUse == MatrixUse::A || Case.RHSUse == MatrixUse::B) &&
+         Case.AccumulatorValues.size() == Elements &&
+         Case.RHSValues.size() == Elements &&
+         toCapabilityDataType(Case.AccumulatorType).has_value() &&
+         toCapabilityDataType(Case.RHSType).has_value() &&
+         !Case.PublicRule.empty();
+}
+
+static const char WaveAccumulateShader[] = R"(
+  #define USE_ACC 2
+  #define SCOPE_WAVE 1
+  #define LAYOUT_ROW_MAJOR 0
+
+  ByteAddressBuffer AccumulatorInput : register(t0);
+  ByteAddressBuffer RHSInput : register(t1);
+  RWByteAddressBuffer Output : register(u2);
+
+  [WaveSize(FORCED_WAVE_SIZE)]
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main() {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        ACCUMULATOR_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+      Accumulator;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Accumulator, AccumulatorInput, 0, ACCUMULATOR_STRIDE,
+      LAYOUT_ROW_MAJOR, 128);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        RHS_COMP_TYPE, M_DIM, N_DIM, RHS_USE, SCOPE_WAVE)]]
+      RHS;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      RHS, RHSInput, 0, RHS_STRIDE, LAYOUT_ROW_MAJOR, 128);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        ACCUMULATOR_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+      Result;
+    __builtin_LinAlg_MatrixAccumulate(Result, Accumulator, RHS);
+    __builtin_LinAlg_MatrixStoreToDescriptor(
+      Result, Output, 0, ACCUMULATOR_STRIDE, LAYOUT_ROW_MAJOR, 128);
+  }
+)";
+
+static std::optional<std::string>
+buildWaveAccumulateCompilerArgs(const WaveAccumulateCaseData &Case,
+                                UINT WaveSize) {
+  if (!isWaveAccumulateCaseValid(Case) || WaveSize == 0)
+    return std::nullopt;
+  const MatrixParams Accumulator = makeWaveArithmeticParams(
+      Case.AccumulatorType, Case.M, Case.N, MatrixUse::Accumulator, WaveSize);
+  const MatrixParams RHS = makeWaveArithmeticParams(
+      Case.RHSType, Case.M, Case.N, Case.RHSUse, WaveSize);
+
+  std::stringstream SS;
+  SS << "-HV 202x";
+  SS << " -DACCUMULATOR_COMP_TYPE=" << static_cast<int>(Case.AccumulatorType);
+  SS << " -DRHS_COMP_TYPE=" << static_cast<int>(Case.RHSType);
+  SS << " -DRHS_USE=" << static_cast<int>(Case.RHSUse);
+  SS << " -DM_DIM=" << Case.M;
+  SS << " -DN_DIM=" << Case.N;
+  SS << " -DACCUMULATOR_STRIDE=" << Accumulator.strideBytes();
+  SS << " -DRHS_STRIDE=" << RHS.strideBytes();
+  SS << " -DNUMTHREADS=" << WaveSize;
+  SS << " -DFORCED_WAVE_SIZE=" << WaveSize;
+  if (needs16BitTypes(Case.AccumulatorType) || needs16BitTypes(Case.RHSType))
+    SS << " -enable-16bit-types";
+  return SS.str();
+}
+
+static void runWaveAccumulateCase(ID3D12Device *Device,
+                                  dxc::SpecificDllLoader &DxcSupport,
+                                  const WaveAccumulateCaseData &Case,
+                                  LPCWSTR CaseName, bool Verbose) {
+  VERIFY_IS_TRUE(isWaveAccumulateCaseValid(Case));
+  if (!isWaveAccumulateCaseValid(Case))
+    return;
+
+  MatrixParams CapabilityParams = makeWaveArithmeticParams(
+      Case.AccumulatorType, Case.M, Case.N, MatrixUse::Accumulator, 1);
+  bool Supported;
+  UINT SelectedWaveSize;
+  const linalg_test::MatrixRole RHSRole = Case.RHSUse == MatrixUse::A
+                                              ? linalg_test::MatrixRole::A
+                                              : linalg_test::MatrixRole::B;
+  const HRESULT HR =
+      queryMatrixConstructionSupport(Device, CapabilityParams,
+                                     {{linalg_test::MatrixRole::Accumulator,
+                                       Case.M, Case.N, Case.AccumulatorType},
+                                      {RHSRole, Case.M, Case.N, Case.RHSType}},
+                                     CaseName, Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          HR, Supported, linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, CaseName))
+    return;
+
+  const MatrixParams Accumulator =
+      makeWaveArithmeticParams(Case.AccumulatorType, Case.M, Case.N,
+                               MatrixUse::Accumulator, SelectedWaveSize);
+  const MatrixParams RHS = makeWaveArithmeticParams(
+      Case.RHSType, Case.M, Case.N, Case.RHSUse, SelectedWaveSize);
+  const std::optional<std::vector<BYTE>> AccumulatorBuffer =
+      cpu_oracle::encodeLogicalMatrixBuffer(Accumulator,
+                                            Case.AccumulatorValues);
+  const std::optional<std::vector<BYTE>> RHSBuffer =
+      cpu_oracle::encodeLogicalMatrixBuffer(RHS, Case.RHSValues);
+  std::vector<int64_t> ExpectedValues(Case.AccumulatorValues.size());
+  bool ExpectedValuesValid = true;
+  for (size_t I = 0; I < ExpectedValues.size(); ++I) {
+    if (!cpu_oracle::checkedAddInt64(Case.AccumulatorValues[I],
+                                     Case.RHSValues[I], ExpectedValues[I])) {
+      ExpectedValuesValid = false;
+      break;
+    }
+  }
+  const std::optional<std::vector<BYTE>> Expected =
+      ExpectedValuesValid
+          ? cpu_oracle::encodeLogicalMatrixBuffer(Accumulator, ExpectedValues)
+          : std::optional<std::vector<BYTE>>();
+  const std::optional<std::string> Args =
+      buildWaveAccumulateCompilerArgs(Case, SelectedWaveSize);
+  VERIFY_IS_TRUE(AccumulatorBuffer.has_value());
+  VERIFY_IS_TRUE(RHSBuffer.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  VERIFY_IS_TRUE(Args.has_value());
+  if (!AccumulatorBuffer.has_value() || !RHSBuffer.has_value() ||
+      !Expected.has_value() || !Args.has_value())
+    return;
+
+  compileShader(DxcSupport, WaveAccumulateShader, "cs_6_10", *Args, Verbose);
+  auto Op = createComputeOp(WaveAccumulateShader, "cs_6_10",
+                            "SRV(t0), SRV(t1), UAV(u2)", Args->c_str());
+  addSRVBuffer(Op.get(), "AccumulatorInput", AccumulatorBuffer->size(),
+               "byname");
+  addSRVBuffer(Op.get(), "RHSInput", RHSBuffer->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", Expected->size(), true);
+  addRootView(Op.get(), 0, "AccumulatorInput");
+  addRootView(Op.get(), 1, "RHSInput");
+  addRootView(Op.get(), 2, "Output");
+
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        const std::vector<BYTE> *Source = nullptr;
+        if (strcmp(Name, "AccumulatorInput") == 0)
+          Source = &*AccumulatorBuffer;
+        else if (strcmp(Name, "RHSInput") == 0)
+          Source = &*RHSBuffer;
+        if (!Source)
+          return;
+        VERIFY_IS_TRUE(Data.size() == Source->size(),
+                       "Wave matrix accumulate initializer size mismatch");
+        std::copy(Source->begin(), Source->end(), Data.begin());
+      });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  const cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(*Expected, Case.PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
+void DxilConf_SM610_LinAlg::MatAccum_Wave_8x32_F16_BUse_NonUniform() {
+  WaveAccumulateCaseData Case = {};
+  Case.AccumulatorType = ComponentType::F16;
+  Case.RHSType = ComponentType::F16;
+  Case.RHSUse = MatrixUse::B;
+  Case.M = 8;
+  Case.N = 32;
+  Case.AccumulatorValues =
+      makeWaveArithmeticPattern(Case.M, Case.N, 2, 1, 7, 3);
+  Case.RHSValues = makeWaveArithmeticPattern(Case.M, Case.N, 1, 3, 5, 2);
+  Case.PublicRule =
+      L"Exact non-uniform F16 accumulator plus a B-use F16 matrix";
+  runWaveAccumulateCase(D3DDevice, DxcSupport, Case,
+                        L"MatAccum_Wave_8x32_F16_BUse_NonUniform",
+                        VerboseLogging);
+}
+
 static const char MatVecMulShader[] = R"(
   #define USE_A 0
   #define SCOPE_THREAD 0
@@ -4038,47 +4838,6 @@ static bool isMatVecCaseValid(const MatVecCaseData &Case) {
           cpu_oracle::hlslVectorStorageTypeName(Case.BiasInputType) != nullptr);
 }
 
-static std::optional<std::vector<BYTE>>
-encodeMatVecMatrix(const MatVecCaseData &Case) {
-  const std::optional<std::vector<BYTE>> LogicalComponents =
-      cpu_oracle::encodeExactComponents(Case.Matrix.CompType,
-                                        Case.MatrixValues);
-  if (!LogicalComponents.has_value())
-    return std::nullopt;
-
-  const size_t ComponentSize = elementSize(Case.Matrix.CompType);
-  const size_t LogicalByteCount =
-      static_cast<size_t>(Case.Matrix.M) * Case.Matrix.N * ComponentSize;
-  const size_t Stride = Case.Matrix.strideBytes();
-  const size_t MinorCount = Case.Matrix.Layout == MatrixLayout::RowMajor
-                                ? Case.Matrix.N
-                                : Case.Matrix.M;
-  const size_t MajorCount = Case.Matrix.Layout == MatrixLayout::RowMajor
-                                ? Case.Matrix.M
-                                : Case.Matrix.N;
-  if (LogicalComponents->size() < LogicalByteCount ||
-      Stride < MinorCount * ComponentSize)
-    return std::nullopt;
-
-  size_t BufferSize;
-  if (!cpu_oracle::checkedMultiply(MajorCount, Stride, BufferSize))
-    return std::nullopt;
-  std::vector<BYTE> Buffer(BufferSize, 0);
-  for (MatrixDim Row = 0; Row < Case.Matrix.M; ++Row) {
-    for (MatrixDim Column = 0; Column < Case.Matrix.N; ++Column) {
-      const size_t SourceOffset =
-          (static_cast<size_t>(Row) * Case.Matrix.N + Column) * ComponentSize;
-      const size_t DestinationOffset =
-          Case.Matrix.Layout == MatrixLayout::RowMajor
-              ? static_cast<size_t>(Row) * Stride + Column * ComponentSize
-              : static_cast<size_t>(Column) * Stride + Row * ComponentSize;
-      std::memcpy(Buffer.data() + DestinationOffset,
-                  LogicalComponents->data() + SourceOffset, ComponentSize);
-    }
-  }
-  return Buffer;
-}
-
 static std::vector<int64_t>
 calculateMatVecExpected(const MatVecCaseData &Case) {
   std::vector<int64_t> Expected(Case.Matrix.M, 0);
@@ -4092,11 +4851,6 @@ calculateMatVecExpected(const MatVecCaseData &Case) {
       Expected[Row] += Case.BiasValues[Row];
   }
   return Expected;
-}
-
-static bool needs16BitTypes(ComponentType CompType) {
-  return CompType == ComponentType::F16 || CompType == ComponentType::I16 ||
-         CompType == ComponentType::U16;
 }
 
 static std::optional<std::string>
@@ -4153,7 +4907,7 @@ static void runMatVecCase(ID3D12Device *Device,
                           dxc::SpecificDllLoader &DxcSupport,
                           const MatVecCaseData &Case, bool Verbose) {
   const std::optional<std::vector<BYTE>> MatrixBuffer =
-      encodeMatVecMatrix(Case);
+      cpu_oracle::encodeLogicalMatrixBuffer(Case.Matrix, Case.MatrixValues);
   const std::optional<std::vector<BYTE>> VectorBuffer =
       Case.NativeF32VectorValues.has_value()
           ? std::optional<std::vector<BYTE>>(
@@ -4630,20 +5384,93 @@ void DxilConf_SM610_LinAlg::OuterProduct_Thread_16x16_F16() {
 }
 
 static const char QueryAccumLayoutShader[] = R"(
+  #define USE_A 0
+  #define USE_B 1
+  #define USE_ACC 2
+  #define SCOPE_WAVE 1
+  #define LAYOUT_ROW_MAJOR 0
+
   RWByteAddressBuffer Output : register(u0);
 
-  [numthreads(1, 1, 1)]
+  [WaveSize(FORCED_WAVE_SIZE)]
+  [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     uint Layout = __builtin_LinAlg_MatrixQueryAccumulatorLayout();
-    Output.Store<uint>(0, Layout);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+      Accumulator;
+    __builtin_LinAlg_FillMatrix(Accumulator, 2.0);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        COMP_TYPE, M_DIM, N_DIM, USE_A, SCOPE_WAVE)]]
+      MatrixA;
+    __builtin_LinAlg_FillMatrix(MatrixA, 3.0);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        COMP_TYPE, M_DIM, N_DIM, USE_B, SCOPE_WAVE)]]
+      MatrixB;
+    __builtin_LinAlg_FillMatrix(MatrixB, 7.0);
+
+    if (Layout == USE_A) {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(
+          COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+        Result;
+      __builtin_LinAlg_MatrixAccumulate(Result, Accumulator, MatrixA);
+      __builtin_LinAlg_MatrixStoreToDescriptor(
+        Result, Output, 0, STRIDE, LAYOUT_ROW_MAJOR, 128);
+    } else {
+      __builtin_LinAlgMatrix
+        [[__LinAlgMatrix_Attributes(
+          COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_WAVE)]]
+        Result;
+      __builtin_LinAlg_MatrixAccumulate(Result, Accumulator, MatrixB);
+      __builtin_LinAlg_MatrixStoreToDescriptor(
+        Result, Output, 0, STRIDE, LAYOUT_ROW_MAJOR, 128);
+    }
+    if (WaveGetLaneIndex() == 0)
+      Output.Store<uint>(LAYOUT_OFFSET, Layout);
   }
 )";
 
 static void runQueryAccumLayout(ID3D12Device *Device,
                                 dxc::SpecificDllLoader &DxcSupport,
                                 bool Verbose) {
-  std::string Args = "-HV 202x";
-  size_t BufferSize = elementSize(ComponentType::I32);
+  MatrixParams Params = makeWaveArithmeticParams(ComponentType::F16, 4, 8,
+                                                 MatrixUse::Accumulator, 1);
+  bool Supported;
+  UINT SelectedWaveSize;
+  const HRESULT HR = queryMatrixConstructionSupport(
+      Device, Params,
+      {{linalg_test::MatrixRole::Accumulator, Params.M, Params.N,
+        ComponentType::F16},
+       {linalg_test::MatrixRole::A, Params.M, Params.N, ComponentType::F16},
+       {linalg_test::MatrixRole::B, Params.M, Params.N, ComponentType::F16}},
+      L"QueryAccumLayout", Supported, SelectedWaveSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          HR, Supported, linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, L"QueryAccumLayout"))
+    return;
+
+  Params.NumThreads = static_cast<int>(SelectedWaveSize);
+  const size_t MatrixBytes = Params.totalBytes();
+  const size_t BufferSize = MatrixBytes + sizeof(uint32_t);
+  std::stringstream ArgsStream;
+  ArgsStream << "-HV 202x";
+  ArgsStream << " -DCOMP_TYPE=" << static_cast<int>(Params.CompType);
+  ArgsStream << " -DM_DIM=" << Params.M;
+  ArgsStream << " -DN_DIM=" << Params.N;
+  ArgsStream << " -DSTRIDE=" << Params.strideBytes();
+  ArgsStream << " -DNUMTHREADS=" << SelectedWaveSize;
+  ArgsStream << " -DFORCED_WAVE_SIZE=" << SelectedWaveSize;
+  ArgsStream << " -DLAYOUT_OFFSET=" << MatrixBytes;
+  ArgsStream << " -enable-16bit-types";
+  const std::string Args = ArgsStream.str();
 
   compileShader(DxcSupport, QueryAccumLayoutShader, "cs_6_10", Args, Verbose);
 
@@ -4656,13 +5483,39 @@ static void runQueryAccumLayout(ID3D12Device *Device,
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
-  const uint32_t *Out = static_cast<const uint32_t *>(OutData.data());
+  VERIFY_IS_TRUE(OutData.size() == BufferSize);
+  if (OutData.size() != BufferSize)
+    return;
 
-  // Accum Layout must be A or B
-  VERIFY_IS_TRUE(Out[0] == static_cast<uint32_t>(MatrixUse::A) ||
-                 Out[0] == static_cast<uint32_t>(MatrixUse::B));
+  uint32_t Layout;
+  std::memcpy(&Layout, static_cast<const BYTE *>(OutData.data()) + MatrixBytes,
+              sizeof(Layout));
+  VERIFY_IS_TRUE(Layout == static_cast<uint32_t>(MatrixUse::A) ||
+                 Layout == static_cast<uint32_t>(MatrixUse::B));
+  if (Layout != static_cast<uint32_t>(MatrixUse::A) &&
+      Layout != static_cast<uint32_t>(MatrixUse::B))
+    return;
+
+  const int64_t ExpectedValue =
+      Layout == static_cast<uint32_t>(MatrixUse::A) ? 5 : 9;
+  const std::vector<int64_t> ExpectedValues(Params.totalElements(),
+                                            ExpectedValue);
+  std::optional<std::vector<BYTE>> Expected =
+      cpu_oracle::encodeLogicalMatrixBuffer(Params, ExpectedValues);
+  VERIFY_IS_TRUE(Expected.has_value());
+  if (!Expected.has_value())
+    return;
+  const std::vector<BYTE> LayoutBytes =
+      cpu_oracle::encodeNativeVector<uint32_t>({Layout});
+  Expected->insert(Expected->end(), LayoutBytes.begin(), LayoutBytes.end());
+  const cpu_oracle::BufferResultOracle Oracle = cpu_oracle::exactBufferResult(
+      std::move(*Expected),
+      L"AccumulatorLayout selects the matching A-use or B-use accumulation "
+      L"path");
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
   if (Verbose)
-    hlsl_test::LogCommentFmt(L"AccumulatorLayout = %u", Out[0]);
+    hlsl_test::LogCommentFmt(L"AccumulatorLayout = %u", Layout);
 }
 
 void DxilConf_SM610_LinAlg::QueryAccumLayout() {

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4038,7 +4038,7 @@ static const char AccumulateMemoryShader[] = R"(
       __builtin_LinAlg_FillMatrix(Mat, FILL_VALUE);
 
       __builtin_LinAlg_MatrixAccumulateToMemory(
-        Mat, GsData, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
+        Mat, GsData, COMP_TYPE, OFFSET / ELEM_SIZE, STRIDE / ELEM_SIZE, LAYOUT);
     }
 
     GroupMemoryBarrierWithGroupSync();
@@ -4434,7 +4434,7 @@ static const char GroupSharedAccumulateShader[] = R"(
           (ELEM_TYPE)(ACCUMULATE_START + Coord.x * N_DIM + Coord.y));
       }
       __builtin_LinAlg_MatrixAccumulateToMemory(
-        Mat, GsData, MEM_OFFSET, MEM_STRIDE, MEM_LAYOUT);
+        Mat, GsData, COMP_TYPE, MEM_OFFSET, MEM_STRIDE, MEM_LAYOUT);
     }
 
     GroupMemoryBarrierWithGroupSync();

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -752,8 +752,7 @@ makeFilledComponentBuffer(ComponentType CompType, size_t BufferSize,
   if (!Fill.has_value())
     return std::nullopt;
 
-  return encodeMatrixBuffer(*Fill,
-                            {LinalgMatrixLayout::RowMajor, 0, BufferSize});
+  return encodeMatrixBuffer(*Fill, {MatrixLayout::RowMajor, 0, BufferSize});
 }
 
 template <typename T>
@@ -4299,7 +4298,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4318,10 +4317,10 @@ void DxilConf_SM610_LinAlg::
                           L"MatrixConstruction"))
     return;
 
-  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Target = {{MatrixLayout::RowMajor,
                                          /*OffsetBytes=*/8,
                                          /*StrideBytes=*/24}};
-  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Canonical = {{MatrixLayout::RowMajor,
                                             /*OffsetBytes=*/0,
                                             /*StrideBytes=*/16}};
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
@@ -4337,7 +4336,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.Layout = MatrixLayout::ColumnMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = false;
 
@@ -4357,10 +4356,10 @@ void DxilConf_SM610_LinAlg::
           L"MatrixConstruction"))
     return;
 
-  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+  const GroupSharedMemorySpec Target = {{MatrixLayout::ColumnMajor,
                                          /*OffsetBytes=*/16,
                                          /*StrideBytes=*/24}};
-  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Canonical = {{MatrixLayout::RowMajor,
                                             /*OffsetBytes=*/0,
                                             /*StrideBytes=*/32}};
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
@@ -4375,7 +4374,7 @@ void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
   Params.N = 8;
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::ThreadGroup;
-  Params.Layout = LinalgMatrixLayout::ColumnMajor;
+  Params.Layout = MatrixLayout::ColumnMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4393,10 +4392,10 @@ void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
           L"LoadStoreMemory_ThreadGroup_4x8_F16 MatrixConstruction"))
     return;
 
-  const GroupSharedMemorySpec Target = {{LinalgMatrixLayout::ColumnMajor,
+  const GroupSharedMemorySpec Target = {{MatrixLayout::ColumnMajor,
                                          /*OffsetBytes=*/8,
                                          /*StrideBytes=*/12}};
-  const GroupSharedMemorySpec Canonical = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Canonical = {{MatrixLayout::RowMajor,
                                             /*OffsetBytes=*/0,
                                             /*StrideBytes=*/16}};
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
@@ -4533,7 +4532,7 @@ void DxilConf_SM610_LinAlg::
   Params.N = 8;
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
-  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
 
@@ -4552,7 +4551,7 @@ void DxilConf_SM610_LinAlg::
                           L"AtomicAccumulateStore"))
     return;
 
-  const GroupSharedMemorySpec Memory = {{LinalgMatrixLayout::RowMajor,
+  const GroupSharedMemorySpec Memory = {{MatrixLayout::RowMajor,
                                          /*OffsetBytes=*/8,
                                          /*StrideBytes=*/24}};
   runGroupSharedAccumulate(D3DDevice, DxcSupport, Params, Memory,

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -2126,6 +2126,8 @@ public:
   TEST_METHOD(MatVecMulAdd_Thread_4x8_F32);
   TEST_METHOD(MatVecMulAdd_Thread_4x8_F16_IndependentBias);
   TEST_METHOD(OuterProduct_Thread_16x16_F16);
+  TEST_METHOD(OuterProduct_Thread_8x16_F16_NonUniform);
+  TEST_METHOD(OuterProduct_Thread_4x8_F32_NonUniform);
 
   // Query Accumulator Layout
   TEST_METHOD(QueryAccumLayout);
@@ -2138,6 +2140,8 @@ public:
 
   // Vector Accumulate
   TEST_METHOD(VectorAccumulateDescriptor_Thread_F16);
+  TEST_METHOD(VectorAccumulateDescriptor_Thread_F16_Length8_NonZero);
+  TEST_METHOD(VectorAccumulateDescriptor_Thread_F32_Length8_NonZero);
 
 private:
   CComPtr<ID3D12Device> D3DDevice;
@@ -3180,6 +3184,71 @@ static HRESULT queryThreadVectorMatrixMultiplySupport(
   if (!Supported)
     hlsl_test::LogCommentFmt(
         L"Thread-vector matrix multiplication is unsupported for %s", CaseName);
+  return S_OK;
+}
+
+static HRESULT queryThreadOuterProductSupport(ID3D12Device *Device,
+                                              ComponentType InputType,
+                                              ComponentType ResultType,
+                                              LPCWSTR CaseName,
+                                              bool &Supported) {
+  Supported = false;
+  const std::optional<linalg_test::DataType> InputDataType =
+      toCapabilityDataType(InputType);
+  const std::optional<linalg_test::DataType> ResultDataType =
+      toCapabilityDataType(ResultType);
+  if (!Device || !CaseName || !InputDataType.has_value() ||
+      !ResultDataType.has_value() ||
+      !linalg_test::isLegalScope(linalg_test::OperationType::ThreadOuterProduct,
+                                 linalg_test::ExecutionScope::Thread))
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  linalg_test::ThreadOuterProductSupport Support;
+  HR = linalg_test::queryThreadOuterProduct(
+      Device, {*InputDataType, *ResultDataType}, Support);
+  if (FAILED(HR))
+    return HR;
+
+  Supported = Support.supported();
+  if (!Supported)
+    hlsl_test::LogCommentFmt(L"Thread OuterProduct is unsupported for %s",
+                             CaseName);
+  return S_OK;
+}
+
+static HRESULT queryVectorAccumulateDescriptorSupport(ID3D12Device *Device,
+                                                      ComponentType CompType,
+                                                      LPCWSTR CaseName,
+                                                      bool &Supported) {
+  Supported = false;
+  const std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(CompType);
+  if (!Device || !CaseName || !DataType.has_value() ||
+      !linalg_test::isLegalScope(
+          linalg_test::OperationType::AtomicAccumulateStore,
+          linalg_test::ExecutionScope::Thread))
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  linalg_test::AtomicAccumulateStoreSupport Support;
+  HR = linalg_test::queryAtomicAccumulateStore(Device, {*DataType}, Support);
+  if (FAILED(HR))
+    return HR;
+
+  Supported =
+      Support.supports(linalg_test::AtomicDestination::RWByteAddressBuffer);
+  if (!Supported)
+    hlsl_test::LogCommentFmt(
+        L"Vector descriptor accumulation is unsupported for %s", CaseName);
   return S_OK;
 }
 
@@ -5749,160 +5818,237 @@ void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F16_IndependentBias() {
                              VerboseLogging);
 }
 
-// Map a DXIL ComponentType to the D3D12 linear-algebra datatype used by the
-// host-side matrix conversion API.
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
-static D3D12_LINEAR_ALGEBRA_DATATYPE toLinAlgDataType(ComponentType CT) {
-  switch (CT) {
-  case ComponentType::F16:
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16;
-  case ComponentType::F32:
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32;
-  case ComponentType::I16:
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_SINT16;
-  case ComponentType::U16:
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_UINT16;
-  case ComponentType::I32:
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_SINT32;
-  case ComponentType::U32:
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_UINT32;
-  default:
-    VERIFY_IS_TRUE(false, "Unsupported component type for linalg conversion");
-    return D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT16;
+struct OuterProductCaseData {
+  ComponentType InputType = ComponentType::Invalid;
+  ComponentType ResultType = ComponentType::Invalid;
+  MatrixDim M = 0;
+  MatrixDim N = 0;
+  std::vector<int64_t> VectorAValues;
+  std::vector<int64_t> VectorBValues;
+  std::wstring PublicRule;
+};
+
+static bool isOuterProductCaseValid(const OuterProductCaseData &Case) {
+  return Case.M != 0 && Case.N != 0 && Case.VectorAValues.size() == Case.M &&
+         Case.VectorBValues.size() == Case.N &&
+         toCapabilityDataType(Case.InputType).has_value() &&
+         toCapabilityDataType(Case.ResultType).has_value() &&
+         cpu_oracle::hlslElementTypeName(Case.InputType) &&
+         cpu_oracle::hlslElementTypeName(Case.ResultType) &&
+         !Case.PublicRule.empty();
+}
+
+static std::optional<std::vector<int64_t>>
+calculateOuterProductExpected(const OuterProductCaseData &Case) {
+  if (!isOuterProductCaseValid(Case))
+    return std::nullopt;
+
+  std::vector<int64_t> Expected(static_cast<size_t>(Case.M) * Case.N);
+  for (MatrixDim Row = 0; Row < Case.M; ++Row) {
+    for (MatrixDim Column = 0; Column < Case.N; ++Column) {
+      const size_t Index = static_cast<size_t>(Row) * Case.N + Column;
+      if (!cpu_oracle::checkedMultiplyInt64(Case.VectorAValues[Row],
+                                            Case.VectorBValues[Column],
+                                            Expected[Index]))
+        return std::nullopt;
+    }
   }
+  return Expected;
 }
 
 static const char OuterProductShader[] = R"(
+  #define USE_ACC 2
   #define SCOPE_THREAD 0
 
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
-  [numthreads(NUMTHREADS, 1, 1)]
+  [numthreads(1, 1, 1)]
   void main() {
-    vector<ELEM_TYPE, M_DIM> VecA;
+    vector<INPUT_ELEM_TYPE, M_DIM> VecA;
     for (uint I = 0; I < M_DIM; ++I) {
-      VecA[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
+      VecA[I] = Input.Load<INPUT_ELEM_TYPE>(I * INPUT_ELEM_SIZE);
     }
 
-    uint EndVecA = M_DIM * ELEM_SIZE;
-
-    vector<ELEM_TYPE, N_DIM> VecB;
+    vector<INPUT_ELEM_TYPE, N_DIM> VecB;
+    uint VecBOffset = M_DIM * INPUT_ELEM_SIZE;
     for (uint I = 0; I < N_DIM; ++I) {
-      VecB[I] = Input.Load<ELEM_TYPE>(EndVecA + I * ELEM_SIZE);
+      VecB[I] =
+        Input.Load<INPUT_ELEM_TYPE>(VecBOffset + I * INPUT_ELEM_SIZE);
     }
 
     __builtin_LinAlgMatrix
-      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE_THREAD)]]
+      [[__LinAlgMatrix_Attributes(
+        RESULT_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_THREAD)]]
       Mat;
     __builtin_LinAlg_MatrixOuterProduct(Mat, VecA, VecB);
 
-    // Outer product accumulators are stored in the OuterProductOptimal layout
-    // with stride 0 and no alignment requirement (align 0), matching the
-    // dx::linalg header's thread-scoped InterlockedAccumulate.
     __builtin_LinAlg_MatrixAccumulateToDescriptor(
-      Mat, Output, 0, STRIDE, LAYOUT, 0);
+      Mat, Output, 0, 0, OUTPUT_LAYOUT, 0);
   }
 )";
 
-static void runOuterProduct(ID3D12Device *Device,
-                            dxc::SpecificDllLoader &DxcSupport,
-                            const MatrixParams &Params, bool Verbose) {
-  VERIFY_IS_TRUE(
-      Params.Layout == MatrixLayout::OuterProductOptimal,
-      "Outer product must output its matrix in OuterProductOptimal layout");
-  VERIFY_IS_TRUE(Params.Use == MatrixUse::Accumulator,
-                 "Outer product must output an accumulator matrix");
-  const size_t NumVecElements = Params.M + Params.N;
-  const size_t InBuffSize = NumVecElements * elementSize(Params.CompType);
-  const size_t NumMatElements = Params.totalElements();
-  const D3D12_LINEAR_ALGEBRA_DATATYPE DataType =
-      toLinAlgDataType(Params.CompType);
+static std::optional<std::string>
+buildOuterProductCompilerArgs(const OuterProductCaseData &Case) {
+  if (!isOuterProductCaseValid(Case))
+    return std::nullopt;
 
-  const UINT OutBufferSize = getLinAlgMatrixByteSize(
-      Device, Params.M, Params.N, DataType,
-      D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL, /*Stride=*/0);
+  std::stringstream SS;
+  SS << "-HV 202x";
+  SS << " -DINPUT_ELEM_TYPE="
+     << cpu_oracle::hlslElementTypeName(Case.InputType);
+  SS << " -DRESULT_COMP_TYPE=" << static_cast<int>(Case.ResultType);
+  SS << " -DINPUT_ELEM_SIZE=" << static_cast<int>(elementSize(Case.InputType));
+  SS << " -DOUTPUT_LAYOUT="
+     << static_cast<int>(LinalgMatrixLayout::OuterProductOptimal);
+  SS << " -DM_DIM=" << Case.M;
+  SS << " -DN_DIM=" << Case.N;
+  if (needs16BitTypes(Case.InputType) || needs16BitTypes(Case.ResultType))
+    SS << " -enable-16bit-types";
+  return SS.str();
+}
 
+static void runOuterProductCase(ID3D12Device *Device,
+                                dxc::SpecificDllLoader &DxcSupport,
+                                const OuterProductCaseData &Case,
+                                LPCWSTR CaseName, bool Verbose) {
+  VERIFY_IS_TRUE(isOuterProductCaseValid(Case));
+  if (!isOuterProductCaseValid(Case))
+    return;
+
+  bool Supported;
+  const HRESULT HR = queryThreadOuterProductSupport(
+      Device, Case.InputType, Case.ResultType, CaseName, Supported);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          HR, Supported, linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, CaseName))
+    return;
+
+  const std::optional<std::vector<BYTE>> VectorA =
+      cpu_oracle::encodeExactComponents(Case.InputType, Case.VectorAValues);
+  const std::optional<std::vector<BYTE>> VectorB =
+      cpu_oracle::encodeExactComponents(Case.InputType, Case.VectorBValues);
+  const std::optional<std::vector<int64_t>> ExpectedValues =
+      calculateOuterProductExpected(Case);
+  const std::optional<std::vector<BYTE>> Expected =
+      ExpectedValues.has_value()
+          ? cpu_oracle::encodeExactComponents(Case.ResultType, *ExpectedValues)
+          : std::optional<std::vector<BYTE>>();
+  const std::optional<std::string> Args = buildOuterProductCompilerArgs(Case);
+  const std::optional<linalg_test::DataType> DataType =
+      toCapabilityDataType(Case.ResultType);
+  VERIFY_IS_TRUE(VectorA.has_value());
+  VERIFY_IS_TRUE(VectorB.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  VERIFY_IS_TRUE(Args.has_value());
+  VERIFY_IS_TRUE(DataType.has_value());
+  if (!VectorA.has_value() || !VectorB.has_value() || !Expected.has_value() ||
+      !Args.has_value() || !DataType.has_value())
+    return;
+
+  std::vector<BYTE> Input;
+  Input.reserve(VectorA->size() + VectorB->size());
+  Input.insert(Input.end(), VectorA->begin(), VectorA->end());
+  Input.insert(Input.end(), VectorB->begin(), VectorB->end());
+
+  const UINT OptimalBufferSize = getLinAlgMatrixByteSize(
+      Device, Case.M, Case.N, *DataType,
+      linalg_test::MatrixLayout::OuterProductOptimal, /*Stride=*/0);
   const UINT RowMajorStride =
-      static_cast<UINT>(Params.N * elementSize(Params.CompType));
-  const UINT RowMajorSize = getLinAlgMatrixByteSize(
-      Device, Params.M, Params.N, DataType,
-      D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR, RowMajorStride);
+      static_cast<UINT>(Case.N * elementSize(Case.ResultType));
+  const UINT RowMajorBufferSize = getLinAlgMatrixByteSize(
+      Device, Case.M, Case.N, *DataType, linalg_test::MatrixLayout::RowMajor,
+      RowMajorStride);
+  VERIFY_IS_TRUE(OptimalBufferSize != 0);
+  VERIFY_IS_TRUE(RowMajorBufferSize == Expected->size());
+  if (OptimalBufferSize == 0 || RowMajorBufferSize != Expected->size())
+    return;
+  const std::vector<BYTE> InitialOptimal(OptimalBufferSize, 0);
 
-  std::string Args = buildCompilerArgs(Params);
-
-  compileShader(DxcSupport, OuterProductShader, "cs_6_10", Args, Verbose);
-
-  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 4,
-                                  /*Increment=*/false);
-
+  compileShader(DxcSupport, OuterProductShader, "cs_6_10", *Args, Verbose);
   auto Op = createComputeOp(OuterProductShader, "cs_6_10", "UAV(u0), UAV(u1)",
-                            Args.c_str());
-  addUAVBuffer(Op.get(), "Input", InBuffSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", OutBufferSize, /*ReadBack=*/false);
-  addUAVBuffer(Op.get(), "OutputRowMajor", RowMajorSize, /*ReadBack=*/true);
+                            Args->c_str());
+  addUAVBuffer(Op.get(), "Input", Input.size(), false, "byname");
+  addUAVBuffer(Op.get(), "Output", OptimalBufferSize, false, "byname");
+  addUAVBuffer(Op.get(), "OutputRowMajor", RowMajorBufferSize, true);
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 
   auto Result = runShaderOp(
       Device, DxcSupport, std::move(Op),
-      [NumVecElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
-                               st::ShaderOp *) {
-        VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
-                                       NumVecElements,
-                                       /*StartingVal=*/2, /*Increment=*/false),
-                       "Saw unsupported component type");
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        const std::vector<BYTE> *Source = nullptr;
+        if (strcmp(Name, "Input") == 0)
+          Source = &Input;
+        else if (strcmp(Name, "Output") == 0)
+          Source = &InitialOptimal;
+        if (!Source)
+          return;
+        VERIFY_IS_TRUE(Data.size() == Source->size(),
+                       "OuterProduct initializer size mismatch");
+        std::copy(Source->begin(), Source->end(), Data.begin());
       },
-      [OutBufferSize, RowMajorSize, RowMajorStride, DataType,
-       Params](ID3D12GraphicsCommandList *List, st::ShaderOpTest *Test) {
+      [OptimalBufferSize, RowMajorBufferSize, RowMajorStride, DataType,
+       Case](ID3D12GraphicsCommandList *List, st::ShaderOpTest *Test) {
         ID3D12Resource *OptimalBuffer = nullptr;
         ID3D12Resource *RowMajorBuffer = nullptr;
         Test->GetResource("Output", &OptimalBuffer);
         Test->GetResource("OutputRowMajor", &RowMajorBuffer);
         recordLinAlgMatrixConversion(
-            List, OptimalBuffer, OutBufferSize, RowMajorBuffer, RowMajorSize,
-            Params.M, Params.N, DataType,
-            D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_OUTER_PRODUCT_OPTIMAL,
-            /*SrcStride=*/0, D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT_ROW_MAJOR,
-            RowMajorStride);
+            List, OptimalBuffer, OptimalBufferSize, RowMajorBuffer,
+            RowMajorBufferSize, Case.M, Case.N, *DataType,
+            linalg_test::MatrixLayout::OuterProductOptimal, /*SrcStride=*/0,
+            linalg_test::MatrixLayout::RowMajor, RowMajorStride);
       });
 
   MappedData OutData;
   Result->Test->GetReadBackData("OutputRowMajor", &OutData);
-
-  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
-                                       Expected, NumMatElements, Verbose));
+  const cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(*Expected, Case.PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
 }
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
 
 void DxilConf_SM610_LinAlg::OuterProduct_Thread_16x16_F16() {
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
-  MatrixParams Params = {};
-  Params.CompType = ComponentType::F16;
-  Params.M = 16;
-  Params.N = 16;
-  Params.Use = MatrixUse::Accumulator;
-  Params.Scope = MatrixScope::Thread;
-  Params.Layout = MatrixLayout::OuterProductOptimal;
-  Params.NumThreads = 1;
-  Params.Enable16Bit = true;
-  runOuterProduct(D3DDevice, DxcSupport, Params, VerboseLogging);
-#else
-#ifdef _HLK_CONF
-  // HLK forbids skipping, so treat the missing linear-algebra matrix-conversion
-  // API as a failure rather than emitting a (compiled-out) skip.
-  hlsl_test::LogErrorFmt(L"OuterProduct_Thread_16x16_F16 requires the "
-                         L"linear-algebra matrix-conversion API "
-                         L"(DIRECT3D_LINEAR_ALGEBRA), which this build lacks");
-#else
-  WEX::Logging::Log::Comment(
-      L"Skipping OuterProduct_Thread_16x16_F16: built against a D3D12 SDK "
-      L"without the linear-algebra matrix-conversion API "
-      L"(DIRECT3D_LINEAR_ALGEBRA undefined); the host-side conversion helpers "
-      L"are compiled out.");
-  WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-#endif // _HLK_CONF
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+  OuterProductCaseData Case = {};
+  Case.InputType = ComponentType::F16;
+  Case.ResultType = ComponentType::F16;
+  Case.M = 16;
+  Case.N = 16;
+  Case.VectorAValues.assign(Case.M, 2);
+  Case.VectorBValues.assign(Case.N, 2);
+  Case.PublicRule = L"Exact uniform F16 Thread OuterProduct";
+  runOuterProductCase(D3DDevice, DxcSupport, Case,
+                      L"OuterProduct_Thread_16x16_F16", VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::OuterProduct_Thread_8x16_F16_NonUniform() {
+  OuterProductCaseData Case = {};
+  Case.InputType = ComponentType::F16;
+  Case.ResultType = ComponentType::F16;
+  Case.M = 8;
+  Case.N = 16;
+  Case.VectorAValues = makeMatrixArithmeticPattern(/*M=*/1, Case.M, 0, 2, 7, 3);
+  Case.VectorBValues = makeMatrixArithmeticPattern(/*M=*/1, Case.N, 0, 3, 5, 2);
+  Case.PublicRule = L"Exact non-uniform F16 Thread OuterProduct";
+  runOuterProductCase(D3DDevice, DxcSupport, Case,
+                      L"OuterProduct_Thread_8x16_F16_NonUniform",
+                      VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::OuterProduct_Thread_4x8_F32_NonUniform() {
+  OuterProductCaseData Case = {};
+  Case.InputType = ComponentType::F32;
+  Case.ResultType = ComponentType::F32;
+  Case.M = 4;
+  Case.N = 8;
+  Case.VectorAValues = makeMatrixArithmeticPattern(/*M=*/1, Case.M, 0, 3, 7, 2);
+  Case.VectorBValues = makeMatrixArithmeticPattern(/*M=*/1, Case.N, 0, 2, 5, 2);
+  Case.PublicRule = L"Exact non-uniform F32 Thread OuterProduct";
+  runOuterProductCase(D3DDevice, DxcSupport, Case,
+                      L"OuterProduct_Thread_4x8_F32_NonUniform",
+                      VerboseLogging);
 }
 
 static const char QueryAccumLayoutShader[] = R"(
@@ -6983,43 +7129,166 @@ void DxilConf_SM610_LinAlg::Convert_F16_FP8_RoundTrip() {
 }
 
 static const char VectorAccumulateDescriptorShader[] = R"(
-  RWByteAddressBuffer Output : register(u0);
+  ByteAddressBuffer Input : register(t0);
+  RWByteAddressBuffer Output : register(u1);
 
   [numthreads(1, 1, 1)]
   void main() {
-    vector<half, 4> InVec = {1.0, 2.0, 3.0, 4.0};
-    __builtin_LinAlg_VectorAccumulateToDescriptor(Output, 0, 64, InVec);
+    vector<ELEM_TYPE, VECTOR_LENGTH> InVec;
+    for (uint I = 0; I < VECTOR_LENGTH; ++I) {
+      InVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
+    }
+    __builtin_LinAlg_VectorAccumulateToDescriptor(
+      Output, 0, 64, InVec);
   }
 )";
 
+struct VectorAccumulateCaseData {
+  ComponentType CompType = ComponentType::Invalid;
+  std::vector<int64_t> InputValues;
+  std::vector<int64_t> InitialValues;
+  std::wstring PublicRule;
+};
+
+static bool isVectorAccumulateCaseValid(const VectorAccumulateCaseData &Case) {
+  return !Case.InputValues.empty() &&
+         Case.InputValues.size() == Case.InitialValues.size() &&
+         toCapabilityDataType(Case.CompType).has_value() &&
+         cpu_oracle::hlslElementTypeName(Case.CompType) &&
+         !Case.PublicRule.empty();
+}
+
+static std::optional<std::vector<int64_t>>
+calculateVectorAccumulateExpected(const VectorAccumulateCaseData &Case) {
+  if (!isVectorAccumulateCaseValid(Case))
+    return std::nullopt;
+  std::vector<int64_t> Expected(Case.InputValues.size());
+  for (size_t I = 0; I < Expected.size(); ++I) {
+    if (!cpu_oracle::checkedAddInt64(Case.InitialValues[I], Case.InputValues[I],
+                                     Expected[I]))
+      return std::nullopt;
+  }
+  return Expected;
+}
+
+static std::optional<std::string>
+buildVectorAccumulateCompilerArgs(const VectorAccumulateCaseData &Case) {
+  if (!isVectorAccumulateCaseValid(Case))
+    return std::nullopt;
+  std::stringstream SS;
+  SS << "-HV 202x";
+  SS << " -DELEM_TYPE=" << cpu_oracle::hlslElementTypeName(Case.CompType);
+  SS << " -DELEM_SIZE=" << static_cast<int>(elementSize(Case.CompType));
+  SS << " -DVECTOR_LENGTH=" << Case.InputValues.size();
+  if (needs16BitTypes(Case.CompType))
+    SS << " -enable-16bit-types";
+  return SS.str();
+}
+
 static void runVectorAccumulateDescriptor(ID3D12Device *Device,
                                           dxc::SpecificDllLoader &DxcSupport,
-                                          bool Verbose) {
-  std::string Args = "-HV 202x -enable-16bit-types";
-  MatrixDim NumElements = 4;
-  size_t BufferSize = elementSize(ComponentType::F16) * NumElements;
+                                          const VectorAccumulateCaseData &Case,
+                                          LPCWSTR CaseName, bool Verbose) {
+  VERIFY_IS_TRUE(isVectorAccumulateCaseValid(Case));
+  if (!isVectorAccumulateCaseValid(Case))
+    return;
 
-  compileShader(DxcSupport, VectorAccumulateDescriptorShader, "cs_6_10", Args,
+  bool Supported;
+  const HRESULT HR = queryVectorAccumulateDescriptorSupport(
+      Device, Case.CompType, CaseName, Supported);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(
+          HR, Supported, linalg_test::CapabilityRequirement::CapabilityGated);
+  if (!applyApplicability(Applicability, CaseName))
+    return;
+
+  const std::optional<std::vector<BYTE>> Input =
+      cpu_oracle::encodeExactComponents(Case.CompType, Case.InputValues);
+  const std::optional<std::vector<BYTE>> Initial =
+      cpu_oracle::encodeExactComponents(Case.CompType, Case.InitialValues);
+  const std::optional<std::vector<int64_t>> ExpectedValues =
+      calculateVectorAccumulateExpected(Case);
+  const std::optional<std::vector<BYTE>> Expected =
+      ExpectedValues.has_value()
+          ? cpu_oracle::encodeExactComponents(Case.CompType, *ExpectedValues)
+          : std::optional<std::vector<BYTE>>();
+  const std::optional<std::string> Args =
+      buildVectorAccumulateCompilerArgs(Case);
+  VERIFY_IS_TRUE(Input.has_value());
+  VERIFY_IS_TRUE(Initial.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  VERIFY_IS_TRUE(Args.has_value());
+  if (!Input.has_value() || !Initial.has_value() || !Expected.has_value() ||
+      !Args.has_value())
+    return;
+
+  compileShader(DxcSupport, VectorAccumulateDescriptorShader, "cs_6_10", *Args,
                 Verbose);
-
-  auto Expected = makeExpectedVec(ComponentType::F16, NumElements, 1.0);
-
   auto Op = createComputeOp(VectorAccumulateDescriptorShader, "cs_6_10",
-                            "UAV(u0)", Args.c_str());
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Output");
+                            "SRV(t0), UAV(u1)", Args->c_str());
+  addSRVBuffer(Op.get(), "Input", Input->size(), "byname");
+  addUAVBuffer(Op.get(), "Output", Initial->size(), true, "byname");
+  addRootView(Op.get(), 0, "Input");
+  addRootView(Op.get(), 1, "Output");
 
-  auto Result = runShaderOp(Device, DxcSupport, std::move(Op));
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        const std::vector<BYTE> *Source = nullptr;
+        if (strcmp(Name, "Input") == 0)
+          Source = &*Input;
+        else if (strcmp(Name, "Output") == 0)
+          Source = &*Initial;
+        if (!Source)
+          return;
+        VERIFY_IS_TRUE(Data.size() == Source->size(),
+                       "Vector accumulation initializer size mismatch");
+        std::copy(Source->begin(), Source->end(), Data.begin());
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
-
-  VERIFY_IS_TRUE(verifyComponentBuffer(ComponentType::F16, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  const cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(*Expected, Case.PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::VectorAccumulateDescriptor_Thread_F16() {
-  runVectorAccumulateDescriptor(D3DDevice, DxcSupport, VerboseLogging);
+  VectorAccumulateCaseData Case = {};
+  Case.CompType = ComponentType::F16;
+  Case.InputValues = {1, 2, 3, 4};
+  Case.InitialValues = {0, 0, 0, 0};
+  Case.PublicRule = L"Exact F16 vector descriptor accumulation";
+  runVectorAccumulateDescriptor(D3DDevice, DxcSupport, Case,
+                                L"VectorAccumulateDescriptor_Thread_F16",
+                                VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    VectorAccumulateDescriptor_Thread_F16_Length8_NonZero() {
+  VectorAccumulateCaseData Case = {};
+  Case.CompType = ComponentType::F16;
+  Case.InputValues = {-3, 2, 5, -1, 4, 0, -2, 6};
+  Case.InitialValues = {10, 11, 12, 13, 14, 15, 16, 17};
+  Case.PublicRule =
+      L"Exact non-contended F16 vector accumulation onto non-zero values";
+  runVectorAccumulateDescriptor(
+      D3DDevice, DxcSupport, Case,
+      L"VectorAccumulateDescriptor_Thread_F16_Length8_NonZero", VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    VectorAccumulateDescriptor_Thread_F32_Length8_NonZero() {
+  VectorAccumulateCaseData Case = {};
+  Case.CompType = ComponentType::F32;
+  Case.InputValues = {6, -2, 0, 3, -5, 4, 1, -1};
+  Case.InitialValues = {20, 21, 22, 23, 24, 25, 26, 27};
+  Case.PublicRule =
+      L"Exact non-contended F32 vector accumulation onto non-zero values";
+  runVectorAccumulateDescriptor(
+      D3DDevice, DxcSupport, Case,
+      L"VectorAccumulateDescriptor_Thread_F32_Length8_NonZero", VerboseLogging);
 }
 
 } // namespace LinAlg

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -4210,11 +4210,14 @@ static bool isWaveMultiplyCaseValid(const WaveMultiplyCaseData &Case) {
   const size_t MatrixAElements = static_cast<size_t>(Case.M) * Case.K;
   const size_t MatrixBElements = static_cast<size_t>(Case.K) * Case.N;
   const size_t AccumulatorElements = static_cast<size_t>(Case.M) * Case.N;
+  const bool AccumulatorValuesValid =
+      Case.hasInitialAccumulator()
+          ? Case.AccumulatorValues.size() == AccumulatorElements
+          : Case.AccumulatorValues.empty();
   return Case.M != 0 && Case.K != 0 && Case.N != 0 &&
          Case.MatrixAValues.size() == MatrixAElements &&
          Case.MatrixBValues.size() == MatrixBElements &&
-         Case.hasInitialAccumulator() ==
-             (Case.AccumulatorValues.size() == AccumulatorElements) &&
+         AccumulatorValuesValid &&
          toCapabilityDataType(Case.MatrixAType).has_value() &&
          toCapabilityDataType(Case.MatrixBType).has_value() &&
          toCapabilityDataType(Case.AccumulatorType).has_value() &&

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -5914,7 +5914,7 @@ buildOuterProductCompilerArgs(const OuterProductCaseData &Case) {
   SS << " -DRESULT_COMP_TYPE=" << static_cast<int>(Case.ResultType);
   SS << " -DINPUT_ELEM_SIZE=" << static_cast<int>(elementSize(Case.InputType));
   SS << " -DOUTPUT_LAYOUT="
-     << static_cast<int>(LinalgMatrixLayout::OuterProductOptimal);
+     << static_cast<int>(MatrixLayout::OuterProductOptimal);
   SS << " -DM_DIM=" << Case.M;
   SS << " -DN_DIM=" << Case.N;
   if (needs16BitTypes(Case.InputType) || needs16BitTypes(Case.ResultType))

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -2071,6 +2071,9 @@ public:
   TEST_METHOD(MatMatMulAccum_Wave_8x32x16_F16_ToF32_NonUniform);
   TEST_METHOD(MatAccum_Wave_16x16_F16);
   TEST_METHOD(MatAccum_Wave_8x32_F16_BUse_NonUniform);
+  TEST_METHOD(MatMatMul_ThreadGroup_8x16x8_F16_NonUniform);
+  TEST_METHOD(MatMatMulAccum_ThreadGroup_8x16x8_F16_ToF32_NonUniform);
+  TEST_METHOD(MatMatMul_ThreadGroup_8x8x8_I32);
 
   // Matrix Vector Arithmetic
   TEST_METHOD(MatVecMul_Thread_16x16_F16);
@@ -2950,6 +2953,125 @@ static HRESULT queryWaveMatrixMultiplyCaseSupport(
 
   hlsl_test::LogCommentFmt(
       L"No WaveMatrixMultiply query within the device wave range supports %s",
+      CaseName);
+  return S_OK;
+}
+
+static HRESULT queryThreadGroupMatrixMultiplyCaseSupport(
+    ID3D12Device *Device, ComponentType MatrixAType, ComponentType MatrixBType,
+    ComponentType AccumulatorType, MatrixDim M, MatrixDim K, MatrixDim N,
+    LPCWSTR CaseName, bool &Supported, UINT &SelectedWaveSize,
+    UINT &SelectedThreadGroupSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  SelectedThreadGroupSize = 0;
+  const std::optional<linalg_test::DataType> MatrixADataType =
+      toCapabilityDataType(MatrixAType);
+  const std::optional<linalg_test::DataType> MatrixBDataType =
+      toCapabilityDataType(MatrixBType);
+  const std::optional<linalg_test::DataType> AccumulatorDataType =
+      toCapabilityDataType(AccumulatorType);
+  if (!Device || !CaseName || M == 0 || K == 0 || N == 0 ||
+      !MatrixADataType.has_value() || !MatrixBDataType.has_value() ||
+      !AccumulatorDataType.has_value() ||
+      !linalg_test::isLegalScope(
+          linalg_test::OperationType::ThreadGroupMatrixMultiply,
+          linalg_test::ExecutionScope::ThreadGroup))
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
+                                   sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!WaveOptions.WaveOps || !IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    if (!WaveOptions.WaveOps)
+      return S_OK;
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  constexpr UINT MaxThreadsPerGroup = 1024;
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < WaveOptions.WaveLaneCountMin ||
+        WaveSize > WaveOptions.WaveLaneCountMax)
+      continue;
+
+    linalg_test::MatrixConstructionSupport MatrixASupport;
+    linalg_test::MatrixConstructionSupport MatrixBSupport;
+    linalg_test::MatrixConstructionSupport AccumulatorSupport;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*MatrixADataType, WaveSize}, MatrixASupport);
+    if (FAILED(HR))
+      return HR;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*MatrixBDataType, WaveSize}, MatrixBSupport);
+    if (FAILED(HR))
+      return HR;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*AccumulatorDataType, WaveSize}, AccumulatorSupport);
+    if (FAILED(HR))
+      return HR;
+    if (!MatrixASupport.supports(linalg_test::MatrixRole::A, M, K) ||
+        !MatrixBSupport.supports(linalg_test::MatrixRole::B, K, N) ||
+        !AccumulatorSupport.supports(linalg_test::MatrixRole::Accumulator, M,
+                                     N))
+      continue;
+
+    linalg_test::ThreadGroupMatrixMultiplySupport MultiplySupport;
+    HR = linalg_test::queryThreadGroupMatrixMultiply(
+        Device,
+        {{WaveSize, *MatrixADataType, *MatrixBDataType, *AccumulatorDataType},
+         {M, K, N}},
+        MultiplySupport);
+    if (FAILED(HR))
+      return HR;
+    if (!MultiplySupport.supported())
+      continue;
+
+    UINT ThreadGroupSize = MultiplySupport.PreferredThreadGroupSize;
+    if (ThreadGroupSize == 0 || ThreadGroupSize > MaxThreadsPerGroup)
+      ThreadGroupSize = MultiplySupport.MinThreadGroupSize;
+    if (!MultiplySupport.supportsThreadGroupSize(ThreadGroupSize) ||
+        ThreadGroupSize > MaxThreadsPerGroup) {
+      hlsl_test::LogCommentFmt(
+          L"ThreadGroupMatrixMultiply returned no executable group size for "
+          L"%s: min=%u, max=%u, preferred=%u",
+          CaseName, MultiplySupport.MinThreadGroupSize,
+          MultiplySupport.MaxThreadGroupSize,
+          MultiplySupport.PreferredThreadGroupSize);
+      return E_UNEXPECTED;
+    }
+
+    hlsl_test::LogCommentFmt(
+        L"ThreadGroupMatrixMultiply capability matched wave=%u, threads=%u, "
+        L"M=%u, K=%u, N=%u for %s",
+        WaveSize, ThreadGroupSize, M, K, N, CaseName);
+    Supported = true;
+    SelectedWaveSize = WaveSize;
+    SelectedThreadGroupSize = ThreadGroupSize;
+    return S_OK;
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No ThreadGroupMatrixMultiply query within the device wave range "
+      L"supports %s",
       CaseName);
   return S_OK;
 }
@@ -4162,11 +4284,10 @@ static MatrixParams makeWaveArithmeticParams(ComponentType CompType,
   return Params;
 }
 
-static std::vector<int64_t> makeWaveArithmeticPattern(MatrixDim M, MatrixDim N,
-                                                      int64_t RowScale,
-                                                      int64_t ColumnScale,
-                                                      int64_t Modulus,
-                                                      int64_t Center) {
+static std::vector<int64_t>
+makeMatrixArithmeticPattern(MatrixDim M, MatrixDim N, int64_t RowScale,
+                            int64_t ColumnScale, int64_t Modulus,
+                            int64_t Center) {
   VERIFY_IS_TRUE(M != 0 && N != 0 && Modulus > 0);
   if (M == 0 || N == 0 || Modulus <= 0)
     return {};
@@ -4183,30 +4304,30 @@ static std::vector<int64_t> makeWaveArithmeticPattern(MatrixDim M, MatrixDim N,
   return Values;
 }
 
-enum class WaveMultiplyOperation {
+enum class MatrixMultiplyOperation {
   Multiply,
   MultiplyAccumulate,
 };
 
-struct WaveMultiplyCaseData {
+struct MatrixMultiplyCaseData {
   ComponentType MatrixAType = ComponentType::Invalid;
   ComponentType MatrixBType = ComponentType::Invalid;
   ComponentType AccumulatorType = ComponentType::Invalid;
   MatrixDim M = 0;
   MatrixDim K = 0;
   MatrixDim N = 0;
-  WaveMultiplyOperation Operation = WaveMultiplyOperation::Multiply;
+  MatrixMultiplyOperation Operation = MatrixMultiplyOperation::Multiply;
   std::vector<int64_t> MatrixAValues;
   std::vector<int64_t> MatrixBValues;
   std::vector<int64_t> AccumulatorValues;
   std::wstring PublicRule;
 
   bool hasInitialAccumulator() const {
-    return Operation == WaveMultiplyOperation::MultiplyAccumulate;
+    return Operation == MatrixMultiplyOperation::MultiplyAccumulate;
   }
 };
 
-static bool isWaveMultiplyCaseValid(const WaveMultiplyCaseData &Case) {
+static bool isMatrixMultiplyCaseValid(const MatrixMultiplyCaseData &Case) {
   const size_t MatrixAElements = static_cast<size_t>(Case.M) * Case.K;
   const size_t MatrixBElements = static_cast<size_t>(Case.K) * Case.N;
   const size_t AccumulatorElements = static_cast<size_t>(Case.M) * Case.N;
@@ -4225,7 +4346,7 @@ static bool isWaveMultiplyCaseValid(const WaveMultiplyCaseData &Case) {
 }
 
 static std::optional<std::vector<int64_t>>
-calculateWaveMultiplyExpected(const WaveMultiplyCaseData &Case) {
+calculateMatrixMultiplyExpected(const MatrixMultiplyCaseData &Case) {
   const std::vector<int64_t> *Accumulator =
       Case.hasInitialAccumulator() ? &Case.AccumulatorValues : nullptr;
   return cpu_oracle::multiplyIntegerMatrices(Case.M, Case.K, Case.N,
@@ -4293,8 +4414,9 @@ static const char WaveMultiplyShader[] = R"(
 )";
 
 static std::optional<std::string>
-buildWaveMultiplyCompilerArgs(const WaveMultiplyCaseData &Case, UINT WaveSize) {
-  if (!isWaveMultiplyCaseValid(Case) || WaveSize == 0)
+buildWaveMultiplyCompilerArgs(const MatrixMultiplyCaseData &Case,
+                              UINT WaveSize) {
+  if (!isMatrixMultiplyCaseValid(Case) || WaveSize == 0)
     return std::nullopt;
 
   const MatrixParams MatrixA = makeWaveArithmeticParams(
@@ -4326,8 +4448,8 @@ buildWaveMultiplyCompilerArgs(const WaveMultiplyCaseData &Case, UINT WaveSize) {
 
 static void runWaveMultiplyCase(ID3D12Device *Device,
                                 dxc::SpecificDllLoader &DxcSupport,
-                                const WaveMultiplyCaseData &Case, UINT WaveSize,
-                                bool Verbose) {
+                                const MatrixMultiplyCaseData &Case,
+                                UINT WaveSize, bool Verbose) {
   const MatrixParams MatrixA = makeWaveArithmeticParams(
       Case.MatrixAType, Case.M, Case.K, MatrixUse::A, WaveSize);
   const MatrixParams MatrixB = makeWaveArithmeticParams(
@@ -4343,7 +4465,7 @@ static void runWaveMultiplyCase(ID3D12Device *Device,
                                          Accumulator, Case.AccumulatorValues)
                                    : std::optional<std::vector<BYTE>>();
   const std::optional<std::vector<int64_t>> ExpectedValues =
-      calculateWaveMultiplyExpected(Case);
+      calculateMatrixMultiplyExpected(Case);
   const std::optional<std::vector<BYTE>> Expected =
       ExpectedValues.has_value()
           ? cpu_oracle::encodeLogicalMatrixBuffer(Accumulator, *ExpectedValues)
@@ -4412,11 +4534,11 @@ static void runWaveMultiplyCase(ID3D12Device *Device,
 static void
 runCapabilityCheckedWaveMultiply(ID3D12Device *Device,
                                  dxc::SpecificDllLoader &DxcSupport,
-                                 const WaveMultiplyCaseData &Case,
+                                 const MatrixMultiplyCaseData &Case,
                                  linalg_test::CapabilityRequirement Requirement,
                                  LPCWSTR CaseName, bool Verbose) {
-  VERIFY_IS_TRUE(isWaveMultiplyCaseValid(Case));
-  if (!isWaveMultiplyCaseValid(Case))
+  VERIFY_IS_TRUE(isMatrixMultiplyCaseValid(Case));
+  if (!isMatrixMultiplyCaseValid(Case))
     return;
 
   bool Supported;
@@ -4431,10 +4553,10 @@ runCapabilityCheckedWaveMultiply(ID3D12Device *Device,
   runWaveMultiplyCase(Device, DxcSupport, Case, SelectedWaveSize, Verbose);
 }
 
-static WaveMultiplyCaseData
+static MatrixMultiplyCaseData
 makeRectangularF16WaveMultiplyCase(ComponentType AccumulatorType,
-                                   WaveMultiplyOperation Operation) {
-  WaveMultiplyCaseData Case = {};
+                                   MatrixMultiplyOperation Operation) {
+  MatrixMultiplyCaseData Case = {};
   Case.MatrixAType = ComponentType::F16;
   Case.MatrixBType = ComponentType::F16;
   Case.AccumulatorType = AccumulatorType;
@@ -4442,11 +4564,11 @@ makeRectangularF16WaveMultiplyCase(ComponentType AccumulatorType,
   Case.K = 32;
   Case.N = 16;
   Case.Operation = Operation;
-  Case.MatrixAValues = makeWaveArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
-  Case.MatrixBValues = makeWaveArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
+  Case.MatrixAValues = makeMatrixArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
+  Case.MatrixBValues = makeMatrixArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
   if (Case.hasInitialAccumulator()) {
     Case.AccumulatorValues =
-        makeWaveArithmeticPattern(Case.M, Case.N, 2, 1, 5, 2);
+        makeMatrixArithmeticPattern(Case.M, Case.N, 2, 1, 5, 2);
     Case.PublicRule =
         L"Exact non-uniform F16 products plus an independent F32 accumulator";
   } else if (AccumulatorType == ComponentType::F32) {
@@ -4459,8 +4581,8 @@ makeRectangularF16WaveMultiplyCase(ComponentType AccumulatorType,
 }
 
 void DxilConf_SM610_LinAlg::MatMatMul_Wave_8x32x16_F16_NonUniform() {
-  const WaveMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
-      ComponentType::F16, WaveMultiplyOperation::Multiply);
+  const MatrixMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
+      ComponentType::F16, MatrixMultiplyOperation::Multiply);
   runCapabilityCheckedWaveMultiply(
       D3DDevice, DxcSupport, Case,
       linalg_test::CapabilityRequirement::CapabilityGated,
@@ -4468,8 +4590,8 @@ void DxilConf_SM610_LinAlg::MatMatMul_Wave_8x32x16_F16_NonUniform() {
 }
 
 void DxilConf_SM610_LinAlg::MatMatMul_Wave_8x32x16_F16_ToF32() {
-  const WaveMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
-      ComponentType::F32, WaveMultiplyOperation::Multiply);
+  const MatrixMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
+      ComponentType::F32, MatrixMultiplyOperation::Multiply);
   runCapabilityCheckedWaveMultiply(
       D3DDevice, DxcSupport, Case,
       linalg_test::CapabilityRequirement::CapabilityGated,
@@ -4477,8 +4599,8 @@ void DxilConf_SM610_LinAlg::MatMatMul_Wave_8x32x16_F16_ToF32() {
 }
 
 void DxilConf_SM610_LinAlg::MatMatMulAccum_Wave_8x32x16_F16_ToF32_NonUniform() {
-  const WaveMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
-      ComponentType::F32, WaveMultiplyOperation::MultiplyAccumulate);
+  const MatrixMultiplyCaseData Case = makeRectangularF16WaveMultiplyCase(
+      ComponentType::F32, MatrixMultiplyOperation::MultiplyAccumulate);
   runCapabilityCheckedWaveMultiply(
       D3DDevice, DxcSupport, Case,
       linalg_test::CapabilityRequirement::CapabilityGated,
@@ -4486,20 +4608,361 @@ void DxilConf_SM610_LinAlg::MatMatMulAccum_Wave_8x32x16_F16_ToF32_NonUniform() {
 }
 
 void DxilConf_SM610_LinAlg::MatMatMul_Wave_16x16x16_I32() {
-  WaveMultiplyCaseData Case = {};
+  MatrixMultiplyCaseData Case = {};
   Case.MatrixAType = ComponentType::I32;
   Case.MatrixBType = ComponentType::I32;
   Case.AccumulatorType = ComponentType::I32;
   Case.M = 16;
   Case.K = 16;
   Case.N = 16;
-  Case.MatrixAValues = makeWaveArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
-  Case.MatrixBValues = makeWaveArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
+  Case.MatrixAValues = makeMatrixArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
+  Case.MatrixBValues = makeMatrixArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
   Case.PublicRule = L"Exact non-uniform I32 matrix product";
   runCapabilityCheckedWaveMultiply(
       D3DDevice, DxcSupport, Case,
       linalg_test::CapabilityRequirement::CapabilityGated,
       L"MatMatMul_Wave_16x16x16_I32", VerboseLogging);
+}
+
+static MatrixParams makeThreadGroupArithmeticParams(ComponentType CompType,
+                                                    MatrixDim M, MatrixDim N,
+                                                    MatrixUse Use,
+                                                    UINT ThreadGroupSize) {
+  MatrixParams Params = {};
+  Params.CompType = CompType;
+  Params.M = M;
+  Params.N = N;
+  Params.Use = Use;
+  Params.Scope = MatrixScope::ThreadGroup;
+  Params.Layout = LinalgMatrixLayout::RowMajor;
+  Params.NumThreads = static_cast<int>(ThreadGroupSize);
+  Params.Enable16Bit = needs16BitTypes(CompType);
+  return Params;
+}
+
+static const char ThreadGroupMultiplyShader[] = R"(
+  #define USE_A 0
+  #define USE_B 1
+  #define USE_ACC 2
+  #define SCOPE_THREAD_GROUP 2
+  #define LAYOUT_ROW_MAJOR 0
+
+  ByteAddressBuffer MatrixAInput : register(t0);
+  ByteAddressBuffer MatrixBInput : register(t1);
+  #if DO_ACCUMULATE
+  ByteAddressBuffer AccumulatorInput : register(t2);
+  RWByteAddressBuffer Output : register(u3);
+  #else
+  RWByteAddressBuffer Output : register(u2);
+  #endif
+
+  groupshared MATRIX_A_ELEM_TYPE MatrixAData[MATRIX_A_ELEMENTS];
+  groupshared MATRIX_B_ELEM_TYPE MatrixBData[MATRIX_B_ELEMENTS];
+  #if DO_ACCUMULATE
+  groupshared ACCUMULATOR_ELEM_TYPE AccumulatorData[ACCUMULATOR_ELEMENTS];
+  #endif
+  groupshared ACCUMULATOR_ELEM_TYPE ResultData[ACCUMULATOR_ELEMENTS];
+
+  [WaveSize(FORCED_WAVE_SIZE)]
+  [numthreads(THREADGROUP_SIZE, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    for (uint Index = threadID; Index < MATRIX_A_ELEMENTS;
+         Index += THREADGROUP_SIZE) {
+      MatrixAData[Index] =
+        MatrixAInput.Load<MATRIX_A_ELEM_TYPE>(Index * MATRIX_A_ELEM_SIZE);
+    }
+    for (uint Index = threadID; Index < MATRIX_B_ELEMENTS;
+         Index += THREADGROUP_SIZE) {
+      MatrixBData[Index] =
+        MatrixBInput.Load<MATRIX_B_ELEM_TYPE>(Index * MATRIX_B_ELEM_SIZE);
+    }
+    #if DO_ACCUMULATE
+    for (uint Index = threadID; Index < ACCUMULATOR_ELEMENTS;
+         Index += THREADGROUP_SIZE) {
+      AccumulatorData[Index] =
+        AccumulatorInput.Load<ACCUMULATOR_ELEM_TYPE>(
+          Index * ACCUMULATOR_ELEM_SIZE);
+    }
+    #endif
+    for (uint Index = threadID; Index < ACCUMULATOR_ELEMENTS;
+         Index += THREADGROUP_SIZE) {
+      ResultData[Index] = (ACCUMULATOR_ELEM_TYPE)-4096;
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        MATRIX_A_COMP_TYPE, M_DIM, K_DIM, USE_A, SCOPE_THREAD_GROUP)]]
+      MatA;
+    __builtin_LinAlg_MatrixLoadFromMemory(
+      MatA, MatrixAData, 0, MATRIX_A_STRIDE, LAYOUT_ROW_MAJOR);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        MATRIX_B_COMP_TYPE, K_DIM, N_DIM, USE_B, SCOPE_THREAD_GROUP)]]
+      MatB;
+    __builtin_LinAlg_MatrixLoadFromMemory(
+      MatB, MatrixBData, 0, MATRIX_B_STRIDE, LAYOUT_ROW_MAJOR);
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        ACCUMULATOR_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_THREAD_GROUP)]]
+      Result;
+    #if DO_ACCUMULATE
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(
+        ACCUMULATOR_COMP_TYPE, M_DIM, N_DIM, USE_ACC, SCOPE_THREAD_GROUP)]]
+      Accumulator;
+    __builtin_LinAlg_MatrixLoadFromMemory(
+      Accumulator, AccumulatorData, 0, ACCUMULATOR_STRIDE, LAYOUT_ROW_MAJOR);
+    __builtin_LinAlg_MatrixMatrixMultiplyAccumulate(
+      Result, MatA, MatB, Accumulator);
+    #else
+    __builtin_LinAlg_MatrixMatrixMultiply(Result, MatA, MatB);
+    #endif
+
+    __builtin_LinAlg_MatrixStoreToMemory(
+      Result, ResultData, 0, ACCUMULATOR_STRIDE, LAYOUT_ROW_MAJOR);
+
+    GroupMemoryBarrierWithGroupSync();
+
+    for (uint Index = threadID; Index < ACCUMULATOR_ELEMENTS;
+         Index += THREADGROUP_SIZE) {
+      Output.Store<ACCUMULATOR_ELEM_TYPE>(
+        Index * ACCUMULATOR_ELEM_SIZE, ResultData[Index]);
+    }
+  }
+)";
+
+static std::optional<std::string>
+buildThreadGroupMultiplyCompilerArgs(const MatrixMultiplyCaseData &Case,
+                                     UINT WaveSize, UINT ThreadGroupSize) {
+  if (!isMatrixMultiplyCaseValid(Case) || WaveSize == 0 || ThreadGroupSize == 0)
+    return std::nullopt;
+
+  const char *MatrixAElementType =
+      cpu_oracle::hlslElementTypeName(Case.MatrixAType);
+  const char *MatrixBElementType =
+      cpu_oracle::hlslElementTypeName(Case.MatrixBType);
+  const char *AccumulatorElementType =
+      cpu_oracle::hlslElementTypeName(Case.AccumulatorType);
+  if (!MatrixAElementType || !MatrixBElementType || !AccumulatorElementType)
+    return std::nullopt;
+
+  const MatrixParams MatrixA = makeThreadGroupArithmeticParams(
+      Case.MatrixAType, Case.M, Case.K, MatrixUse::A, ThreadGroupSize);
+  const MatrixParams MatrixB = makeThreadGroupArithmeticParams(
+      Case.MatrixBType, Case.K, Case.N, MatrixUse::B, ThreadGroupSize);
+  const MatrixParams Accumulator =
+      makeThreadGroupArithmeticParams(Case.AccumulatorType, Case.M, Case.N,
+                                      MatrixUse::Accumulator, ThreadGroupSize);
+
+  std::stringstream SS;
+  SS << "-HV 202x";
+  SS << " -DMATRIX_A_COMP_TYPE=" << static_cast<int>(Case.MatrixAType);
+  SS << " -DMATRIX_B_COMP_TYPE=" << static_cast<int>(Case.MatrixBType);
+  SS << " -DACCUMULATOR_COMP_TYPE=" << static_cast<int>(Case.AccumulatorType);
+  SS << " -DMATRIX_A_ELEM_TYPE=" << MatrixAElementType;
+  SS << " -DMATRIX_B_ELEM_TYPE=" << MatrixBElementType;
+  SS << " -DACCUMULATOR_ELEM_TYPE=" << AccumulatorElementType;
+  SS << " -DM_DIM=" << Case.M;
+  SS << " -DK_DIM=" << Case.K;
+  SS << " -DN_DIM=" << Case.N;
+  SS << " -DMATRIX_A_ELEMENTS=" << MatrixA.totalElements();
+  SS << " -DMATRIX_B_ELEMENTS=" << MatrixB.totalElements();
+  SS << " -DACCUMULATOR_ELEMENTS=" << Accumulator.totalElements();
+  SS << " -DMATRIX_A_ELEM_SIZE="
+     << static_cast<int>(elementSize(Case.MatrixAType));
+  SS << " -DMATRIX_B_ELEM_SIZE="
+     << static_cast<int>(elementSize(Case.MatrixBType));
+  SS << " -DACCUMULATOR_ELEM_SIZE="
+     << static_cast<int>(elementSize(Case.AccumulatorType));
+  SS << " -DMATRIX_A_STRIDE=" << MatrixA.N;
+  SS << " -DMATRIX_B_STRIDE=" << MatrixB.N;
+  SS << " -DACCUMULATOR_STRIDE=" << Accumulator.N;
+  SS << " -DTHREADGROUP_SIZE=" << ThreadGroupSize;
+  SS << " -DFORCED_WAVE_SIZE=" << WaveSize;
+  SS << " -DDO_ACCUMULATE=" << Case.hasInitialAccumulator();
+  if (needs16BitTypes(Case.MatrixAType) || needs16BitTypes(Case.MatrixBType) ||
+      needs16BitTypes(Case.AccumulatorType))
+    SS << " -enable-16bit-types";
+  return SS.str();
+}
+
+static void runThreadGroupMultiplyCase(ID3D12Device *Device,
+                                       dxc::SpecificDllLoader &DxcSupport,
+                                       const MatrixMultiplyCaseData &Case,
+                                       UINT WaveSize, UINT ThreadGroupSize,
+                                       bool Verbose) {
+  const MatrixParams MatrixA = makeThreadGroupArithmeticParams(
+      Case.MatrixAType, Case.M, Case.K, MatrixUse::A, ThreadGroupSize);
+  const MatrixParams MatrixB = makeThreadGroupArithmeticParams(
+      Case.MatrixBType, Case.K, Case.N, MatrixUse::B, ThreadGroupSize);
+  const MatrixParams Accumulator =
+      makeThreadGroupArithmeticParams(Case.AccumulatorType, Case.M, Case.N,
+                                      MatrixUse::Accumulator, ThreadGroupSize);
+  const std::optional<std::vector<BYTE>> MatrixABuffer =
+      cpu_oracle::encodeLogicalMatrixBuffer(MatrixA, Case.MatrixAValues);
+  const std::optional<std::vector<BYTE>> MatrixBBuffer =
+      cpu_oracle::encodeLogicalMatrixBuffer(MatrixB, Case.MatrixBValues);
+  const std::optional<std::vector<BYTE>> AccumulatorBuffer =
+      Case.hasInitialAccumulator() ? cpu_oracle::encodeLogicalMatrixBuffer(
+                                         Accumulator, Case.AccumulatorValues)
+                                   : std::optional<std::vector<BYTE>>();
+  const std::optional<std::vector<int64_t>> ExpectedValues =
+      calculateMatrixMultiplyExpected(Case);
+  const std::optional<std::vector<BYTE>> Expected =
+      ExpectedValues.has_value()
+          ? cpu_oracle::encodeLogicalMatrixBuffer(Accumulator, *ExpectedValues)
+          : std::optional<std::vector<BYTE>>();
+  const std::optional<std::string> Args =
+      buildThreadGroupMultiplyCompilerArgs(Case, WaveSize, ThreadGroupSize);
+  VERIFY_IS_TRUE(MatrixABuffer.has_value());
+  VERIFY_IS_TRUE(MatrixBBuffer.has_value());
+  VERIFY_IS_TRUE(!Case.hasInitialAccumulator() ||
+                 AccumulatorBuffer.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  VERIFY_IS_TRUE(Args.has_value());
+  if (!MatrixABuffer.has_value() || !MatrixBBuffer.has_value() ||
+      (Case.hasInitialAccumulator() && !AccumulatorBuffer.has_value()) ||
+      !Expected.has_value() || !Args.has_value())
+    return;
+
+  const char *RootSignature = Case.hasInitialAccumulator()
+                                  ? "SRV(t0), SRV(t1), SRV(t2), UAV(u3)"
+                                  : "SRV(t0), SRV(t1), UAV(u2)";
+  compileShader(DxcSupport, ThreadGroupMultiplyShader, "cs_6_10", *Args,
+                Verbose);
+
+  auto Op = createComputeOp(ThreadGroupMultiplyShader, "cs_6_10", RootSignature,
+                            Args->c_str());
+  addSRVBuffer(Op.get(), "MatrixAInput", MatrixABuffer->size(), "byname");
+  addSRVBuffer(Op.get(), "MatrixBInput", MatrixBBuffer->size(), "byname");
+  if (Case.hasInitialAccumulator())
+    addSRVBuffer(Op.get(), "AccumulatorInput", AccumulatorBuffer->size(),
+                 "byname");
+  addUAVBuffer(Op.get(), "Output", Expected->size(), true);
+  addRootView(Op.get(), 0, "MatrixAInput");
+  addRootView(Op.get(), 1, "MatrixBInput");
+  if (Case.hasInitialAccumulator()) {
+    addRootView(Op.get(), 2, "AccumulatorInput");
+    addRootView(Op.get(), 3, "Output");
+  } else {
+    addRootView(Op.get(), 2, "Output");
+  }
+
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        const std::vector<BYTE> *Source = nullptr;
+        if (strcmp(Name, "MatrixAInput") == 0)
+          Source = &*MatrixABuffer;
+        else if (strcmp(Name, "MatrixBInput") == 0)
+          Source = &*MatrixBBuffer;
+        else if (Case.hasInitialAccumulator() &&
+                 strcmp(Name, "AccumulatorInput") == 0)
+          Source = &*AccumulatorBuffer;
+        if (!Source)
+          return;
+        VERIFY_IS_TRUE(
+            Data.size() == Source->size(),
+            "ThreadGroup matrix arithmetic initializer size mismatch");
+        std::copy(Source->begin(), Source->end(), Data.begin());
+      });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  const cpu_oracle::BufferResultOracle Oracle =
+      cpu_oracle::exactBufferResult(*Expected, Case.PublicRule);
+  VERIFY_IS_TRUE(cpu_oracle::verifyBufferResult(OutData.data(), OutData.size(),
+                                                Oracle, Verbose));
+}
+
+static void runCapabilityCheckedThreadGroupMultiply(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const MatrixMultiplyCaseData &Case,
+    linalg_test::CapabilityRequirement Requirement, LPCWSTR CaseName,
+    bool Verbose) {
+  VERIFY_IS_TRUE(isMatrixMultiplyCaseValid(Case));
+  if (!isMatrixMultiplyCaseValid(Case))
+    return;
+
+  bool Supported;
+  UINT SelectedWaveSize;
+  UINT SelectedThreadGroupSize;
+  const HRESULT HR = queryThreadGroupMatrixMultiplyCaseSupport(
+      Device, Case.MatrixAType, Case.MatrixBType, Case.AccumulatorType, Case.M,
+      Case.K, Case.N, CaseName, Supported, SelectedWaveSize,
+      SelectedThreadGroupSize);
+  const linalg_test::Applicability Applicability =
+      linalg_test::classifyApplicability(HR, Supported, Requirement);
+  if (!applyApplicability(Applicability, CaseName))
+    return;
+  runThreadGroupMultiplyCase(Device, DxcSupport, Case, SelectedWaveSize,
+                             SelectedThreadGroupSize, Verbose);
+}
+
+static MatrixMultiplyCaseData
+makeRectangularF16ThreadGroupMultiplyCase(ComponentType AccumulatorType,
+                                          MatrixMultiplyOperation Operation) {
+  MatrixMultiplyCaseData Case = {};
+  Case.MatrixAType = ComponentType::F16;
+  Case.MatrixBType = ComponentType::F16;
+  Case.AccumulatorType = AccumulatorType;
+  Case.M = 8;
+  Case.K = 16;
+  Case.N = 8;
+  Case.Operation = Operation;
+  Case.MatrixAValues = makeMatrixArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
+  Case.MatrixBValues = makeMatrixArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
+  if (Case.hasInitialAccumulator()) {
+    Case.AccumulatorValues =
+        makeMatrixArithmeticPattern(Case.M, Case.N, 2, 1, 5, 2);
+    Case.PublicRule =
+        L"Exact ThreadGroup F16 products plus an independent F32 accumulator";
+  } else {
+    Case.PublicRule =
+        L"Exact non-uniform rectangular ThreadGroup F16 matrix product";
+  }
+  return Case;
+}
+
+void DxilConf_SM610_LinAlg::MatMatMul_ThreadGroup_8x16x8_F16_NonUniform() {
+  const MatrixMultiplyCaseData Case = makeRectangularF16ThreadGroupMultiplyCase(
+      ComponentType::F16, MatrixMultiplyOperation::Multiply);
+  runCapabilityCheckedThreadGroupMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMul_ThreadGroup_8x16x8_F16_NonUniform", VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    MatMatMulAccum_ThreadGroup_8x16x8_F16_ToF32_NonUniform() {
+  const MatrixMultiplyCaseData Case = makeRectangularF16ThreadGroupMultiplyCase(
+      ComponentType::F32, MatrixMultiplyOperation::MultiplyAccumulate);
+  runCapabilityCheckedThreadGroupMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMulAccum_ThreadGroup_8x16x8_F16_ToF32_NonUniform",
+      VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::MatMatMul_ThreadGroup_8x8x8_I32() {
+  MatrixMultiplyCaseData Case = {};
+  Case.MatrixAType = ComponentType::I32;
+  Case.MatrixBType = ComponentType::I32;
+  Case.AccumulatorType = ComponentType::I32;
+  Case.M = 8;
+  Case.K = 8;
+  Case.N = 8;
+  Case.MatrixAValues = makeMatrixArithmeticPattern(Case.M, Case.K, 3, 2, 5, 2);
+  Case.MatrixBValues = makeMatrixArithmeticPattern(Case.K, Case.N, 1, 3, 7, 3);
+  Case.PublicRule = L"Exact non-uniform ThreadGroup I32 matrix product";
+  runCapabilityCheckedThreadGroupMultiply(
+      D3DDevice, DxcSupport, Case,
+      linalg_test::CapabilityRequirement::CapabilityGated,
+      L"MatMatMul_ThreadGroup_8x8x8_I32", VerboseLogging);
 }
 
 struct WaveAccumulateCaseData {
@@ -4692,8 +5155,8 @@ void DxilConf_SM610_LinAlg::MatAccum_Wave_8x32_F16_BUse_NonUniform() {
   Case.M = 8;
   Case.N = 32;
   Case.AccumulatorValues =
-      makeWaveArithmeticPattern(Case.M, Case.N, 2, 1, 7, 3);
-  Case.RHSValues = makeWaveArithmeticPattern(Case.M, Case.N, 1, 3, 5, 2);
+      makeMatrixArithmeticPattern(Case.M, Case.N, 2, 1, 7, 3);
+  Case.RHSValues = makeMatrixArithmeticPattern(Case.M, Case.N, 1, 3, 5, 2);
   Case.PublicRule =
       L"Exact non-uniform F16 accumulator plus a B-use F16 matrix";
   runWaveAccumulateCase(D3DDevice, DxcSupport, Case,


### PR DESCRIPTION
## Summary

- add capability-gated non-uniform Thread OuterProduct coverage for F16 8x16 and F32 4x8, while retaining and activating the existing F16 16x16 case
- accumulate in DXIL `OuterProductOptimal` layout and use the preview D3D12 matrix-conversion API for tight RowMajor host readback, with exact checked CPU expectations
- migrate the existing F16 length-four VectorAccumulate case to the shared harness and add F16/F32 length-eight cases with non-zero destinations and checked host multiplication/addition oracles
- replace the released-SDK OuterProduct skip with SDK-neutral preview ABI mirrors, validated against the preview headers
- require OuterProduct cases to advertise both ThreadOuterProduct and RWByteAddressBuffer atomic accumulation, assert every field offset in the conversion ABI mirrors, and guard every vector destination with typed trailing sentinels

The shader and host APIs intentionally use their respective enum values for `OuterProductOptimal`: DXIL layout value 4 and D3D12 conversion layout value 3.

## Validation

- built the Release `ExecHLSLTests` target
- compiled both changed implementation units against the preview D3D12 headers, activating exhaustive ABI size, alignment, field-offset and enum assertions
- ran the capability-policy host test plus all 3 OuterProduct methods on the compatible WARP/Agility runtime: 4 passed; each OuterProduct case positively queried both operation capabilities
- ran all 3 VectorAccumulate methods on the compatible WARP decoder: 3 passed, including exact verification of typed trailing guards
- ran the complete 60-case LinAlg selection with the compatible local runtime: 57 passed, the unchanged FP8 and ColumnMajor capability cases skipped, and only the already-documented mandatory native-F32/SInt8 MatVec WARP defect failed
- inspected emitted DXIL for Thread scope, Accumulator use, non-uniform shapes, layout value 4 and handle-first VectorAccumulate operands
- clang-format 17.0.1, `git diff --check` and a focused correctness review pass

## Runtime compatibility notes

Public preview WARP currently decodes VectorAccumulate using the obsolete vector-first operand order, while current DXC emits the specified handle-first order. Agility SDK 1.721 also rejects `ConvertLinearAlgebraMatrix` on a compute command list; the local OuterProduct run used the documented DIRECT-list compatibility workaround. Neither disposable runtime change is included here, and the tests retain the current compiler/runtime contract rather than hiding either defect.
- after the MatVec, Wave, ThreadGroup, and outer-vector review corrections were propagated through the complete stack, the 66-method suite on the compatible local runtime reported 61 passed, 0 failed, and 5 capability-backed skips

No physical GPU or packaged-HLK qualification is claimed.

## Stack

This draft is stacked on PR #8674, which is stacked on PR #8673, PR #8672, PR #8671, PR #8670, PR #8669, PR #8668, PR #8667, PR #8666, PR #8665 and PR #8662. Until those ancestors land, this diff contains their commits as well. The OuterProduct and VectorAccumulate implementation is commit `8ac77765e6`; review correction `353ca9a02` adds complete applicability, ABI-offset, and trailing-guard validation.

This remains a draft for named human review. The reviewer should verify the complete preview ABI mirrors, distinct DXIL/host layout values, intersected OuterProduct/atomic capability tuples, conversion/readback path, VectorAccumulate operand contract, trailing guards, and independent exact oracles before requesting maintainer review.

Refs #7841
Refs #8563
Refs #8565

Assisted-by: GitHub Copilot

Closes #8694
