### PR TITLE
[Exec] Enable the D3D12 debug layer on the Agility device factory

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -35,6 +35,12 @@ using namespace hlsl_test;
 
 static bool useDebugIfaces() { return true; }
 
+// Diagnostic only: records whether the D3D12 debug layer was successfully
+// enabled, so that a device unexpectedly missing ID3D12InfoQueue can be
+// reported without warning on every device creation on machines where the
+// debug layer is simply unavailable.
+static bool DebugLayerEnabled = false;
+
 bool useDxbc() {
 #ifdef _HLK_CONF
   return false;
@@ -94,6 +100,82 @@ static UINT getD3D12SDKVersion(std::wstring SDKPath) {
     LogCommentFmt(L"%s - unable to load", D3DCorePath.c_str());
   }
   return SDKVersion;
+}
+
+// D3D12 message severities are ordered most-to-least severe
+// (D3D12_MESSAGE_SEVERITY_CORRUPTION == 0), so a message is reported when its
+// severity is <= this threshold. -1 disables reporting entirely.
+//
+// Errors and corruption indicate a real defect and are near-zero volume, so
+// they are reported by default. Warnings are informative but repeat per
+// resource and per PSO, so they are opt-in.
+static int DebugMessageSeverityThreshold = D3D12_MESSAGE_SEVERITY_ERROR;
+
+// Reads the D3D12DebugMessageSeverity runtime parameter. Accepts "none" or any
+// D3D12_MESSAGE_SEVERITY name: "corruption", "error", "warning", "info" or
+// "message".
+static int getDebugMessageSeverityThreshold() {
+  WEX::Common::String Value;
+  if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
+          L"D3D12DebugMessageSeverity", Value)))
+    return D3D12_MESSAGE_SEVERITY_ERROR;
+
+  const wchar_t *Name = Value;
+  if (_wcsicmp(Name, L"none") == 0)
+    return -1;
+  if (_wcsicmp(Name, L"corruption") == 0)
+    return D3D12_MESSAGE_SEVERITY_CORRUPTION;
+  if (_wcsicmp(Name, L"error") == 0)
+    return D3D12_MESSAGE_SEVERITY_ERROR;
+  if (_wcsicmp(Name, L"warning") == 0)
+    return D3D12_MESSAGE_SEVERITY_WARNING;
+  if (_wcsicmp(Name, L"info") == 0)
+    return D3D12_MESSAGE_SEVERITY_INFO;
+  if (_wcsicmp(Name, L"message") == 0)
+    return D3D12_MESSAGE_SEVERITY_MESSAGE;
+
+  LogWarningFmt(L"Unrecognized D3D12DebugMessageSeverity '%s'. Using 'error'.",
+                Name);
+  return D3D12_MESSAGE_SEVERITY_ERROR;
+}
+
+// The D3D12 debug layer emits messages via OutputDebugString, which is not
+// visible outside a debugger, so validation failures are otherwise invisible in
+// a plain test run. Route them into the test log instead.
+//
+// This is diagnostic only: messages are logged as comments and deliberately do
+// not alter the outcome of any test.
+static void __stdcall logD3D12DebugMessage(D3D12_MESSAGE_CATEGORY Category,
+                                           D3D12_MESSAGE_SEVERITY Severity,
+                                           D3D12_MESSAGE_ID ID,
+                                           LPCSTR Description, void *Context) {
+  (void)Category;
+  (void)Context;
+
+  if (static_cast<int>(Severity) > DebugMessageSeverityThreshold)
+    return;
+
+  const wchar_t *SeverityName;
+  switch (Severity) {
+  case D3D12_MESSAGE_SEVERITY_CORRUPTION:
+    SeverityName = L"CORRUPTION";
+    break;
+  case D3D12_MESSAGE_SEVERITY_ERROR:
+    SeverityName = L"ERROR";
+    break;
+  case D3D12_MESSAGE_SEVERITY_WARNING:
+    SeverityName = L"WARNING";
+    break;
+  case D3D12_MESSAGE_SEVERITY_INFO:
+    SeverityName = L"INFO";
+    break;
+  default:
+    SeverityName = L"MESSAGE";
+    break;
+  }
+
+  LogCommentFmt(L"D3D12 %s [id %u]: %s", SeverityName, static_cast<UINT>(ID),
+                static_cast<const wchar_t *>(CA2W(Description)));
 }
 
 static bool createDevice(
@@ -223,8 +305,30 @@ static bool createDevice(
 
   if (useDebugIfaces()) {
     CComPtr<ID3D12InfoQueue> InfoQueue;
-    if (SUCCEEDED(D3DDeviceCom->QueryInterface(&InfoQueue)))
+    if (SUCCEEDED(D3DDeviceCom->QueryInterface(&InfoQueue))) {
       InfoQueue->SetMuteDebugOutput(FALSE);
+
+      // The callback is unregistered implicitly when the device is destroyed.
+      CComPtr<ID3D12InfoQueue1> InfoQueue1;
+      if (SUCCEEDED(InfoQueue->QueryInterface(&InfoQueue1))) {
+        DebugMessageSeverityThreshold = getDebugMessageSeverityThreshold();
+        DWORD CallbackCookie = 0;
+        HRESULT HR = InfoQueue1->RegisterMessageCallback(
+            logD3D12DebugMessage, D3D12_MESSAGE_CALLBACK_FLAG_NONE, nullptr,
+            &CallbackCookie);
+        if (FAILED(HR))
+          LogWarningFmt(L"RegisterMessageCallback failed: 0x%08x. D3D12 debug "
+                        L"layer messages will not be reported.",
+                        HR);
+      } else {
+        LogWarningFmt(L"Device does not expose ID3D12InfoQueue1. D3D12 debug "
+                      L"layer messages will not be reported.");
+      }
+    } else if (DebugLayerEnabled) {
+      LogWarningFmt(L"The debug layer was enabled but this device does not "
+                    L"expose ID3D12InfoQueue. D3D12 debug layer messages will "
+                    L"not be reported.");
+    }
   }
 
   *D3DDevice = D3DDeviceCom.Detach();
@@ -246,7 +350,12 @@ void readHlslDataIntoNewStream(LPCWSTR RelativePath, IStream **Stream,
   *Stream = StreamCom.Detach();
 }
 
-static bool enableDebugLayer() {
+// Enables the debug layer for the process-global D3D12 runtime. This resolves
+// against whichever D3D12Core the loader has bound for the process, so it must
+// only be called after the global Agility SDK version has been selected.
+// It has no effect on devices created through an ID3D12DeviceFactory, which
+// host their own D3D12Core instance; use enableDebugLayerOnFactory() for those.
+static bool enableGlobalDebugLayer() {
   CComPtr<ID3D12Debug> DebugController;
   HRESULT HR;
   if (FAILED(HR = D3D12GetDebugInterface(IID_PPV_ARGS(&DebugController)))) {
@@ -255,6 +364,7 @@ static bool enableDebugLayer() {
   }
 
   DebugController->EnableDebugLayer();
+  DebugLayerEnabled = true;
   return true;
 }
 
@@ -374,6 +484,14 @@ setGlobalConfiguration(const std::optional<AgilitySDKConfiguration> &C) {
   else
     LogCommentFmt(L"Agility SDK not enabled.");
 
+  // Must follow Agility SDK selection so the debug layer is retrieved from the
+  // D3D12Core that will actually service device creation, rather than from the
+  // inbox runtime.
+  if (enableGlobalDebugLayer())
+    LogCommentFmt(L"Debug layer enabled.");
+  else
+    LogCommentFmt(L"Debug layer not enabled.");
+
   if (enableGlobalExperimentalMode())
     LogCommentFmt(L"Experimental mode enabled.");
   else
@@ -393,6 +511,23 @@ static bool enableExperimentalMode(ID3D12DeviceFactory *DeviceFactory) {
     return false;
   }
 
+  return true;
+}
+
+// An ID3D12DeviceFactory hosts its own D3D12Core instance, so the debug layer
+// must be enabled through the factory's configuration interface. Enabling it
+// globally has no effect on devices the factory creates.
+static bool enableDebugLayerOnFactory(ID3D12DeviceFactory *DeviceFactory) {
+  CComPtr<ID3D12Debug> DebugController;
+  HRESULT HR;
+  if (FAILED(HR = DeviceFactory->GetConfigurationInterface(
+                 CLSID_D3D12Debug, IID_PPV_ARGS(&DebugController)))) {
+    LogWarningFmt(L"Failed to get ID3D12Debug from device factory: 0x%08x", HR);
+    return false;
+  }
+
+  DebugController->EnableDebugLayer();
+  DebugLayerEnabled = true;
   return true;
 }
 
@@ -420,6 +555,11 @@ createDeviceFactorySDK(const AgilitySDKConfiguration &C) {
   LogCommentFmt(L"Using DeviceFactory for SDKVersion %d, SDKPath %s",
                 C.SDKVersion, static_cast<const wchar_t *>(C.SDKPath));
 
+  if (enableDebugLayerOnFactory(DeviceFactory))
+    LogCommentFmt(L"Debug layer enabled on device factory.");
+  else
+    LogCommentFmt(L"Debug layer not enabled on device factory.");
+
   if (enableExperimentalMode(DeviceFactory))
     LogCommentFmt(L"Experimental mode enabled.");
   else
@@ -429,14 +569,10 @@ createDeviceFactorySDK(const AgilitySDKConfiguration &C) {
 }
 
 D3D12SDKSelector::D3D12SDKSelector() {
-  if (enableDebugLayer())
-    LogCommentFmt(L"Debug layer enabled");
-  else
-    LogCommentFmt(L"Debug layer not enabled");
-
   std::optional<AgilitySDKConfiguration> C = getAgilitySDKConfiguration();
 
   if (C && C->SDKVersion > 0) {
+    // createDeviceFactorySDK() enables the debug layer on the factory itself.
     CComPtr<ID3D12DeviceFactory> DeviceFactory = createDeviceFactorySDK(*C);
     if (DeviceFactory) {
       this->DeviceFactory = DeviceFactory;

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -33,44 +33,38 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
 
 using namespace hlsl_test;
 
-// Reads the D3D12DebugLayer runtime parameter. Accepts "true", "1", "*" or an
-// empty value to enable, and "false" or "0" to disable.
-//
-// GetTestParamBool is deliberately not used here. Despite its name it matches
-// its value as a pattern against the current test name, which is not available
-// while the SDK selector is being constructed.
-static bool isDebugLayerRequested() {
-  WEX::Common::String Value;
-  if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
-          L"D3D12DebugLayer", Value)))
-    return false;
-
-  const wchar_t *Text = Value;
-  if (Value.IsEmpty() || _wcsicmp(Text, L"true") == 0 ||
-      _wcsicmp(Text, L"1") == 0 || wcscmp(Text, L"*") == 0)
-    return true;
-  if (_wcsicmp(Text, L"false") == 0 || _wcsicmp(Text, L"0") == 0)
-    return false;
-
-  LogWarningFmt(L"Unrecognized D3D12DebugLayer '%s'. The debug layer will not "
-                L"be enabled.",
-                Text);
+// Disabled by default for HLK runs.
+static bool debugLayerOnByDefault() {
+#ifdef _HLK_CONF
   return false;
+#else
+  return true;
+#endif
 }
 
-// The D3D12 debug layer is opt-in. It requires the Graphics Tools optional
-// feature, costs significant runtime overhead, and is unexpected during HLK
-// conformance runs, so it stays off unless /p:D3D12DebugLayer=true is passed.
-// Development and debugging runs are expected to pass it.
+// /p:D3D12DebugLayer=true or /p:D3D12DebugLayer=false overrides the default.
 static bool useDebugIfaces() {
-  static const bool Requested = isDebugLayerRequested();
-  return Requested;
+  static const bool Enabled = [] {
+    WEX::Common::String Value;
+    if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
+            L"D3D12DebugLayer", Value)))
+      return debugLayerOnByDefault();
+
+    const wchar_t *Text = Value;
+    if (_wcsicmp(Text, L"true") == 0)
+      return true;
+    if (_wcsicmp(Text, L"false") == 0)
+      return false;
+
+    LogWarningFmt(L"Unrecognized D3D12DebugLayer '%s'. Expected \"true\" or "
+                  L"\"false\". Using the default.",
+                  Text);
+    return debugLayerOnByDefault();
+  }();
+  return Enabled;
 }
 
-// Diagnostic only: records whether the D3D12 debug layer was successfully
-// enabled, so that a device unexpectedly missing ID3D12InfoQueue can be
-// reported without warning on every device creation on machines where the
-// debug layer is simply unavailable.
+// Set when the debug layer has been enabled.
 static bool DebugLayerEnabled = false;
 
 bool useDxbc() {
@@ -134,19 +128,12 @@ static UINT getD3D12SDKVersion(std::wstring SDKPath) {
   return SDKVersion;
 }
 
-// D3D12 message severities are ordered most-to-least severe
-// (D3D12_MESSAGE_SEVERITY_CORRUPTION == 0), so a message is reported when its
-// severity is <= this threshold. -1 disables reporting entirely. Only has an
-// effect when the debug layer is enabled.
-//
-// Errors and corruption indicate a real defect and are near-zero volume, so
-// they are reported by default. Warnings are informative but repeat per
-// resource and per PSO, so they are opt-in.
+// Severities are ordered most-to-least severe (CORRUPTION == 0), so a message
+// is reported when its severity is <= this threshold. -1 reports nothing.
 static int DebugMessageSeverityThreshold = D3D12_MESSAGE_SEVERITY_ERROR;
 
-// Reads the D3D12DebugMessageSeverity runtime parameter. Accepts "none" or any
-// D3D12_MESSAGE_SEVERITY name: "corruption", "error", "warning", "info" or
-// "message".
+// /p:D3D12DebugMessageSeverity accepts "none" or a D3D12_MESSAGE_SEVERITY name:
+// "corruption", "error", "warning", "info" or "message".
 static int getDebugMessageSeverityThreshold() {
   WEX::Common::String Value;
   if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
@@ -172,12 +159,9 @@ static int getDebugMessageSeverityThreshold() {
   return D3D12_MESSAGE_SEVERITY_ERROR;
 }
 
-// The D3D12 debug layer emits messages via OutputDebugString, which is not
-// visible outside a debugger, so validation failures are otherwise invisible in
-// a plain test run. Route them into the test log instead.
-//
-// This is diagnostic only: messages are logged as comments and deliberately do
-// not alter the outcome of any test.
+// Routes debug layer messages into the test log; they are otherwise emitted via
+// OutputDebugString and only visible under a debugger. Logged as comments, so
+// they never alter a test outcome.
 static void __stdcall logD3D12DebugMessage(D3D12_MESSAGE_CATEGORY Category,
                                            D3D12_MESSAGE_SEVERITY Severity,
                                            D3D12_MESSAGE_ID ID,
@@ -383,11 +367,9 @@ void readHlslDataIntoNewStream(LPCWSTR RelativePath, IStream **Stream,
   *Stream = StreamCom.Detach();
 }
 
-// Enables the debug layer for the process-global D3D12 runtime. This resolves
-// against whichever D3D12Core the loader has bound for the process, so it must
-// only be called after the global Agility SDK version has been selected.
-// It has no effect on devices created through an ID3D12DeviceFactory, which
-// host their own D3D12Core instance; use enableDebugLayerOnFactory() for those.
+// Enables the debug layer on the process-global D3D12Core, so it must be called
+// after the global Agility SDK version has been selected. Devices created
+// through an ID3D12DeviceFactory need enableDebugLayerOnFactory() instead.
 static bool enableGlobalDebugLayer() {
   CComPtr<ID3D12Debug> DebugController;
   HRESULT HR;
@@ -517,11 +499,8 @@ setGlobalConfiguration(const std::optional<AgilitySDKConfiguration> &C) {
   else
     LogCommentFmt(L"Agility SDK not enabled.");
 
-  // Must follow Agility SDK selection so the debug layer is retrieved from the
-  // D3D12Core that will actually service device creation, rather than from the
-  // inbox runtime.
   if (!useDebugIfaces())
-    LogCommentFmt(L"Debug layer not requested.");
+    LogCommentFmt(L"Debug layer disabled.");
   else if (enableGlobalDebugLayer())
     LogCommentFmt(L"Debug layer enabled.");
   else
@@ -549,9 +528,8 @@ static bool enableExperimentalMode(ID3D12DeviceFactory *DeviceFactory) {
   return true;
 }
 
-// An ID3D12DeviceFactory hosts its own D3D12Core instance, so the debug layer
-// must be enabled through the factory's configuration interface. Enabling it
-// globally has no effect on devices the factory creates.
+// An ID3D12DeviceFactory hosts its own D3D12Core, so the debug layer must be
+// enabled through the factory's configuration interface.
 static bool enableDebugLayerOnFactory(ID3D12DeviceFactory *DeviceFactory) {
   CComPtr<ID3D12Debug> DebugController;
   HRESULT HR;
@@ -591,7 +569,7 @@ createDeviceFactorySDK(const AgilitySDKConfiguration &C) {
                 C.SDKVersion, static_cast<const wchar_t *>(C.SDKPath));
 
   if (!useDebugIfaces())
-    LogCommentFmt(L"Debug layer not requested.");
+    LogCommentFmt(L"Debug layer disabled.");
   else if (enableDebugLayerOnFactory(DeviceFactory))
     LogCommentFmt(L"Debug layer enabled on device factory.");
   else

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -33,7 +33,39 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
 
 using namespace hlsl_test;
 
-static bool useDebugIfaces() { return true; }
+// Reads the D3D12DebugLayer runtime parameter. Accepts "true", "1", "*" or an
+// empty value to enable, and "false" or "0" to disable.
+//
+// GetTestParamBool is deliberately not used here. Despite its name it matches
+// its value as a pattern against the current test name, which is not available
+// while the SDK selector is being constructed.
+static bool isDebugLayerRequested() {
+  WEX::Common::String Value;
+  if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
+          L"D3D12DebugLayer", Value)))
+    return false;
+
+  const wchar_t *Text = Value;
+  if (Value.IsEmpty() || _wcsicmp(Text, L"true") == 0 ||
+      _wcsicmp(Text, L"1") == 0 || wcscmp(Text, L"*") == 0)
+    return true;
+  if (_wcsicmp(Text, L"false") == 0 || _wcsicmp(Text, L"0") == 0)
+    return false;
+
+  LogWarningFmt(L"Unrecognized D3D12DebugLayer '%s'. The debug layer will not "
+                L"be enabled.",
+                Text);
+  return false;
+}
+
+// The D3D12 debug layer is opt-in. It requires the Graphics Tools optional
+// feature, costs significant runtime overhead, and is unexpected during HLK
+// conformance runs, so it stays off unless /p:D3D12DebugLayer=true is passed.
+// Development and debugging runs are expected to pass it.
+static bool useDebugIfaces() {
+  static const bool Requested = isDebugLayerRequested();
+  return Requested;
+}
 
 // Diagnostic only: records whether the D3D12 debug layer was successfully
 // enabled, so that a device unexpectedly missing ID3D12InfoQueue can be
@@ -104,7 +136,8 @@ static UINT getD3D12SDKVersion(std::wstring SDKPath) {
 
 // D3D12 message severities are ordered most-to-least severe
 // (D3D12_MESSAGE_SEVERITY_CORRUPTION == 0), so a message is reported when its
-// severity is <= this threshold. -1 disables reporting entirely.
+// severity is <= this threshold. -1 disables reporting entirely. Only has an
+// effect when the debug layer is enabled.
 //
 // Errors and corruption indicate a real defect and are near-zero volume, so
 // they are reported by default. Warnings are informative but repeat per
@@ -487,7 +520,9 @@ setGlobalConfiguration(const std::optional<AgilitySDKConfiguration> &C) {
   // Must follow Agility SDK selection so the debug layer is retrieved from the
   // D3D12Core that will actually service device creation, rather than from the
   // inbox runtime.
-  if (enableGlobalDebugLayer())
+  if (!useDebugIfaces())
+    LogCommentFmt(L"Debug layer not requested.");
+  else if (enableGlobalDebugLayer())
     LogCommentFmt(L"Debug layer enabled.");
   else
     LogCommentFmt(L"Debug layer not enabled.");
@@ -555,7 +590,9 @@ createDeviceFactorySDK(const AgilitySDKConfiguration &C) {
   LogCommentFmt(L"Using DeviceFactory for SDKVersion %d, SDKPath %s",
                 C.SDKVersion, static_cast<const wchar_t *>(C.SDKPath));
 
-  if (enableDebugLayerOnFactory(DeviceFactory))
+  if (!useDebugIfaces())
+    LogCommentFmt(L"Debug layer not requested.");
+  else if (enableDebugLayerOnFactory(DeviceFactory))
     LogCommentFmt(L"Debug layer enabled on device factory.");
   else
     LogCommentFmt(L"Debug layer not enabled on device factory.");

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -45,21 +45,10 @@ static bool debugLayerOnByDefault() {
 // /p:D3D12DebugLayer=true or /p:D3D12DebugLayer=false overrides the default.
 static bool useDebugIfaces() {
   static const bool Enabled = [] {
-    WEX::Common::String Value;
-    if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
-            L"D3D12DebugLayer", Value)))
-      return debugLayerOnByDefault();
-
-    const wchar_t *Text = Value;
-    if (_wcsicmp(Text, L"true") == 0)
-      return true;
-    if (_wcsicmp(Text, L"false") == 0)
-      return false;
-
-    LogWarningFmt(L"Unrecognized D3D12DebugLayer '%s'. Expected \"true\" or "
-                  L"\"false\". Using the default.",
-                  Text);
-    return debugLayerOnByDefault();
+    bool Value = debugLayerOnByDefault();
+    WEX::TestExecution::RuntimeParameters::TryGetValue(L"D3D12DebugLayer",
+                                                       Value);
+    return Value;
   }();
   return Enabled;
 }
@@ -195,6 +184,39 @@ static void __stdcall logD3D12DebugMessage(D3D12_MESSAGE_CATEGORY Category,
                 static_cast<const wchar_t *>(CA2W(Description)));
 }
 
+// Routes debug layer messages for this device into the test log.
+static void logDebugLayerMessages(ID3D12Device *Device) {
+  CComPtr<ID3D12InfoQueue> InfoQueue;
+  if (FAILED(Device->QueryInterface(&InfoQueue))) {
+    if (DebugLayerEnabled)
+      LogWarningFmt(L"The debug layer was enabled but this device does not "
+                    L"expose ID3D12InfoQueue. D3D12 debug layer messages will "
+                    L"not be reported.");
+    return;
+  }
+
+  InfoQueue->SetMuteDebugOutput(FALSE);
+
+  CComPtr<ID3D12InfoQueue1> InfoQueue1;
+  if (FAILED(InfoQueue->QueryInterface(&InfoQueue1))) {
+    LogWarningFmt(L"Device does not expose ID3D12InfoQueue1. D3D12 debug "
+                  L"layer messages will not be reported.");
+    return;
+  }
+
+  DebugMessageSeverityThreshold = getDebugMessageSeverityThreshold();
+
+  // The callback is unregistered implicitly when the device is destroyed.
+  DWORD CallbackCookie = 0;
+  HRESULT HR = InfoQueue1->RegisterMessageCallback(
+      logD3D12DebugMessage, D3D12_MESSAGE_CALLBACK_FLAG_NONE, nullptr,
+      &CallbackCookie);
+  if (FAILED(HR))
+    LogWarningFmt(L"RegisterMessageCallback failed: 0x%08x. D3D12 debug "
+                  L"layer messages will not be reported.",
+                  HR);
+}
+
 static bool createDevice(
     ID3D12Device **D3DDevice, D3D_SHADER_MODEL TestModel, bool SkipUnsupported,
     std::function<HRESULT(IUnknown *, D3D_FEATURE_LEVEL, REFIID, void **)>
@@ -320,33 +342,8 @@ static bool createDevice(
     }
   }
 
-  if (useDebugIfaces()) {
-    CComPtr<ID3D12InfoQueue> InfoQueue;
-    if (SUCCEEDED(D3DDeviceCom->QueryInterface(&InfoQueue))) {
-      InfoQueue->SetMuteDebugOutput(FALSE);
-
-      // The callback is unregistered implicitly when the device is destroyed.
-      CComPtr<ID3D12InfoQueue1> InfoQueue1;
-      if (SUCCEEDED(InfoQueue->QueryInterface(&InfoQueue1))) {
-        DebugMessageSeverityThreshold = getDebugMessageSeverityThreshold();
-        DWORD CallbackCookie = 0;
-        HRESULT HR = InfoQueue1->RegisterMessageCallback(
-            logD3D12DebugMessage, D3D12_MESSAGE_CALLBACK_FLAG_NONE, nullptr,
-            &CallbackCookie);
-        if (FAILED(HR))
-          LogWarningFmt(L"RegisterMessageCallback failed: 0x%08x. D3D12 debug "
-                        L"layer messages will not be reported.",
-                        HR);
-      } else {
-        LogWarningFmt(L"Device does not expose ID3D12InfoQueue1. D3D12 debug "
-                      L"layer messages will not be reported.");
-      }
-    } else if (DebugLayerEnabled) {
-      LogWarningFmt(L"The debug layer was enabled but this device does not "
-                    L"expose ID3D12InfoQueue. D3D12 debug layer messages will "
-                    L"not be reported.");
-    }
-  }
+  if (useDebugIfaces())
+    logDebugLayerMessages(D3DDeviceCom);
 
   *D3DDevice = D3DDeviceCom.Detach();
   return true;


### PR DESCRIPTION
## Summary

The HLSLExec harness logged `Debug layer enabled` on every run, but the D3D12 debug layer was never active on the device under test and no validation message ever reached the test log.

This enables the debug layer on the code path the harness actually uses, and routes its messages into the test log.

## Why this is needed

Two defects made the debug layer silently inert.

**Ordering.** `enableDebugLayer()` ran as the first statement of the `D3D12SDKSelector` constructor, before `SetSDKVersion` or `CreateDeviceFactory`. With no Agility redirection in effect yet, `D3D12GetDebugInterface` bound the *inbox* `D3D12Core`.

**Scope.** When `D3D12SDKPath` resolves to an Agility SDK, `D3D12SDKSelector` takes the `ID3D12DeviceFactory` path. A factory hosts its own `D3D12Core`, so process-global debug state never reaches the devices it creates; it must be enabled through `ID3D12DeviceFactory::GetConfigurationInterface(CLSID_D3D12Debug, ...)`.

The inbox call succeeded, so the harness reported success. The follow-up `QueryInterface<ID3D12InfoQueue>` on the real device failed, but had no `else` branch, so every log claimed the debug layer was fine while it did nothing.

Separately, the debug layer only emits through `OutputDebugString`, which is invisible outside a debugger. `SetMuteDebugOutput(FALSE)` un-mutes that channel but nothing pumped it into the test log.

The practical cost: two long-standing LinAlg failures presented only as `DXGI_ERROR_DEVICE_REMOVED (0x887a0005)` at `CreateCommandQueue`, with no indication of cause.

## What changed

- `enableDebugLayerOnFactory()` enables the layer through the device factory's configuration interface, called from `createDeviceFactorySDK`.
- The global path (renamed `enableGlobalDebugLayer`) moved to after Agility SDK selection, so it binds the `D3D12Core` that actually services device creation.
- An `ID3D12InfoQueue1` message callback writes debug layer messages to the test log. Diagnostic only: they are logged as comments and never alter a test outcome.
- Previously silent `ID3D12InfoQueue` / `ID3D12InfoQueue1` `QueryInterface` failures are now reported.
- Two runtime parameters:

```
/p:D3D12DebugLayer=true|false
/p:D3D12DebugMessageSeverity=none|corruption|error|warning|info|message
```

### Default

On for developer builds, off for HLK conformance builds (`_HLK_CONF`). `/p:D3D12DebugLayer` overrides it either way.

Errors and corruption are reported by default. Warnings repeat per resource and per PSO, so they need `D3D12DebugMessageSeverity`.

## Validation

Built Release, run on WARP against an SM6.10 Agility SDK.

| Suite | Unmodified `main` | This PR |
| --- | --- | --- |
| `ExecutionTest::*` | 207 total, 204 passed, 3 failed | identical, same 3 |
| `LinAlg::DxilConf_SM610_LinAlg::*` | 22 total, 19 passed, 2 failed, 1 skipped | identical, same 2 |
| Full `ExecHLSLTests` | - | 1190 total, 1184 passed, 5 failed, 1 skipped (the 5 above) |

The 3 `ExecutionTest` failures are pre-existing and unrelated: `D3D12_FEATURE_D3D12_OPTIONS_PREVIEW` returns `E_INVALIDARG` on this `D3D12Core`.

Both SDK selection paths were exercised, and `D3D12DebugLayer` verified for absent, `true`, `false` and an invalid value. Test outcomes are identical in every case. `clang-format` clean.

Refs #7841

Closes #8709

---

Assisted-by: GitHub Copilot
