### PR TITLE
Fix payload access qualifier ICEs on member method calls

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,6 +28,12 @@ line upon naming the release. Refer to previous for appropriate section names.
   instead of crashing
   [#6661](https://github.com/microsoft/DirectXShaderCompiler/issues/6661).
 
+#### Bug Fixes
+
+- Fixed internal compiler errors when a member method is called on a ray payload
+  or on one of its fields with payload access qualifiers enabled
+  [#6464](https://github.com/microsoft/DirectXShaderCompiler/issues/6464).
+
 ### Upcoming Preview Release
 
 These changes apply to experimental preview shader models only and will not be

--- a/tools/clang/lib/Sema/SemaDXR.cpp
+++ b/tools/clang/lib/Sema/SemaDXR.cpp
@@ -69,9 +69,10 @@ struct PayloadAccessInfo {
 };
 
 struct DxrShaderDiagnoseInfo {
-  const FunctionDecl *funcDecl;
-  const VarDecl *Payload;
-  DXIL::PayloadAccessShaderStage Stage;
+  const FunctionDecl *funcDecl = nullptr;
+  const VarDecl *Payload = nullptr;
+  DXIL::PayloadAccessShaderStage Stage =
+      DXIL::PayloadAccessShaderStage::Invalid;
   std::vector<PayloadBuiltinCall> PayloadBuiltinCalls;
   std::map<const FieldDecl *, std::vector<PayloadUse>> WritesPerField;
   std::map<const FieldDecl *, std::vector<PayloadUse>> ReadsPerField;
@@ -85,6 +86,7 @@ DiagnosePayloadAccess(Sema &S, DxrShaderDiagnoseInfo &Info,
                       std::set<const FunctionDecl *> VisitedFunctions);
 
 const Stmt *IgnoreParensAndDecay(const Stmt *S);
+const MemberExpr *GetPayloadFieldMember(const Stmt *S);
 
 // Transform the shader stage to string to be used in diagnostics
 StringRef GetStringForShaderStage(DXIL::PayloadAccessShaderStage Stage) {
@@ -180,7 +182,7 @@ void GetPayloadAccesses(const Stmt *S, const DxrShaderDiagnoseInfo &Info,
     }
 
     GetPayloadAccesses(C, Info, Accesses, IsLValue,
-                       Member ? Member : dyn_cast<MemberExpr>(C),
+                       Member ? Member : GetPayloadFieldMember(C),
                        Call ? Call : dyn_cast<CallExpr>(C));
   }
 }
@@ -190,18 +192,20 @@ void CollectReadsWritesAndCallsForPayload(const Stmt *S,
                                           DxrShaderDiagnoseInfo &Info,
                                           const CFGBlock *Block) {
   std::vector<PayloadAccessInfo> PayloadAccesses;
-  GetPayloadAccesses(S, Info, PayloadAccesses, true, dyn_cast<MemberExpr>(S),
+  GetPayloadAccesses(S, Info, PayloadAccesses, true, GetPayloadFieldMember(S),
                      dyn_cast<CallExpr>(S));
   for (auto &Access : PayloadAccesses) {
     // An access to a payload member was found.
     if (Access.Member) {
-      FieldDecl *Field = cast<FieldDecl>(Access.Member->getMemberDecl());
-      if (Access.IsLValue) {
-        Info.WritesPerField[Field].push_back(
-            PayloadUse{S, Block, Access.Member});
-      } else {
-        Info.ReadsPerField[Field].push_back(
-            PayloadUse{S, Block, Access.Member});
+      if (FieldDecl *Field =
+              dyn_cast<FieldDecl>(Access.Member->getMemberDecl())) {
+        if (Access.IsLValue) {
+          Info.WritesPerField[Field].push_back(
+              PayloadUse{S, Block, Access.Member});
+        } else {
+          Info.ReadsPerField[Field].push_back(
+              PayloadUse{S, Block, Access.Member});
+        }
       }
     } else if (Access.Call) {
       Info.PayloadAsCallArg.push_back(PayloadUse{S, Block});
@@ -1061,6 +1065,13 @@ const Stmt *IgnoreParensAndDecay(const Stmt *S) {
       return S;
     }
   }
+}
+
+const MemberExpr *GetPayloadFieldMember(const Stmt *S) {
+  const MemberExpr *Member = dyn_cast_or_null<MemberExpr>(S);
+  if (!Member || !isa<FieldDecl>(Member->getMemberDecl()))
+    return nullptr;
+  return Member;
 }
 
 // Emit warnings for calls that pass the payload to extern functions.

--- a/tools/clang/test/DXC/payload_qualifier_nested_method_call.hlsl
+++ b/tools/clang/test/DXC/payload_qualifier_nested_method_call.hlsl
@@ -1,0 +1,46 @@
+// RUN: %dxc -T lib_6_9 %s -enable-payload-qualifiers | FileCheck %s
+
+// Regression test for two crashes in the payload-access analysis triggered by
+// calling a member method under -enable-payload-qualifiers:
+//  - a method on a nested payload field used to be mistaken for a field
+//    access, crashing in cast<FieldDecl>() with "llvm::cast<X>() argument of
+//    incompatible type!"
+//  - a method on the payload itself has no payload argument to bind, which
+//    used to leave DxrShaderDiagnoseInfo::Payload uninitialized and fault.
+// Compiling to a complete module is the actual check here.
+// CHECK: !dx.entryPoints
+
+struct Export {
+  uint x;
+  float hitT;
+  uint getType() { return x >> 24; }
+};
+
+struct [raypayload] P {
+  Export e : write(caller, closesthit) : read(caller, closesthit);
+  uint tag : write(caller, closesthit) : read(caller, closesthit);
+
+  // A method on the payload itself: the analysis has no explicit payload
+  // argument to bind here, so it must skip the call rather than crash.
+  uint getTag() { return tag; }
+};
+
+RaytracingAccelerationStructure asScene : register(t0);
+RWBuffer<float> outBuf : register(u0);
+
+[shader("closesthit")]
+void chs(inout P p, in BuiltInTriangleIntersectionAttributes a) {
+  // Method call on a nested payload field.
+  p.e.x = p.e.getType();
+  // Method call on the payload itself.
+  p.tag = p.getTag() + 1;
+}
+
+[shader("raygeneration")]
+void rgs() {
+  P p = (P)0;
+  RayDesc r = (RayDesc)0;
+  TraceRay(asScene, 0, 0xFF, 0, 0, 0, r, p);
+  outBuf[0] = p.e.hitT + p.tag;
+}
+

--- a/tools/clang/test/DXC/payload_qualifier_nested_method_call.hlsl
+++ b/tools/clang/test/DXC/payload_qualifier_nested_method_call.hlsl
@@ -1,4 +1,5 @@
-// RUN: %dxc -T lib_6_9 %s -enable-payload-qualifiers | FileCheck %s
+// REQUIRES: dxil-1-7
+// RUN: %dxc -T lib_6_7 %s -enable-payload-qualifiers | FileCheck %s
 
 // Regression test for two crashes in the payload-access analysis triggered by
 // calling a member method under -enable-payload-qualifiers:


### PR DESCRIPTION
Calling a member method on a ray payload crashed the payload access qualifier
analysis, on any `lib_6_7`+ target or with `-enable-payload-qualifiers`. It goes
back to at least DXC 1.7.2207.

 - Fix the `cast<FieldDecl>` failure when the method is called on a payload field
 - Fix the uninitialized read when the method is called on the payload itself
 - Add a regression test that fails if either fix is reverted

Method bodies are still not analyzed, so a write inside a payload method is not
seen by the "never unconditionally written" check. That already matches how a
write through an `inout` free function parameter behaves today.

Fixes #6464
Assisted-by: copilot
