### PR TITLE
Update release issue template to handle latest release procedure

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -22,7 +22,7 @@ assignees: ''
 
 # Tasks
 
-<!-- This is only required if the release branch don't exist -->
+<!-- This is only required if the release branch doesn't exist -->
 ## Before Fork
 
 This part of the release process is to 'prime the pump' - that is to make sure

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -51,9 +51,10 @@ we are confident we can generate builds for the new branch
 
 ## Release
 
-- [ ] Tag final release and post binaries
 - [ ] Add the new compiler to Compiler Explorer
 - [ ] Email LunarG the release tag and update the release spreadsheet.
+- [ ] Publish the new compiler Nuget package.
+- [ ] Tag final release and post binaries
 
 
 [^1]: [Ask Mode](https://devblogs.microsoft.com/oldnewthing/20140722-00/?p=433)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -62,7 +62,7 @@ we are confident we can generate builds for the new branch
 - [ ] Tag final release and post binaries
 - [ ] Add the new compiler to Compiler Explorer
 - [ ] Email LunarG the release tag and update the release spreadsheet.
-- [ ] Publish the new compiler Nuget package.
+- [ ] Publish the new compiler NuGet package.
 
 
 [^1]: [Ask Mode](https://devblogs.microsoft.com/oldnewthing/20140722-00/?p=433)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+
+<!-- Some of the steps bellow might not be required, delete them as appropriate -->
 # Schedule
 
 - [ ] MM/DD/YYYY - Release branch forks from `main`
@@ -20,6 +22,7 @@ assignees: ''
 
 # Tasks
 
+<!-- This is only required if the release branch don't exist -->
 ## Before Fork
 
 This part of the release process is to 'prime the pump' - that is to make sure

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -30,12 +30,14 @@ we are confident we can generate builds for the new branch
 - [ ] Create the release branch from `main`
     - The release branch is kept into sync with main via regular fast-forward
       merges.
+- [ ] Final merge of `main` into the release branch
+- [ ] Update SPIRV-Headers and SPIRV-Tools submodules, in the release branch,
+      to target the commits specified by LunarG.
 - [ ] Internal branches and build pipelines configured
     - Verify that the engineering system can build:
     - [ ] Zip files for github release
     - [ ] NuGet package
     - [ ] VPack
-- [ ] Final merge of `main` into the release branch
 
 ## After Fork
 
@@ -45,12 +47,13 @@ we are confident we can generate builds for the new branch
 ## Quality Sign Off
 
 - [ ] Microsoft Testing Sign-off (@damyanp)
-- [ ] Google Testing Sign-off (@s-perron / @Keenuts)
+- [ ] NVIDIA Testing Sign-off (@dnovillo / @pow2clk)
 
 ## Release
 
 - [ ] Tag final release and post binaries
 - [ ] Add the new compiler to Compiler Explorer
+- [ ] Email LunarG the release tag and update the release spreadsheet.
 
 
 [^1]: [Ask Mode](https://devblogs.microsoft.com/oldnewthing/20140722-00/?p=433)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -8,7 +8,12 @@ assignees: ''
 ---
 
 
-<!-- Some of the steps bellow might not be required, delete them as appropriate -->
+<!-- 
+Some of the steps below might not be required; delete them as appropriate.
+Some known scenarios that might require editing include, but are not limited to: 
+point releases; targeting a specific release, such as a Vulkan SDK only; and preview releases.
+-->
+
 # Schedule
 
 - [ ] MM/DD/YYYY - Release branch forks from `main`
@@ -33,14 +38,14 @@ we are confident we can generate builds for the new branch
 - [ ] Create the release branch from `main`
     - The release branch is kept into sync with main via regular fast-forward
       merges.
-- [ ] Final merge of `main` into the release branch
-- [ ] Update SPIRV-Headers and SPIRV-Tools submodules, in the release branch,
-      to target the commits specified by LunarG.
 - [ ] Internal branches and build pipelines configured
     - Verify that the engineering system can build:
     - [ ] Zip files for github release
     - [ ] NuGet package
     - [ ] VPack
+- [ ] Update SPIRV-Headers and SPIRV-Tools submodules, in the release branch,
+      to target the commits specified by LunarG.
+- [ ] Final merge of `main` into the release branch
 
 ## After Fork
 
@@ -54,10 +59,10 @@ we are confident we can generate builds for the new branch
 
 ## Release
 
+- [ ] Tag final release and post binaries
 - [ ] Add the new compiler to Compiler Explorer
 - [ ] Email LunarG the release tag and update the release spreadsheet.
 - [ ] Publish the new compiler Nuget package.
-- [ ] Tag final release and post binaries
 
 
 [^1]: [Ask Mode](https://devblogs.microsoft.com/oldnewthing/20140722-00/?p=433)


### PR DESCRIPTION
This patch updates the Release issue template to also account for the SPIRV SDK release and to account for NVIDIA validating SPIRV instead of google.

Fix: https://github.com/microsoft/hlsl-specs/issues/888