### PR TITLE
[SPIR-V] Preserve members after merged bitfields in flat conversions

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3951,8 +3951,16 @@ SpirvEmitter::processFlatConversion(const QualType type,
       initInstr->setAstResultType(astContext.UnsignedLongLongTy);
   }
 
-  // Decompose `initInstr`.
-  std::vector<SpirvInstruction *> flatValues = decomposeToScalars(initInstr);
+  QualType sourceType = initInstr->getAstResultType();
+  if (hlsl::IsHLSLResourceType(sourceType))
+    sourceType = hlsl::GetHLSLResourceResultType(sourceType);
+
+  // Converting the same AST type between layouts preserves its physical field
+  // sequence. Shape-changing flat conversions operate on AST fields.
+  const bool includeMergedBitfields =
+      !astContext.hasSameUnqualifiedType(type, sourceType);
+  std::vector<SpirvInstruction *> flatValues =
+      decomposeToScalars(initInstr, includeMergedBitfields);
 
   if (flatValues.size() == 1) {
     return splatScalarToGenerate(type, flatValues[0], SpirvLayoutRule::Void);
@@ -16783,7 +16791,8 @@ SpirvEmitter::doUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *expr) {
 }
 
 std::vector<SpirvInstruction *>
-SpirvEmitter::decomposeToScalars(SpirvInstruction *inst) {
+SpirvEmitter::decomposeToScalars(SpirvInstruction *inst,
+                                 bool includeMergedBitfields) {
   QualType elementType;
   uint32_t elementCount = 0;
   uint32_t numOfRows = 0;
@@ -16828,7 +16837,8 @@ SpirvEmitter::decomposeToScalars(SpirvInstruction *inst) {
       auto *element = spvBuilder.createCompositeExtract(
           elementType, inst, {i}, inst->getSourceLocation());
       element->setLayoutRule(inst->getLayoutRule());
-      auto decomposedElement = decomposeToScalars(element);
+      auto decomposedElement =
+          decomposeToScalars(element, includeMergedBitfields);
 
       // See how we can improve the performance by avoiding this copy.
       result.insert(result.end(), decomposedElement.begin(),
@@ -16848,20 +16858,22 @@ SpirvEmitter::decomposeToScalars(SpirvInstruction *inst) {
 
     forEachSpirvField(
         recordType, dyn_cast<StructType>(type),
-        [this, inst, &result](size_t spirvFieldIndex, const QualType &fieldType,
-                              const StructType::FieldInfo &fieldInfo) {
+        [this, inst, &result, includeMergedBitfields](
+            size_t spirvFieldIndex, const QualType &fieldType,
+            const StructType::FieldInfo &fieldInfo) {
           auto *field = spvBuilder.createCompositeExtract(
               fieldType, inst, {fieldInfo.fieldIndex},
               inst->getSourceLocation());
           field->setLayoutRule(inst->getLayoutRule());
-          auto decomposedField = decomposeToScalars(field);
+          auto decomposedField =
+              decomposeToScalars(field, includeMergedBitfields);
 
           // See how we can improve the performance by avoiding this copy.
           result.insert(result.end(), decomposedField.begin(),
                         decomposedField.end());
           return true;
         },
-        true);
+        includeMergedBitfields);
     return result;
   }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3955,8 +3955,9 @@ SpirvEmitter::processFlatConversion(const QualType type,
   if (hlsl::IsHLSLResourceType(sourceType))
     sourceType = hlsl::GetHLSLResourceResultType(sourceType);
 
-  // Converting the same AST type between layouts preserves its physical field
-  // sequence. Shape-changing flat conversions operate on AST fields.
+  // A same-type conversion emits one scalar per SPIR-V field, but a cast that
+  // changes the shape, keeps one scalar (potentially with merged bitfields) per
+  // AST field. includeMergedBitfields determines which indexing is used.
   const bool includeMergedBitfields =
       !astContext.hasSameUnqualifiedType(type, sourceType);
   std::vector<SpirvInstruction *> flatValues =

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1404,8 +1404,10 @@ private:
 
   /// Returns a vector of SpirvInstruction that is the decompostion of `inst`
   /// into scalars. This is recursive. For example, a struct of a 4 element
-  /// vector will return 4 scalars.
-  std::vector<SpirvInstruction *> decomposeToScalars(SpirvInstruction *inst);
+  /// vector will return 4 scalars. If `includeMergedBitfields` is false,
+  /// fields that share the same SPIR-V storage field produce one scalar.
+  std::vector<SpirvInstruction *>
+  decomposeToScalars(SpirvInstruction *inst, bool includeMergedBitfields);
 
   /// Returns a spirv instruction with the value of the given type and layout
   /// rule that is obtained by assigning each scalar in `type` to corresponding

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.fn-var.bitfield.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.fn-var.bitfield.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_0 -E main -HV 2021 -fcgl %s -spirv | FileCheck %s
+
+struct MyData {
+  uint a : 16;
+  uint b : 16;
+  uint c;
+};
+
+ConstantBuffer<MyData> input;
+
+uint main() : SV_Target {
+  // CHECK:      [[SOURCE:%[0-9]+]] = OpLoad {{%[^ ]+}} %input
+  // CHECK-NEXT: [[BITFIELDS:%[0-9]+]] = OpCompositeExtract %uint [[SOURCE]] 0
+  // CHECK-NEXT: [[C:%[0-9]+]] = OpCompositeExtract %uint [[SOURCE]] 1
+  // CHECK-NEXT: [[VALUE:%[0-9]+]] = OpCompositeConstruct {{%[^ ]+}} [[BITFIELDS]] [[C]]
+  // CHECK-NEXT: OpStore %local [[VALUE]]
+  MyData local = input;
+
+  // CHECK: [[C_PTR:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %local %int_1
+  // CHECK: [[C_VALUE:%[0-9]+]] = OpLoad %uint [[C_PTR]]
+  // CHECK: OpReturnValue [[C_VALUE]]
+  return local.c;
+}


### PR DESCRIPTION
Since I was doing bitfield fixes in #8713, I took this one too.

This PR fixes #8526.

Copying a `ConstantBuffer` value with merged bitfields into a local struct overwrites the members after the bitfields. For `struct MyData { uint a : 16; uint b : 16; uint c; }`, reading `c` returns the word holding `a` and `b`.

This change makes `processFlatConversion` pick the decomposition mode from the source and destination AST types. A same-type conversion emits one scalar per SPIR-V field. But a cast that changes the shape, keeps one scalar per AST field.

I added the test from the original issue.