### PR TITLE
ci: temporarily disable offload tests while artifact publishing is broken

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,15 @@ parameters:
     displayName: 'WARP version'
     type: string
     default: '1.0.19'
+  # TEMPORARY: Azure Artifacts publishing is failing org-wide with
+  # "Artifact cannot be uploaded because max quantity has been exceeded or the
+  # payment instrument is invalid" (https://aka.ms/artbilling). The offload
+  # tests hand binaries between jobs via a pipeline artifact, so they cannot
+  # run until that is resolved. Flip this back to true once it is.
+  - name: enableOffloadTests
+    displayName: 'Run offload tests (requires pipeline artifact publishing)'
+    type: boolean
+    default: false
 
 trigger:
   - main
@@ -38,7 +47,10 @@ stages:
         VS2022_Release:
          configuration: Release
          spirvBuildFlag: -spirvtest
-         artifactName: dxc_spirv_release
+         ${{ if parameters.enableOffloadTests }}:
+           artifactName: dxc_spirv_release
+         ${{ else }}:
+           artifactName: ''
         VS2022_Debug:
          configuration: Debug
          spirvBuildFlag: -spirvtest
@@ -235,7 +247,10 @@ stages:
   dependsOn:
   - Build
   - OffloadGate
-  condition: and(succeededOrFailed(), eq(dependencies.OffloadGate.outputs['gate.decide.run'], 'true'))
+  ${{ if parameters.enableOffloadTests }}:
+    condition: and(succeededOrFailed(), eq(dependencies.OffloadGate.outputs['gate.decide.run'], 'true'))
+  ${{ else }}:
+    condition: false
 
   jobs:
   - job: Offload


### PR DESCRIPTION
## Summary

Azure Artifacts publishing is currently failing across the entire `DirectXShaderCompiler` Azure DevOps organization:

```
##[error]Artifact cannot be uploaded because max quantity has been exceeded
or the payment instrument is invalid. https://aka.ms/artbilling for details.
```

**`main` is currently red because of this**, along with every open PR. This is a temporary measure to get CI green again while the underlying billing issue is sorted out.

## Impact

Every run since ~11:25 on 2026-07-30 has failed on the `Publish DXC binaries` step:

| Build | Branch | Started | Result |
|---|---|---|---|
| 10659 | PR 8672 | 10:32 | last clean run |
| 10660-10664 | PRs 8673-8677 | 11:25-14:52 | artifact publish failure |
| 10667 | PR 8718 | 18:04 | artifact publish failure |
| 10668 | **main** | 18:31 | artifact publish failure |
| 10670 | PR 8666 | 19:35 | artifact publish failure |
| 10671 | PR 8717 | 20:26 | artifact publish failure |

On `main` (10668) it also cascades: the missing artifact fails `Download DXC binaries`, which takes down both the WARP and lavapipe offload jobs.

## Why the pipeline cannot just publish less

Pipeline artifacts are [exempt from Azure Artifacts storage billing](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops), so this is not a quota the pipeline can stay under by shrinking or expiring the artifact. The error string covers two conditions, and this is the *payment instrument* half - an org-level billing problem. Project retention settings are already tight (10 days, `PipelineArtifact` included in `artifactTypesToDelete`), so there is no headroom to reclaim there either.

The real fix is under **Organization settings > Billing** and needs someone with Project Collection Administrator access.

## Change

The offload tests hand the built binaries from the Windows build job to the test jobs via a pipeline artifact, so they cannot run at all until publishing works. This adds an `enableOffloadTests` parameter, defaulted to `false`, which:

- clears `artifactName` on the `VS2022_Release` matrix leg, so the existing `ne(variables['artifactName'], '')` guard skips both `Stage DXC binaries` and `Publish DXC binaries` - the same mechanism `VS2022_Debug` and `VS2022_Release_NoSPIRV` already use, so no new logic
- forces the `OffloadTests` stage `condition` to `false`, so it never attempts the download that is guaranteed to fail

`OffloadGate` still runs. It takes ~6 seconds and always passes, and leaving it in place keeps the published check name stable.

## Reverting

One word, once org billing is fixed:

```yaml
  - name: enableOffloadTests
    default: false   # -> true
```

## Trade-off

This does mean **no offload test coverage on `main`** while it is in effect. That is unavoidable given the transport is the thing that is broken, but it is worth restoring promptly rather than letting the flag quietly become permanent.

## Release notes

Skipping per `CONTRIBUTING.md` - infrastructure-only change with no user-visible compiler behavior change.
