### PR TITLE
[SM6.10] LinAlg: Update Header to match spec

### DIFF
--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -19,8 +19,6 @@
 #pragma dxc diagnostic push
 #pragma dxc diagnostic ignored "-Whlsl-groupshared-202x"
 
-#define SIZE_TYPE int
-
 namespace dxil {
 
 // This enum must _exactly_ match the DXIL constants.
@@ -242,8 +240,8 @@ class Matrix {
 
   template <ComponentEnum NewCompTy, MatrixUseEnum NewUse = Use,
             bool Transpose = false>
-  Matrix<NewCompTy, __detail::DimMN<M, N, Transpose>::M,
-         __detail::DimMN<M, N, Transpose>::N, NewUse, Scope>
+  [[nodiscard]] Matrix<NewCompTy, __detail::DimMN<M, N, Transpose>::M,
+                       __detail::DimMN<M, N, Transpose>::N, NewUse, Scope>
   Cast() {
     Matrix<NewCompTy, __detail::DimMN<M, N, Transpose>::M,
            __detail::DimMN<M, N, Transpose>::N, NewUse, Scope>
@@ -261,16 +259,18 @@ class Matrix {
     return Result;
   }
 
-  static Matrix Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
-                     MatrixLayoutEnum Layout, uint Align = 128) {
+  [[nodiscard]] static Matrix Load(ByteAddressBuffer Res, uint StartOffset,
+                                   uint Stride, MatrixLayoutEnum Layout,
+                                   uint Align = 128) {
     Matrix Result;
     __builtin_LinAlg_MatrixLoadFromDescriptor(Result.__handle, Res, StartOffset,
                                               Stride, Layout, Align);
     return Result;
   }
 
-  static Matrix Load(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
-                     MatrixLayoutEnum Layout, uint Align = 128) {
+  [[nodiscard]] static Matrix Load(RWByteAddressBuffer Res, uint StartOffset,
+                                   uint Stride, MatrixLayoutEnum Layout,
+                                   uint Align = 128) {
     Matrix Result;
     __builtin_LinAlg_MatrixLoadFromDescriptor(Result.__handle, Res, StartOffset,
                                               Stride, Layout, Align);
@@ -278,9 +278,12 @@ class Matrix {
   }
 
   template <typename T, SIZE_TYPE Size>
-  static typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                                      (M * N / ElementsPerScalar <= Size),
-                                  Matrix>::type
+  [[nodiscard]] static typename hlsl::enable_if<
+      (hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                     ElementType>::value ||
+       hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                     uint8_t4_packed>::value),
+      Matrix>::type
   Load(groupshared T Arr[Size], uint StartIdx, uint Stride,
        MatrixLayoutEnum Layout) {
     Matrix Result;
@@ -326,9 +329,12 @@ class Matrix {
   }
 
   template <typename T, SIZE_TYPE Size>
-  typename hlsl::enable_if<hlsl::is_arithmetic<T>::value &&
-                               (M * N / ElementsPerScalar <= Size),
-                           void>::type
+  typename hlsl::enable_if<
+      (hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                     ElementType>::value ||
+       hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                     uint8_t4_packed>::value),
+      void>::type
   Store(groupshared T Arr[Size], uint StartIdx, uint Stride,
         MatrixLayoutEnum Layout) {
     __builtin_LinAlg_MatrixStoreToMemory(__handle, Arr, StartIdx, Stride,
@@ -348,14 +354,28 @@ class Matrix {
   template <typename T, MatrixUseEnum UseLocal = Use,
             MatrixScopeEnum ScopeLocal = Scope, SIZE_TYPE Size>
   typename hlsl::enable_if<
-      hlsl::is_arithmetic<T>::value && Use == MatrixUse::Accumulator &&
-          UseLocal == Use && (M * N / ElementsPerScalar <= Size) &&
+      hlsl::is_arithmetic_vector<T>::value && Use == MatrixUse::Accumulator &&
+          UseLocal == Use && Scope == MatrixScope::Wave && ScopeLocal == Scope,
+      void>::type
+  InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx, uint Stride,
+                        MatrixLayoutEnum Layout) {
+    __builtin_LinAlg_MatrixAccumulateToMemory(__handle, Arr, ComponentTy,
+                                              StartIdx, Stride, Layout);
+  }
+
+  template <ComponentEnum TargetCompTy = ComponentTy, typename T,
+            MatrixUseEnum UseLocal = Use, MatrixScopeEnum ScopeLocal = Scope,
+            SIZE_TYPE Size>
+  typename hlsl::enable_if<
+      hlsl::is_same<typename hlsl::strip_vector_type<T>::type,
+                    uint8_t4_packed>::value &&
+          Use == MatrixUse::Accumulator && UseLocal == Use &&
           Scope == MatrixScope::Wave && ScopeLocal == Scope,
       void>::type
   InterlockedAccumulate(groupshared T Arr[Size], uint StartIdx, uint Stride,
                         MatrixLayoutEnum Layout) {
-    __builtin_LinAlg_MatrixAccumulateToMemory(__handle, Arr, 0, StartIdx,
-                                              Stride, Layout);
+    __builtin_LinAlg_MatrixAccumulateToMemory(__handle, Arr, TargetCompTy,
+                                              StartIdx, Stride, Layout);
   }
 
   template <ComponentEnum CompTy, MatrixUseEnum UseLocal = Use>
@@ -395,9 +415,11 @@ class Matrix<ComponentTy, M, N, Use, MatrixScope::Thread> {
   HandleT __handle;
 
   template <MatrixLayoutEnum Layout, MatrixUseEnum UseLocal = Use>
-  static typename hlsl::enable_if<Use == MatrixUse::A && UseLocal == Use,
-                                  Matrix>::type
-  Load(ByteAddressBuffer Res, uint StartOffset, uint Stride, uint Align = 128) {
+  [[nodiscard]] static
+      typename hlsl::enable_if<Use == MatrixUse::A && UseLocal == Use,
+                               Matrix>::type
+      Load(ByteAddressBuffer Res, uint StartOffset, uint Stride,
+           uint Align = 128) {
     Matrix Result;
     __builtin_LinAlg_MatrixLoadFromDescriptor(Result.__handle, Res, StartOffset,
                                               Stride, Layout, Align);
@@ -419,7 +441,7 @@ MatrixUseEnum AccumulatorLayout() {
 
 template <ComponentEnum OutTy, ComponentEnum ATy, ComponentEnum BTy,
           SIZE_TYPE M, SIZE_TYPE N, SIZE_TYPE K>
-Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Wave>
+[[nodiscard]] Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Wave>
 Multiply(const Matrix<ATy, M, K, MatrixUse::A, MatrixScope::Wave> MatrixA,
          const Matrix<BTy, K, N, MatrixUse::B, MatrixScope::Wave> MatrixB) {
   Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Wave> Result;
@@ -429,7 +451,7 @@ Multiply(const Matrix<ATy, M, K, MatrixUse::A, MatrixScope::Wave> MatrixA,
 }
 
 template <ComponentEnum CompTy, SIZE_TYPE M, SIZE_TYPE N, SIZE_TYPE K>
-Matrix<CompTy, M, N, MatrixUse::Accumulator, MatrixScope::Wave>
+[[nodiscard]] Matrix<CompTy, M, N, MatrixUse::Accumulator, MatrixScope::Wave>
 Multiply(const Matrix<CompTy, M, K, MatrixUse::A, MatrixScope::Wave> MatrixA,
          const Matrix<CompTy, K, N, MatrixUse::B, MatrixScope::Wave> MatrixB) {
   Matrix<CompTy, M, N, MatrixUse::Accumulator, MatrixScope::Wave> Result;
@@ -440,7 +462,9 @@ Multiply(const Matrix<CompTy, M, K, MatrixUse::A, MatrixScope::Wave> MatrixA,
 
 template <ComponentEnum OutTy, ComponentEnum ATy, ComponentEnum BTy,
           SIZE_TYPE M, SIZE_TYPE N, SIZE_TYPE K>
-Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::ThreadGroup> Multiply(
+[[nodiscard]] Matrix<OutTy, M, N, MatrixUse::Accumulator,
+                     MatrixScope::ThreadGroup>
+Multiply(
     const Matrix<ATy, M, K, MatrixUse::A, MatrixScope::ThreadGroup> MatrixA,
     const Matrix<BTy, K, N, MatrixUse::B, MatrixScope::ThreadGroup> MatrixB) {
   Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::ThreadGroup> Result;
@@ -450,7 +474,9 @@ Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::ThreadGroup> Multiply(
 }
 
 template <ComponentEnum CompTy, SIZE_TYPE M, SIZE_TYPE N, SIZE_TYPE K>
-Matrix<CompTy, M, N, MatrixUse::Accumulator, MatrixScope::ThreadGroup> Multiply(
+[[nodiscard]] Matrix<CompTy, M, N, MatrixUse::Accumulator,
+                     MatrixScope::ThreadGroup>
+Multiply(
     const Matrix<CompTy, M, K, MatrixUse::A, MatrixScope::ThreadGroup> MatrixA,
     const Matrix<CompTy, K, N, MatrixUse::B, MatrixScope::ThreadGroup>
         MatrixB) {
@@ -493,7 +519,8 @@ Multiply(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
 
 template <typename OutputElTy, typename InputElTy, typename BiasElTy,
           SIZE_TYPE M, SIZE_TYPE K, ComponentEnum MatrixDT>
-typename hlsl::enable_if<hlsl::is_arithmetic<InputElTy>::value,
+typename hlsl::enable_if<hlsl::is_arithmetic<InputElTy>::value &&
+                             hlsl::is_arithmetic<BiasElTy>::value,
                          vector<OutputElTy, M> >::type
 MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
             vector<InputElTy, K> Vec, vector<BiasElTy, M> Bias) {
@@ -511,10 +538,11 @@ MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
 }
 
 template <typename OutputElTy, typename InputElTy, ComponentEnum InputInterp,
-          typename BiasElTy, SIZE_TYPE M, SIZE_TYPE VecK, SIZE_TYPE K,
+          typename BiasElTy, SIZE_TYPE M, SIZE_TYPE K, SIZE_TYPE VecK,
           ComponentEnum MatrixDT>
 typename hlsl::enable_if<
-    VecK == __detail::ScalarCountFromPackedComponents<InputInterp, K>::Value,
+    VecK == __detail::ScalarCountFromPackedComponents<InputInterp, K>::Value &&
+        hlsl::is_arithmetic<BiasElTy>::value,
     vector<OutputElTy, M> >::type
 MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
             InterpretedVector<InputElTy, VecK, InputInterp> InterpVec,
@@ -532,16 +560,16 @@ MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
   return Result;
 }
 
-template <typename OutputElTy, typename InputElTy, ComponentEnum BiasInterp,
+template <typename OutputElTy, typename InputElTy, ComponentEnum BiasElTy,
           SIZE_TYPE M, SIZE_TYPE K, ComponentEnum MatrixDT>
 typename hlsl::enable_if<hlsl::is_arithmetic<InputElTy>::value,
                          vector<OutputElTy, M> >::type
 MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
-            vector<InputElTy, K> Vec, VectorRef<BiasInterp, M> BiasRef) {
+            vector<InputElTy, K> Vec, VectorRef<BiasElTy, M> BiasRef) {
 
   using BiasVecTy =
-      vector<typename __detail::ComponentTypeTraits<BiasInterp>::Type,
-             __detail::ScalarCountFromPackedComponents<BiasInterp, M>::Value>;
+      vector<typename __detail::ComponentTypeTraits<BiasElTy>::Type,
+             __detail::ScalarCountFromPackedComponents<BiasElTy, M>::Value>;
   BiasVecTy Bias = BiasRef.Buf.template Load<BiasVecTy>(BiasRef.Offset);
 
   // FIXME: Convert currently does not support packed type vector sizes that
@@ -555,13 +583,13 @@ MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
   // Convert to OutputElTy vector with padding
   using BiasConvInterpPaddedTy = InterpretedVector<
       OutputElTy,
-      __detail::DstN<__detail::TypeTraits<OutputElTy>::CompType, BiasInterp,
+      __detail::DstN<__detail::TypeTraits<OutputElTy>::CompType, BiasElTy,
                      __detail::ScalarCountFromPackedComponents<
-                         BiasInterp, M>::Value>::Value,
+                         BiasElTy, M>::Value>::Value,
       __detail::TypeTraits<OutputElTy>::CompType>;
 
   BiasConvInterpPaddedTy BiasConvInterpPadded =
-      Convert<__detail::TypeTraits<OutputElTy>::CompType, BiasInterp>(Bias);
+      Convert<__detail::TypeTraits<OutputElTy>::CompType, BiasElTy>(Bias);
 
   // Truncate the vector to the correct size M
   vector<OutputElTy, M> BiasConv =
@@ -576,17 +604,17 @@ MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
 }
 
 template <typename OutputElTy, typename InputElTy, ComponentEnum InputInterp,
-          ComponentEnum BiasInterp, SIZE_TYPE M, SIZE_TYPE VecK, SIZE_TYPE K,
+          ComponentEnum BiasElTy, SIZE_TYPE M, SIZE_TYPE K, SIZE_TYPE VecK,
           ComponentEnum MatrixDT>
 typename hlsl::enable_if<
     VecK == __detail::ScalarCountFromPackedComponents<InputInterp, K>::Value,
     vector<OutputElTy, M> >::type
 MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
             InterpretedVector<InputElTy, VecK, InputInterp> InterpVec,
-            VectorRef<BiasInterp, M> BiasRef) {
+            VectorRef<BiasElTy, M> BiasRef) {
   using BiasVecTy =
-      vector<typename __detail::ComponentTypeTraits<BiasInterp>::Type,
-             __detail::ScalarCountFromPackedComponents<BiasInterp, M>::Value>;
+      vector<typename __detail::ComponentTypeTraits<BiasElTy>::Type,
+             __detail::ScalarCountFromPackedComponents<BiasElTy, M>::Value>;
   BiasVecTy Bias = BiasRef.Buf.template Load<BiasVecTy>(BiasRef.Offset);
 
   // FIXME: Convert currently does not support packed type vector sizes that
@@ -600,13 +628,13 @@ MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
   // Convert to OutputElTy vector with padding
   using BiasConvInterpPaddedTy = InterpretedVector<
       OutputElTy,
-      __detail::DstN<__detail::TypeTraits<OutputElTy>::CompType, BiasInterp,
+      __detail::DstN<__detail::TypeTraits<OutputElTy>::CompType, BiasElTy,
                      __detail::ScalarCountFromPackedComponents<
-                         BiasInterp, M>::Value>::Value,
+                         BiasElTy, M>::Value>::Value,
       __detail::TypeTraits<OutputElTy>::CompType>;
 
   BiasConvInterpPaddedTy BiasConvInterpPadded =
-      Convert<__detail::TypeTraits<OutputElTy>::CompType, BiasInterp>(Bias);
+      Convert<__detail::TypeTraits<OutputElTy>::CompType, BiasElTy>(Bias);
 
   // Truncate the vector to the correct size M
   vector<OutputElTy, M> BiasConv =
@@ -622,7 +650,9 @@ MultiplyAdd(Matrix<MatrixDT, M, K, MatrixUse::A, MatrixScope::Thread> MatrixA,
 
 // Outer product functions
 template <ComponentEnum OutTy, typename InputElTy, SIZE_TYPE M, SIZE_TYPE N>
-Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Thread>
+[[nodiscard]] typename hlsl::enable_if<
+    hlsl::is_arithmetic<InputElTy>::value,
+    Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Thread> >::type
 OuterProduct(vector<InputElTy, M> VecA, vector<InputElTy, N> VecB) {
   Matrix<OutTy, M, N, MatrixUse::Accumulator, MatrixScope::Thread> Result;
   __builtin_LinAlg_MatrixOuterProduct(Result.__handle, VecA, VecB);

--- a/tools/clang/lib/Headers/hlsl/type_traits
+++ b/tools/clang/lib/Headers/hlsl/type_traits
@@ -14,7 +14,17 @@
 
 #if __HLSL_VERSION >= 2021
 
+#define SIZE_TYPE int
+
 namespace hlsl {
+
+template <typename T, typename U> struct is_same {
+  static const bool value = false;
+};
+
+template <typename T> struct is_same<T, T> {
+  static const bool value = true;
+};
 
 template <typename T> struct is_arithmetic {
   static const bool value = false;
@@ -37,6 +47,8 @@ __ARITHMETIC_TYPE(half)
 __ARITHMETIC_TYPE(float)
 __ARITHMETIC_TYPE(double)
 
+#undef __ARITHMETIC_TYPE
+
 template <typename T> struct is_signed {
   static const bool value = true;
 };
@@ -53,6 +65,29 @@ __UNSIGNED_TYPE(uint)
 __UNSIGNED_TYPE(uint64_t)
 
 #undef __UNSIGNED_TYPE
+
+template <typename T> struct is_vector {
+  static const bool value = false;
+};
+
+template <typename T, uint N> struct is_vector<vector<T, N> > {
+  static const bool value = true;
+};
+
+template <typename T> struct strip_vector_type {
+  using type = T;
+};
+
+template <typename T, SIZE_TYPE N> struct strip_vector_type<vector<T, N> > {
+  using type = T;
+};
+
+template <typename T> struct is_arithmetic_vector {
+  static const bool value =
+      is_arithmetic<T>::value ||
+      (is_vector<T>::value &&
+       is_arithmetic<typename strip_vector_type<T>::type>::value);
+};
 
 } // namespace hlsl
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
@@ -18,6 +18,7 @@ using Matrix84TyInt = Matrix<ComponentType::I32, 8, 4, MatrixUse::A, MatrixScope
 ByteAddressBuffer BAB : register(t0);
 RWByteAddressBuffer RWBAB : register(u0);
 groupshared float SharedArr[256];
+groupshared uint8_t4_packed PackedArr[256];
 
 [numthreads(4, 4, 4)]
 void main(uint ID : SV_GroupID)
@@ -78,6 +79,15 @@ void main(uint ID : SV_GroupID)
 // CHECK-SAME: i32 0, i32 16, i32 1)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
   MatrixBTy MatB3 = MatrixBTy::Load(SharedArr, 0, 16, MatrixLayoutEnum::ColMajor);
 
+// Matrix::Load from packed groupshared memory
+//
+// CHECK: %[[MATB4:.*]] = call %dx.types.LinAlgMatrixC9M4N4U1S1
+// CHECK-SAME: @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U1S1.i32(i32 -2147483633,
+// CHECK-SAME: i32 addrspace(3)* getelementptr inbounds ([256 x i32],
+// CHECK-SAME: [256 x i32] addrspace(3)* @"\01?PackedArr@@3PA$ui8_4pk@A", i32 0, i32 0),
+// CHECK-SAME: i32 0, i32 16, i32 1)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  MatrixBTy MatB4 = MatrixBTy::Load(PackedArr, 0, 16, MatrixLayoutEnum::ColMajor);
+
 // Matrix::Length
 //
 // CHECK: call i32 @dx.op.linAlgMatrixLength.mC9M4N4U0S1(i32 -2147483632,
@@ -118,9 +128,17 @@ void main(uint ID : SV_GroupID)
 //
 // CHECK: call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U1S1.f32(i32 -2147483627,
 // CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U1S1 %[[MATB2]], float addrspace(3)* getelementptr inbounds
- // CHECK-SAME: ([256 x float], [256 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0),
+// CHECK-SAME: ([256 x float], [256 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0),
 // CHECK-SAME: i32 0, i32 16, i32 1)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
   MatB2.Store(SharedArr, 0, 16, MatrixLayoutEnum::ColMajor);
+
+// Matrix::Store to packed groupshared memory
+//
+// CHECK: call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U1S1.i32(i32 -2147483627,
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U1S1 %[[MATB4]], i32 addrspace(3)* getelementptr inbounds
+// CHECK-SAME: ([256 x i32], [256 x i32] addrspace(3)* @"\01?PackedArr@@3PA$ui8_4pk@A", i32 0, i32 0),
+// CHECK-SAME: i32 0, i32 16, i32 1)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
+  MatB4.Store(PackedArr, 0, 16, MatrixLayoutEnum::ColMajor);
 
 // CHECK: %[[ACCUM0:.*]] = call %dx.types.LinAlgMatrixC9M4N4U2S1 @dx.op.linAlgFillMatrix.mC9M4N4U2S1.f32(
 // CHECK-SAME: i32 -2147483636, float 1.400000e+01)  ; LinAlgFillMatrix(value)
@@ -138,9 +156,24 @@ void main(uint ID : SV_GroupID)
 // CHECK: call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620,
 // CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM0]],
 // CHECK-SAME: float addrspace(3)* getelementptr inbounds ([256 x float],
-// CHECK-SAME: [256 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 0, i32 0, i32 16, i32 1)
+// CHECK-SAME: [256 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 0, i32 16, i32 1)
 // CHECK-SAME: ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
   AccMat1.InterlockedAccumulate(SharedArr, 0, 16, MatrixLayoutEnum::ColMajor);
+
+// Matrix::InterlockedAccumulate to packed groupshared memory
+//
+// CHECK: call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.i32(i32 -2147483620,
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM0]],
+// CHECK-SAME: i32 addrspace(3)* getelementptr inbounds ([256 x i32],
+// CHECK-SAME: [256 x i32] addrspace(3)* @"\01?PackedArr@@3PA$ui8_4pk@A", i32 0, i32 0), i32 9, i32 0, i32 16, i32 1)
+// CHECK-SAME: ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
+  AccMat1.InterlockedAccumulate(PackedArr, 0, 16, MatrixLayoutEnum::ColMajor);
+// CHECK: call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.i32(i32 -2147483620,
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM0]],
+// CHECK-SAME: i32 addrspace(3)* getelementptr inbounds ([256 x i32],
+// CHECK-SAME: [256 x i32] addrspace(3)* @"\01?PackedArr@@3PA$ui8_4pk@A", i32 0, i32 0), i32 4, i32 0, i32 16, i32 1)
+// CHECK-SAME: ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
+  AccMat1.InterlockedAccumulate<ComponentType::I32>(PackedArr, 0, 16, MatrixLayoutEnum::ColMajor);
 
 // Matrix::Accumulate
 //


### PR DESCRIPTION
Fixes #8634 

Updates the header file and tests to match https://github.com/microsoft/hlsl-specs/pull/879

Also adds `[[nodiscard]]` to all functions that return a Matrix