### PR TITLE
[HLK] Gate GroupSharedLimit tests on runtime feature support (not D3D12_PREVIEW_SDK_VERSION)

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -10647,8 +10647,9 @@ static bool CreateGSMLimitTestDevice(D3D12SDKSelector *D3D12SDK,
   // released-SDK runtime): the group-shared-memory query returns 0.
   if (getMaxGroupSharedMemoryCS(Device) == 0) {
     if (FailIfRequirementsNotMet)
-      LogErrorFmt(L"D3D12_FEATURE_D3D12_OPTIONS_PREVIEW not supported, resulting "
-                  L"in test failure, since FailIfRequirementsNotMet is set.");
+      LogErrorFmt(
+          L"D3D12_FEATURE_D3D12_OPTIONS_PREVIEW not supported, resulting "
+          L"in test failure, since FailIfRequirementsNotMet is set.");
     else
       LogCommentFmt(L"Skipping: D3D12_FEATURE_D3D12_OPTIONS_PREVIEW not "
                     L"supported by this runtime.");

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -210,13 +210,9 @@ public:
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(WaveSizeTest);
   TEST_METHOD(WaveSizeRangeTest);
-  // TODO(#8661): Remove me when GroupSharedLimit is available in a released
-  // Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
   TEST_METHOD(GroupSharedLimitTest);
   TEST_METHOD(GroupSharedLimitASTest);
   TEST_METHOD(GroupSharedLimitMSTest);
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
   TEST_METHOD(GroupWaveIndexTest);
   TEST_METHOD(PartialDerivTest);
   TEST_METHOD(DerivativesTest);
@@ -10628,9 +10624,6 @@ void ExecutionTest::WaveSizeRangeTest() {
                        m_support);
 }
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released
-// Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
 // Helper: create a SM 6.10 device with HLK-aware skip/fail logic.
 // Returns true if device was created, false if skipped.
 static bool CreateGSMLimitTestDevice(D3D12SDKSelector *D3D12SDK,
@@ -10648,6 +10641,17 @@ static bool CreateGSMLimitTestDevice(D3D12SDKSelector *D3D12SDK,
     if (FailIfRequirementsNotMet)
       LogErrorFmt(L"Device creation failed, resulting in test failure, since "
                   L"FailIfRequirementsNotMet is set.");
+    return false;
+  }
+  // Skip when the runtime lacks the preview OPTIONS_PREVIEW feature (e.g. a
+  // released-SDK runtime): the group-shared-memory query returns 0.
+  if (getMaxGroupSharedMemoryCS(Device) == 0) {
+    if (FailIfRequirementsNotMet)
+      LogErrorFmt(L"D3D12_FEATURE_D3D12_OPTIONS_PREVIEW not supported, resulting "
+                  L"in test failure, since FailIfRequirementsNotMet is set.");
+    else
+      LogCommentFmt(L"Skipping: D3D12_FEATURE_D3D12_OPTIONS_PREVIEW not "
+                    L"supported by this runtime.");
     return false;
   }
   return true;
@@ -10941,7 +10945,6 @@ void ExecutionTest::GroupSharedLimitMSTest() {
         L"MS Test passed: GroupSharedLimit in mesh shader succeeded.");
   }
 }
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
 
 void ExecutionTest::GroupWaveIndexTest() {
   WEX::TestExecution::SetVerifyOutput VerifySettings(

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -12,24 +12,22 @@
 #include <filesystem>
 #include <optional>
 
-// D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
-// the released Windows SDK. Define locally so the test can query variable
-// group shared memory capabilities from the Agility SDK runtime.
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released
-// Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION < 720
-
-#ifndef D3D12_FEATURE_D3D12_OPTIONS_PREVIEW
-#define D3D12_FEATURE_D3D12_OPTIONS_PREVIEW ((D3D12_FEATURE)72)
-#endif
-
-typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
+// D3D12_FEATURE_D3D12_OPTIONS_PREVIEW (feature 72) reports variable group-shared
+// memory limits. It is not in the released Windows SDK, and internal D3D headers
+// only expose it in preview deployment tiers -- yet those headers still define
+// D3D12_PREVIEW_SDK_VERSION unconditionally, so that macro cannot be used to
+// detect the feature. Define the query privately (matching the runtime ABI:
+// feature id 72, three UINTs) so the test compiles against any SDK/tier without
+// colliding with the header's typedef; execution is gated on a runtime
+// CheckFeatureSupport query instead.
+namespace {
+constexpr D3D12_FEATURE DxcFeatureOptionsPreview = static_cast<D3D12_FEATURE>(72);
+struct DxcOptionsPreview {
   UINT MaxGroupSharedMemoryPerGroupCS;
   UINT MaxGroupSharedMemoryPerGroupAS;
   UINT MaxGroupSharedMemoryPerGroupMS;
-} D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW;
-
-#endif
+};
+} // namespace
 
 using namespace hlsl_test;
 
@@ -620,30 +618,31 @@ bool isFallbackPathEnabled() {
   return EnableFallbackValue != 0;
 }
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released
-// Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
+// Return the device's variable group-shared-memory limits, or 0 when the runtime
+// does not support the preview feature (callers skip in that case).
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
-  D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
-  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
+  DxcOptionsPreview O = {};
+  if (FAILED(Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O,
+                                         sizeof(O))))
+    return 0;
   return O.MaxGroupSharedMemoryPerGroupCS;
 }
 
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device) {
-  D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
-  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
+  DxcOptionsPreview O = {};
+  if (FAILED(Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O,
+                                         sizeof(O))))
+    return 0;
   return O.MaxGroupSharedMemoryPerGroupAS;
 }
 
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device) {
-  D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
-  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
+  DxcOptionsPreview O = {};
+  if (FAILED(Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O,
+                                         sizeof(O))))
+    return 0;
   return O.MaxGroupSharedMemoryPerGroupMS;
 }
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
 
 std::unique_ptr<st::ShaderOp> createComputeOp(const char *Source,
                                               const char *Target,

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -12,16 +12,17 @@
 #include <filesystem>
 #include <optional>
 
-// D3D12_FEATURE_D3D12_OPTIONS_PREVIEW (feature 72) reports variable group-shared
-// memory limits. It is not in the released Windows SDK, and internal D3D headers
-// only expose it in preview deployment tiers -- yet those headers still define
-// D3D12_PREVIEW_SDK_VERSION unconditionally, so that macro cannot be used to
-// detect the feature. Define the query privately (matching the runtime ABI:
-// feature id 72, three UINTs) so the test compiles against any SDK/tier without
-// colliding with the header's typedef; execution is gated on a runtime
-// CheckFeatureSupport query instead.
+// D3D12_FEATURE_D3D12_OPTIONS_PREVIEW (feature 72) reports variable
+// group-shared memory limits. It is not in the released Windows SDK, and
+// internal D3D headers only expose it in preview deployment tiers -- yet those
+// headers still define D3D12_PREVIEW_SDK_VERSION unconditionally, so that macro
+// cannot be used to detect the feature. Define the query privately (matching
+// the runtime ABI: feature id 72, three UINTs) so the test compiles against any
+// SDK/tier without colliding with the header's typedef; execution is gated on a
+// runtime CheckFeatureSupport query instead.
 namespace {
-constexpr D3D12_FEATURE DxcFeatureOptionsPreview = static_cast<D3D12_FEATURE>(72);
+constexpr D3D12_FEATURE DxcFeatureOptionsPreview =
+    static_cast<D3D12_FEATURE>(72);
 struct DxcOptionsPreview {
   UINT MaxGroupSharedMemoryPerGroupCS;
   UINT MaxGroupSharedMemoryPerGroupAS;
@@ -618,28 +619,28 @@ bool isFallbackPathEnabled() {
   return EnableFallbackValue != 0;
 }
 
-// Return the device's variable group-shared-memory limits, or 0 when the runtime
-// does not support the preview feature (callers skip in that case).
+// Return the device's variable group-shared-memory limits, or 0 when the
+// runtime does not support the preview feature (callers skip in that case).
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
   DxcOptionsPreview O = {};
-  if (FAILED(Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O,
-                                         sizeof(O))))
+  if (FAILED(
+          Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O, sizeof(O))))
     return 0;
   return O.MaxGroupSharedMemoryPerGroupCS;
 }
 
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device) {
   DxcOptionsPreview O = {};
-  if (FAILED(Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O,
-                                         sizeof(O))))
+  if (FAILED(
+          Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O, sizeof(O))))
     return 0;
   return O.MaxGroupSharedMemoryPerGroupAS;
 }
 
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device) {
   DxcOptionsPreview O = {};
-  if (FAILED(Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O,
-                                         sizeof(O))))
+  if (FAILED(
+          Device->CheckFeatureSupport(DxcFeatureOptionsPreview, &O, sizeof(O))))
     return 0;
   return O.MaxGroupSharedMemoryPerGroupMS;
 }

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -74,13 +74,11 @@ bool doesDeviceSupportEnhancedBarriers(ID3D12Device *pDevice);
 bool doesDeviceSupportRelaxedFormatCasting(ID3D12Device *pDevice);
 bool isFallbackPathEnabled();
 
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released
-// Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
+// Return the device's variable group-shared-memory limits, or 0 if the runtime
+// does not support the preview feature.
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device);
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
 
 /// Create a ShaderOp for a compute shader dispatch.
 std::unique_ptr<st::ShaderOp>


### PR DESCRIPTION
### What
Replaces the `#if defined(D3D12_PREVIEW_SDK_VERSION)` compile-time guard on the **GroupSharedLimit** HLK tests with a private feature definition + **runtime** capability gate. The tests are kept.

- `HlslExecTestUtils.cpp`: replace the local `D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW` fallback with a private `DxcOptionsPreview` struct + `DxcFeatureOptionsPreview = (D3D12_FEATURE)72`; helpers now return `0` on `CheckFeatureSupport` failure (no guard).
- `HlslExecTestUtils.h`: drop the guard around the helper declarations.
- `ExecutionTest.cpp`: drop the guards around the `TEST_METHOD`s and implementations; `CreateGSMLimitTestDevice` now skips (or fails under `FailIfRequirementsNotMet`) when the runtime lacks the feature (query returns 0).

### Why
`D3D12_PREVIEW_SDK_VERSION` is a valid feature proxy only for the **public** Windows SDK (macro present only in preview Agility headers, which also ship the struct). In **internal D3D/OS** builds the macro is defined **unconditionally** (a version constant, currently 721) while the `;preview` struct is DXSPLIT-stripped in retail tiers -- so `#if defined(...)` is always true, the helpers compile, and the missing struct breaks retail builds (Direct3D `Default`/`OSPrereleaseRetail` tiers; OS `D3d12.Dxil` pass). Gating on **actual feature/runtime availability** is correct across public SDK, Agility preview, and every internal deployment tier.

### Notes
- Compiles in all tiers (private names never collide with the header typedef).
- On runtimes without the feature (e.g. released SDK on GitHub CI), the tests **skip** instead of failing.
- Companion to the release-branch removal (#8703); this keeps coverage on `main`.
- Draft until reviewed.