### PR TITLE
[HLSL] Gate the LinAlg outer product test on accumulate-store support

### DIFF
--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3667,6 +3667,17 @@ void DxilConf_SM610_LinAlg::OuterProduct_Thread_16x16_F16() {
                               L"OuterProduct_Thread_16x16_F16"))
     return;
 
+  // The shader accumulates its result into an RWByteAddressBuffer, which is
+  // reported independently of the outer product itself. A device may produce
+  // the outer product yet not support accumulating this component type into a
+  // buffer, so the destination has to be gated too or that device fails to
+  // create the pipeline instead of skipping.
+  if (!accumulateStoreApplicable(
+          D3DDevice, Params.CompType,
+          linalg_test::AtomicDestination::RWByteAddressBuffer,
+          L"OuterProduct_Thread_16x16_F16"))
+    return;
+
   runOuterProduct(D3DDevice, DxcSupport, Params, VerboseLogging);
 #else
 #ifdef _HLK_CONF


### PR DESCRIPTION
## Summary

`OuterProduct_Thread_16x16_F16` gated only on outer product support, but the shader it dispatches also accumulates into an `RWByteAddressBuffer`. Accumulation destinations are reported by a separate capability query, so a device that produces the outer product but cannot accumulate F16 into a buffer would fail pipeline creation instead of reporting the case as unsupported.

Adds the matching `accumulateStoreApplicable` check, mirroring the pair already in `AccumulateDescriptor_Wave_16x16_F16`.

Found by review of #8742.

Assisted-by: GitHub Copilot
