### PR TITLE
[HLSL] Add LinAlg element boundary coverage and gate remaining tests

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -32,8 +32,6 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
 
 #endif
 
-namespace {
-
 constexpr UINT KnownMultiplicationFlags = 0xf;
 constexpr UINT MatrixMultiplicationFlags =
     static_cast<UINT>(
@@ -43,7 +41,7 @@ constexpr UINT MatrixMultiplicationFlags =
         linalg_abi::
             D3D12_LINEAR_ALGEBRA_MULTIPLICATION_SUPPORT_FLAG_EMULATED_OUTPUTS);
 
-bool isValidMultiplicationFlags(UINT Flags, UINT AllowedFlags) {
+static bool isValidMultiplicationFlags(UINT Flags, UINT AllowedFlags) {
   if ((Flags & ~AllowedFlags) != 0)
     return false;
   return Flags == 0 ||
@@ -54,12 +52,12 @@ bool isValidMultiplicationFlags(UINT Flags, UINT AllowedFlags) {
              0;
 }
 
-bool isFloat8DataType(linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type) {
+static bool isFloat8DataType(linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type) {
   return Type == linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT8_E4M3FN ||
          Type == linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT8_E5M2;
 }
 
-bool isValidThreadVectorMultiplicationFlags(
+static bool isValidThreadVectorMultiplicationFlags(
     UINT Flags, linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE MatrixInputType) {
   if (!isValidMultiplicationFlags(Flags, KnownMultiplicationFlags))
     return false;
@@ -69,7 +67,7 @@ bool isValidThreadVectorMultiplicationFlags(
   return (Flags & EmulatedInputs) == 0 || isFloat8DataType(MatrixInputType);
 }
 
-LPCWSTR dataTypeName(linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type) {
+static LPCWSTR dataTypeName(linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type) {
   switch (Type) {
   case linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE_NONE:
     return L"None";
@@ -97,7 +95,7 @@ LPCWSTR dataTypeName(linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type) {
   return L"Unknown";
 }
 
-void setWaveInputs(
+static void setWaveInputs(
     linalg_abi::D3D12_LINEAR_ALGEBRA_WAVE_MATRIX_MULTIPLY_INPUTS &RuntimeInputs,
     const linalg_test::WaveMatrixMultiplyInputs &Inputs) {
   RuntimeInputs.WaveSize = Inputs.WaveSize;
@@ -108,8 +106,6 @@ void setWaveInputs(
   RuntimeInputs.AccumulatorComponentType =
       static_cast<UINT>(Inputs.AccumulatorComponentType);
 }
-
-} // namespace
 
 using namespace hlsl_test;
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -198,7 +198,7 @@ static HRESULT supportsMatrixShape(
   return S_OK;
 }
 
-// The shaders declare [WaveSize(4, 64)], so a capability query is only
+// The shaders declare [WaveSize(4, 128)], so a capability query is only
 // meaningful for wave sizes the device can actually launch within that range.
 static HRESULT queryLaunchableWaveSizes(ID3D12Device *Device, UINT &MinWaveSize,
                                         UINT &MaxWaveSize) {
@@ -237,7 +237,7 @@ static HRESULT queryLaunchableWaveSizes(ID3D12Device *Device, UINT &MinWaveSize,
 // MATRIX_CONSTRUCTION is answered per wave size, so a case that queries it must
 // also compile for the size it asked about. Callers pass SelectedWaveSize to
 // their runner, which pins it with FORCED_WAVE_SIZE. Without that pin the
-// shader declares WaveSize(4, 64), the driver picks whatever it likes, and the
+// shader declares WaveSize(4, 128), the driver picks whatever it likes, and the
 // query answers a question the test never asks.
 //
 // Uses lists every matrix role the case constructs. A wave size only qualifies
@@ -277,8 +277,9 @@ queryMatrixConstructionSupport(ID3D12Device *Device, const MatrixParams &Params,
     return S_OK;
   }
 
-  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
+  for (UINT WaveSize = 4; WaveSize <= 128; WaveSize *= 2) {
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize ||
+        WaveSize > static_cast<UINT>(Params.NumThreads))
       continue;
 
     bool AllRolesSupported = true;
@@ -437,8 +438,9 @@ static HRESULT queryWaveMatMulSupport(ID3D12Device *Device,
     return S_OK;
   }
 
-  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
+  for (UINT WaveSize = 4; WaveSize <= 128; WaveSize *= 2) {
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize ||
+        WaveSize > static_cast<UINT>(Params.NumThreads))
       continue;
 
     bool ConstructionSupported = true;
@@ -1837,7 +1839,7 @@ static const char LoadStoreDescriptorShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -1907,7 +1909,7 @@ void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -1926,7 +1928,7 @@ static const char SplatStoreShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -1984,7 +1986,7 @@ void DxilConf_SM610_LinAlg::SplatStore_Wave_16x16_F16() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -2006,7 +2008,7 @@ static const char AccumulateDescriptorShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -2076,7 +2078,7 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -2114,7 +2116,7 @@ static const char ElementAccessShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
@@ -2206,7 +2208,7 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -2227,7 +2229,7 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = false;
 
   UINT SelectedWaveSize = 0;
@@ -2250,7 +2252,7 @@ static const char ElementSetShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -2325,7 +2327,7 @@ void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -2367,7 +2369,7 @@ static const char ElementGetOOBShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
@@ -2508,7 +2510,7 @@ void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = false;
 
   UINT SelectedWaveSize = 0;
@@ -2528,7 +2530,7 @@ static const char ElementSetOOBShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
@@ -2625,7 +2627,7 @@ void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = false;
 
   UINT SelectedWaveSize = 0;
@@ -2645,7 +2647,7 @@ static const char CopyConvertShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -2707,8 +2709,9 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
     Destination.N = Params.M;
   }
 
-  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
+  for (UINT WaveSize = 4; WaveSize <= 128; WaveSize *= 2) {
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize ||
+        WaveSize > static_cast<UINT>(Params.NumThreads))
       continue;
 
     bool SourceSupported = false;
@@ -2845,7 +2848,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16() {
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -2865,7 +2868,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16_Transpose() {
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -2886,7 +2889,7 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = false;
 
   bool Supported;
@@ -2917,7 +2920,7 @@ static const char MatMatMulShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -2987,7 +2990,7 @@ void DxilConf_SM610_LinAlg::MatMatMul_Wave_16x16x16_F16() {
   Params.N = 16;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -3009,7 +3012,7 @@ static const char MatMatMulAccumShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -3084,7 +3087,7 @@ void DxilConf_SM610_LinAlg::MatMatMulAccum_Wave_16x16x16_F16() {
   Params.N = 16;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -3107,7 +3110,7 @@ static const char MatAccumShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -3172,7 +3175,7 @@ void DxilConf_SM610_LinAlg::MatAccum_Wave_16x16_F16() {
   Params.N = 16;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   // MatAccum builds both an accumulator and an A matrix, and the two roles pin
@@ -3725,7 +3728,7 @@ static const char LoadMemoryShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
@@ -3799,7 +3802,7 @@ void DxilConf_SM610_LinAlg::LoadMemory_Wave_16x16_F16() {
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -3819,7 +3822,7 @@ static const char StoreMemoryShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
@@ -3883,7 +3886,7 @@ void DxilConf_SM610_LinAlg::StoreMemory_Wave_16x16_F16() {
   Params.Use = MatrixUse::A;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
@@ -3905,7 +3908,7 @@ static const char AccumulateMemoryShader[] = R"(
   #ifdef FORCED_WAVE_SIZE
   [WaveSize(FORCED_WAVE_SIZE)]
   #else
-  [WaveSize(4, 64)]
+  [WaveSize(4, 128)]
   #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
@@ -3977,7 +3980,7 @@ void DxilConf_SM610_LinAlg::AccumulateMemory_Wave_16x16_F16() {
   Params.Use = MatrixUse::Accumulator;
   Params.Scope = MatrixScope::Wave;
   Params.Layout = MatrixLayout::RowMajor;
-  Params.NumThreads = 64;
+  Params.NumThreads = 128;
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -244,9 +244,10 @@ static HRESULT queryLaunchableWaveSizes(ID3D12Device *Device, UINT &MinWaveSize,
 // if every role is supported there, because the roles pin different extents of
 // the same {M, K, N} shape.
 static HRESULT
-queryMatrixConstructionSupport(ID3D12Device *Device, const MatrixParams &Params,
-                               std::initializer_list<MatrixUse> Uses,
-                               bool &Supported, UINT &SelectedWaveSize) {
+selectMatrixConstructionWaveSize(ID3D12Device *Device,
+                                 const MatrixParams &Params,
+                                 std::initializer_list<MatrixUse> Uses,
+                                 bool &Supported, UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
   if (!Device || Uses.size() == 0 ||
@@ -312,19 +313,29 @@ queryMatrixConstructionSupport(ID3D12Device *Device, const MatrixParams &Params,
   return S_OK;
 }
 
+// SelectedWaveSize is only meaningful when one of these helpers returns true.
+// The selectors set it on the same path that reports support, so a case cleared
+// to run always has a wave size to pin with FORCED_WAVE_SIZE. It stays 0 on the
+// skip and failure paths, where the caller has already returned. The assert
+// keeps that an invariant rather than a convention.
 static bool matrixConstructionApplicable(ID3D12Device *Device,
                                          const MatrixParams &Params,
                                          std::initializer_list<MatrixUse> Uses,
                                          LPCWSTR CaseName,
                                          UINT &SelectedWaveSize) {
   bool Supported = false;
-  const HRESULT QueryResult = queryMatrixConstructionSupport(
+  const HRESULT QueryResult = selectMatrixConstructionWaveSize(
       Device, Params, Uses, Supported, SelectedWaveSize);
-  return applyApplicability(
-      linalg_test::classifyApplicability(
-          QueryResult, Supported,
-          linalg_test::CapabilityRequirement::CapabilityGated),
-      CaseName);
+  if (!applyApplicability(
+          linalg_test::classifyApplicability(
+              QueryResult, Supported,
+              linalg_test::CapabilityRequirement::CapabilityGated),
+          CaseName))
+    return false;
+
+  VERIFY_IS_TRUE(SelectedWaveSize != 0,
+                 "A case cleared to run must have a selected wave size");
+  return true;
 }
 
 // Tier support is the only capability the matrix-free operations depend on.
@@ -405,9 +416,10 @@ static bool outerProductApplicable(ID3D12Device *Device,
 // both are answered per wave size, so they are resolved in one pass. Fp16 x
 // Fp16 -> Fp16 is Optional at Tier 1, so these cases are gated rather than
 // mandatory.
-static HRESULT queryWaveMatMulSupport(ID3D12Device *Device,
-                                      const MatrixParams &Params, MatrixDim K,
-                                      bool &Supported, UINT &SelectedWaveSize) {
+static HRESULT selectWaveMatMulWaveSize(ID3D12Device *Device,
+                                        const MatrixParams &Params, MatrixDim K,
+                                        bool &Supported,
+                                        UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
   if (!Device ||
@@ -487,12 +499,17 @@ static bool waveMatMulApplicable(ID3D12Device *Device,
                                  LPCWSTR CaseName, UINT &SelectedWaveSize) {
   bool Supported = false;
   const HRESULT QueryResult =
-      queryWaveMatMulSupport(Device, Params, K, Supported, SelectedWaveSize);
-  return applyApplicability(
-      linalg_test::classifyApplicability(
-          QueryResult, Supported,
-          linalg_test::CapabilityRequirement::CapabilityGated),
-      CaseName);
+      selectWaveMatMulWaveSize(Device, Params, K, Supported, SelectedWaveSize);
+  if (!applyApplicability(
+          linalg_test::classifyApplicability(
+              QueryResult, Supported,
+              linalg_test::CapabilityRequirement::CapabilityGated),
+          CaseName))
+    return false;
+
+  VERIFY_IS_TRUE(SelectedWaveSize != 0,
+                 "A case cleared to run must have a selected wave size");
+  return true;
 }
 
 namespace cpu_oracle {
@@ -2665,10 +2682,10 @@ static const char CopyConvertShader[] = R"(
   }
 )";
 
-static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
-                                       const MatrixParams &Params,
-                                       bool Transpose, bool &Supported,
-                                       UINT &SelectedWaveSize) {
+static HRESULT selectCopyConvertWaveSize(ID3D12Device *Device,
+                                         const MatrixParams &Params,
+                                         bool Transpose, bool &Supported,
+                                         UINT &SelectedWaveSize) {
   Supported = false;
   SelectedWaveSize = 0;
   if (!Device || Params.Use != MatrixUse::A ||
@@ -2746,13 +2763,18 @@ static bool copyConvertApplicable(ID3D12Device *Device,
                                   const MatrixParams &Params, bool Transpose,
                                   LPCWSTR CaseName, UINT &SelectedWaveSize) {
   bool Supported = false;
-  const HRESULT QueryResult = queryCopyConvertSupport(
+  const HRESULT QueryResult = selectCopyConvertWaveSize(
       Device, Params, Transpose, Supported, SelectedWaveSize);
-  return applyApplicability(
-      linalg_test::classifyApplicability(
-          QueryResult, Supported,
-          linalg_test::CapabilityRequirement::CapabilityGated),
-      CaseName);
+  if (!applyApplicability(
+          linalg_test::classifyApplicability(
+              QueryResult, Supported,
+              linalg_test::CapabilityRequirement::CapabilityGated),
+          CaseName))
+    return false;
+
+  VERIFY_IS_TRUE(SelectedWaveSize != 0,
+                 "A case cleared to run must have a selected wave size");
+  return true;
 }
 
 static void runCopyConvert(ID3D12Device *Device,
@@ -2889,17 +2911,10 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
   Params.NumThreads = 128;
   Params.Enable16Bit = false;
 
-  bool Supported;
-  UINT SelectedWaveSize;
-  const HRESULT QueryResult = queryCopyConvertSupport(
-      D3DDevice, Params, /*Transpose=*/true, Supported, SelectedWaveSize);
-  const linalg_test::Applicability Applicability =
-      linalg_test::classifyApplicability(
-          QueryResult, Supported,
-          linalg_test::CapabilityRequirement::CapabilityGated);
-  if (!applyApplicability(
-          Applicability,
-          L"CopyConvert_Wave_4x8_F32_Transpose MatrixConstruction"))
+  UINT SelectedWaveSize = 0;
+  if (!copyConvertApplicable(D3DDevice, Params, /*Transpose=*/true,
+                             L"CopyConvert_Wave_4x8_F32_Transpose",
+                             SelectedWaveSize))
     return;
 
   // Non-square dimensions make the destination shape and row stride observable.

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -228,6 +228,269 @@ static HRESULT queryLaunchableWaveSizes(ID3D12Device *Device, UINT &MinWaveSize,
   return S_OK;
 }
 
+// MATRIX_CONSTRUCTION is answered per wave size, so a case that queries it must
+// also compile for the size it asked about. Callers pass SelectedWaveSize to
+// their runner, which pins it with FORCED_WAVE_SIZE. Without that pin the
+// shader declares WaveSize(4, 64), the driver picks whatever it likes, and the
+// query answers a question the test never asks.
+//
+// Uses lists every matrix role the case constructs. A wave size only qualifies
+// if every role is supported there, because the roles pin different extents of
+// the same {M, K, N} shape.
+static HRESULT
+queryMatrixConstructionSupport(ID3D12Device *Device, const MatrixParams &Params,
+                               std::initializer_list<MatrixUse> Uses,
+                               bool &Supported, UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!Device || Uses.size() == 0 ||
+      !linalg_test::isLegalScope(
+          linalg_abi::D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_MATRIX_CONSTRUCTION,
+          Params.Scope))
+    return E_INVALIDARG;
+
+  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  UINT MinWaveSize = 0;
+  UINT MaxWaveSize = 0;
+  HR = queryLaunchableWaveSizes(Device, MinWaveSize, MaxWaveSize);
+  if (FAILED(HR))
+    return HR;
+  if (MinWaveSize == 0) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; MatrixConstruction is not "
+        L"applicable");
+    return S_OK;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
+      continue;
+
+    bool AllRolesSupported = true;
+    for (const MatrixUse Use : Uses) {
+      bool ShapeSupported = false;
+      HR = supportsMatrixShape(Device, *DataType, WaveSize, Use, Params.M,
+                               Params.N, ShapeSupported);
+      if (FAILED(HR))
+        return HR;
+      if (!ShapeSupported) {
+        AllRolesSupported = false;
+        break;
+      }
+    }
+
+    if (AllRolesSupported) {
+      hlsl_test::LogCommentFmt(
+          L"MatrixConstruction capability matched wave=%u for the %ux%u tile",
+          WaveSize, Params.M, Params.N);
+      Supported = true;
+      SelectedWaveSize = WaveSize;
+      return S_OK;
+    }
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No MatrixConstruction query within shader WaveSize(4,64) supports the "
+      L"%ux%u tile",
+      Params.M, Params.N);
+  return S_OK;
+}
+
+static bool matrixConstructionApplicable(ID3D12Device *Device,
+                                         const MatrixParams &Params,
+                                         std::initializer_list<MatrixUse> Uses,
+                                         LPCWSTR CaseName,
+                                         UINT &SelectedWaveSize) {
+  bool Supported = false;
+  const HRESULT QueryResult = queryMatrixConstructionSupport(
+      Device, Params, Uses, Supported, SelectedWaveSize);
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
+// Tier support is the only capability the matrix-free operations depend on.
+// They construct no matrix, so there is no shape or wave size to query.
+static bool linAlgTierApplicable(ID3D12Device *Device, LPCWSTR CaseName) {
+  linalg_test::TierSupport Tier;
+  const HRESULT QueryResult = linalg_test::queryTierSupport(Device, Tier);
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, SUCCEEDED(QueryResult) && Tier.supported(),
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
+// Accumulation store reports its destinations separately: a device may support
+// accumulating into a buffer but not into groupshared memory, or the reverse.
+// Tier 1 requires no formats at all here, so every case is gated.
+static bool
+accumulateStoreApplicable(ID3D12Device *Device, ComponentType CompType,
+                          linalg_test::AtomicDestination Destination,
+                          LPCWSTR CaseName) {
+  bool Supported = false;
+  HRESULT QueryResult = E_INVALIDARG;
+
+  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> DataType =
+      toCapabilityDataType(CompType);
+  if (DataType.has_value()) {
+    linalg_test::TierSupport Tier;
+    QueryResult = linalg_test::queryTierSupport(Device, Tier);
+    if (SUCCEEDED(QueryResult) && Tier.supported()) {
+      linalg_test::AtomicAccumulateStoreSupport Support;
+      QueryResult =
+          linalg_test::queryAtomicAccumulateStore(Device, {*DataType}, Support);
+      if (SUCCEEDED(QueryResult))
+        Supported = Support.supports(Destination);
+    }
+  }
+
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
+// Tier 1 requires no outer product formats, so this is always gated.
+static bool outerProductApplicable(ID3D12Device *Device,
+                                   ComponentType InputCompType,
+                                   ComponentType ResultCompType,
+                                   LPCWSTR CaseName) {
+  bool Supported = false;
+  HRESULT QueryResult = E_INVALIDARG;
+
+  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> InputType =
+      toCapabilityDataType(InputCompType);
+  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> ResultType =
+      toCapabilityDataType(ResultCompType);
+  if (InputType.has_value() && ResultType.has_value()) {
+    linalg_test::TierSupport Tier;
+    QueryResult = linalg_test::queryTierSupport(Device, Tier);
+    if (SUCCEEDED(QueryResult) && Tier.supported()) {
+      linalg_test::ThreadOuterProductSupport Support;
+      QueryResult = linalg_test::queryThreadOuterProduct(
+          Device, {*InputType, *ResultType}, Support);
+      if (SUCCEEDED(QueryResult))
+        Supported = Support.supported();
+    }
+  }
+
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
+// Wave matrix multiply needs both the matrices and the operation itself, and
+// both are answered per wave size, so they are resolved in one pass. Fp16 x
+// Fp16 -> Fp16 is Optional at Tier 1, so these cases are gated rather than
+// mandatory.
+static HRESULT queryWaveMatMulSupport(ID3D12Device *Device,
+                                      const MatrixParams &Params, MatrixDim K,
+                                      bool &Supported, UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!Device ||
+      !linalg_test::isLegalScope(
+          linalg_abi::D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_WAVE_MATRIX_MULTIPLY,
+          Params.Scope))
+    return E_INVALIDARG;
+
+  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  UINT MinWaveSize = 0;
+  UINT MaxWaveSize = 0;
+  HR = queryLaunchableWaveSizes(Device, MinWaveSize, MaxWaveSize);
+  if (FAILED(HR))
+    return HR;
+  if (MinWaveSize == 0) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; WaveMatrixMultiply is not "
+        L"applicable");
+    return S_OK;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
+      continue;
+
+    bool ConstructionSupported = true;
+    for (const MatrixUse Use :
+         {MatrixUse::A, MatrixUse::B, MatrixUse::Accumulator}) {
+      bool ShapeSupported = false;
+      HR = supportsMatrixShape(Device, *DataType, WaveSize, Use, Params.M,
+                               Params.N, ShapeSupported);
+      if (FAILED(HR))
+        return HR;
+      if (!ShapeSupported) {
+        ConstructionSupported = false;
+        break;
+      }
+    }
+    if (!ConstructionSupported)
+      continue;
+
+    linalg_abi::D3D12_LINEAR_ALGEBRA_MATRIX_SHAPE Shape = {};
+    Shape.M = Params.M;
+    Shape.K = K;
+    Shape.N = Params.N;
+
+    linalg_test::WaveMatrixMultiplySupport Support;
+    HR = linalg_test::queryWaveMatrixMultiply(
+        Device, {{WaveSize, *DataType, *DataType, *DataType}, Shape}, Support);
+    if (FAILED(HR))
+      return HR;
+    if (Support.supported()) {
+      hlsl_test::LogCommentFmt(
+          L"WaveMatrixMultiply capability matched wave=%u for %ux%ux%u",
+          WaveSize, Params.M, K, Params.N);
+      Supported = true;
+      SelectedWaveSize = WaveSize;
+      return S_OK;
+    }
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No WaveMatrixMultiply query within shader WaveSize(4,64) supports "
+      L"%ux%ux%u",
+      Params.M, K, Params.N);
+  return S_OK;
+}
+
+static bool waveMatMulApplicable(ID3D12Device *Device,
+                                 const MatrixParams &Params, MatrixDim K,
+                                 LPCWSTR CaseName, UINT &SelectedWaveSize) {
+  bool Supported = false;
+  const HRESULT QueryResult =
+      queryWaveMatMulSupport(Device, Params, K, Supported, SelectedWaveSize);
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
 namespace cpu_oracle {
 
 using TypedMatrixValues =
@@ -1565,7 +1828,11 @@ static const char LoadStoreDescriptorShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1583,13 +1850,17 @@ static const char LoadStoreDescriptorShader[] = R"(
 
 static void runLoadStoreDescriptor(ID3D12Device *Device,
                                    dxc::SpecificDllLoader &DxcSupport,
-                                   const MatrixParams &Params, bool Verbose) {
+                                   const MatrixParams &Params, bool Verbose,
+                                   UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
   // TODO: these should be varied by test to ensure full coverage
   std::stringstream ExtraDefs;
   ExtraDefs << " -DOFFSET=" << 0;
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1632,13 +1903,25 @@ void DxilConf_SM610_LinAlg::LoadStoreDescriptor_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runLoadStoreDescriptor(D3DDevice, DxcSupport, Params, VerboseLogging);
+
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"LoadStoreDescriptor_Wave_16x16_F16",
+                                    SelectedWaveSize))
+    return;
+
+  runLoadStoreDescriptor(D3DDevice, DxcSupport, Params, VerboseLogging,
+                         SelectedWaveSize);
 }
 
 static const char SplatStoreShader[] = R"(
   RWByteAddressBuffer Output : register(u0);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1656,12 +1939,15 @@ static const char SplatStoreShader[] = R"(
 static void runSplatStore(ID3D12Device *Device,
                           dxc::SpecificDllLoader &DxcSupport,
                           const MatrixParams &Params, float FillValue,
-                          bool Verbose) {
+                          bool Verbose, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
   STREAM_FLOAT(ExtraDefs, "FILL_VALUE", FillValue);
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -1694,7 +1980,15 @@ void DxilConf_SM610_LinAlg::SplatStore_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runSplatStore(D3DDevice, DxcSupport, Params, 42.0f, VerboseLogging);
+
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"SplatStore_Wave_16x16_F16",
+                                    SelectedWaveSize))
+    return;
+
+  runSplatStore(D3DDevice, DxcSupport, Params, 42.0f, VerboseLogging,
+                SelectedWaveSize);
 }
 
 static const char AccumulateDescriptorShader[] = R"(
@@ -1703,7 +1997,11 @@ static const char AccumulateDescriptorShader[] = R"(
   ByteAddressBuffer Input : register(t0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1724,11 +2022,15 @@ static const char AccumulateDescriptorShader[] = R"(
 static void runAccumulateDescriptor(ID3D12Device *Device,
                                     dxc::SpecificDllLoader &DxcSupport,
                                     const MatrixParams &Params, int FillValue,
-                                    bool Verbose) {
+                                    bool Verbose, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
-  std::string Args = buildCompilerArgs(Params);
+  std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+
+  std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, AccumulateDescriptorShader, "cs_6_10", Args,
                 Verbose);
@@ -1770,7 +2072,20 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging);
+
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"AccumulateDescriptor_Wave_16x16_F16",
+                                    SelectedWaveSize))
+    return;
+  if (!accumulateStoreApplicable(
+          D3DDevice, Params.CompType,
+          linalg_test::AtomicDestination::RWByteAddressBuffer,
+          L"AccumulateDescriptor_Wave_16x16_F16"))
+    return;
+
+  runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging,
+                          SelectedWaveSize);
 }
 
 // Element access constructs a wave-scope matrix and then reads or writes its
@@ -1780,79 +2095,6 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
 // supported type, and directs applications wanting smaller shapes to query
 // them case by case. Neither Fp32 nor Fp16 matrices are required at Tier 1, so
 // every element-access case is capability gated rather than mandatory.
-static HRESULT queryElementAccessSupport(ID3D12Device *Device,
-                                         const MatrixParams &Params,
-                                         bool &Supported,
-                                         UINT &SelectedWaveSize) {
-  Supported = false;
-  SelectedWaveSize = 0;
-  if (!Device ||
-      !linalg_test::isLegalScope(
-          linalg_abi::D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_MATRIX_CONSTRUCTION,
-          Params.Scope))
-    return E_INVALIDARG;
-
-  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> DataType =
-      toCapabilityDataType(Params.CompType);
-  if (!DataType.has_value())
-    return E_INVALIDARG;
-
-  linalg_test::TierSupport Tier;
-  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
-  if (FAILED(HR) || !Tier.supported())
-    return HR;
-
-  UINT MinWaveSize = 0;
-  UINT MaxWaveSize = 0;
-  HR = queryLaunchableWaveSizes(Device, MinWaveSize, MaxWaveSize);
-  if (FAILED(HR))
-    return HR;
-  if (MinWaveSize == 0) {
-    hlsl_test::LogCommentFmt(
-        L"Wave operations are unsupported; MatrixConstruction is not "
-        L"applicable");
-    return S_OK;
-  }
-
-  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
-      continue;
-
-    bool ShapeSupported = false;
-    HR = supportsMatrixShape(Device, *DataType, WaveSize, Params.Use, Params.M,
-                             Params.N, ShapeSupported);
-    if (FAILED(HR))
-      return HR;
-    if (ShapeSupported) {
-      hlsl_test::LogCommentFmt(
-          L"MatrixConstruction capability matched wave=%u for the %ux%u tile",
-          WaveSize, Params.M, Params.N);
-      Supported = true;
-      SelectedWaveSize = WaveSize;
-      return S_OK;
-    }
-  }
-
-  hlsl_test::LogCommentFmt(
-      L"No MatrixConstruction query within shader WaveSize(4,64) supports the "
-      L"%ux%u tile",
-      Params.M, Params.N);
-  return S_OK;
-}
-
-static bool elementAccessApplicable(ID3D12Device *Device,
-                                    const MatrixParams &Params,
-                                    LPCWSTR CaseName, UINT &SelectedWaveSize) {
-  bool Supported = false;
-  const HRESULT QueryResult =
-      queryElementAccessSupport(Device, Params, Supported, SelectedWaveSize);
-  return applyApplicability(
-      linalg_test::classifyApplicability(
-          QueryResult, Supported,
-          linalg_test::CapabilityRequirement::CapabilityGated),
-      CaseName);
-}
-
 static const char ElementAccessShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
@@ -1962,8 +2204,9 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
-  if (!elementAccessApplicable(
-          D3DDevice, Params, L"ElementAccess_Wave_16x16_F16", SelectedWaveSize))
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"ElementAccess_Wave_16x16_F16",
+                                    SelectedWaveSize))
     return;
 
   runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging,
@@ -1982,8 +2225,9 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
   Params.Enable16Bit = false;
 
   UINT SelectedWaveSize = 0;
-  if (!elementAccessApplicable(D3DDevice, Params, L"ElementAccess_Wave_4x8_F32",
-                               SelectedWaveSize))
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"ElementAccess_Wave_4x8_F32",
+                                    SelectedWaveSize))
     return;
 
   // Non-square dimensions make the row-major coordinate mapping observable: a
@@ -2079,8 +2323,9 @@ void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
   Params.Enable16Bit = true;
 
   UINT SelectedWaveSize = 0;
-  if (!elementAccessApplicable(D3DDevice, Params, L"ElementSet_Wave_16x16_F16",
-                               SelectedWaveSize))
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"ElementSet_Wave_16x16_F16",
+                                    SelectedWaveSize))
     return;
 
   runElementSet(D3DDevice, DxcSupport, Params, VerboseLogging,
@@ -2249,8 +2494,9 @@ void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
   Params.Enable16Bit = false;
 
   UINT SelectedWaveSize = 0;
-  if (!elementAccessApplicable(D3DDevice, Params, L"ElementGetOOB_Wave_4x8_F32",
-                               SelectedWaveSize))
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"ElementGetOOB_Wave_4x8_F32",
+                                    SelectedWaveSize))
     return;
 
   runElementGetOOB(D3DDevice, DxcSupport, Params, VerboseLogging,
@@ -2365,8 +2611,9 @@ void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
   Params.Enable16Bit = false;
 
   UINT SelectedWaveSize = 0;
-  if (!elementAccessApplicable(D3DDevice, Params, L"ElementSetOOB_Wave_4x8_F32",
-                               SelectedWaveSize))
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"ElementSetOOB_Wave_4x8_F32",
+                                    SelectedWaveSize))
     return;
 
   runElementSetOOB(D3DDevice, DxcSupport, Params, VerboseLogging,
@@ -2477,6 +2724,19 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
   return S_OK;
 }
 
+static bool copyConvertApplicable(ID3D12Device *Device,
+                                  const MatrixParams &Params, bool Transpose,
+                                  LPCWSTR CaseName, UINT &SelectedWaveSize) {
+  bool Supported = false;
+  const HRESULT QueryResult = queryCopyConvertSupport(
+      Device, Params, Transpose, Supported, SelectedWaveSize);
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
 static void runCopyConvert(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
@@ -2569,8 +2829,14 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  UINT SelectedWaveSize = 0;
+  if (!copyConvertApplicable(D3DDevice, Params, /*Transpose=*/false,
+                             L"CopyConvert_Wave_16x16_F16", SelectedWaveSize))
+    return;
+
   runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
-                 /*Transpose=*/false);
+                 /*Transpose=*/false, SelectedWaveSize);
 }
 
 void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16_Transpose() {
@@ -2583,8 +2849,15 @@ void DxilConf_SM610_LinAlg::CopyConvert_Wave_16x16_F16_Transpose() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  UINT SelectedWaveSize = 0;
+  if (!copyConvertApplicable(D3DDevice, Params, /*Transpose=*/true,
+                             L"CopyConvert_Wave_16x16_F16_Transpose",
+                             SelectedWaveSize))
+    return;
+
   runCopyConvert(D3DDevice, DxcSupport, Params, VerboseLogging,
-                 /*Transpose=*/true);
+                 /*Transpose=*/true, SelectedWaveSize);
 }
 
 void DxilConf_SM610_LinAlg::CopyConvert_Wave_4x8_F32_Transpose() {
@@ -2623,7 +2896,11 @@ static const char MatMatMulShader[] = R"(
 
   RWByteAddressBuffer Output : register(u0);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -2652,7 +2929,7 @@ static const char MatMatMulShader[] = R"(
 static void runMatMatMul(ID3D12Device *Device,
                          dxc::SpecificDllLoader &DxcSupport,
                          const MatrixParams &Params, bool Verbose, MatrixDim K,
-                         float AFill, float BFill) {
+                         float AFill, float BFill, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
@@ -2660,6 +2937,9 @@ static void runMatMatMul(ID3D12Device *Device,
   ExtraDefs << " -DK_DIM=" << K;
   STREAM_FLOAT(ExtraDefs, "A_FILL", AFill);
   STREAM_FLOAT(ExtraDefs, "B_FILL", BFill);
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -2691,8 +2971,14 @@ void DxilConf_SM610_LinAlg::MatMatMul_Wave_16x16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  UINT SelectedWaveSize = 0;
+  if (!waveMatMulApplicable(D3DDevice, Params, /*K=*/16,
+                            L"MatMatMul_Wave_16x16x16_F16", SelectedWaveSize))
+    return;
+
   runMatMatMul(D3DDevice, DxcSupport, Params, VerboseLogging, /*K=*/16,
-               /*AFill=*/2.0f, /*BFill=*/3.0f);
+               /*AFill=*/2.0f, /*BFill=*/3.0f, SelectedWaveSize);
 }
 
 static const char MatMatMulAccumShader[] = R"(
@@ -2702,7 +2988,11 @@ static const char MatMatMulAccumShader[] = R"(
 
   RWByteAddressBuffer Output : register(u0);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -2734,7 +3024,7 @@ static void runMatMatMulAccum(ID3D12Device *Device,
                               dxc::SpecificDllLoader &DxcSupport,
                               const MatrixParams &Params, bool Verbose,
                               MatrixDim K, float AFill, float BFill,
-                              float CFill) {
+                              float CFill, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
@@ -2743,6 +3033,9 @@ static void runMatMatMulAccum(ID3D12Device *Device,
   STREAM_FLOAT(ExtraDefs, "A_FILL", AFill);
   STREAM_FLOAT(ExtraDefs, "B_FILL", BFill);
   STREAM_FLOAT(ExtraDefs, "C_FILL", CFill);
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -2775,8 +3068,16 @@ void DxilConf_SM610_LinAlg::MatMatMulAccum_Wave_16x16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  UINT SelectedWaveSize = 0;
+  if (!waveMatMulApplicable(D3DDevice, Params, /*K=*/16,
+                            L"MatMatMulAccum_Wave_16x16x16_F16",
+                            SelectedWaveSize))
+    return;
+
   runMatMatMulAccum(D3DDevice, DxcSupport, Params, VerboseLogging, /*K=*/16,
-                    /*AFill=*/2.0f, /*BFill=*/3.0f, /*CFill=*/4.0f);
+                    /*AFill=*/2.0f, /*BFill=*/3.0f, /*CFill=*/4.0f,
+                    SelectedWaveSize);
 }
 
 static const char MatAccumShader[] = R"(
@@ -2785,7 +3086,11 @@ static const char MatAccumShader[] = R"(
 
   RWByteAddressBuffer Output : register(u0);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -2811,13 +3116,16 @@ static const char MatAccumShader[] = R"(
 static void runMatAccum(ID3D12Device *Device,
                         dxc::SpecificDllLoader &DxcSupport,
                         const MatrixParams &Params, bool Verbose, float LHSFill,
-                        float RHSFill) {
+                        float RHSFill, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
   STREAM_FLOAT(ExtraDefs, "LHS_FILL", LHSFill);
   STREAM_FLOAT(ExtraDefs, "RHS_FILL", RHSFill);
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -2848,8 +3156,17 @@ void DxilConf_SM610_LinAlg::MatAccum_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  // MatAccum builds both an accumulator and an A matrix, and the two roles pin
+  // different extents of the same shape, so both must be constructible.
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(
+          D3DDevice, Params, {MatrixUse::Accumulator, MatrixUse::A},
+          L"MatAccum_Wave_16x16_F16", SelectedWaveSize))
+    return;
+
   runMatAccum(D3DDevice, DxcSupport, Params, VerboseLogging,
-              /*LHSFill=*/2.0f, /*RHSFill=*/3.0f);
+              /*LHSFill=*/2.0f, /*RHSFill=*/3.0f, SelectedWaveSize);
 }
 
 static const char MatVecMulShader[] = R"(
@@ -3311,6 +3628,12 @@ void DxilConf_SM610_LinAlg::OuterProduct_Thread_16x16_F16() {
   Params.Layout = MatrixLayout::OuterProductOptimal;
   Params.NumThreads = 1;
   Params.Enable16Bit = true;
+
+  // Tier 1 requires no outer product formats at all, so this is gated.
+  if (!outerProductApplicable(D3DDevice, Params.CompType, Params.CompType,
+                              L"OuterProduct_Thread_16x16_F16"))
+    return;
+
   runOuterProduct(D3DDevice, DxcSupport, Params, VerboseLogging);
 #else
 #ifdef _HLK_CONF
@@ -3367,6 +3690,10 @@ static void runQueryAccumLayout(ID3D12Device *Device,
 }
 
 void DxilConf_SM610_LinAlg::QueryAccumLayout() {
+  // Constructs no matrix, so tier support is the only capability it needs.
+  if (!linAlgTierApplicable(D3DDevice, L"QueryAccumLayout"))
+    return;
+
   runQueryAccumLayout(D3DDevice, DxcSupport, VerboseLogging);
 }
 
@@ -3377,7 +3704,11 @@ static const char LoadMemoryShader[] = R"(
 
   #define ELEM_PER_THREAD (M_DIM * N_DIM / NUMTHREADS)
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
     for (uint I = 0; I < ELEM_PER_THREAD; ++I) {
@@ -3402,12 +3733,16 @@ static const char LoadMemoryShader[] = R"(
 
 static void runLoadMemory(ID3D12Device *Device,
                           dxc::SpecificDllLoader &DxcSupport,
-                          const MatrixParams &Params, bool Verbose) {
+                          const MatrixParams &Params, bool Verbose,
+                          UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
   ExtraDefs << " -DOFFSET=" << 0;
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -3448,14 +3783,26 @@ void DxilConf_SM610_LinAlg::LoadMemory_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runLoadMemory(D3DDevice, DxcSupport, Params, VerboseLogging);
+
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"LoadMemory_Wave_16x16_F16",
+                                    SelectedWaveSize))
+    return;
+
+  runLoadMemory(D3DDevice, DxcSupport, Params, VerboseLogging,
+                SelectedWaveSize);
 }
 
 static const char StoreMemoryShader[] = R"(
   RWByteAddressBuffer Output : register(u0);
   groupshared ELEM_TYPE GsData[M_DIM * N_DIM];
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -3478,13 +3825,16 @@ static const char StoreMemoryShader[] = R"(
 static void runStoreMemory(ID3D12Device *Device,
                            dxc::SpecificDllLoader &DxcSupport,
                            const MatrixParams &Params, bool Verbose,
-                           float FillValue) {
+                           float FillValue, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
   ExtraDefs << " -DOFFSET=" << 0;
   STREAM_FLOAT(ExtraDefs, "FILL_VALUE", FillValue);
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -3517,8 +3867,15 @@ void DxilConf_SM610_LinAlg::StoreMemory_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"StoreMemory_Wave_16x16_F16",
+                                    SelectedWaveSize))
+    return;
+
   runStoreMemory(D3DDevice, DxcSupport, Params, VerboseLogging,
-                 /*FillValue=*/7.0f);
+                 /*FillValue=*/7.0f, SelectedWaveSize);
 }
 
 static const char AccumulateMemoryShader[] = R"(
@@ -3527,7 +3884,11 @@ static const char AccumulateMemoryShader[] = R"(
 
   #define ELEM_PER_THREAD (M_DIM * N_DIM / NUMTHREADS)
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
     ELEM_TYPE fill = FILL_VALUE;
@@ -3558,13 +3919,16 @@ static const char AccumulateMemoryShader[] = R"(
 static void runAccumulateMemory(ID3D12Device *Device,
                                 dxc::SpecificDllLoader &DxcSupport,
                                 const MatrixParams &Params, bool Verbose,
-                                float FillValue) {
+                                float FillValue, UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t BufferSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
   ExtraDefs << " -DOFFSET=" << 0;
   STREAM_FLOAT(ExtraDefs, "FILL_VALUE", FillValue);
+
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
 
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
@@ -3597,8 +3961,19 @@ void DxilConf_SM610_LinAlg::AccumulateMemory_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
+
+  UINT SelectedWaveSize = 0;
+  if (!matrixConstructionApplicable(D3DDevice, Params, {Params.Use},
+                                    L"AccumulateMemory_Wave_16x16_F16",
+                                    SelectedWaveSize))
+    return;
+  if (!accumulateStoreApplicable(D3DDevice, Params.CompType,
+                                 linalg_test::AtomicDestination::GroupShared,
+                                 L"AccumulateMemory_Wave_16x16_F16"))
+    return;
+
   runAccumulateMemory(D3DDevice, DxcSupport, Params, VerboseLogging,
-                      /*FillValue=*/7.0f);
+                      /*FillValue=*/7.0f, SelectedWaveSize);
 }
 
 static const char ConvertShader[] = R"(
@@ -3643,6 +4018,11 @@ static void runConvert(ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
 }
 
 void DxilConf_SM610_LinAlg::Convert() {
+  // Operates on vectors rather than matrices, so tier support is the only
+  // capability it needs.
+  if (!linAlgTierApplicable(D3DDevice, L"Convert"))
+    return;
+
   runConvert(D3DDevice, DxcSupport, VerboseLogging);
 }
 
@@ -3683,6 +4063,13 @@ static void runVectorAccumulateDescriptor(ID3D12Device *Device,
 }
 
 void DxilConf_SM610_LinAlg::VectorAccumulateDescriptor_Thread_F16() {
+  // Tier 1 requires no accumulation store formats, so this is gated.
+  if (!accumulateStoreApplicable(
+          D3DDevice, ComponentType::F16,
+          linalg_test::AtomicDestination::RWByteAddressBuffer,
+          L"VectorAccumulateDescriptor_Thread_F16"))
+    return;
+
   runVectorAccumulateDescriptor(D3DDevice, DxcSupport, VerboseLogging);
 }
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -306,9 +306,9 @@ queryMatrixConstructionSupport(ID3D12Device *Device, const MatrixParams &Params,
   }
 
   hlsl_test::LogCommentFmt(
-      L"No MatrixConstruction query within shader WaveSize(4,64) supports the "
-      L"%ux%u tile",
-      Params.M, Params.N);
+      L"No MatrixConstruction query supports the %ux%u tile for any wave size "
+      L"launchable within shader WaveSize(4,128) and a %d-thread group",
+      Params.M, Params.N, Params.NumThreads);
   return S_OK;
 }
 
@@ -443,26 +443,22 @@ static HRESULT queryWaveMatMulSupport(ID3D12Device *Device,
         WaveSize > static_cast<UINT>(Params.NumThreads))
       continue;
 
-    bool ConstructionSupported = true;
-    for (const MatrixUse Use :
-         {MatrixUse::A, MatrixUse::B, MatrixUse::Accumulator}) {
-      bool ShapeSupported = false;
-      HR = supportsMatrixShape(Device, *DataType, WaveSize, Use, Params.M,
-                               Params.N, ShapeSupported);
-      if (FAILED(HR))
-        return HR;
-      if (!ShapeSupported) {
-        ConstructionSupported = false;
-        break;
-      }
-    }
-    if (!ConstructionSupported)
-      continue;
-
     linalg_abi::D3D12_LINEAR_ALGEBRA_MATRIX_SHAPE Shape = {};
     Shape.M = Params.M;
     Shape.K = K;
     Shape.N = Params.N;
+
+    // A multiply pins all three extents, so the construction query names the
+    // exact {M,K,N} shape instead of sweeping a free extent per operand. One
+    // answer covers all three operands, because a supported shape means A
+    // (MxK), B (KxN) and the accumulator (MxN) can all be constructed.
+    linalg_test::MatrixConstructionSupport Construction;
+    HR = linalg_test::queryMatrixConstruction(
+        Device, {*DataType, WaveSize, Shape}, Construction);
+    if (FAILED(HR))
+      return HR;
+    if (!Construction.supported())
+      continue;
 
     linalg_test::WaveMatrixMultiplySupport Support;
     HR = linalg_test::queryWaveMatrixMultiply(
@@ -480,9 +476,9 @@ static HRESULT queryWaveMatMulSupport(ID3D12Device *Device,
   }
 
   hlsl_test::LogCommentFmt(
-      L"No WaveMatrixMultiply query within shader WaveSize(4,64) supports "
-      L"%ux%ux%u",
-      Params.M, K, Params.N);
+      L"No WaveMatrixMultiply query supports %ux%ux%u for any wave size "
+      L"launchable within shader WaveSize(4,128) and a %d-thread group",
+      Params.M, K, Params.N, Params.NumThreads);
   return S_OK;
 }
 
@@ -2739,9 +2735,10 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
   }
 
   hlsl_test::LogCommentFmt(
-      L"No MatrixConstruction query within shader WaveSize(4,64) supports "
-      L"CopyConvert source=%ux%u and destination=%ux%u",
-      Params.M, Params.N, Destination.M, Destination.N);
+      L"No MatrixConstruction query supports CopyConvert source=%ux%u and "
+      L"destination=%ux%u for any wave size launchable within shader "
+      L"WaveSize(4,128) and a %d-thread group",
+      Params.M, Params.N, Destination.M, Destination.N, Params.NumThreads);
   return S_OK;
 }
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -145,6 +145,89 @@ static bool applyApplicability(linalg_test::Applicability Result,
   return false;
 }
 
+// MatrixConstruction is queried with a full {M,K,N} multiply shape, but a
+// single tile only pins two of those extents and leaves the third free:
+//
+//   Use          Tile   Pinned          Free
+//   A            MxK    M=Rows, K=Cols  N
+//   B            KxN    K=Rows, N=Cols  M
+//   Accumulator  MxN    M=Rows, N=Cols  K
+//
+// The runtime accepts a shape when every extent is a positive multiple of a
+// native tile, so probe the power-of-two extents that native tiles are built
+// from and accept the tile if any probe matches. Missing an extent skips a
+// test case; it can never report an unsupported tile as supported.
+static constexpr UINT FreeExtentProbes[] = {4, 8, 16, 32, 64, 128};
+
+static HRESULT supportsMatrixShape(
+    ID3D12Device *Device, linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type,
+    UINT WaveSize, MatrixUse Use, UINT Rows, UINT Columns, bool &Supported) {
+  Supported = false;
+  for (UINT FreeExtent : FreeExtentProbes) {
+    linalg_abi::D3D12_LINEAR_ALGEBRA_MATRIX_SHAPE Shape;
+    switch (Use) {
+    case MatrixUse::A:
+      Shape = {Rows, Columns, FreeExtent};
+      break;
+    case MatrixUse::B:
+      Shape = {FreeExtent, Rows, Columns};
+      break;
+    case MatrixUse::Accumulator:
+      Shape = {Rows, FreeExtent, Columns};
+      break;
+    default:
+      return E_INVALIDARG;
+    }
+
+    linalg_test::MatrixConstructionSupport Construction;
+    const HRESULT HR = linalg_test::queryMatrixConstruction(
+        Device, {Type, WaveSize, Shape}, Construction);
+    if (FAILED(HR))
+      return HR;
+    if (Construction.supported()) {
+      Supported = true;
+      return S_OK;
+    }
+  }
+  return S_OK;
+}
+
+// The shaders declare [WaveSize(4, 64)], so a capability query is only
+// meaningful for wave sizes the device can actually launch within that range.
+static HRESULT queryLaunchableWaveSizes(ID3D12Device *Device, UINT &MinWaveSize,
+                                        UINT &MaxWaveSize) {
+  MinWaveSize = 0;
+  MaxWaveSize = 0;
+
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
+  const HRESULT HR = Device->CheckFeatureSupport(
+      D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions, sizeof(WaveOptions));
+  if (FAILED(HR)) {
+    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+    return HR;
+  }
+  if (!WaveOptions.WaveOps)
+    return S_OK;
+
+  const auto IsPowerOfTwo = [](UINT Value) {
+    return Value != 0 && (Value & (Value - 1)) == 0;
+  };
+  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
+      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
+      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
+    hlsl_test::LogCommentFmt(
+        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
+        L"max=%u",
+        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
+        WaveOptions.WaveLaneCountMax);
+    return E_UNEXPECTED;
+  }
+
+  MinWaveSize = WaveOptions.WaveLaneCountMin;
+  MaxWaveSize = WaveOptions.WaveLaneCountMax;
+  return S_OK;
+}
+
 namespace cpu_oracle {
 
 using TypedMatrixValues =
@@ -1397,7 +1480,10 @@ public:
 
   // Element access
   TEST_METHOD(ElementAccess_Wave_16x16_F16);
+  TEST_METHOD(ElementAccess_Wave_4x8_F32);
   TEST_METHOD(ElementSet_Wave_16x16_F16);
+  TEST_METHOD(ElementGetOOB_Wave_4x8_F32);
+  TEST_METHOD(ElementSetOOB_Wave_4x8_F32);
 
   // Cast/Convert
   TEST_METHOD(CopyConvert_Wave_16x16_F16);
@@ -1687,6 +1773,86 @@ void DxilConf_SM610_LinAlg::AccumulateDescriptor_Wave_16x16_F16() {
   runAccumulateDescriptor(D3DDevice, DxcSupport, Params, 12, VerboseLogging);
 }
 
+// Element access constructs a wave-scope matrix and then reads or writes its
+// components, so applicability is exactly MatrixConstruction for the tile the
+// case declares. D3D12LinearAlgebraRuntimeFeatureSupport.md guarantees only
+// that some shape whose largest component is 16 or less is reported for a
+// supported type, and directs applications wanting smaller shapes to query
+// them case by case. Neither Fp32 nor Fp16 matrices are required at Tier 1, so
+// every element-access case is capability gated rather than mandatory.
+static HRESULT queryElementAccessSupport(ID3D12Device *Device,
+                                         const MatrixParams &Params,
+                                         bool &Supported,
+                                         UINT &SelectedWaveSize) {
+  Supported = false;
+  SelectedWaveSize = 0;
+  if (!Device ||
+      !linalg_test::isLegalScope(
+          linalg_abi::D3D12_LINEAR_ALGEBRA_OPERATION_TYPE_MATRIX_CONSTRUCTION,
+          Params.Scope))
+    return E_INVALIDARG;
+
+  const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> DataType =
+      toCapabilityDataType(Params.CompType);
+  if (!DataType.has_value())
+    return E_INVALIDARG;
+
+  linalg_test::TierSupport Tier;
+  HRESULT HR = linalg_test::queryTierSupport(Device, Tier);
+  if (FAILED(HR) || !Tier.supported())
+    return HR;
+
+  UINT MinWaveSize = 0;
+  UINT MaxWaveSize = 0;
+  HR = queryLaunchableWaveSizes(Device, MinWaveSize, MaxWaveSize);
+  if (FAILED(HR))
+    return HR;
+  if (MinWaveSize == 0) {
+    hlsl_test::LogCommentFmt(
+        L"Wave operations are unsupported; MatrixConstruction is not "
+        L"applicable");
+    return S_OK;
+  }
+
+  for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
+      continue;
+
+    bool ShapeSupported = false;
+    HR = supportsMatrixShape(Device, *DataType, WaveSize, Params.Use, Params.M,
+                             Params.N, ShapeSupported);
+    if (FAILED(HR))
+      return HR;
+    if (ShapeSupported) {
+      hlsl_test::LogCommentFmt(
+          L"MatrixConstruction capability matched wave=%u for the %ux%u tile",
+          WaveSize, Params.M, Params.N);
+      Supported = true;
+      SelectedWaveSize = WaveSize;
+      return S_OK;
+    }
+  }
+
+  hlsl_test::LogCommentFmt(
+      L"No MatrixConstruction query within shader WaveSize(4,64) supports the "
+      L"%ux%u tile",
+      Params.M, Params.N);
+  return S_OK;
+}
+
+static bool elementAccessApplicable(ID3D12Device *Device,
+                                    const MatrixParams &Params,
+                                    LPCWSTR CaseName, UINT &SelectedWaveSize) {
+  bool Supported = false;
+  const HRESULT QueryResult =
+      queryElementAccessSupport(Device, Params, Supported, SelectedWaveSize);
+  return applyApplicability(
+      linalg_test::classifyApplicability(
+          QueryResult, Supported,
+          linalg_test::CapabilityRequirement::CapabilityGated),
+      CaseName);
+}
+
 static const char ElementAccessShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
@@ -1697,7 +1863,11 @@ static const char ElementAccessShader[] = R"(
     return (coord.x * N_DIM + coord.y) * ELEM_SIZE;
   }
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main(uint threadID : SV_GroupIndex) {
     if (GetGroupWaveIndex() != 0)
@@ -1728,7 +1898,8 @@ static const char ElementAccessShader[] = R"(
 
 static void runElementAccess(ID3D12Device *Device,
                              dxc::SpecificDllLoader &DxcSupport,
-                             const MatrixParams &Params, bool Verbose) {
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t NumThreads = Params.NumThreads;
   const size_t MatrixSize = Params.totalBytes();
@@ -1736,6 +1907,8 @@ static void runElementAccess(ID3D12Device *Device,
   const size_t OutputBufSize = MatrixSize + NumThreads * sizeof(uint32_t);
 
   std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, ElementAccessShader, "cs_6_10", Args, Verbose);
@@ -1787,14 +1960,48 @@ void DxilConf_SM610_LinAlg::ElementAccess_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging);
+
+  UINT SelectedWaveSize = 0;
+  if (!elementAccessApplicable(
+          D3DDevice, Params, L"ElementAccess_Wave_16x16_F16", SelectedWaveSize))
+    return;
+
+  runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
+}
+
+void DxilConf_SM610_LinAlg::ElementAccess_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = MatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  UINT SelectedWaveSize = 0;
+  if (!elementAccessApplicable(D3DDevice, Params, L"ElementAccess_Wave_4x8_F32",
+                               SelectedWaveSize))
+    return;
+
+  // Non-square dimensions make the row-major coordinate mapping observable: a
+  // transposed GetCoordinate would land inside the matrix for a square tile
+  // but out of it here.
+  runElementAccess(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
 }
 
 static const char ElementSetShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
   RWByteAddressBuffer Output : register(u1);
 
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
   [WaveSize(4, 64)]
+  #endif
   [numthreads(NUMTHREADS, 1, 1)]
   void main() {
     if (GetGroupWaveIndex() != 0)
@@ -1821,11 +2028,14 @@ static const char ElementSetShader[] = R"(
 
 static void runElementSet(ID3D12Device *Device,
                           dxc::SpecificDllLoader &DxcSupport,
-                          const MatrixParams &Params, bool Verbose) {
+                          const MatrixParams &Params, bool Verbose,
+                          UINT ForcedWaveSize = 0) {
   const size_t NumElements = Params.totalElements();
   const size_t MatrixSize = Params.totalBytes();
 
   std::stringstream ExtraDefs;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, ElementSetShader, "cs_6_10", Args, Verbose);
@@ -1867,7 +2077,300 @@ void DxilConf_SM610_LinAlg::ElementSet_Wave_16x16_F16() {
   Params.Layout = MatrixLayout::RowMajor;
   Params.NumThreads = 64;
   Params.Enable16Bit = true;
-  runElementSet(D3DDevice, DxcSupport, Params, VerboseLogging);
+
+  UINT SelectedWaveSize = 0;
+  if (!elementAccessApplicable(D3DDevice, Params, L"ElementSet_Wave_16x16_F16",
+                               SelectedWaveSize))
+    return;
+
+  runElementSet(D3DDevice, DxcSupport, Params, VerboseLogging,
+                SelectedWaveSize);
+}
+
+// Length() is thread local, so the first index past a lane's own length is
+// already out of bounds even though the wave collectively holds more elements.
+// Probing Length() and a index far beyond it covers both a driver that clamps
+// only at the wave total and one that wraps a large index back into range.
+static constexpr UINT FarOOBOffset = 64;
+
+// Per-lane record: {uint Length, uint Executed, ELEM_TYPE Just, ELEM_TYPE Far}.
+static constexpr UINT OOBRecordSize = 16;
+
+// Seeds every output byte so a lane that never writes cannot be mistaken for a
+// lane that correctly wrote the specified zero.
+static constexpr BYTE OOBSentinelByte = 0xCD;
+
+static const char ElementGetOOBShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Output : register(u1);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, Input, 0, STRIDE, LAYOUT, 128);
+
+    uint Len = __builtin_LinAlg_MatrixLength(Mat);
+
+    ELEM_TYPE Just;
+    __builtin_LinAlg_MatrixGetElement(Just, Mat, Len);
+    ELEM_TYPE Far;
+    __builtin_LinAlg_MatrixGetElement(Far, Mat, Len + FAR_OOB_OFFSET);
+
+    // Record unconditionally so the runner can tell that this lane ran.
+    uint Base = threadID * OOB_RECORD_SIZE;
+    Output.Store<uint>(Base + 0, Len);
+    Output.Store<uint>(Base + 4, 1);
+    Output.Store<ELEM_TYPE>(Base + 8, Just);
+    Output.Store<ELEM_TYPE>(Base + 12, Far);
+  }
+)";
+
+// Reads back the {Length, Executed} half of each lane record and checks the
+// wave actually ran. Returns the total element count the wave reported.
+static uint32_t verifyOOBLaneRecords(const BYTE *Records, size_t NumThreads,
+                                     UINT SelectedWaveSize, UINT RecordStride,
+                                     size_t NumElements, bool Verbose) {
+  uint32_t ExecutedLanes = 0;
+  uint32_t TotalLength = 0;
+  for (size_t I = 0; I < NumThreads; ++I) {
+    const BYTE *Record = Records + I * RecordStride;
+    uint32_t Length = 0;
+    uint32_t Executed = 0;
+    memcpy(&Length, Record, sizeof(Length));
+    memcpy(&Executed, Record + 4, sizeof(Executed));
+    if (Executed != 1)
+      continue;
+    ++ExecutedLanes;
+    TotalLength += Length;
+    if (Verbose)
+      hlsl_test::LogCommentFmt(L"lane %u reported Length=%u",
+                               static_cast<UINT>(I), Length);
+  }
+
+  // Only wave 0 runs, so exactly the lanes of the wave the capability query
+  // selected must have written a record.
+  VERIFY_ARE_EQUAL(ExecutedLanes, SelectedWaveSize,
+                   "Every lane of the selected wave must execute");
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(
+      TotalLength, static_cast<uint32_t>(NumElements),
+      "Sum of all lengths must be gte num elements");
+  return TotalLength;
+}
+
+static void runElementGetOOB(ID3D12Device *Device,
+                             dxc::SpecificDllLoader &DxcSupport,
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize) {
+  VERIFY_IS_TRUE(Params.CompType == ComponentType::F32,
+                 "Out-of-bounds Get records assume a 4-byte element");
+  const size_t NumElements = Params.totalElements();
+  const size_t NumThreads = Params.NumThreads;
+  const size_t MatrixSize = Params.totalBytes();
+  const size_t OutputBufSize = NumThreads * OOBRecordSize;
+
+  std::stringstream ExtraDefs;
+  ExtraDefs << " -DFAR_OOB_OFFSET=" << FarOOBOffset;
+  ExtraDefs << " -DOOB_RECORD_SIZE=" << OOBRecordSize;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+
+  compileShader(DxcSupport, ElementGetOOBShader, "cs_6_10", Args, Verbose);
+
+  auto Op = createComputeOp(ElementGetOOBShader, "cs_6_10", "UAV(u0), UAV(u1)",
+                            Args.c_str());
+  addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
+  addUAVBuffer(Op.get(), "Output", OutputBufSize, true);
+  addRootView(Op.get(), 0, "Input");
+  addRootView(Op.get(), 1, "Output");
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
+                                        st::ShaderOp *) {
+                    if (_stricmp(Name, "Output") == 0) {
+                      std::fill(Data.begin(), Data.end(), OOBSentinelByte);
+                      return;
+                    }
+                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
+                                                   NumElements),
+                                   "Saw unsupported component type");
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  const BYTE *Out = static_cast<const BYTE *>(OutData.data());
+
+  verifyOOBLaneRecords(Out, NumThreads, ForcedWaveSize, OOBRecordSize,
+                       NumElements, Verbose);
+
+  // 0035-linalg-matrix.md: reading an index outside [0, Length()-1] yields
+  // zero cast to the element type.
+  for (size_t I = 0; I < NumThreads; ++I) {
+    const BYTE *Record = Out + I * OOBRecordSize;
+    uint32_t Executed = 0;
+    memcpy(&Executed, Record + 4, sizeof(Executed));
+    if (Executed != 1)
+      continue;
+
+    float Just = 0.0f;
+    float Far = 0.0f;
+    memcpy(&Just, Record + 8, sizeof(Just));
+    memcpy(&Far, Record + 12, sizeof(Far));
+    VERIFY_ARE_EQUAL(Just, 0.0f,
+                     "Get at Length() must return zero cast to the element "
+                     "type");
+    VERIFY_ARE_EQUAL(Far, 0.0f,
+                     "Get far past Length() must return zero cast to the "
+                     "element type");
+  }
+}
+
+void DxilConf_SM610_LinAlg::ElementGetOOB_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = MatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  UINT SelectedWaveSize = 0;
+  if (!elementAccessApplicable(D3DDevice, Params, L"ElementGetOOB_Wave_4x8_F32",
+                               SelectedWaveSize))
+    return;
+
+  runElementGetOOB(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
+}
+
+static const char ElementSetOOBShader[] = R"(
+  RWByteAddressBuffer Input : register(u0);
+  RWByteAddressBuffer Output : register(u1);
+
+  #ifdef FORCED_WAVE_SIZE
+  [WaveSize(FORCED_WAVE_SIZE)]
+  #else
+  [WaveSize(4, 64)]
+  #endif
+  [numthreads(NUMTHREADS, 1, 1)]
+  void main(uint threadID : SV_GroupIndex) {
+    if (GetGroupWaveIndex() != 0)
+      return;
+
+    __builtin_LinAlgMatrix
+      [[__LinAlgMatrix_Attributes(COMP_TYPE, M_DIM, N_DIM, USE, SCOPE)]]
+      Mat;
+    __builtin_LinAlg_MatrixLoadFromDescriptor(
+      Mat, Input, 0, STRIDE, LAYOUT, 128);
+
+    uint Len = __builtin_LinAlg_MatrixLength(Mat);
+
+    // Both indices are outside this lane's range, so both writes must be
+    // no-ops and the stored matrix must still equal the loaded one.
+    __builtin_LinAlg_MatrixSetElement(Mat, Mat, Len, (ELEM_TYPE)POISON_VALUE);
+    __builtin_LinAlg_MatrixSetElement(Mat, Mat, Len + FAR_OOB_OFFSET,
+                                      (ELEM_TYPE)POISON_VALUE);
+
+    __builtin_LinAlg_MatrixStoreToDescriptor(
+      Mat, Output, 0, STRIDE, LAYOUT, 128);
+
+    uint Base = MATRIX_BYTES + threadID * OOB_RECORD_SIZE;
+    Output.Store<uint>(Base + 0, Len);
+    Output.Store<uint>(Base + 4, 1);
+  }
+)";
+
+static void runElementSetOOB(ID3D12Device *Device,
+                             dxc::SpecificDllLoader &DxcSupport,
+                             const MatrixParams &Params, bool Verbose,
+                             UINT ForcedWaveSize) {
+  const size_t NumElements = Params.totalElements();
+  const size_t NumThreads = Params.NumThreads;
+  const size_t MatrixSize = Params.totalBytes();
+  const size_t OutputBufSize = MatrixSize + NumThreads * OOBRecordSize;
+
+  // Distinct from every sequential input value, so a stray write is visible.
+  const int PoisonValue = 999;
+
+  std::stringstream ExtraDefs;
+  ExtraDefs << " -DFAR_OOB_OFFSET=" << FarOOBOffset;
+  ExtraDefs << " -DOOB_RECORD_SIZE=" << OOBRecordSize;
+  ExtraDefs << " -DMATRIX_BYTES=" << MatrixSize;
+  ExtraDefs << " -DPOISON_VALUE=" << PoisonValue;
+  if (ForcedWaveSize != 0)
+    ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
+  std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
+
+  compileShader(DxcSupport, ElementSetOOBShader, "cs_6_10", Args, Verbose);
+
+  // The matrix must come back exactly as it went in.
+  auto Expected = makeExpectedMat(Params.CompType, Params.M, Params.N, 1);
+
+  auto Op = createComputeOp(ElementSetOOBShader, "cs_6_10", "UAV(u0), UAV(u1)",
+                            Args.c_str());
+  addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
+  addUAVBuffer(Op.get(), "Output", OutputBufSize, true);
+  addRootView(Op.get(), 0, "Input");
+  addRootView(Op.get(), 1, "Output");
+
+  auto Result =
+      runShaderOp(Device, DxcSupport, std::move(Op),
+                  [NumElements, Params](LPCSTR Name, std::vector<BYTE> &Data,
+                                        st::ShaderOp *) {
+                    if (_stricmp(Name, "Output") == 0) {
+                      std::fill(Data.begin(), Data.end(), OOBSentinelByte);
+                      return;
+                    }
+                    VERIFY_IS_TRUE(fillInputBuffer(Name, Data, Params.CompType,
+                                                   NumElements),
+                                   "Saw unsupported component type");
+                  });
+
+  MappedData OutData;
+  Result->Test->GetReadBackData("Output", &OutData);
+  const BYTE *Out = static_cast<const BYTE *>(OutData.data());
+
+  verifyOOBLaneRecords(Out + MatrixSize, NumThreads, ForcedWaveSize,
+                       OOBRecordSize, NumElements, Verbose);
+
+  // 0035-linalg-matrix.md: setting an index outside [0, Length()-1] is a
+  // no-op, so no poisoned value may appear anywhere in the matrix.
+  VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
+                                       Expected, NumElements, Verbose));
+}
+
+void DxilConf_SM610_LinAlg::ElementSetOOB_Wave_4x8_F32() {
+  MatrixParams Params = {};
+  Params.CompType = ComponentType::F32;
+  Params.M = 4;
+  Params.N = 8;
+  Params.Use = MatrixUse::Accumulator;
+  Params.Scope = MatrixScope::Wave;
+  Params.Layout = MatrixLayout::RowMajor;
+  Params.NumThreads = 64;
+  Params.Enable16Bit = false;
+
+  UINT SelectedWaveSize = 0;
+  if (!elementAccessApplicable(D3DDevice, Params, L"ElementSetOOB_Wave_4x8_F32",
+                               SelectedWaveSize))
+    return;
+
+  runElementSetOOB(D3DDevice, DxcSupport, Params, VerboseLogging,
+                   SelectedWaveSize);
 }
 
 static const char CopyConvertShader[] = R"(
@@ -1899,33 +2402,6 @@ static const char CopyConvertShader[] = R"(
   }
 )";
 
-// MatrixConstruction is queried with a full {M,K,N} multiply shape, but a use-A
-// tile only pins M and K; the N extent is free. The runtime accepts a shape
-// when every extent is a positive multiple of a native tile, so probe the
-// power-of-two extents that native tiles are built from and accept the tile if
-// any probe matches. Missing an extent skips a test case; it can never report
-// an unsupported tile as supported.
-static constexpr UINT FreeExtentProbes[] = {4, 8, 16, 32, 64, 128};
-
-static HRESULT
-supportsUseAMatrix(ID3D12Device *Device,
-                   linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type,
-                   UINT WaveSize, UINT Rows, UINT Columns, bool &Supported) {
-  Supported = false;
-  for (UINT FreeExtent : FreeExtentProbes) {
-    linalg_test::MatrixConstructionSupport Construction;
-    const HRESULT HR = linalg_test::queryMatrixConstruction(
-        Device, {Type, WaveSize, {Rows, Columns, FreeExtent}}, Construction);
-    if (FAILED(HR))
-      return HR;
-    if (Construction.supported()) {
-      Supported = true;
-      return S_OK;
-    }
-  }
-  return S_OK;
-}
-
 static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
                                        const MatrixParams &Params,
                                        bool Transpose, bool &Supported,
@@ -1948,32 +2424,16 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
   if (FAILED(HR) || !Tier.supported())
     return HR;
 
-  D3D12_FEATURE_DATA_D3D12_OPTIONS1 WaveOptions = {};
-  HR = Device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &WaveOptions,
-                                   sizeof(WaveOptions));
-  if (FAILED(HR)) {
-    hlsl_test::LogCommentFmt(L"Wave-size capability query failed: 0x%08x", HR);
+  UINT MinWaveSize = 0;
+  UINT MaxWaveSize = 0;
+  HR = queryLaunchableWaveSizes(Device, MinWaveSize, MaxWaveSize);
+  if (FAILED(HR))
     return HR;
-  }
-  if (!WaveOptions.WaveOps) {
+  if (MinWaveSize == 0) {
     hlsl_test::LogCommentFmt(
         L"Wave operations are unsupported; MatrixConstruction is not "
         L"applicable");
     return S_OK;
-  }
-
-  const auto IsPowerOfTwo = [](UINT Value) {
-    return Value != 0 && (Value & (Value - 1)) == 0;
-  };
-  if (!IsPowerOfTwo(WaveOptions.WaveLaneCountMin) ||
-      !IsPowerOfTwo(WaveOptions.WaveLaneCountMax) ||
-      WaveOptions.WaveLaneCountMax < WaveOptions.WaveLaneCountMin) {
-    hlsl_test::LogCommentFmt(
-        L"Wave-size capability response is malformed: WaveOps=%u, min=%u, "
-        L"max=%u",
-        WaveOptions.WaveOps, WaveOptions.WaveLaneCountMin,
-        WaveOptions.WaveLaneCountMax);
-    return E_UNEXPECTED;
   }
 
   MatrixParams Destination = Params;
@@ -1983,19 +2443,19 @@ static HRESULT queryCopyConvertSupport(ID3D12Device *Device,
   }
 
   for (UINT WaveSize = 4; WaveSize <= 64; WaveSize *= 2) {
-    if (WaveSize < WaveOptions.WaveLaneCountMin ||
-        WaveSize > WaveOptions.WaveLaneCountMax)
+    if (WaveSize < MinWaveSize || WaveSize > MaxWaveSize)
       continue;
 
     bool SourceSupported = false;
-    HR = supportsUseAMatrix(Device, *DataType, WaveSize, Params.M, Params.N,
-                            SourceSupported);
+    HR = supportsMatrixShape(Device, *DataType, WaveSize, MatrixUse::A,
+                             Params.M, Params.N, SourceSupported);
     if (FAILED(HR))
       return HR;
 
     bool DestinationSupported = false;
-    HR = supportsUseAMatrix(Device, *DataType, WaveSize, Destination.M,
-                            Destination.N, DestinationSupported);
+    HR =
+        supportsMatrixShape(Device, *DataType, WaveSize, MatrixUse::A,
+                            Destination.M, Destination.N, DestinationSupported);
     if (FAILED(HR))
       return HR;
 

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -154,16 +154,22 @@ static bool applyApplicability(linalg_test::Applicability Result,
 //   Accumulator  MxN    M=Rows, N=Cols  K
 //
 // The runtime accepts a shape when every extent is a positive multiple of a
-// native tile, so probe the power-of-two extents that native tiles are built
-// from and accept the tile if any probe matches. Missing an extent skips a
-// test case; it can never report an unsupported tile as supported.
-static constexpr UINT FreeExtentProbes[] = {4, 8, 16, 32, 64, 128};
+// native tile, so the free extent must be swept until one is accepted. Missing
+// an extent silently skips a test case, which is the dangerous direction, so
+// the sweep is exhaustive rather than a sampled set: native tile extents are
+// not required to be powers of two, and the specification's own example cites
+// an 8x32x16 tile. Wave-Scope Matrix Dimensions guarantees at least one
+// reported shape whose largest component is <= 16 for types of 16 bits or
+// larger (<= 256 bits for smaller types), so a sweep to 128 is certain to
+// reach a native extent whenever the device supports the type at all. Each
+// probe is a CheckFeatureSupport call with no GPU work, so the sweep is cheap.
+static constexpr UINT MaxFreeExtentProbe = 128;
 
 static HRESULT supportsMatrixShape(
     ID3D12Device *Device, linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE Type,
     UINT WaveSize, MatrixUse Use, UINT Rows, UINT Columns, bool &Supported) {
   Supported = false;
-  for (UINT FreeExtent : FreeExtentProbes) {
+  for (UINT FreeExtent = 1; FreeExtent <= MaxFreeExtentProbe; ++FreeExtent) {
     linalg_abi::D3D12_LINEAR_ALGEBRA_MATRIX_SHAPE Shape;
     switch (Use) {
     case MatrixUse::A:
@@ -2342,8 +2348,17 @@ static constexpr UINT FarOOBOffset = 64;
 static constexpr UINT OOBRecordSize = 16;
 
 // Seeds every output byte so a lane that never writes cannot be mistaken for a
-// lane that correctly wrote the specified zero.
+// lane that correctly wrote the specified zero. The output buffer must be
+// created "byname" for this to run at all: ShaderOpTest only invokes the
+// initializer callback for that mode, and the default "zero" mode would leave
+// the buffer holding exactly the value the out-of-bounds read is required to
+// produce, making the comparison vacuous.
 static constexpr BYTE OOBSentinelByte = 0xCD;
+
+// Seeds the shader's destination locals. Distinct from zero, so a read that is
+// dropped rather than performed cannot masquerade as a correct out-of-bounds
+// result, and exactly representable in F32.
+static constexpr int OOBGetPoisonValue = 999;
 
 static const char ElementGetOOBShader[] = R"(
   RWByteAddressBuffer Input : register(u0);
@@ -2367,9 +2382,11 @@ static const char ElementGetOOBShader[] = R"(
 
     uint Len = __builtin_LinAlg_MatrixLength(Mat);
 
-    ELEM_TYPE Just;
+    // Seeded so that a dropped read leaves a value distinguishable from the
+    // zero a correct out-of-bounds read must produce.
+    ELEM_TYPE Just = (ELEM_TYPE)POISON_VALUE;
     __builtin_LinAlg_MatrixGetElement(Just, Mat, Len);
-    ELEM_TYPE Far;
+    ELEM_TYPE Far = (ELEM_TYPE)POISON_VALUE;
     __builtin_LinAlg_MatrixGetElement(Far, Mat, Len + FAR_OOB_OFFSET);
 
     // Record unconditionally so the runner can tell that this lane ran.
@@ -2427,6 +2444,7 @@ static void runElementGetOOB(ID3D12Device *Device,
   std::stringstream ExtraDefs;
   ExtraDefs << " -DFAR_OOB_OFFSET=" << FarOOBOffset;
   ExtraDefs << " -DOOB_RECORD_SIZE=" << OOBRecordSize;
+  ExtraDefs << " -DPOISON_VALUE=" << OOBGetPoisonValue;
   if (ForcedWaveSize != 0)
     ExtraDefs << " -DFORCED_WAVE_SIZE=" << ForcedWaveSize;
   std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
@@ -2436,7 +2454,7 @@ static void runElementGetOOB(ID3D12Device *Device,
   auto Op = createComputeOp(ElementGetOOBShader, "cs_6_10", "UAV(u0), UAV(u1)",
                             Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", OutputBufSize, true);
+  addUAVBuffer(Op.get(), "Output", OutputBufSize, true, "byname");
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 
@@ -2569,7 +2587,7 @@ static void runElementSetOOB(ID3D12Device *Device,
   auto Op = createComputeOp(ElementSetOOBShader, "cs_6_10", "UAV(u0), UAV(u1)",
                             Args.c_str());
   addUAVBuffer(Op.get(), "Input", MatrixSize, false, "byname");
-  addUAVBuffer(Op.get(), "Output", OutputBufSize, true);
+  addUAVBuffer(Op.get(), "Output", OutputBufSize, true, "byname");
   addRootView(Op.get(), 0, "Input");
   addRootView(Op.get(), 1, "Output");
 


### PR DESCRIPTION
## Summary

Adds boundary coverage for LinAlg matrix element access, and capability-gates every remaining LinAlg execution test.

- adds `ElementAccess_Wave_4x8_F32`, which is non-square so a row/column transposition cannot pass, plus out-of-bounds Get and Set coverage
- gates the 15 tests that still ran unconditionally, so all 25 now resolve device capability before dispatching
- pins the wave size to the one the capability query selected, because construction support is reported per wave size

Nothing these tests exercise is required at tier 1, so a driver that honours its own reported capability could legitimately fail them. WARP reports F16 16x16x16 construction as unsupported at wave 16, 32 and 64, yet the ungated tests declared `[WaveSize(4, 64)]` and let the driver choose -- so they were passing only because WARP is more permissive than the capability it reports.

Out-of-bounds behaviour is defined per-thread in DXIL, so `Length()` is per-lane and verification is per-lane too. The free matrix extent is swept exhaustively rather than sampled at powers of two, since native tile extents are not required to be powers of two and missing one would silently skip a test.

Also picks up two review comments from #8735 that merged before they were addressed: the wave size sweep now runs to 128 rather than 64, which is the maximum D3D permits, and the anonymous namespace in `HlslExecTestUtils.cpp` is gone.

Closes #8687

Assisted-by: GitHub Copilot
