### PR TITLE
Improve Copilot release note review guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ When to skip a release note comment:
 
 When reviewing an existing release note:
 - Check it against the release note policy and entry rules in `CONTRIBUTING.md`.
+- Review the PR as merged with the current base branch, not only the head branch's file contents. If the head branch is behind or diverged from the base branch, account for newer release headings already on the base branch and flag the PR for an update when the stale branch makes the entry's final placement ambiguous or incorrect.
 - Put changes targeting the next release under `### Upcoming Release`.
 - Use `### Upcoming Preview Release` only for changes that apply exclusively to experimental preview shader models.
 - Do not add entries to an already named release unless the change explicitly targets that release.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,9 +16,15 @@ How to comment when release notes are missing:
 - If it is not obvious whether one is required, leave only a gentle prompt: **"Did you consider adding a release note?"**
 
 When to skip a release note comment:
-- If the PR already updates `docs/ReleaseNotes.md`, do not ask for an additional release note.
+- If the PR already updates `docs/ReleaseNotes.md`, review the entry's placement and content instead of asking for an additional release note.
 - If the PR is docs-only, do not leave a release note comment.
 - If the PR is a dependency bump (for example, a "Bump ..." PR), do not leave a release note comment.
+
+When reviewing an existing release note:
+- Check it against the release note policy and entry rules in `CONTRIBUTING.md`.
+- Put changes targeting the next release under `### Upcoming Release`.
+- Use `### Upcoming Preview Release` only for changes that apply exclusively to experimental preview shader models or other preview-only behavior.
+- Do not add entries to an already named release unless the change explicitly targets that release.
 
 Comment tone:
 - Use a stronger ask when the PR clearly appears to be a user-visible bug fix or feature.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,13 +17,13 @@ How to comment when release notes are missing:
 
 When to skip a release note comment:
 - If the PR already updates `docs/ReleaseNotes.md`, review the entry's placement and content instead of asking for an additional release note.
-- If the PR is docs-only, do not leave a release note comment.
+- If the PR is docs-only and does not modify `docs/ReleaseNotes.md`, do not leave a release note comment.
 - If the PR is a dependency bump (for example, a "Bump ..." PR), do not leave a release note comment.
 
 When reviewing an existing release note:
 - Check it against the release note policy and entry rules in `CONTRIBUTING.md`.
 - Put changes targeting the next release under `### Upcoming Release`.
-- Use `### Upcoming Preview Release` only for changes that apply exclusively to experimental preview shader models or other preview-only behavior.
+- Use `### Upcoming Preview Release` only for changes that apply exclusively to experimental preview shader models.
 - Do not add entries to an already named release unless the change explicitly targets that release.
 
 Comment tone:


### PR DESCRIPTION
Teach Copilot reviews to validate the placement and content of existing release-note entries, rather than treating any update to docs/ReleaseNotes.md as sufficient.

This should catch entries for ordinary fixes that are incorrectly placed under the preview-only release section.

Assissted-by: copilot