### PR TITLE
[Sema] Reject scalar casts to aggregates containing resources

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,6 +22,12 @@ The included licenses apply to the following files:
 Place release notes for the upcoming release below this line and remove this
 line upon naming the release. Refer to previous for appropriate section names.
 
+#### HLSL Language
+
+- Casting a scalar to a struct or array containing a resource is now an error
+  instead of crashing
+  [#6661](https://github.com/microsoft/DirectXShaderCompiler/issues/6661).
+
 ### Upcoming Preview Release
 
 These changes apply to experimental preview shader models only and will not be

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10283,6 +10283,15 @@ bool HLSLExternalSource::CanConvert(SourceLocation loc, Expr *sourceExpr,
     // Handle explicit splats from single element numerical types (scalars,
     // vector1s and matrix1x1s) to aggregate types.
     if (explicitConversion) {
+      const bool SourceIsSingleElement =
+          SourceInfo.ShapeKind == AR_TOBJ_SCALAR ||
+          (hlsl::IsHLSLVecMatType(source) &&
+           hlsl::GetElementCount(source) == 1);
+      if (SourceIsSingleElement &&
+          (m_sema->RequireCompleteType(loc, target, 0) ||
+           !hlsl::IsHLSLNumericOrAggregateOfNumericType(target)))
+        return false;
+
       const BuiltinType *sourceSingleElementBuiltinType =
           source->getAs<BuiltinType>();
       if (sourceSingleElementBuiltinType == nullptr &&
@@ -10292,11 +10301,7 @@ bool HLSLExternalSource::CanConvert(SourceLocation loc, Expr *sourceExpr,
             hlsl::GetElementTypeOrType(source)->getAs<BuiltinType>();
       }
 
-      // We can only splat to target types that do not contain object/resource
-      // types
-      if (sourceSingleElementBuiltinType != nullptr &&
-          !m_sema->RequireCompleteType(loc, target, 0) &&
-          hlsl::IsHLSLNumericOrAggregateOfNumericType(target)) {
+      if (sourceSingleElementBuiltinType != nullptr) {
         BuiltinType::Kind kind = sourceSingleElementBuiltinType->getKind();
         switch (kind) {
         case BuiltinType::Kind::UInt:

--- a/tools/clang/test/SemaHLSL/conversions-non-numeric-aggregates.hlsl
+++ b/tools/clang/test/SemaHLSL/conversions-non-numeric-aggregates.hlsl
@@ -5,12 +5,24 @@
 
 struct NumStruct { int a; };
 struct ObjStruct { Buffer a; };
+struct SpecializedObjStruct {
+  int a;
+  RWStructuredBuffer<float> b;
+};
+struct NestedSpecializedObjStruct {
+  int a;
+  SpecializedObjStruct b;
+};
+enum ResourceEnum { ResourceEnumValue };
 
 [shader("vertex")]
 void main()
 {
   (Buffer[1])0; /* expected-error {{cannot convert from 'literal int' to 'Buffer [1]'}} fxc-error {{X3017: cannot convert from 'int' to 'Buffer<float4>[1]'}} */
   (ObjStruct)0; /* expected-error {{cannot convert from 'literal int' to 'ObjStruct'}} fxc-error {{X3017: cannot convert from 'int' to 'struct ObjStruct'}} */
+  (SpecializedObjStruct)0; /* expected-error {{cannot convert from 'literal int' to 'SpecializedObjStruct'}} */
+  (NestedSpecializedObjStruct)0; /* expected-error {{cannot convert from 'literal int' to 'NestedSpecializedObjStruct'}} */
+  (SpecializedObjStruct)ResourceEnumValue; /* expected-error {{cannot convert from 'ResourceEnum' to 'SpecializedObjStruct'}} */
   (Buffer[1])(int[1])0; /* expected-error {{cannot convert from 'int [1]' to 'Buffer [1]'}} fxc-error {{X3017: cannot convert from 'const int[1]' to 'Buffer<float4>[1]'}} */
   (ObjStruct)(NumStruct)0; /* expected-error {{cannot convert from 'NumStruct' to 'ObjStruct'}} fxc-error {{X3017: cannot convert from 'const struct NumStruct' to 'struct ObjStruct'}} */
 

--- a/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-struct.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-struct.hlsl
@@ -200,7 +200,7 @@ TYPE userFunc(TYPE arg) {
 
 [shader("raygeneration")]
 void raygen() {
-  RTTYPE p = (RTTYPE)0;
+  RTTYPE p;
   RayDesc ray = (RayDesc)0;
   TraceRay(RTAS, RAY_FLAG_NONE, 0, 0, 1, 0, ray, p); 
   // expected-error@-1{{object 'dx::HitObject' is not allowed in user-defined struct parameter}}
@@ -262,7 +262,7 @@ void Miss(
 [shader("intersection")]
 void Intersection() {
   float hitT = RayTCurrent();
-  RTTYPE attr = (RTTYPE)0;
+  RTTYPE attr;
   bool bReported = ReportHit(hitT, 0, attr);
   // expected-error@-1{{object 'dx::HitObject' is not allowed in attributes}}
   // expected-note@16{{'dx::HitObject' field declared here}}

--- a/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-templated.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/types/invalid-hitobject-decls-templated.hlsl
@@ -211,7 +211,7 @@ TYPE userFunc(TYPE arg) {
 
 [shader("raygeneration")]
 void raygen() {
-  RTTYPE p = (RTTYPE)0;
+  RTTYPE p;
   RayDesc ray = (RayDesc)0;
   TraceRay(RTAS, RAY_FLAG_NONE, 0, 0, 1, 0, ray, p); 
   // expected-error@-1{{object 'dx::HitObject' is not allowed in user-defined struct parameter}}
@@ -273,7 +273,7 @@ void Miss(
 [shader("intersection")]
 void Intersection() {
   float hitT = RayTCurrent();
-  RTTYPE attr = (RTTYPE)0;
+  RTTYPE attr;
   bool bReported = ReportHit(hitT, 0, attr);
   // expected-error@-1{{object 'dx::HitObject' is not allowed in attributes}}
   // expected-note@40{{'dx::HitObject' field declared here}}

--- a/tools/clang/test/SemaHLSL/object-operators.hlsl
+++ b/tools/clang/test/SemaHLSL/object-operators.hlsl
@@ -516,9 +516,9 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
   (f3_ss = SamplerStates); // expected-error {{cannot convert from 'SamplerState' to 'f3_s'}} fxc-error {{X3017: cannot implicitly convert from 'SamplerState' to 'struct f3_s'}}
   _Static_assert(std::is_same<f3_s, __decltype(f3_ss = f3_ss)>::value, "");
   (f3_ss = mixed_ss); // expected-error {{cannot implicitly convert from 'mixed_s' to 'f3_s'}} fxc-error {{X3017: cannot convert from 'struct mixed_s' to 'struct f3_s'}}
-  (mixed_ss = bools); // expected-error {{cannot implicitly convert from 'bool' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'bool' to 'struct mixed_s'}}
-  (mixed_ss = ints); // expected-error {{cannot implicitly convert from 'int' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'int' to 'struct mixed_s'}}
-  (mixed_ss = floats); // expected-error {{cannot implicitly convert from 'float' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'float' to 'struct mixed_s'}}
+  (mixed_ss = bools); // expected-error {{cannot convert from 'bool' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'bool' to 'struct mixed_s'}}
+  (mixed_ss = ints); // expected-error {{cannot convert from 'int' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'int' to 'struct mixed_s'}}
+  (mixed_ss = floats); // expected-error {{cannot convert from 'float' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'float' to 'struct mixed_s'}}
   (mixed_ss = SamplerStates); // expected-error {{cannot convert from 'SamplerState' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'SamplerState' to 'struct mixed_s'}}
   (mixed_ss = f3_ss); // expected-error {{cannot convert from 'f3_s' to 'mixed_s'}} fxc-error {{X3017: cannot implicitly convert from 'struct f3_s' to 'struct mixed_s'}}
   // This confuses the semantic checks on template types, which are assumed to be only for built-in template-like constructs.


### PR DESCRIPTION
Casting a scalar to a struct or array containing an HLSL resource or object type (for example `(MyStruct)0` where MyStruct holds a RWStructuredBuffer<uint64_t>) was accepted by Sema. CodeGen then hit the DXASSERT in CGMSHLSLRuntime::EmitHLSLSplat ("cannot cast to hlsl object, Sema should reject"), which surfaced as "Internal compiler error: Terminal Error 0x80000003" in assertion-enabled builds and as silently bogus DXIL otherwise.

Fixes #6661

Assisted-by: copilot