### PR TITLE
[SM6.10] LinAlg Validation: Fill GetElem SetElem GetCoord

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3220,6 +3220,7 @@ INSTR.LINALGMATRIXNOTEXACTMATCH                       Matrix '%0' must exactly m
 INSTR.LINALGMATRIXOUTPUTBIASVECMISMATCH               Output vector element type '%0' must match Bias vector element type '%1'
 INSTR.LINALGMATRIXREQUIRESRWBAB                       %0 requires RWByteAddressBuffer.
 INSTR.LINALGMATRIXSCOPEMISMATCH                       Matrix Scope '%0' does not match expected scope %1.
+INSTR.LINALGMATRIXSCOPEMISMATCH2                      Matrix Scope '%0' does not match expected scope %1 or %2.
 INSTR.LINALGMATRIXSCOPENOTALLOWED                     Matrix Scope '%0' not allowed in %1 operation.
 INSTR.LINALGMATRIXSCOPEREQLAYOUT2                     Matrix scope '%0' requires layout %1 or %2.
 INSTR.LINALGMATRIXUNSIGNEDFLOATTYPENOTALLOWED         Float-like type '%0' must be signed

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3221,7 +3221,6 @@ INSTR.LINALGMATRIXOUTPUTBIASVECMISMATCH               Output vector element type
 INSTR.LINALGMATRIXREQUIRESRWBAB                       %0 requires RWByteAddressBuffer.
 INSTR.LINALGMATRIXSCOPEMISMATCH                       Matrix Scope '%0' does not match expected scope %1.
 INSTR.LINALGMATRIXSCOPEMISMATCH2                      Matrix Scope '%0' does not match expected scope %1 or %2.
-INSTR.LINALGMATRIXSCOPENOTALLOWED                     Matrix Scope '%0' not allowed in %1 operation.
 INSTR.LINALGMATRIXSCOPEREQLAYOUT2                     Matrix scope '%0' requires layout %1 or %2.
 INSTR.LINALGMATRIXUNSIGNEDFLOATTYPENOTALLOWED         Float-like type '%0' must be signed
 INSTR.LINALGMATRIXUSEMISMATCH                         Matrix Use '%0' does not match expected use %1.

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1089,11 +1089,39 @@ static void ValidateLinAlgMatrixLength(CallInst *CI,
 static void ValidateLinAlgMatrixGetCoordinate(CallInst *CI,
                                               ValidationContext &ValCtx) {
   ValidateLinAlgOpParameters(CI, ValCtx);
+
+  DxilInst_LinAlgMatrixGetCoordinate Op(CI);
+  Type *MatTy = Op.get_matrix()->getType();
+
+  assert(dxilutil::IsHLSLLinAlgMatrixType(MatTy) && "Must be LinAlg type");
+  auto MatIt = ValCtx.LinAlgTargetTypeMap.find(MatTy);
+  if (MatIt == ValCtx.LinAlgTargetTypeMap.end())
+    return;
+  LinAlgTargetType MatLATT = MatIt->second;
+
+  if (MatLATT.Scope == DXIL::MatrixScope::Thread)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixGetElement(CallInst *CI,
                                            ValidationContext &ValCtx) {
   ValidateLinAlgOpParameters(CI, ValCtx);
+
+  DxilInst_LinAlgMatrixGetElement Op(CI);
+  Type *MatTy = Op.get_matrix()->getType();
+
+  assert(dxilutil::IsHLSLLinAlgMatrixType(MatTy) && "Must be LinAlg type");
+  auto MatIt = ValCtx.LinAlgTargetTypeMap.find(MatTy);
+  if (MatIt == ValCtx.LinAlgTargetTypeMap.end())
+    return;
+  LinAlgTargetType MatLATT = MatIt->second;
+
+  if (MatLATT.Scope == DXIL::MatrixScope::Thread)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixStoreToDescriptor(CallInst *CI,
@@ -1315,6 +1343,20 @@ ValidateLinAlgVectorAccumulateToDescriptor(CallInst *CI,
 static void ValidateLinAlgFillMatrix(CallInst *CI, ValidationContext &ValCtx) {
   ValidateLinAlgOpReturnMatrix(CI, ValCtx);
   ValidateLinAlgOpParameters(CI, ValCtx);
+
+  DxilInst_LinAlgMatrixSetElement Op(CI);
+  Type *RetMatTy = CI->getType();
+
+  assert(dxilutil::IsHLSLLinAlgMatrixType(RetMatTy) && "Must be LinAlg type");
+  auto RetMatIt = ValCtx.LinAlgTargetTypeMap.find(RetMatTy);
+  if (RetMatIt == ValCtx.LinAlgTargetTypeMap.end())
+    return;
+  LinAlgTargetType RetMatLATT = RetMatIt->second;
+
+  if (RetMatLATT.Scope == DXIL::MatrixScope::Thread)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(RetMatLATT.Scope), "Wave", "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
@@ -1327,6 +1369,31 @@ static void ValidateLinAlgMatrixSetElement(CallInst *CI,
                                            ValidationContext &ValCtx) {
   ValidateLinAlgOpReturnMatrix(CI, ValCtx);
   ValidateLinAlgOpParameters(CI, ValCtx);
+
+  DxilInst_LinAlgMatrixSetElement Op(CI);
+  Type *RetMatTy = CI->getType();
+  Type *InMatTy = Op.get_matrix()->getType();
+
+  assert(dxilutil::IsHLSLLinAlgMatrixType(InMatTy) &&
+         dxilutil::IsHLSLLinAlgMatrixType(RetMatTy) && "Must be LinAlg types");
+  auto InMatIt = ValCtx.LinAlgTargetTypeMap.find(InMatTy);
+  if (InMatIt == ValCtx.LinAlgTargetTypeMap.end())
+    return;
+  auto RetMatIt = ValCtx.LinAlgTargetTypeMap.find(RetMatTy);
+  if (RetMatIt == ValCtx.LinAlgTargetTypeMap.end())
+    return;
+  LinAlgTargetType InMatLATT = InMatIt->second;
+  LinAlgTargetType RetMatLATT = RetMatIt->second;
+
+  if (InMatLATT.Scope == DXIL::MatrixScope::Thread)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(InMatLATT.Scope), "Wave", "ThreadGroup"});
+
+  if (RetMatLATT.Scope == DXIL::MatrixScope::Thread)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(RetMatLATT.Scope), "Wave", "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixMultiply(CallInst *CI,

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1346,7 +1346,6 @@ static void ValidateLinAlgFillMatrix(CallInst *CI, ValidationContext &ValCtx) {
   ValidateLinAlgOpReturnMatrix(CI, ValCtx);
   ValidateLinAlgOpParameters(CI, ValCtx);
 
-  DxilInst_LinAlgFillMatrix Op(CI);
   Type *RetMatTy = CI->getType();
 
   assert(dxilutil::IsHLSLLinAlgMatrixType(RetMatTy) && "Must be LinAlg type");

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1099,7 +1099,8 @@ static void ValidateLinAlgMatrixGetCoordinate(CallInst *CI,
     return;
   LinAlgTargetType MatLATT = MatIt->second;
 
-  if (MatLATT.Scope == DXIL::MatrixScope::Thread)
+  if (MatLATT.Scope != DXIL::MatrixScope::Wave &&
+      MatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
         {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
@@ -1118,7 +1119,8 @@ static void ValidateLinAlgMatrixGetElement(CallInst *CI,
     return;
   LinAlgTargetType MatLATT = MatIt->second;
 
-  if (MatLATT.Scope == DXIL::MatrixScope::Thread)
+  if (MatLATT.Scope != DXIL::MatrixScope::Wave &&
+      MatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
         {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
@@ -1344,7 +1346,7 @@ static void ValidateLinAlgFillMatrix(CallInst *CI, ValidationContext &ValCtx) {
   ValidateLinAlgOpReturnMatrix(CI, ValCtx);
   ValidateLinAlgOpParameters(CI, ValCtx);
 
-  DxilInst_LinAlgMatrixSetElement Op(CI);
+  DxilInst_LinAlgFillMatrix Op(CI);
   Type *RetMatTy = CI->getType();
 
   assert(dxilutil::IsHLSLLinAlgMatrixType(RetMatTy) && "Must be LinAlg type");
@@ -1353,7 +1355,8 @@ static void ValidateLinAlgFillMatrix(CallInst *CI, ValidationContext &ValCtx) {
     return;
   LinAlgTargetType RetMatLATT = RetMatIt->second;
 
-  if (RetMatLATT.Scope == DXIL::MatrixScope::Thread)
+  if (RetMatLATT.Scope != DXIL::MatrixScope::Wave &&
+      RetMatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
         {MatrixScopeToString(RetMatLATT.Scope), "Wave", "ThreadGroup"});
@@ -1385,12 +1388,14 @@ static void ValidateLinAlgMatrixSetElement(CallInst *CI,
   LinAlgTargetType InMatLATT = InMatIt->second;
   LinAlgTargetType RetMatLATT = RetMatIt->second;
 
-  if (InMatLATT.Scope == DXIL::MatrixScope::Thread)
+  if (InMatLATT.Scope != DXIL::MatrixScope::Wave &&
+      InMatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
         {MatrixScopeToString(InMatLATT.Scope), "Wave", "ThreadGroup"});
 
-  if (RetMatLATT.Scope == DXIL::MatrixScope::Thread)
+  if (RetMatLATT.Scope != DXIL::MatrixScope::Wave &&
+      RetMatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
         {MatrixScopeToString(RetMatLATT.Scope), "Wave", "ThreadGroup"});
@@ -1531,10 +1536,11 @@ static void ValidateLinAlgMatrixAccumulate(CallInst *CI,
                                 {MatrixScopeToString(RHSLATT.Scope),
                                  MatrixScopeToString(RetLATT.Scope)});
 
-  if (RetLATT.Scope == DXIL::MatrixScope::Thread)
+  if (RetLATT.Scope != DXIL::MatrixScope::Wave &&
+      RetLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
-        CI, ValidationRule::InstrLinAlgMatrixScopeNotAllowed,
-        {"Thread", "LinAlgMatrixAccumulate"});
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(RetLATT.Scope), "Wave", "ThreadGroup"});
 
   if (RetLATT.M != RHSLATT.M || RetLATT.N != RHSLATT.N)
     ValCtx.EmitInstrFormatError(
@@ -1572,11 +1578,17 @@ static void ValidateLinAlgCopyConvertMatrix(CallInst *CI,
   LinAlgTargetType DstLATT = DstIt->second;
   LinAlgTargetType SrcLATT = SrcIt->second;
 
-  if (DstLATT.Scope == DXIL::MatrixScope::Thread ||
-      SrcLATT.Scope == DXIL::MatrixScope::Thread)
+  if (DstLATT.Scope != DXIL::MatrixScope::Wave &&
+      DstLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
-        CI, ValidationRule::InstrLinAlgMatrixScopeNotAllowed,
-        {"Thread", "LinAlgCopyConvertMatrix"});
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(DstLATT.Scope), "Wave", "ThreadGroup"});
+
+  if (SrcLATT.Scope != DXIL::MatrixScope::Wave &&
+      SrcLATT.Scope != DXIL::MatrixScope::ThreadGroup)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {MatrixScopeToString(DstLATT.Scope), "Wave", "ThreadGroup"});
 
   if (DstLATT.Scope != SrcLATT.Scope)
     ValCtx.EmitInstrFormatError(CI,

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1587,7 +1587,7 @@ static void ValidateLinAlgCopyConvertMatrix(CallInst *CI,
       SrcLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(DstLATT.Scope), "Wave", "ThreadGroup"});
+        {MatrixScopeToString(SrcLATT.Scope), "Wave", "ThreadGroup"});
 
   if (DstLATT.Scope != SrcLATT.Scope)
     ValCtx.EmitInstrFormatError(CI,

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/fillmatrix/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/fillmatrix/nominal.hlsl
@@ -20,7 +20,7 @@ void main() {
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M8N4U0S1*, float)"
   // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M8N4U0S1* {{.*}}, float 0x40091EB860000000)
-  // Matrix<U32, 3, 4, A, Wave>
+  // Matrix<U32, 8, 4, A, Wave>
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 4, 0, 1)]] mat2;
   __builtin_LinAlg_FillMatrix(mat2, 3.14);
 
@@ -41,7 +41,7 @@ void main() {
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M4N4U1S1*, i64)"
   // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M4N4U1S1* {{.*}}, i64 %{{.+}})
-  // Matrix<U32, 3, 4, B, Wave>
+  // Matrix<U32, 4, 4, B, Wave>
   int64_t i64Val = 12345;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 1, 1)]] mat4;
   __builtin_LinAlg_FillMatrix(mat4, i64Val);

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/fillmatrix/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/fillmatrix/nominal.hlsl
@@ -11,34 +11,38 @@ void main() {
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC4M5N4U1S2*, i32)"
   // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC4M5N4U1S2* {{.*}}, i32 5),
+  // Matrix<I32, 5, 4, B, ThreadGroup>
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 5, 4, 1, 2)]] mat1;
   __builtin_LinAlg_FillMatrix(mat1, 5);
 
-  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC5M3N4U0S0 @dx.op.linAlgFillMatrix.mC5M3N4U0S0.f32
+  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC5M8N4U0S1 @dx.op.linAlgFillMatrix.mC5M8N4U0S1.f32
   // CHECK-SAME: (i32 -2147483636, float {{.*}})  ; LinAlgFillMatrix(value)
 
-  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M3N4U0S0*, float)"
-  // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M3N4U0S0* {{.*}}, float 0x40091EB860000000)
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat2;
+  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M8N4U0S1*, float)"
+  // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M8N4U0S1* {{.*}}, float 0x40091EB860000000)
+  // Matrix<U32, 3, 4, A, Wave>
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 4, 0, 1)]] mat2;
   __builtin_LinAlg_FillMatrix(mat2, 3.14);
 
 
-  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC5M3N4U0S0 @dx.op.linAlgFillMatrix.mC5M3N4U0S0.f64
+  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC5M8N4U0S2 @dx.op.linAlgFillMatrix.mC5M8N4U0S2.f64
   // CHECK-SAME: (i32 -2147483636, double {{.*}})  ; LinAlgFillMatrix(value)
 
-  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M3N4U0S0*, double)"
-  // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M3N4U0S0* {{.*}}, double %{{.+}})
+  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M8N4U0S2*, double)"
+  // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M8N4U0S2* {{.*}}, double %{{.+}})
+  // Matrix<U32, 3, 4, A, ThreadGroup>
   double dVal = 9.87;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat3;
-  __builtin_LinAlg_FillMatrix(mat2, dVal);
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 4, 0, 2)]] mat3;
+  __builtin_LinAlg_FillMatrix(mat3, dVal);
 
 
-  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC5M3N4U0S0 @dx.op.linAlgFillMatrix.mC5M3N4U0S0.i64
+  // CHECK: %{{.*}} = call %dx.types.LinAlgMatrixC5M4N4U1S1 @dx.op.linAlgFillMatrix.mC5M4N4U1S1.i64
   // CHECK-SAME: (i32 -2147483636, i64 {{.*}})  ; LinAlgFillMatrix(value)
 
-  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M3N4U0S0*, i64)"
-  // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M3N4U0S0* {{.*}}, i64 %{{.+}})
+  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M4N4U1S1*, i64)"
+  // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M4N4U1S1* {{.*}}, i64 %{{.+}})
+  // Matrix<U32, 3, 4, B, Wave>
   int64_t i64Val = 12345;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 3, 4, 0, 0)]] mat4;
-  __builtin_LinAlg_FillMatrix(mat2, i64Val);
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 1, 1)]] mat4;
+  __builtin_LinAlg_FillMatrix(mat4, i64Val);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/fillmatrix/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/fillmatrix/nominal.hlsl
@@ -30,7 +30,7 @@ void main() {
 
   // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC5M8N4U0S2*, double)"
   // CHECK2-SAME: (i32 402, %dx.types.LinAlgMatrixC5M8N4U0S2* {{.*}}, double %{{.+}})
-  // Matrix<U32, 3, 4, A, ThreadGroup>
+  // Matrix<U32, 8, 4, A, ThreadGroup>
   double dVal = 9.87;
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 4, 0, 2)]] mat3;
   __builtin_LinAlg_FillMatrix(mat3, dVal);

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulatetodescriptor/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixaccumulatetodescriptor/nominal.hlsl
@@ -8,15 +8,15 @@ RWByteAddressBuffer outbuf;
 void main() {
   // CHECK-LABEL: define void @main()
 
-  // CHECK: call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC9M4N4U2S0(i32 -2147483621,
-  // CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S0 %{{.*}}, %dx.types.Handle %{{.*}}, i32 0, i32 0, i32 4, i32 128)
+  // CHECK: call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC9M4N4U2S1(i32 -2147483621,
+  // CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %{{.*}}, %dx.types.Handle %{{.*}}, i32 0, i32 0, i32 0, i32 128)
   // CHECK-SAME: ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC9M4N4U2S0, %dx.types.Handle, i32, i32, i32, i32)"
-  // CHECK2-SAME: (i32 415, %dx.types.LinAlgMatrixC9M4N4U2S0 %{{.*}}, %dx.types.Handle {{.*}}, i32 0, i32 0, i32 4, i32 128)
+  // CHECK2: call void @"dx.hl.op..void (i32, %dx.types.LinAlgMatrixC9M4N4U2S1, %dx.types.Handle, i32, i32, i32, i32)"
+  // CHECK2-SAME: (i32 415, %dx.types.LinAlgMatrixC9M4N4U2S1 %{{.*}}, %dx.types.Handle {{.*}}, i32 0, i32 0, i32 0, i32 128)
 
-  // Matrix<F16, 4, 4, Accumulator, Thread>
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(9, 4, 4, 2, 0)]] mat;
+  // Matrix<F16, 4, 4, Accumulator, Wave>
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(9, 4, 4, 2, 1)]] mat;
   __builtin_LinAlg_FillMatrix(mat, 1);
-  __builtin_LinAlg_MatrixAccumulateToDescriptor(mat, outbuf, 0, 0, 4, 128);
+  __builtin_LinAlg_MatrixAccumulateToDescriptor(mat, outbuf, 0, 0, 0, 128);
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiply/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiply/nominal.hlsl
@@ -2,12 +2,15 @@
 // RUN: %dxc -T cs_6_10 -E main %s | FileCheck %s
 // RUN: %dxc -T cs_6_10 -E main -fcgl %s | FileCheck %s --check-prefix=CHECK2 
 
+ByteAddressBuffer inbuf;
+
 [numthreads(1,1,1)]
 void main() {
   // CHECK-LABEL: define void @main()
 
+  // Matrix<I32, 4, 4, A, Thread>
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 4, 4, 0, 0)]] mat;
-  __builtin_LinAlg_FillMatrix(mat, 1);
+  __builtin_LinAlg_MatrixLoadFromDescriptor(mat, inbuf, 0, 0, 0, 128);
   float4 vec = {1,2,3,4};
   float4 result;
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiplyadd/nominal.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/builtins/matrixvectormultiplyadd/nominal.hlsl
@@ -2,11 +2,15 @@
 // RUN: %dxc -T cs_6_10 -E main %s | FileCheck %s
 // RUN: %dxc -T cs_6_10 -E main -fcgl %s | FileCheck %s --check-prefix=CHECK2
 
+ByteAddressBuffer inbuf;
+
 [numthreads(1,1,1)]
 void main() {
   // CHECK-LABEL: define void @main()
+
+  // Matrix<U32, 4, 4, A, Thread>
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 0, 0)]] mat1;
-  __builtin_LinAlg_FillMatrix(mat1, 1);
+  __builtin_LinAlg_MatrixLoadFromDescriptor(mat1, inbuf, 0, 0, 0, 128);
   float4 vec = {1,2,3,4};
   float4 result = 0;
 
@@ -21,8 +25,6 @@ void main() {
 
   __builtin_LinAlg_MatrixVectorMultiplyAdd(result, mat1, true, vec, 9, result);
 
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 0, 0)]] mat2;
-  __builtin_LinAlg_FillMatrix(mat2, 2);
   double4 vec2 = {1,2,3,4};
   double4 result2 = 0;
 
@@ -35,10 +37,8 @@ void main() {
   // CHECK2-SAME: i32, <4 x double>)"(i32 419, <4 x double>* %result2, %dx.types.LinAlgMatrixC5M4N4U0S0 %{{[0-9]+}},
   // CHECK2-SAME: i1 true, <4 x double> %{{[0-9]+}}, i32 10, <4 x double> %{{[0-9]+}})
 
-  __builtin_LinAlg_MatrixVectorMultiplyAdd(result2, mat2, true, vec2, 10, result2);
+  __builtin_LinAlg_MatrixVectorMultiplyAdd(result2, mat1, true, vec2, 10, result2);
 
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 4, 4, 0, 0)]] mat3;
-  __builtin_LinAlg_FillMatrix(mat3, 3);
   vector<int64_t, 4> vec3 = {1,2,3,4};
   vector<int64_t, 4> result3 = 0;
 
@@ -51,10 +51,11 @@ void main() {
   // CHECK2-SAME: i32, <4 x i64>)"(i32 419, <4 x i64>* %result3, %dx.types.LinAlgMatrixC5M4N4U0S0 %{{[0-9]+}},
   // CHECK2-SAME: i1 true, <4 x i64> %{{[0-9]+}}, i32 6, <4 x i64> %{{[0-9]+}})
 
-  __builtin_LinAlg_MatrixVectorMultiplyAdd(result3, mat3, true, vec3, 6, result3);
+  __builtin_LinAlg_MatrixVectorMultiplyAdd(result3, mat1, true, vec3, 6, result3);
 
+  // Matrix<I32, 8, 8, A, Thread>
   __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 8, 8, 0, 0)]] mat4;
-  __builtin_LinAlg_FillMatrix(mat4, 4);
+  __builtin_LinAlg_MatrixLoadFromDescriptor(mat4, inbuf, 0, 0, 0, 128);
   vector<int8_t4_packed, 8> vec4 = 0;
   vector<int8_t4_packed, 8> result4 = 0;
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-compute.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-compute.hlsl
@@ -8,13 +8,13 @@
 // return values and arguments of LinAlgMatrix operations.
 
 uint useMatrix1() {
-  // Matrix<ComponentType::I32, 4, 5, MatrixUse::A, MatrixScope::Thread> m;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 4, 5, 0, 0)]] mat1;
+  // Matrix<ComponentType::I32, 4, 5, MatrixUse::A, MatrixScope::ThreadGroup> m;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 4, 5, 0, 2)]] mat1;
   // mat1 = Matrix::Splat(5);
   __builtin_LinAlg_FillMatrix(mat1, 5);
 
-  // Matrix<ComponentType::U32, 8, 8, MatrixUse::A, MatrixScope::Thread> m;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 8, 0, 0)]] mat2;
+  // Matrix<ComponentType::U32, 8, 8, MatrixUse::A, MatrixScope::ThreadGroup> m;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(5, 8, 8, 0, 2)]] mat2;
   // mat2 = Matrix::Splat(1);
   __builtin_LinAlg_FillMatrix(mat2, 1);
   // return mat2.Length();
@@ -38,6 +38,6 @@ void main() {
 }
 
 // CHECK: !dx.targetTypes = !{!{{[0-9]+}}, !{{[0-9]+}}}
-// CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC4M4N5U0S0 undef, i32 4, i32 4, i32 5, i32 0, i32 0}
-// CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC5M8N8U0S0 undef, i32 5, i32 8, i32 8, i32 0, i32 0}
+// CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC4M4N5U0S2 undef, i32 4, i32 4, i32 5, i32 0, i32 2}
+// CHECK: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC5M8N8U0S2 undef, i32 5, i32 8, i32 8, i32 0, i32 2}
 // CHECK-NOT: !{%dx.types.LinAlgMatrixC10M2N2U1S1 undef, i32 10, i32 2, i32 2, i32 1, i32 1}

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-lib.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/trim-target-types-metadata-lib.hlsl
@@ -21,8 +21,8 @@ void useMatrix3();
 #ifdef LIB1
 
 uint useMatrix1() {
-  // Matrix<ComponentType::I32, 4, 5, MatrixUse::A, MatrixScope::Thread> m;
-  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 4, 5, 0, 0)]] mat1;
+  // Matrix<ComponentType::I32, 4, 5, MatrixUse::A, MatrixScope::ThreadGroup> m;
+  __builtin_LinAlgMatrix [[__LinAlgMatrix_Attributes(4, 4, 5, 0, 2)]] mat1;
   // mat1 = Matrix::Splat(5);
   __builtin_LinAlg_FillMatrix(mat1, 5);
   // return mat1.Length();
@@ -75,7 +75,7 @@ void CSMain3() {
 
 // Target types in lib1
 // LIB1: !dx.targetTypes = !{![[TT1:.*]], ![[TT2:.*]]}
-// LIB1: ![[TT1]] = !{%dx.types.LinAlgMatrixC4M4N5U0S0 undef, i32 4, i32 4, i32 5, i32 0, i32 0}
+// LIB1: ![[TT1]] = !{%dx.types.LinAlgMatrixC4M4N5U0S2 undef, i32 4, i32 4, i32 5, i32 0, i32 2}
 // LIB1: ![[TT2]] = !{%dx.types.LinAlgMatrixC10M4N4U1S1 undef, i32 10, i32 4, i32 4, i32 1, i32 1}
 
 // Target types in lib2
@@ -89,7 +89,7 @@ void CSMain3() {
 
 // CSMain2 uses one type of matrix
 // CSMAIN2: !dx.targetTypes = !{!{{[0-9]+}}}
-// CSMAIN2: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC4M4N5U0S0 undef, i32 4, i32 4, i32 5, i32 0, i32 0}
+// CSMAIN2: !{{[0-9]+}} = !{%dx.types.LinAlgMatrixC4M4N5U0S2 undef, i32 4, i32 4, i32 5, i32 0, i32 2}
 
 // CSMain3 uses two types of matrices
 // CSMAIN3: !dx.targetTypes = !{!{{[0-9]+}}, !{{[0-9]+}}}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-copyconvert.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-copyconvert.ll
@@ -3,13 +3,21 @@
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 
+%dx.types.Handle = type { i8* }
+%dx.types.ResBind = type { i32, i32, i32, i8 }
+%dx.types.ResourceProperties = type { i32, i32 }
 %dx.types.LinAlgMatrixC2M5N4U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC4M8N4U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC4M5N8U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC4M5N4U1S2 = type { i8* }
 %dx.types.LinAlgMatrixC2M4N5U1S1 = type { i8* }
 %dx.types.LinAlgMatrixC2M4N5U1S0 = type { i8* }
+%struct.ByteAddressBuffer = type { i32 }
+
 define void @main() {
+  %h1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+  %bab = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %h1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
+
   %1 = call %dx.types.LinAlgMatrixC2M5N4U1S2 @dx.op.linAlgFillMatrix.mC2M5N4U1S2.i32(i32 -2147483636, i32 1)  ; LinAlgFillMatrix(value)
 
   ; CHECK: Function: main: error: Matrix Dimension '8x4' does not match expected dimension 5x4.
@@ -28,7 +36,7 @@ define void @main() {
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S1.mC2M5N4U1S2
   %5 = call %dx.types.LinAlgMatrixC2M4N5U1S1 @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S1.mC2M5N4U1S2(i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 %1, i1 true)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 
-  %6 = call %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgFillMatrix.mC2M4N5U1S0.i32(i32 -2147483636, i32 1)  ; LinAlgFillMatrix(value)
+  %6 = call %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC2M4N5U1S0(i32 -2147483634, %dx.types.Handle %bab, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
   ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' not allowed in LinAlgCopyConvertMatrix operation.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0
@@ -53,18 +61,26 @@ declare %dx.types.LinAlgMatrixC4M5N4U1S2 @dx.op.linAlgCopyConvertMatrix.mC4M5N4U
 declare %dx.types.LinAlgMatrixC2M4N5U1S1 @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S1.mC2M5N4U1S2(i32, %dx.types.LinAlgMatrixC2M5N4U1S2, i1) #0
 
 ; Function Attrs: nounwind
-declare %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgFillMatrix.mC2M4N5U1S0.i32(i32, i32) #0
+declare %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC2M4N5U1S0(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0(i32, %dx.types.LinAlgMatrixC2M4N5U1S0, i1) #0
 
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, i32, i1) #1
+
 attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
 
 !dx.targetTypes = !{!0, !1, !2, !3, !4, !5}
 !llvm.ident = !{!6}
 !dx.version = !{!7}
 !dx.valver = !{!7}
 !dx.shaderModel = !{!8}
+!dx.resources = !{!12}
 !dx.entryPoints = !{!9}
 
 !0 = !{%dx.types.LinAlgMatrixC2M5N4U1S2 undef, i32 2, i32 5, i32 4, i32 1, i32 2}
@@ -79,3 +95,6 @@ attributes #0 = { nounwind }
 !9 = !{void ()* @main, !"main", null, null, !10}
 !10 = !{i32 4, !11}
 !11 = !{i32 1, i32 1, i32 1}
+!12 = !{!13, null, null, null}
+!13 = !{!14}
+!14 = !{i32 0, %struct.ByteAddressBuffer* undef, !"", i32 0, i32 0, i32 1, i32 11, i32 0, null}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-copyconvert.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-copyconvert.ll
@@ -38,9 +38,12 @@ define void @main() {
 
   %6 = call %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC2M4N5U1S0(i32 -2147483634, %dx.types.Handle %bab, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' not allowed in LinAlgCopyConvertMatrix operation.
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0
   %7 = call %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0(i32 -2147483635, %dx.types.LinAlgMatrixC2M4N5U1S0 %6, i1 false)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
+
   ; CHECK-NEXT: Validation failed.
   ret void
 }

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulate.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulate.ll
@@ -34,7 +34,7 @@ define void @main() {
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M4N4U1S1
   %10 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M4N4U1S1(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U2S2 %1, %dx.types.LinAlgMatrixC8M4N4U1S1 %5)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' not allowed in LinAlgMatrixAccumulate operation.
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S0.mC8M4N4U2S0.mC8M4N4U1S0
   %11 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S0.mC8M4N4U2S0.mC8M4N4U1S0(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U2S0 %3, %dx.types.LinAlgMatrixC8M4N4U1S0 %4)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-non-thread-ops.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-non-thread-ops.ll
@@ -1,0 +1,60 @@
+; REQUIRES: dxil-1-10
+; RUN: not %dxv %s 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.LinAlgMatrixC8M4N4U2S0 = type { i8* }
+
+define void @main() {
+  ; CHECK: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix.mC8M4N4U2S0.i32
+  %1 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgFillMatrix.mC8M4N4U2S0.i32(i32 -2147483636, i32 1)  ; LinAlgFillMatrix(value)
+
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement.f32.mC8M4N4U2S0
+  %2 = call float @dx.op.linAlgMatrixGetElement.f32.mC8M4N4U2S0(i32 -2147483630, %dx.types.LinAlgMatrixC8M4N4U2S0 %1, i32 1)  ; LinAlgMatrixGetElement(matrix,threadLocalIndex)
+
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32
+  %3 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32(i32 -2147483629, %dx.types.LinAlgMatrixC8M4N4U2S0 %1, i32 1, float %2)  ; LinAlgMatrixSetElement(matrix,threadLocalIndex,value)
+
+  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate.mC8M4N4U2S0
+  %4 = call <2 x i32> @dx.op.linAlgMatrixGetCoordinate.mC8M4N4U2S0(i32 -2147483631, %dx.types.LinAlgMatrixC8M4N4U2S0 %3, i32 0)  ; LinAlgMatrixGetCoordinate(matrix,threadLocalIndex)
+
+  ; CHECK-NEXT: Validation failed.
+  ret void
+}
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgFillMatrix.mC8M4N4U2S0.i32(i32, i32) #0
+
+; Function Attrs: nounwind
+declare float @dx.op.linAlgMatrixGetElement.f32.mC8M4N4U2S0(i32, %dx.types.LinAlgMatrixC8M4N4U2S0, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32(i32, %dx.types.LinAlgMatrixC8M4N4U2S0, i32, float) #0
+
+; Function Attrs: nounwind
+declare <2 x i32> @dx.op.linAlgMatrixGetCoordinate.mC8M4N4U2S0(i32, %dx.types.LinAlgMatrixC8M4N4U2S0, i32) #0
+
+attributes #0 = { nounwind }
+
+!dx.targetTypes = !{!0}
+!llvm.ident = !{!1}
+!dx.version = !{!2}
+!dx.valver = !{!2}
+!dx.shaderModel = !{!3}
+!dx.entryPoints = !{!4}
+
+!0 = !{%dx.types.LinAlgMatrixC8M4N4U2S0 undef, i32 8, i32 4, i32 4, i32 2, i32 0}
+!1 = !{!"dxc(private) 1.9.0.5430 (linalg-vali-matrixaccumtodescriptor, b02cf0883-dirty)"}
+!2 = !{i32 1, i32 10}
+!3 = !{!"cs", i32 6, i32 10}
+!4 = !{void ()* @main, !"main", null, null, !5}
+!5 = !{i32 0, i64 8388608, i32 4, !6}
+!6 = !{i32 1, i32 1, i32 1}
+

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8658,6 +8658,10 @@ class db_dxil(object):
             "Matrix Scope '%0' does not match expected scope %1.",
         )
         self.add_valrule(
+            "Instr.LinAlgMatrixScopeMismatch2",
+            "Matrix Scope '%0' does not match expected scope %1 or %2.",
+        )
+        self.add_valrule(
             "Instr.LinAlgMatrixDimMismatch",
             "Matrix Dimension '%0x%1' does not match expected dimension %2x%3.",
         )

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8650,10 +8650,6 @@ class db_dxil(object):
             "Component Type '%0' not allowed in LinAlg Matrix.",
         )
         self.add_valrule(
-            "Instr.LinAlgMatrixScopeNotAllowed",
-            "Matrix Scope '%0' not allowed in %1 operation.",
-        )
-        self.add_valrule(
             "Instr.LinAlgMatrixScopeMismatch",
             "Matrix Scope '%0' does not match expected scope %1.",
         )


### PR DESCRIPTION
Fixes #8698
Fixes #8699
Fixes #8700 
Fixes #8701 

Implements validation rules for Fill, GetElement, SetElement, and GetCoordinate that all share the same singular rule