### PR TITLE
Scope vector test sizes for x86 WARP

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -484,6 +484,19 @@ bool D3D12SDKSelector::createDevice(ID3D12Device **D3DDevice,
                         D3D12CreateDevice);
 }
 
+bool isWarp(ID3D12Device *D3DDevice) {
+  CComPtr<IDXGIFactory4> DXGIFactory;
+  VERIFY_SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&DXGIFactory)));
+
+  CComPtr<IDXGIAdapter1> DXGIAdapter;
+  VERIFY_SUCCEEDED(DXGIFactory->EnumAdapterByLuid(D3DDevice->GetAdapterLuid(),
+                                                  IID_PPV_ARGS(&DXGIAdapter)));
+
+  DXGI_ADAPTER_DESC1 AdapterDesc;
+  VERIFY_SUCCEEDED(DXGIAdapter->GetDesc1(&AdapterDesc));
+  return (AdapterDesc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) != 0;
+}
+
 bool doesDeviceSupportInt64(ID3D12Device *pDevice) {
   D3D12_FEATURE_DATA_D3D12_OPTIONS1 O;
   if (FAILED(pDevice->CheckFeatureSupport(

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -54,6 +54,8 @@ public:
                     bool SkipUnsupported = true);
 };
 
+bool isWarp(ID3D12Device *D3DDevice);
+
 void readHlslDataIntoNewStream(LPCWSTR RelativePath, IStream **Stream,
                                dxc::SpecificDllLoader &Support);
 

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1721,7 +1721,8 @@ constexpr bool isX86WarpMemoryLimitedOp(OpType Op) {
 #endif
 
 template <typename T, OpType OP>
-std::vector<size_t> getInputSizesToTest(size_t OverrideInputSize) {
+std::vector<size_t> getInputSizesToTest(size_t OverrideInputSize,
+                                        ID3D12Device *D3DDevice) {
   std::vector<size_t> InputVectorSizes;
   const std::array<size_t, 8> DefaultInputSizes = {3,  5,   16,  17,
                                                    35, 100, 256, 1024};
@@ -1734,13 +1735,13 @@ std::vector<size_t> getInputSizesToTest(size_t OverrideInputSize) {
         IsStructuredBufferLoadAndStoreOp(OP) ? 2048 / sizeof(T) : 1024;
 
 #if defined(_M_IX86) && !defined(_HLK_CONF)
-    // This implies that we will create a WARP device.
-    const bool IsWarp = GetTestParamUseWARP(true);
     // x86 execution tests default to WARP, which cannot run the
     // largest vector sizes within the available address space for
     // some Ops. This is a simple workaround for that.
-    if (IsWarp && isX86WarpMemoryLimitedOp(OP))
+    if (isX86WarpMemoryLimitedOp(OP) && isWarp(D3DDevice))
       MaxInputSize = std::min(MaxInputSize, size_t{256});
+#else
+    (void)D3DDevice;
 #endif
 
     for (size_t Size : DefaultInputSizes) {
@@ -1760,7 +1761,7 @@ void dispatchTest(ID3D12Device *D3DDevice, bool VerboseLogging,
                   size_t OverrideInputSize) {
 
   const std::vector<size_t> InputVectorSizes =
-      getInputSizesToTest<T, OP>(OverrideInputSize);
+      getInputSizesToTest<T, OP>(OverrideInputSize, D3DDevice);
 
   constexpr const Operation &Operation = getOperation(OP);
   Op<OP, T, Operation.Arity> Op;
@@ -1781,7 +1782,7 @@ void dispatchWaveOpTest(ID3D12Device *D3DDevice, bool VerboseLogging,
                         size_t OverrideInputSize, UINT WaveSize) {
 
   const std::vector<size_t> InputVectorSizes =
-      getInputSizesToTest<T, OP>(OverrideInputSize);
+      getInputSizesToTest<T, OP>(OverrideInputSize, D3DDevice);
 
   constexpr const Operation &Operation = getOperation(OP);
   Op<OP, T, Operation.Arity> Op;

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1735,9 +1735,9 @@ std::vector<size_t> getInputSizesToTest(size_t OverrideInputSize,
         IsStructuredBufferLoadAndStoreOp(OP) ? 2048 / sizeof(T) : 1024;
 
 #if defined(_M_IX86) && !defined(_HLK_CONF)
-    // x86 execution tests default to WARP, which cannot run the
+    // X86 Execution tests running against WARP cannot run the
     // largest vector sizes within the available address space for
-    // some Ops. This is a simple workaround for that.
+    // some Ops. Cap the max size to work around that.
     if (isX86WarpMemoryLimitedOp(OP) && isWarp(D3DDevice))
       MaxInputSize = std::min(MaxInputSize, size_t{256});
 #else

--- a/tools/clang/unittests/HLSLExec/LongVectors.cpp
+++ b/tools/clang/unittests/HLSLExec/LongVectors.cpp
@@ -1704,6 +1704,22 @@ template <OpType OP, typename T> struct ExpectedBuilder {
   }
 };
 
+#if defined(_M_IX86) && !defined(_HLK_CONF)
+constexpr bool isX86WarpMemoryLimitedOp(OpType Op) {
+  switch (Op) {
+  case OpType::QuadReadLaneAt:
+  case OpType::QuadReadAcrossX:
+  case OpType::QuadReadAcrossY:
+  case OpType::QuadReadAcrossDiagonal:
+  case OpType::AsDouble:
+  case OpType::AsUint_SplitDouble:
+    return true;
+  default:
+    return false;
+  }
+}
+#endif
+
 template <typename T, OpType OP>
 std::vector<size_t> getInputSizesToTest(size_t OverrideInputSize) {
   std::vector<size_t> InputVectorSizes;
@@ -1714,8 +1730,18 @@ std::vector<size_t> getInputSizesToTest(size_t OverrideInputSize) {
     InputVectorSizes.push_back(OverrideInputSize);
   else {
     // StructuredBuffers have a max size of 2048 bytes.
-    const size_t MaxInputSize =
+    size_t MaxInputSize =
         IsStructuredBufferLoadAndStoreOp(OP) ? 2048 / sizeof(T) : 1024;
+
+#if defined(_M_IX86) && !defined(_HLK_CONF)
+    // This implies that we will create a WARP device.
+    const bool IsWarp = GetTestParamUseWARP(true);
+    // x86 execution tests default to WARP, which cannot run the
+    // largest vector sizes within the available address space for
+    // some Ops. This is a simple workaround for that.
+    if (IsWarp && isX86WarpMemoryLimitedOp(OP))
+      MaxInputSize = std::min(MaxInputSize, size_t{256});
+#endif
 
     for (size_t Size : DefaultInputSizes) {
       if (Size <= MaxInputSize)


### PR DESCRIPTION
This change works around failures in several long vector execution tests that occur only when running against WARP in an x86 process. These failures are caused by the limited address space available to 32-bit processes. 

The workaround is to simply cap the max input size for the offending test cases.