### PR TITLE
Condition Artifact Upload to running lavapipe

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,29 @@ resources:
 - repo: self
 
 stages:
+
+- stage: OffloadGate
+  dependsOn: []
+  jobs:
+  - job: gate
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none
+    - bash: |
+        run=true
+        if [ "$(Build.Reason)" = "PullRequest" ]; then
+          run=false
+          labels=$(curl -sf "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
+          for l in $labels; do [ "$l" = "run-offload-tests" ] && run=true; done
+        fi
+        echo "Build.Reason=$(Build.Reason) run=$run"
+        echo "##vso[task.setvariable variable=run;isOutput=true]$run"
+      name: decide
+
 - stage: Build
+  dependsOn:
+    - OffloadGate
   jobs:
   - job: Windows
     timeoutInMinutes: 180
@@ -32,6 +54,7 @@ stages:
       HLSL_SRC_DIR: '$(Build.SourcesDirectory)'
       HLSL_BLD_DIR: '$(Agent.BuildDirectory)'
       platform: x64
+      uploadArtifact: $[ stageDependencies.OffloadGate.gate.outputs['decide.run'] ]
 
     strategy:
       matrix:
@@ -105,7 +128,7 @@ stages:
       condition: and(succeeded(), ne(variables['artifactName'], ''))
     - task: PublishPipelineArtifact@1
       displayName: 'Publish DXC binaries'
-      condition: and(succeeded(), ne(variables['artifactName'], ''))
+      condition: and(succeeded(), ne(variables['artifactName'], ''), eq(variables['uploadArtifact'], 'true'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)\dxc'
         artifact: '$(artifactName)'
@@ -210,25 +233,6 @@ stages:
         testResultsFormat: 'JUnit'
         testResultsFiles: '**/testresults.xunit.xml'
       condition: succeededOrFailed()
-
-- stage: OffloadGate
-  dependsOn: []
-  jobs:
-  - job: gate
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-    - checkout: none
-    - bash: |
-        run=true
-        if [ "$(Build.Reason)" = "PullRequest" ]; then
-          run=false
-          labels=$(curl -sf "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
-          for l in $labels; do [ "$l" = "run-offload-tests" ] && run=true; done
-        fi
-        echo "Build.Reason=$(Build.Reason) run=$run"
-        echo "##vso[task.setvariable variable=run;isOutput=true]$run"
-      name: decide
 
 - stage: OffloadTests
   displayName: 'Offload tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,6 @@ resources:
 - repo: self
 
 stages:
-
 - stage: Build
   condition: succeededOrFailed()
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,6 +125,7 @@ stages:
         targetPath: '$(Build.ArtifactStagingDirectory)\dxc'
         artifact: '$(artifactName)'
 
+
   - job: Nix
     timeoutInMinutes: 165
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,28 +21,7 @@ resources:
 
 stages:
 
-- stage: OffloadGate
-  dependsOn: []
-  jobs:
-  - job: gate
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-    - checkout: none
-    - bash: |
-        run=true
-        if [ "$(Build.Reason)" = "PullRequest" ]; then
-          run=false
-          labels=$(curl -sf "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" | python3 -c "import sys, json; print(' '.join(l['name'] for l in json.load(sys.stdin)))")
-          for l in $labels; do [ "$l" = "run-offload-tests" ] && run=true; done
-        fi
-        echo "Build.Reason=$(Build.Reason) run=$run"
-        echo "##vso[task.setvariable variable=run;isOutput=true]$run"
-      name: decide
-
 - stage: Build
-  dependsOn:
-    - OffloadGate
   jobs:
   - job: Windows
     timeoutInMinutes: 180
@@ -54,7 +33,6 @@ stages:
       HLSL_SRC_DIR: '$(Build.SourcesDirectory)'
       HLSL_BLD_DIR: '$(Agent.BuildDirectory)'
       platform: x64
-      uploadArtifact: $[ stageDependencies.OffloadGate.gate.outputs['decide.run'] ]
 
     strategy:
       matrix:
@@ -126,9 +104,21 @@ stages:
         }
       displayName: 'Stage DXC binaries'
       condition: and(succeeded(), ne(variables['artifactName'], ''))
+    - pwsh: |
+        $run = $true
+        if ("$(Build.Reason)" -eq "PullRequest") {
+          $run = $false
+          $labels = Invoke-RestMethod "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels"
+          if ($labels.name -contains "run-offload-tests") { $run = $true }
+        }
+        Write-Host "Build.Reason=$(Build.Reason) run=$run"
+        Write-Host "##vso[task.setvariable variable=run;isOutput=true]$($run.ToString().ToLower())"
+      name: decide
+      displayName: 'Decide whether to run offload tests'
+      condition: and(succeeded(), ne(variables['artifactName'], ''))
     - task: PublishPipelineArtifact@1
       displayName: 'Publish DXC binaries'
-      condition: and(succeeded(), ne(variables['artifactName'], ''), eq(variables['uploadArtifact'], 'true'))
+      condition: and(succeeded(), ne(variables['artifactName'], ''), eq(variables['decide.run'], 'true'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)\dxc'
         artifact: '$(artifactName)'
@@ -238,8 +228,7 @@ stages:
   displayName: 'Offload tests'
   dependsOn:
   - Build
-  - OffloadGate
-  condition: and(succeededOrFailed(), eq(dependencies.OffloadGate.outputs['gate.decide.run'], 'true'))
+  condition: and(succeededOrFailed(), eq(dependencies.Build.outputs['Windows.VS2022_Release.decide.run'], 'true'))
 
   jobs:
   - job: Offload

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,8 +108,12 @@ stages:
         $run = $true
         if ("$(Build.Reason)" -eq "PullRequest") {
           $run = $false
-          $labels = Invoke-RestMethod "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels"
-          if ($labels.name -contains "run-offload-tests") { $run = $true }
+          try {
+            $labels = Invoke-RestMethod "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" -ErrorAction Stop
+            if ($labels.name -contains "run-offload-tests") { $run = $true }
+          } catch {
+            Write-Warning "Unable to check pull request labels; skipping offload tests: $_"
+          }
         }
         Write-Host "Build.Reason=$(Build.Reason) run=$run"
         Write-Host "##vso[task.setvariable variable=run;isOutput=true]$($run.ToString().ToLower())"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ resources:
 
 stages:
 - stage: Build
-  condition: succeededOrFailed()
   jobs:
   - job: Windows
     timeoutInMinutes: 180
@@ -40,19 +39,34 @@ stages:
          configuration: Release
          spirvBuildFlag: -spirvtest
          artifactName: dxc_spirv_release
+         offloadCandidate: true
         VS2022_Debug:
          configuration: Debug
          spirvBuildFlag: -spirvtest
-         artifactName: ''
         VS2022_Release_NoSPIRV:
          configuration: Release
          spirvBuildFlag: ''
-         artifactName: ''
 
     steps:
     - checkout: self
       clean: true
       submodules: true
+    - pwsh: |
+        $run = $true
+        if ("$(Build.Reason)" -eq "PullRequest") {
+          $run = $false
+          try {
+            $labels = Invoke-RestMethod "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" -ErrorAction Stop
+            if ($labels.name -contains "run-offload-tests") { $run = $true }
+          } catch {
+            Write-Warning "Unable to check pull request labels; skipping offload tests: $_"
+          }
+        }
+        Write-Host "Build.Reason=$(Build.Reason) runOffloadTests=$run"
+        Write-Host "##vso[task.setvariable variable=runOffloadTests;isOutput=true]$($run.ToString().ToLower())"
+      name: decide
+      displayName: 'Decide whether to run offload tests'
+      condition: and(succeeded(), eq(variables['offloadCandidate'], 'true'))
     - script: |
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
         call utils\hct\hctbuild.cmd -vs2022 -$(platform) -$(configuration) -show-cmake-log $(spirvBuildFlag) -warp-nuget-version 1.0.16.1
@@ -103,30 +117,13 @@ stages:
           if (Test-Path "$bin\$f") { Copy-Item "$bin\$f" $dst } else { throw "Required file not found: $bin\$f" }
         }
       displayName: 'Stage DXC binaries'
-      condition: and(succeeded(), ne(variables['artifactName'], ''))
-    - pwsh: |
-        $run = $true
-        if ("$(Build.Reason)" -eq "PullRequest") {
-          $run = $false
-          try {
-            $labels = Invoke-RestMethod "https://api.github.com/repos/$(Build.Repository.Name)/issues/$(System.PullRequest.PullRequestNumber)/labels" -ErrorAction Stop
-            if ($labels.name -contains "run-offload-tests") { $run = $true }
-          } catch {
-            Write-Warning "Unable to check pull request labels; skipping offload tests: $_"
-          }
-        }
-        Write-Host "Build.Reason=$(Build.Reason) run=$run"
-        Write-Host "##vso[task.setvariable variable=run;isOutput=true]$($run.ToString().ToLower())"
-      name: decide
-      displayName: 'Decide whether to run offload tests'
-      condition: and(succeeded(), ne(variables['artifactName'], ''))
+      condition: and(succeeded(), eq(variables['decide.runOffloadTests'], 'true'))
     - task: PublishPipelineArtifact@1
       displayName: 'Publish DXC binaries'
-      condition: and(succeeded(), ne(variables['artifactName'], ''), eq(variables['decide.run'], 'true'))
+      condition: and(succeeded(), eq(variables['decide.runOffloadTests'], 'true'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)\dxc'
         artifact: '$(artifactName)'
-
 
   - job: Nix
     timeoutInMinutes: 165
@@ -228,14 +225,9 @@ stages:
         testResultsFiles: '**/testresults.xunit.xml'
       condition: succeededOrFailed()
 
-- stage: OffloadTests
-  displayName: 'Offload tests'
-  dependsOn:
-  - Build
-  condition: and(succeededOrFailed(), eq(dependencies.Build.outputs['Windows.VS2022_Release.decide.run'], 'true'))
-
-  jobs:
   - job: Offload
+    dependsOn: Windows
+    condition: and(succeededOrFailed(), eq(dependencies.Windows.outputs['VS2022_Release.decide.runOffloadTests'], 'true'))
     timeoutInMinutes: 180
     pool:
       vmImage: windows-2025

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ stages:
 - stage: Build
   dependsOn:
     - OffloadGate
+  condition: succeededOrFailed()
   jobs:
   - job: Windows
     timeoutInMinutes: 180


### PR DESCRIPTION
Currently we upload a new DXC artifact every time we run a test; this leads us to consume a lot more artifact storage than intended. This patch changes that so we only upload artifacts when lavapipe needs to run.