### PR TITLE
[HLSL] Pass a valid alignment from the LinAlg outer product test shader

### DIFF
--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3866,7 +3866,7 @@ static const char OuterProductShader[] = R"(
     __builtin_LinAlg_MatrixOuterProduct(Mat, VecA, VecB);
 
     // Outer product accumulators are stored in the OuterProductOptimal layout
-    // with stride 0, matching the dx::linalg header's thread-scoped
+    // Matching the dx::linalg header's thread-scoped
     // InterlockedAccumulate. The alignment argument must be a non-zero
     // multiple of 128; the matrix starts at offset 0 in a buffer D3D12 aligns
     // far more strongly than that.

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3866,10 +3866,12 @@ static const char OuterProductShader[] = R"(
     __builtin_LinAlg_MatrixOuterProduct(Mat, VecA, VecB);
 
     // Outer product accumulators are stored in the OuterProductOptimal layout
-    // with stride 0 and no alignment requirement (align 0), matching the
-    // dx::linalg header's thread-scoped InterlockedAccumulate.
+    // with stride 0, matching the dx::linalg header's thread-scoped
+    // InterlockedAccumulate. The alignment argument must be a non-zero
+    // multiple of 128; the matrix starts at offset 0 in a buffer D3D12 aligns
+    // far more strongly than that.
     __builtin_LinAlg_MatrixAccumulateToDescriptor(
-      Mat, Output, 0, STRIDE, LAYOUT, 0);
+      Mat, Output, 0, STRIDE, LAYOUT, 128);
   }
 )";
 


### PR DESCRIPTION
`OuterProductShader` passes 0 as the alignment argument to `MatrixAccumulateToDescriptor`. That was correct when written, but #8743 added validation requiring a non-zero multiple of 128 and updated `InterlockedAccumulate` to pass 128. The shader was missed, so it now fails validation, and its comment still cites the header as justification.

This is invisible in a test run. `OuterProduct_Thread_16x16_F16` is gated on outer product and F16 accumulate-store support, neither of which WARP reports, so it skips before compiling the shader. It would fail on a device supporting both.

Verified by extracting the shader text and compiling it with the test's defines: 0 fails with "parameter 'Align' must be greater than 0, got 0", 128 passes. WARP unchanged at 28 total, 23 passed, 4 pre-existing failures, 1 skip.
