### PR TITLE
[SM6.10] Add BFloat16 Support

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -40,10 +40,6 @@ line upon naming the release. Refer to previous for appropriate section names.
   or on one of its fields with payload access qualifiers enabled
   [#6464](https://github.com/microsoft/DirectXShaderCompiler/issues/6464).
 
-#### LinAlg Matrix
-- Adds `BFloat16` to the ComponentType enum in DxilConstants and the linalg
-  header [#8722](https://github.com/microsoft/DirectXShaderCompiler/issues/8722)
-
 ### Upcoming Preview Release
 
 These changes apply to experimental preview shader models only and will not be
@@ -62,6 +58,8 @@ first shipped in the 1.10.2605 preview.
   [#8588](https://github.com/microsoft/DirectXShaderCompiler/pull/8588).
 - Restricted the component types allowed in LinAlg matrices
   [#8608](https://github.com/microsoft/DirectXShaderCompiler/pull/8608).
+- Added `BFloat16` to the ComponentType enum in DxilConstants and the linalg
+  header [#8722](https://github.com/microsoft/DirectXShaderCompiler/issues/8722)
 
 ### Version 1.9.2607
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -40,6 +40,10 @@ line upon naming the release. Refer to previous for appropriate section names.
   or on one of its fields with payload access qualifiers enabled
   [#6464](https://github.com/microsoft/DirectXShaderCompiler/issues/6464).
 
+#### LinAlg Matrix
+- Adds `BFloat16` to the ComponentType enum in DxilConstants and the linalg
+  header [#8722](https://github.com/microsoft/DirectXShaderCompiler/issues/8722)
+
 ### Upcoming Preview Release
 
 These changes apply to experimental preview shader models only and will not be

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -199,6 +199,10 @@ enum class ComponentType : uint32_t {
   F8_E5M2 = 22,
   // END
 
+  // BEGIN NEW FOR SM 6.10
+  BFloat16 = 23,
+  // END
+
   LastEntry
 };
 

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -569,9 +569,10 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
   RDAT_ENUM_VALUE_NODEF(I8)
   RDAT_ENUM_VALUE_NODEF(F8_E4M3FN)
   RDAT_ENUM_VALUE_NODEF(F8_E5M2)
+  RDAT_ENUM_VALUE_NODEF(BFloat16)
   RDAT_ENUM_VALUE_NODEF(LastEntry)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 23,
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 24,
                 "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1040,6 +1040,7 @@ static void ValidateLinAlgOpReturnMatrix(CallInst *CI,
   case DXIL::ComponentType::F16:
   case DXIL::ComponentType::F32:
   case DXIL::ComponentType::F64:
+  case DXIL::ComponentType::BFloat16:
     break;
   default:
     ValCtx.EmitInstrFormatError(CI,

--- a/lib/DxilValidation/DxilValidationUtils.cpp
+++ b/lib/DxilValidation/DxilValidationUtils.cpp
@@ -665,6 +665,8 @@ llvm::StringRef ComponentTypeToString(DXIL::ComponentType CT) {
     return "F8_E4M3FN";
   case DXIL::ComponentType::F8_E5M2:
     return "F8_E5M2";
+  case DXIL::ComponentType::BFloat16:
+    return "BFloat16";
   default:
     return "Unknown ComponentType";
   }

--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -238,8 +238,8 @@ template <ComponentEnum ComponentTy, SIZE_TYPE M, SIZE_TYPE N,
           MatrixUseEnum Use, MatrixScopeEnum Scope>
 class Matrix {
   using ElementType = typename __detail::ComponentTypeTraits<ComponentTy>::Type;
-  // If this isn't a native scalar, we have an 8-bit type, so we have 4 elements
-  // packed in each scalar value.
+  // If this isn't a native scalar, we have a type that may pack more than 1
+  // element in each scalar value. (Ex. 8bit => 4elems, 16bit => 2elems)
   static const uint ElementsPerScalar =
       __detail::ComponentTypeTraits<ComponentTy>::ElementsPerScalar;
   static const bool IsNativeScalar =

--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -43,11 +43,15 @@ enum class ComponentType : uint32_t {
   PackedS8x32 = 17,
   PackedU8x32 = 18,
 
-  // BEGIN NEW FOR SM 6.10
+  // BEGIN NEW FOR SM 6.9
   I8 = 19,
   U8 = 20,
   F8_E4M3FN = 21,
   F8_E5M2 = 22,
+  // END
+
+  // BEGIN NEW FOR SM 6.10
+  BFloat16 = 23,
   // END
 
   LastEntry
@@ -83,6 +87,7 @@ struct ComponentType {
     __COMPONENT_TYPE(F16),
     __COMPONENT_TYPE(F32),
     __COMPONENT_TYPE(F64),
+    __COMPONENT_TYPE(BFloat16),
   };
 };
 
@@ -130,6 +135,12 @@ template <ComponentEnum CompTy> struct ComponentTypeTraits {
 template <typename T> struct TypeTraits {
   static const ComponentEnum CompType =
       (ComponentEnum)dxil::ComponentType::Invalid;
+};
+
+template <> struct ComponentTypeTraits<ComponentType::BFloat16> {
+  using Type = uint;
+  static const bool IsNativeScalar = false;
+  static const uint ElementsPerScalar = 2;
 };
 
 #define __MATRIX_SCALAR_COMPONENT_MAPPING(enum_val, type)                      \

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -17896,6 +17896,8 @@ ConvertLinAlgMatrixComponentTypeToString(hlsl::DXIL::ComponentType CompType) {
     return "ComponentType::F8_E4M3FN";
   case DXIL::ComponentType::F8_E5M2:
     return "ComponentType::F8_E5M2";
+  case DXIL::ComponentType::BFloat16:
+    return "ComponentType::BFloat16";
   default:
     llvm_unreachable("Unknown ComponentType");
   }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/vectors.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/vectors.hlsl
@@ -9,6 +9,7 @@ using MatrixAccum_8_8_Ty = Matrix<ComponentType::F16, 8, 8, MatrixUse::Accumulat
 using MatrixAccum_8_4_Ty = Matrix<ComponentType::F16, 8, 4, MatrixUse::Accumulator, MatrixScope::Thread>;
 using Matrix_7_15_ATy = Matrix<ComponentType::F16, 7, 15, MatrixUse::A, MatrixScope::Thread>;
 using MatrixPacked_7_15_ATy = Matrix<ComponentType::F8_E4M3FN, 7, 15, MatrixUse::A, MatrixScope::Thread>;
+using MatrixA_BFloat = Matrix<ComponentType::BFloat16, 8, 4, MatrixUse::A, MatrixScope::Thread>;
 
 RWByteAddressBuffer RWBAB : register(u0);
 ByteAddressBuffer BAB : register(t0);
@@ -111,6 +112,10 @@ void main(uint ID : SV_GroupID) {
   // CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   Matrix_7_15_ATy Mat_7_15 = Matrix_7_15_ATy::Load<MatrixLayoutEnum::ColMajor>(BAB, 0, 16);
 
+  // CHECK: %[[MATBF:.*]] = call %dx.types.LinAlgMatrixC23M8N4U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC23M8N4U0S0(i32 -2147483634,
+  // CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
+  MatrixA_BFloat MatBF = MatrixA_BFloat::Load<MatrixLayoutEnum::ColMajor>(BAB, 0, 16);
+
   // CHECK: call <7 x half> @dx.op.linAlgMatVecMulAdd.v7f16.mC8M7N15U0S0.v15f16.v7f16(i32 -2147483622,
   // CHECK-SAME: %dx.types.LinAlgMatrixC8M7N15U0S0 %[[MAT_7_15]], i1 true, <15 x half> %{{[0-9]+}}, i32 8, <7 x half> %{{[0-9]+}})
   // CHECK-SAME: ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
@@ -155,7 +160,14 @@ void main(uint ID : SV_GroupID) {
   // CHECK-SAME: %dx.types.LinAlgMatrixC8M7N15U0S0 %[[MAT_7_15]], i1 true, <4 x i32> %[[INTERP_VEC_H15_PACKED]], i32 21, <7 x half> %[[MEM_BIAS3]])
   // CHECK-SAME: ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
 
-   vector<half, 7> vec12 = MultiplyAdd<half>(Mat_7_15, interpVecH15Packed, memBias7);
+  vector<half, 7> vec12 = MultiplyAdd<half>(Mat_7_15, interpVecH15Packed, memBias7);
+
+  // CHECK: call <8 x half> @dx.op.linAlgMatVecMul.v8f16.mC23M8N4U0S0.v2i32(i32 -2147483623,
+  // CHECK-SAME: %dx.types.LinAlgMatrixC23M8N4U0S0 %[[MATBF]], i1 true, <2 x i32> <i32 12345, i32 12345>, i32 23)
+  // CHECK-SAME: ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
+  vector<uint, 2> vecBfloatBin = 12345;
+  InterpretedVector<uint, 2, ComponentType::BFloat16> vecBfloat = MakeInterpretedVector<ComponentType::BFloat16>(vecBfloatBin);
+  vector<half, 8> vecBFMul = Multiply<half>(MatBF, vecBfloat);
 
   // Test Convert and MultiplyAdd with odd sizes and packed types
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-illegal-component-type.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-illegal-component-type.ll
@@ -7,17 +7,22 @@ target triple = "dxil-ms-dx"
 %dx.types.Handle = type { i8* }
 %dx.types.ResBind = type { i32, i32, i32, i8 }
 %dx.types.LinAlgMatrixC0M128N128U0S0 = type { i8* }
+%dx.types.LinAlgMatrixC23M128N128U0S0 = type { i8* }
 %dx.types.ResourceProperties = type { i32, i32 }
 %struct.RWByteAddressBuffer = type { i32 }
 
 define void @main() {
   %1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 1 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
-  %handle = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+  %h1 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
 
   ; CHECK: Function: main: error: Matrix Component Type 'Invalid' not allowed in LinAlg Matrix.
   ; CHECK-NEXT: note: at '%mC0M128N128U0S0
   ; Matrix<Invalid, 128, 128, A, Thread>
-  %mC0M128N128U0S0 = call %dx.types.LinAlgMatrixC0M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC0M128N128U0S0(i32 -2147483634, %dx.types.Handle %handle, i32 0, i32 0, i32 0, i32 0)
+  %mC0M128N128U0S0 = call %dx.types.LinAlgMatrixC0M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC0M128N128U0S0(i32 -2147483634, %dx.types.Handle %h1, i32 0, i32 0, i32 0, i32 0)
+
+  ; C23 (BFloat16) is not invalid
+  %h2 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+  %mC23M128N128U0S0 = call %dx.types.LinAlgMatrixC23M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC23M128N128U0S0(i32 -2147483634, %dx.types.Handle %h2, i32 0, i32 0, i32 0, i32 0)
 
   ; CHECK-NEXT: Validation failed.
 
@@ -26,6 +31,9 @@ define void @main() {
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC0M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC0M128N128U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC23M128N128U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC23M128N128U0S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind readnone
 declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #1
@@ -36,7 +44,7 @@ declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
 
-!dx.targetTypes = !{!26}
+!dx.targetTypes = !{!26, !27}
 !llvm.ident = !{!17}
 !dx.version = !{!18}
 !dx.valver = !{!18}
@@ -54,3 +62,4 @@ attributes #1 = { nounwind readnone }
 !24 = !{i32 0, i64 8589934608, i32 4, !25}
 !25 = !{i32 4, i32 4, i32 4}
 !26 = !{%dx.types.LinAlgMatrixC0M128N128U0S0 undef, i32 0, i32 128, i32 128, i32 0, i32 0}
+!27 = !{%dx.types.LinAlgMatrixC23M128N128U0S0 undef, i32 23, i32 128, i32 128, i32 0, i32 0}


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/8722


https://github.com/microsoft/hlsl-specs/pull/907 added `BFloat16` as an allowed ComponentType in the LinAlg API. This PR adds support for it to the implementation.