### PR TITLE
[SM6.10] LinAlg Validation: Rework Error Messages

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3209,23 +3209,24 @@ INSTR.ILLEGALDXILOPCODE                               DXILOpCode must be valid o
 INSTR.ILLEGALDXILOPFUNCTION                           '%0' is not a DXILOpFuncition for DXILOpcode '%1'.
 INSTR.IMMBIASFORSAMPLEB                               bias amount for sample_b must be in the range [%0,%1], but %2 was specified as an immediate.
 INSTR.INBOUNDSACCESS                                  Access to out-of-bounds memory is disallowed.
-INSTR.LINALGILLEGALCOMPONENTTYPE                      Component Type '%0' not allowed in LinAlg Matrix.
-INSTR.LINALGILLEGALKDIM                               Matrix K Dimension out of bounds. K=%0 must be >= %1 and <= %2.
-INSTR.LINALGMATRIXDIMKVECKMISMATCH                    %0 vector size '%1' must be %2 for matrix with K '%3' and Type '%4'
-INSTR.LINALGMATRIXDIMMISMATCH                         Matrix Dimension '%0x%1' does not match expected dimension %2x%3.
-INSTR.LINALGMATRIXDIMVECTORMISMATCH                   %0 vector size '%1' must match matrix %2 dimension '%3'
-INSTR.LINALGMATRIXLAYOUTREQSTRIDE                     Matrix layout '%0' requires stride 0.
+INSTR.LINALGILLEGALCOMPONENTTYPE                      Component type '%0' from %1 not allowed in LinAlg Matrix operations.
+INSTR.LINALGILLEGALKDIM                               %0 matrix K dimension out of bounds. K=%1 must be >= %2 and <= %3.
+INSTR.LINALGMATRIX2PARTSMUSTMATCH                     %0 matrix %1 '%2' must match %3 matrix %4 '%5'.
+INSTR.LINALGMATRIXDIMKVECKMISMATCH                    %0 vector size '%1' must be %2 for input matrix with K '%3' and Type '%4'
+INSTR.LINALGMATRIXDIMVECTORMISMATCH                   %0 vector size '%1' must match input matrix M dimension '%2'
+INSTR.LINALGMATRIXLAYOUTREQSTRIDE                     %0 with layout '%1' requires stride 0.
 INSTR.LINALGMATRIXLOADTHREADREQUIRESBAB               Loading matrix with Thread scope requires ByteAddressBuffer.
-INSTR.LINALGMATRIXNOTEXACTMATCH                       Matrix '%0' must exactly match matrix '%1'.
-INSTR.LINALGMATRIXOUTPUTBIASVECMISMATCH               Output vector element type '%0' must match Bias vector element type '%1'
+INSTR.LINALGMATRIXNOTEXACTMATCH                       %0 matrix '%1' must exactly match %2 matrix '%3'.
+INSTR.LINALGMATRIXOUTPUTBIASVECMISMATCH               Output vector element type '%0' must match bias vector element type '%1'
 INSTR.LINALGMATRIXREQUIRESLAYOUT2                     %0 requires layout %1 or %2.
 INSTR.LINALGMATRIXREQUIRESRWBAB                       %0 requires RWByteAddressBuffer.
-INSTR.LINALGMATRIXSCOPEMISMATCH                       Matrix Scope '%0' does not match expected scope %1.
-INSTR.LINALGMATRIXSCOPEMISMATCH2                      Matrix Scope '%0' does not match expected scope %1 or %2.
-INSTR.LINALGMATRIXSCOPEREQLAYOUT2                     Matrix scope '%0' requires layout %1 or %2.
+INSTR.LINALGMATRIXSCOPEMISMATCH                       %0 matrix scope '%1' does not match expected scope %2.
+INSTR.LINALGMATRIXSCOPEMISMATCH2                      %0 matrix scope '%1' does not match expected scope %2 or %3.
+INSTR.LINALGMATRIXSCOPEREQLAYOUT2                     %0 matrix with scope '%1' requires layout %2 or %3 for %4.
 INSTR.LINALGMATRIXUNSIGNEDFLOATTYPENOTALLOWED         Float-like type '%0' must be signed
-INSTR.LINALGMATRIXUSEMISMATCH                         Matrix Use '%0' does not match expected use %1.
-INSTR.LINALGMATRIXUSEMISMATCH2                        Matrix Use '%0' does not match expected use %1 or %2.
+INSTR.LINALGMATRIXUSEMISMATCH                         %0 matrix use '%1' does not match expected use %2.
+INSTR.LINALGMATRIXUSEMISMATCH2                        %0 matrix use '%1' does not match expected use %2 or %3.
+INSTR.LINALGMETADATAMISSING                           %0 matrix must have well-formed metadata.
 INSTR.MAYREORDERTHREADUNDEFCOHERENCEHINTPARAM         Use of undef coherence hint or num coherence hint bits in MaybeReorderThread.
 INSTR.MINPRECISIONNOTPRECISE                          Instructions marked precise may not refer to minprecision values.
 INSTR.MINPRECISONBITCAST                              Bitcast on minprecison types is not allowed.

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -975,29 +975,9 @@ static void ValidateImmOperandForMathDxilOp(CallInst *CI, DXIL::OpCode Opcode,
   }
 }
 
-static void ValidateLinAlgOpParameters(CallInst *CI,
-                                       ValidationContext &ValCtx) {
-  for (uint32_t Idx = 0; Idx < CI->getNumArgOperands(); ++Idx) {
-    Value *Arg = CI->getArgOperand(Idx);
-    Type *Ty = Arg->getType();
-
-    // No parameters may be undef
-    if (isa<UndefValue>(Arg))
-      ValCtx.EmitInstrError(CI, ValidationRule::InstrNoReadingUninitialized);
-
-    // If we have a LinAlg Matrix, validate that we have correct metadata.
-    if (!dxilutil::IsHLSLLinAlgMatrixType(Ty))
-      continue;
-    if (ValCtx.LinAlgTargetTypeMap.find(Ty) ==
-        ValCtx.LinAlgTargetTypeMap.end()) {
-      ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
-      continue;
-    }
-  }
-}
-
 static void ValidateLinAlgComponentType(CallInst *CI, DXIL::ComponentType CT,
-                                        ValidationContext &ValCtx) {
+                                        ValidationContext &ValCtx,
+                                        StringRef SourceName) {
   switch (CT) {
   case DXIL::ComponentType::I8:
   case DXIL::ComponentType::I16:
@@ -1017,8 +997,60 @@ static void ValidateLinAlgComponentType(CallInst *CI, DXIL::ComponentType CT,
   default:
     ValCtx.EmitInstrFormatError(CI,
                                 ValidationRule::InstrLinAlgIllegalComponentType,
-                                {ComponentTypeToString(CT)});
+                                {ComponentTypeToString(CT), SourceName});
     break;
+  }
+}
+
+static void ValidateLinAlgKDim(CallInst *CI, LinAlgTargetType &LATT,
+                               ValidationContext &ValCtx,
+                               StringRef SourceName) {
+  // This validation can't be applied to an accumulator matrix
+  if (LATT.Use == DXIL::MatrixUse::Accumulator) {
+    return;
+  }
+
+  // Validate the K dim is in bounds. Which dim is K depends on use.
+  unsigned MinK = DXIL::kLinAlgMatrixMinK;
+  unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
+  unsigned MaxK = DXIL::kLinAlgMatrixMaxK;
+  if (LATT.Scope == DXIL::MatrixScope::ThreadGroup) {
+    MinK = DXIL::kLinAlgThreadGroupMatrixMinK;
+    MaxK = DXIL::kLinAlgThreadGroupMatrixMaxK;
+  }
+  if (K < MinK || K > MaxK)
+    ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrLinAlgIllegalKDim,
+                                {SourceName, std::to_string(K),
+                                 std::to_string(MinK), std::to_string(MaxK)});
+}
+
+static void ValidateLinAlgOpParameters(CallInst *CI,
+                                       ValidationContext &ValCtx) {
+  for (uint32_t Idx = 0; Idx < CI->getNumArgOperands(); ++Idx) {
+    Value *Arg = CI->getArgOperand(Idx);
+    Type *Ty = Arg->getType();
+    std::string Name = "Arg " + std::to_string(Idx);
+
+    // No parameters may be undef
+    if (isa<UndefValue>(Arg))
+      ValCtx.EmitInstrError(CI, ValidationRule::InstrNoReadingUninitialized);
+
+    // If we have a LinAlg Matrix, validate that we have correct metadata.
+    if (!dxilutil::IsHLSLLinAlgMatrixType(Ty))
+      continue;
+
+    auto it = ValCtx.LinAlgTargetTypeMap.find(Ty);
+    if (it == ValCtx.LinAlgTargetTypeMap.end()) {
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMetadataMissing, {Name});
+      continue;
+    }
+
+    LinAlgTargetType LATT = it->second;
+
+    ValidateLinAlgKDim(CI, LATT, ValCtx, Name);
+    ValidateLinAlgComponentType(CI, LATT.Type, ValCtx,
+                                "arg " + std::to_string(Idx) + " matrix");
   }
 }
 
@@ -1056,29 +1088,14 @@ static void ValidateLinAlgOpReturnMatrix(CallInst *CI,
   // Metadata is malformed if we don't have metadata
   auto it = ValCtx.LinAlgTargetTypeMap.find(Ty);
   if (it == ValCtx.LinAlgTargetTypeMap.end()) {
-    ValCtx.EmitInstrError(CI, ValidationRule::MetaWellFormed);
+    ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrLinAlgMetadataMissing,
+                                {"Return"});
     return;
   }
 
   LinAlgTargetType LATT = it->second;
-
-  // Validate the K dim is in bounds. Which dim is K depends on use.
-  // This validation isn't applied to an accumulator matrix
-  if (LATT.Use != DXIL::MatrixUse::Accumulator) {
-    unsigned MinK = DXIL::kLinAlgMatrixMinK;
-    unsigned K = (LATT.Use == DXIL::MatrixUse::A) ? LATT.N : LATT.M;
-    unsigned MaxK = DXIL::kLinAlgMatrixMaxK;
-    if (LATT.Scope == DXIL::MatrixScope::ThreadGroup) {
-      MinK = DXIL::kLinAlgThreadGroupMatrixMinK;
-      MaxK = DXIL::kLinAlgThreadGroupMatrixMaxK;
-    }
-    if (K < MinK || K > MaxK)
-      ValCtx.EmitInstrFormatError(
-          CI, ValidationRule::InstrLinAlgIllegalKDim,
-          {std::to_string(K), std::to_string(MinK), std::to_string(MaxK)});
-  }
-
-  ValidateLinAlgComponentType(CI, LATT.Type, ValCtx);
+  ValidateLinAlgKDim(CI, LATT, ValCtx, "Return");
+  ValidateLinAlgComponentType(CI, LATT.Type, ValCtx, "return matrix");
 }
 
 static void ValidateLinAlgMatrixLength(CallInst *CI,
@@ -1103,7 +1120,7 @@ static void ValidateLinAlgMatrixGetCoordinate(CallInst *CI,
       MatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
+        {"Input", MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixGetElement(CallInst *CI,
@@ -1123,7 +1140,7 @@ static void ValidateLinAlgMatrixGetElement(CallInst *CI,
       MatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
+        {"Input", MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixStoreToDescriptor(CallInst *CI,
@@ -1159,7 +1176,7 @@ static void ValidateLinAlgMatrixStoreToDescriptor(CallInst *CI,
       MatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
+        {"Input", MatrixScopeToString(MatLATT.Scope), "Wave", "ThreadGroup"});
 
   // handle must be a UAV Raw buffer (RWByteAddressBuffer)
   DXIL::ComponentType ResCompTy;
@@ -1214,19 +1231,19 @@ static void ValidateLinAlgMatVecMul(CallInst *CI, ValidationContext &ValCtx,
 
   // Mat must be A matrix of Thread scope
   if (MatLATT.Scope != DXIL::MatrixScope::Thread)
-    ValCtx.EmitInstrFormatError(CI,
-                                ValidationRule::InstrLinAlgMatrixScopeMismatch,
-                                {MatrixScopeToString(MatLATT.Scope), "Thread"});
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch,
+        {"Input", MatrixScopeToString(MatLATT.Scope), "Thread"});
   if (MatLATT.Use != DXIL::MatrixUse::A)
     ValCtx.EmitInstrFormatError(CI,
                                 ValidationRule::InstrLinAlgMatrixUseMismatch,
-                                {MatrixUseToString(MatLATT.Use), "A"});
+                                {"Input", MatrixUseToString(MatLATT.Use), "A"});
 
   // Input Interp must be a immarg of allowed ComponentType
   DXIL::ComponentType Interp = DXIL::ComponentType::Invalid;
   if (InputInterpCI) {
     Interp = static_cast<DXIL::ComponentType>(InputInterpCI->getLimitedValue());
-    ValidateLinAlgComponentType(CI, Interp, ValCtx);
+    ValidateLinAlgComponentType(CI, Interp, ValCtx, "InputInterp");
   } else
     ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrOpConst,
                                 {"InputInterp", OpName});
@@ -1250,7 +1267,7 @@ static void ValidateLinAlgMatVecMul(CallInst *CI, ValidationContext &ValCtx,
   if (MatLATT.M != OutputVecTy->getNumElements())
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixDimVectorMismatch,
-        {"Output", std::to_string(OutputVecTy->getNumElements()), "M",
+        {"Output", std::to_string(OutputVecTy->getNumElements()),
          std::to_string(MatLATT.M)});
 
   // Sign bit must be immarg and must be true if output vec is a
@@ -1285,7 +1302,7 @@ static void ValidateLinAlgMatVecMulAdd(CallInst *CI,
   if (MatLATT.M != BiasVecTy->getNumElements())
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixDimVectorMismatch,
-        {"Bias", std::to_string(BiasVecTy->getNumElements()), "M",
+        {"Bias", std::to_string(BiasVecTy->getNumElements()),
          std::to_string(MatLATT.M)});
 
   // Bias element type must match output element type
@@ -1327,14 +1344,17 @@ ValidateLinAlgMatrixAccumulateToDescriptor(CallInst *CI,
        Layout != DXIL::MatrixLayout::OuterProductOptimalTranspose))
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeReqLayout2,
-        {MatrixScopeToString(MatLATT.Scope), "OuterProductOptimal",
-         "OuterProductOptimalTranspose"});
+        {"Input", MatrixScopeToString(MatLATT.Scope), "OuterProductOptimal",
+         "OuterProductOptimalTranspose", "LinAlgMatrixAccumulateToDescriptor"});
 
   // Wave/ThreadGroup matrix must have layout RowMajor/ColMajor
-  if (MatLATT.Scope != DXIL::MatrixScope::Thread && !LayoutIsRowColMajor)
+  if ((MatLATT.Scope == DXIL::MatrixScope::Wave ||
+       MatLATT.Scope == DXIL::MatrixScope::ThreadGroup) &&
+      !LayoutIsRowColMajor)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeReqLayout2,
-        {MatrixScopeToString(MatLATT.Scope), "RowMajor", "ColumnMajor"});
+        {"Input", MatrixScopeToString(MatLATT.Scope), "RowMajor", "ColumnMajor",
+         "LinAlgMatrixAccumulateToDescriptor"});
 
   // Stride must be an imm 0 if layout is not Row/Col Major
   if (!LayoutIsRowColMajor) {
@@ -1343,7 +1363,8 @@ ValidateLinAlgMatrixAccumulateToDescriptor(CallInst *CI,
       if (!StrideCI->isZero())
         ValCtx.EmitInstrFormatError(
             CI, ValidationRule::InstrLinAlgMatrixLayoutReqStride,
-            {MatrixLayoutToString(Layout)});
+            {"LinAlgMatrixAccumulateToDescriptor",
+             MatrixLayoutToString(Layout)});
     } else
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrOpConst,
@@ -1354,7 +1375,7 @@ ValidateLinAlgMatrixAccumulateToDescriptor(CallInst *CI,
   if (MatLATT.Use != DXIL::MatrixUse::Accumulator)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixUseMismatch,
-        {MatrixUseToString(MatLATT.Use), "Accumulator"});
+        {"Input", MatrixUseToString(MatLATT.Use), "Accumulator"});
 
   // handle must be a UAV Raw buffer (RWByteAddressBuffer)
   DXIL::ComponentType ResCompTy;
@@ -1415,7 +1436,8 @@ static void ValidateLinAlgFillMatrix(CallInst *CI, ValidationContext &ValCtx) {
       RetMatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(RetMatLATT.Scope), "Wave", "ThreadGroup"});
+        {"Return", MatrixScopeToString(RetMatLATT.Scope), "Wave",
+         "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
@@ -1448,13 +1470,14 @@ static void ValidateLinAlgMatrixSetElement(CallInst *CI,
       InMatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(InMatLATT.Scope), "Wave", "ThreadGroup"});
+        {"Input", MatrixScopeToString(InMatLATT.Scope), "Wave", "ThreadGroup"});
 
   if (RetMatLATT.Scope != DXIL::MatrixScope::Wave &&
       RetMatLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(RetMatLATT.Scope), "Wave", "ThreadGroup"});
+        {"Return", MatrixScopeToString(RetMatLATT.Scope), "Wave",
+         "ThreadGroup"});
 }
 
 static void ValidateLinAlgMatrixMultiply(CallInst *CI,
@@ -1501,10 +1524,13 @@ static void ValidateLinAlgMatrixLoadFromDescriptor(CallInst *CI,
                               Layout == DXIL::MatrixLayout::ColumnMajor);
 
   // Layout must be Row/Col Major if Scope is Wave/ThreadGroup
-  if (RetLATT.Scope != DXIL::MatrixScope::Thread && !LayoutIsRowColMajor)
+  if ((RetLATT.Scope == DXIL::MatrixScope::Wave ||
+       RetLATT.Scope == DXIL::MatrixScope::ThreadGroup) &&
+      !LayoutIsRowColMajor)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeReqLayout2,
-        {MatrixScopeToString(RetLATT.Scope), "RowMajor", "ColumnMajor"});
+        {"Return", MatrixScopeToString(RetLATT.Scope), "RowMajor",
+         "ColumnMajor", "LinAlgMatrixLoadFromDescriptor"});
 
   // Stride must be an imm 0 if Layout is not Row/Col Major
   if (!LayoutIsRowColMajor) {
@@ -1513,7 +1539,7 @@ static void ValidateLinAlgMatrixLoadFromDescriptor(CallInst *CI,
       if (!StrideCI->isZero())
         ValCtx.EmitInstrFormatError(
             CI, ValidationRule::InstrLinAlgMatrixLayoutReqStride,
-            {MatrixLayoutToString(Layout)});
+            {"LinAlgMatrixLoadFromDescriptor", MatrixLayoutToString(Layout)});
     } else
       ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrOpConst,
                                   {"Stride", "LinAlgMatrixLoadFromDescriptor"});
@@ -1551,9 +1577,11 @@ static void ValidateLinAlgMatrixAccumulate(CallInst *CI,
   ValidateLinAlgOpReturnMatrix(CI, ValCtx);
   ValidateLinAlgOpParameters(CI, ValCtx);
 
+  DxilInst_LinAlgMatrixAccumulate Op(CI);
+
   Type *RetMatTy = CI->getType();
-  Type *LHSMatTy = CI->getArgOperand(1)->getType();
-  Type *RHSMatTy = CI->getArgOperand(2)->getType();
+  Type *LHSMatTy = Op.get_matrixLHS()->getType();
+  Type *RHSMatTy = Op.get_matrixRHS()->getType();
   assert(dxilutil::IsHLSLLinAlgMatrixType(RetMatTy) &&
          dxilutil::IsHLSLLinAlgMatrixType(LHSMatTy) &&
          dxilutil::IsHLSLLinAlgMatrixType(RHSMatTy) && "Must be LinAlg types");
@@ -1563,10 +1591,11 @@ static void ValidateLinAlgMatrixAccumulate(CallInst *CI,
     StructType *RetST = cast<StructType>(RetMatTy);
     StructType *LHSST = cast<StructType>(LHSMatTy);
 
-    ValCtx.EmitInstrFormatError(CI,
-                                ValidationRule::InstrLinAlgMatrixNotExactMatch,
-                                {RetST->getName(), LHSST->getName()});
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixNotExactMatch,
+        {"Return", RetST->getName(), "arg 1", LHSST->getName()});
   }
+
   auto RetIt = ValCtx.LinAlgTargetTypeMap.find(RetMatTy);
   auto RHSIt = ValCtx.LinAlgTargetTypeMap.find(RHSMatTy);
   if (RetIt == ValCtx.LinAlgTargetTypeMap.end())
@@ -1579,30 +1608,38 @@ static void ValidateLinAlgMatrixAccumulate(CallInst *CI,
   if (RetLATT.Use != DXIL::MatrixUse::Accumulator)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixUseMismatch,
-        {MatrixUseToString(RetLATT.Use), "Accumulator"});
+        {"Return", MatrixUseToString(RetLATT.Use), "Accumulator"});
 
-  if (RHSLATT.Use == DXIL::MatrixUse::Accumulator)
-    ValCtx.EmitInstrFormatError(CI,
-                                ValidationRule::InstrLinAlgMatrixUseMismatch2,
-                                {MatrixUseToString(RHSLATT.Use), "A", "B"});
+  if (RHSLATT.Use != DXIL::MatrixUse::A && RHSLATT.Use != DXIL::MatrixUse::B)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixUseMismatch2,
+        {"Arg 2", MatrixUseToString(RHSLATT.Use), "A", "B"});
 
   if (RetLATT.Scope != RHSLATT.Scope)
-    ValCtx.EmitInstrFormatError(CI,
-                                ValidationRule::InstrLinAlgMatrixScopeMismatch,
-                                {MatrixScopeToString(RHSLATT.Scope),
-                                 MatrixScopeToString(RetLATT.Scope)});
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrix2PartsMustMatch,
+        {"Return", "scope", MatrixScopeToString(RetLATT.Scope), "Arg 2",
+         "scope", MatrixScopeToString(RHSLATT.Scope)});
+
+  if (RHSLATT.Scope != DXIL::MatrixScope::Wave &&
+      RHSLATT.Scope != DXIL::MatrixScope::ThreadGroup)
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
+        {"Arg 2", MatrixScopeToString(RetLATT.Scope), "Wave", "ThreadGroup"});
 
   if (RetLATT.Scope != DXIL::MatrixScope::Wave &&
       RetLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(RetLATT.Scope), "Wave", "ThreadGroup"});
+        {"Return", MatrixScopeToString(RetLATT.Scope), "Wave", "ThreadGroup"});
 
   if (RetLATT.M != RHSLATT.M || RetLATT.N != RHSLATT.N)
     ValCtx.EmitInstrFormatError(
-        CI, ValidationRule::InstrLinAlgMatrixDimMismatch,
-        {std::to_string(RHSLATT.M), std::to_string(RHSLATT.N),
-         std::to_string(RetLATT.M), std::to_string(RetLATT.N)});
+        CI, ValidationRule::InstrLinAlgMatrix2PartsMustMatch,
+        {"Arg 2", "dimension",
+         std::to_string(RHSLATT.M) + "x" + std::to_string(RHSLATT.N), "return",
+         "dimension",
+         std::to_string(RetLATT.M) + "x" + std::to_string(RetLATT.N)});
 }
 
 static void ValidateLinAlgCopyConvertMatrix(CallInst *CI,
@@ -1638,19 +1675,20 @@ static void ValidateLinAlgCopyConvertMatrix(CallInst *CI,
       DstLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(DstLATT.Scope), "Wave", "ThreadGroup"});
+        {"Destination", MatrixScopeToString(DstLATT.Scope), "Wave",
+         "ThreadGroup"});
 
   if (SrcLATT.Scope != DXIL::MatrixScope::Wave &&
       SrcLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {MatrixScopeToString(SrcLATT.Scope), "Wave", "ThreadGroup"});
+        {"Source", MatrixScopeToString(SrcLATT.Scope), "Wave", "ThreadGroup"});
 
   if (DstLATT.Scope != SrcLATT.Scope)
-    ValCtx.EmitInstrFormatError(CI,
-                                ValidationRule::InstrLinAlgMatrixScopeMismatch,
-                                {MatrixScopeToString(DstLATT.Scope),
-                                 MatrixScopeToString(SrcLATT.Scope)});
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrix2PartsMustMatch,
+        {"Destination", "scope", MatrixScopeToString(DstLATT.Scope), "source",
+         "scope", MatrixScopeToString(SrcLATT.Scope)});
 
   unsigned DstM = DstLATT.M;
   unsigned DstN = DstLATT.N;
@@ -1662,10 +1700,11 @@ static void ValidateLinAlgCopyConvertMatrix(CallInst *CI,
   }
 
   if (DstM != SrcM || DstN != SrcN)
-    ValCtx.EmitInstrFormatError(CI,
-                                ValidationRule::InstrLinAlgMatrixDimMismatch,
-                                {std::to_string(DstM), std::to_string(DstN),
-                                 std::to_string(SrcM), std::to_string(SrcN)});
+    ValCtx.EmitInstrFormatError(
+        CI, ValidationRule::InstrLinAlgMatrix2PartsMustMatch,
+        {"Destination", "dimension",
+         std::to_string(DstM) + "x" + std::to_string(DstN), "source",
+         "dimension", std::to_string(SrcM) + "x" + std::to_string(SrcN)});
 }
 
 // Validate the type-defined mask compared to the store value mask which

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1625,7 +1625,7 @@ static void ValidateLinAlgMatrixAccumulate(CallInst *CI,
       RHSLATT.Scope != DXIL::MatrixScope::ThreadGroup)
     ValCtx.EmitInstrFormatError(
         CI, ValidationRule::InstrLinAlgMatrixScopeMismatch2,
-        {"Arg 2", MatrixScopeToString(RetLATT.Scope), "Wave", "ThreadGroup"});
+        {"Arg 2", MatrixScopeToString(RHSLATT.Scope), "Wave", "ThreadGroup"});
 
   if (RetLATT.Scope != DXIL::MatrixScope::Wave &&
       RetLATT.Scope != DXIL::MatrixScope::ThreadGroup)

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-copyconvert.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-copyconvert.ll
@@ -20,27 +20,27 @@ define void @main() {
 
   %1 = call %dx.types.LinAlgMatrixC2M5N4U1S2 @dx.op.linAlgFillMatrix.mC2M5N4U1S2.i32(i32 -2147483636, i32 1)  ; LinAlgFillMatrix(value)
 
-  ; CHECK: Function: main: error: Matrix Dimension '8x4' does not match expected dimension 5x4.
+  ; CHECK: Function: main: error: Destination matrix dimension '8x4' must match source matrix dimension '5x4'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC4M8N4U1S2.mC2M5N4U1S2
   %2 = call %dx.types.LinAlgMatrixC4M8N4U1S2 @dx.op.linAlgCopyConvertMatrix.mC4M8N4U1S2.mC2M5N4U1S2(i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 %1, i1 false)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Dimension '5x8' does not match expected dimension 5x4.
+  ; CHECK-NEXT: Function: main: error: Destination matrix dimension '5x8' must match source matrix dimension '5x4'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC4M5N8U1S2.mC2M5N4U1S2
   %3 = call %dx.types.LinAlgMatrixC4M5N8U1S2 @dx.op.linAlgCopyConvertMatrix.mC4M5N8U1S2.mC2M5N4U1S2(i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 %1, i1 false)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Dimension '5x4' does not match expected dimension 4x5.
+  ; CHECK-NEXT: Function: main: error: Destination matrix dimension '5x4' must match source matrix dimension '4x5'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC4M5N4U1S2.mC2M5N4U1S2
   %4 = call %dx.types.LinAlgMatrixC4M5N4U1S2 @dx.op.linAlgCopyConvertMatrix.mC4M5N4U1S2.mC2M5N4U1S2(i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 %1, i1 true)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Wave' does not match expected scope ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Destination matrix scope 'Wave' must match source matrix scope 'ThreadGroup'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S1.mC2M5N4U1S2
   %5 = call %dx.types.LinAlgMatrixC2M4N5U1S1 @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S1.mC2M5N4U1S2(i32 -2147483635, %dx.types.LinAlgMatrixC2M5N4U1S2 %1, i1 true)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 
   %6 = call %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC2M4N5U1S0(i32 -2147483634, %dx.types.Handle %bab, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Destination matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Source matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0
   %7 = call %dx.types.LinAlgMatrixC2M4N5U1S0 @dx.op.linAlgCopyConvertMatrix.mC2M4N5U1S0.mC2M4N5U1S0(i32 -2147483635, %dx.types.LinAlgMatrixC2M4N5U1S0 %6, i1 false)  ; LinAlgCopyConvertMatrix(srcMatrix,transpose)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-illegal-component-type.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-illegal-component-type.ll
@@ -13,7 +13,7 @@ define void @main() {
   %1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
   %2 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
 
-  ; CHECK: Function: main: error: Component Type 'Invalid' not allowed in LinAlg Matrix.
+  ; CHECK: Function: main: error: Component type 'Invalid' from return matrix not allowed in LinAlg Matrix operations.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC0M16N16U0S0
   ; Matrix<Invalid, 16, 16, A, Thread>
   %3 = call %dx.types.LinAlgMatrixC0M16N16U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC0M16N16U0S0(i32 -2147483634, %dx.types.Handle %2, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulate.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulate.ll
@@ -18,27 +18,29 @@ define void @main() {
   %5 = call %dx.types.LinAlgMatrixC8M4N4U1S1 @dx.op.linAlgFillMatrix.mC8M4N4U1S1.i32(i32 -2147483636, i32 6)  ; LinAlgFillMatrix(value)
   %6 = call %dx.types.LinAlgMatrixC8M8N8U0S2 @dx.op.linAlgFillMatrix.mC8M8N8U0S2.i32(i32 -2147483636, i32 7)  ; LinAlgFillMatrix(value)
 
-  ; CHECK: Function: main: error: Matrix 'dx.types.LinAlgMatrixC8M4N4U2S2' must exactly match matrix 'dx.types.LinAlgMatrixC8M4N4U0S2'.
+  ; CHECK: Function: main: error: Return matrix 'dx.types.LinAlgMatrixC8M4N4U2S2' must exactly match arg 1 matrix 'dx.types.LinAlgMatrixC8M4N4U0S2'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U0S2.mC8M4N4U0S2
   %7 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U0S2.mC8M4N4U0S2(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U0S2 %2, %dx.types.LinAlgMatrixC8M4N4U0S2 %2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Use 'A' does not match expected use Accumulator.
+  ; CHECK-NEXT: Function: main: error: Return matrix use 'A' does not match expected use Accumulator.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U0S2.mC8M4N4U0S2.mC8M4N4U0S2
   %8 = call %dx.types.LinAlgMatrixC8M4N4U0S2 @dx.op.linAlgMatrixAccumulate.mC8M4N4U0S2.mC8M4N4U0S2.mC8M4N4U0S2(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U0S2 %2, %dx.types.LinAlgMatrixC8M4N4U0S2 %2)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Use 'Accumulator' does not match expected use A or B.
+  ; CHECK-NEXT: Function: main: error: Arg 2 matrix use 'Accumulator' does not match expected use A or B.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M4N4U2S2
   %9 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M4N4U2S2(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U2S2 %1, %dx.types.LinAlgMatrixC8M4N4U2S2 %1)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Wave' does not match expected scope ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Return matrix scope 'ThreadGroup' must match Arg 2 matrix scope 'Wave'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M4N4U1S1
   %10 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M4N4U1S1(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U2S2 %1, %dx.types.LinAlgMatrixC8M4N4U1S1 %5)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Arg 2 matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S0.mC8M4N4U2S0.mC8M4N4U1S0
+  ; CHECK-NEXT: Function: main: error: Return matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S0.mC8M4N4U2S0.mC8M4N4U1S0
   %11 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S0.mC8M4N4U2S0.mC8M4N4U1S0(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U2S0 %3, %dx.types.LinAlgMatrixC8M4N4U1S0 %4)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Dimension '8x8' does not match expected dimension 4x4.
+  ; CHECK-NEXT: Function: main: error: Arg 2 matrix dimension '8x8' must match return matrix dimension '4x4'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M8N8U0S2
   %12 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixAccumulate.mC8M4N4U2S2.mC8M4N4U2S2.mC8M8N8U0S2(i32 -2147483624, %dx.types.LinAlgMatrixC8M4N4U2S2 %1, %dx.types.LinAlgMatrixC8M8N8U0S2 %6)  ; LinAlgMatrixAccumulate(matrixLHS,matrixRHS)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetodescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetodescriptor.ll
@@ -32,7 +32,7 @@ define void @main() {
   %12 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S0 %4, %dx.types.Handle %12, i32 0, i32 0, i32 %11, i32 128)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix scope 'Thread' requires layout OuterProductOptimal or OuterProductOptimalTranspose.
+  ; CHECK-NEXT: Function: main: error: Input matrix with scope 'Thread' requires layout OuterProductOptimal or OuterProductOptimalTranspose for LinAlgMatrixAccumulateToDescriptor.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S0
   %13 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S0 %4, %dx.types.Handle %13, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
@@ -62,17 +62,17 @@ define void @main() {
   %18 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S0 %4, %dx.types.Handle %18, i32 0, i32 0, i32 4, i32 215)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix layout 'OuterProductOptimal' requires stride 0.
+  ; CHECK-NEXT: Function: main: error: LinAlgMatrixAccumulateToDescriptor with layout 'OuterProductOptimal' requires stride 0.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S0
   %19 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S0 %4, %dx.types.Handle %19, i32 0, i32 1, i32 4, i32 128)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix scope 'Wave' requires layout RowMajor or ColumnMajor.
+  ; CHECK-NEXT: Function: main: error: Input matrix with scope 'Wave' requires layout RowMajor or ColumnMajor for LinAlgMatrixAccumulateToDescriptor.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S1
   %20 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S1(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S1 %6, %dx.types.Handle %20, i32 0, i32 0, i32 3, i32 256)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Use 'A' does not match expected use Accumulator.
+  ; CHECK-NEXT: Function: main: error: Input matrix use 'A' does not match expected use Accumulator.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U0S0
   %21 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U0S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U0S0 %8, %dx.types.Handle %21, i32 0, i32 0, i32 4, i32 128)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfromdescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfromdescriptor.ll
@@ -27,13 +27,13 @@ define void @main() {
   %4 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
 
 
-  ; CHECK: Function: main: error: Matrix scope 'ThreadGroup' requires layout RowMajor or ColumnMajor.
+  ; CHECK: Function: main: error: Return matrix with scope 'ThreadGroup' requires layout RowMajor or ColumnMajor for LinAlgMatrixLoadFromDescriptor.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2
   %5 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2(i32 -2147483634, %dx.types.Handle %4, i32 0, i32 0, i32 4, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   %6 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
 
 
-  ; CHECK-NEXT: Function: main: error: Matrix layout 'OuterProductOptimal' requires stride 0.
+  ; CHECK-NEXT: Function: main: error: LinAlgMatrixLoadFromDescriptor with layout 'OuterProductOptimal' requires stride 0.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S0
   %7 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S0(i32 -2147483634, %dx.types.Handle %6, i32 0, i32 4, i32 4, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %2, %dx.types.ResourceProperties { i32 12, i32 4 })  ; AnnotateHandle(res,props)  resource: StructuredBuffer<stride=4>

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretodescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretodescriptor.ll
@@ -52,7 +52,7 @@ define void @main() {
   %13 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U0S1(i32 -2147483628, %dx.types.LinAlgMatrixC8M4N4U0S1 %4, %dx.types.Handle %13, i32 0, i32 0, i32 %11, i32 256)  ; LinAlgMatrixStoreToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U2S0
   %14 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %2, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %15 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S0(i32 -2147483634, %dx.types.Handle %14, i32 0, i32 0, i32 4, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matvecmul.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matvecmul.ll
@@ -19,35 +19,35 @@ define void @main() {
   %2 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %3 = call %dx.types.LinAlgMatrixC9M4N32U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N32U0S0(i32 -2147483634, %dx.types.Handle %2, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK: Function: main: error: Component Type 'I1' not allowed in LinAlg Matrix.
+  ; CHECK: Function: main: error: Component type 'I1' from InputInterp not allowed in LinAlg Matrix operations.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMul.v4f32.mC9M4N32U0S0.v8f32
   %4 = call <4 x float> @dx.op.linAlgMatVecMul.v4f32.mC9M4N32U0S0.v8f32(i32 -2147483623, %dx.types.LinAlgMatrixC9M4N32U0S0 %3, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 1)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
   %5 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %6 = call %dx.types.LinAlgMatrixC9M4N8U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N8U0S2(i32 -2147483634, %dx.types.Handle %5, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'ThreadGroup' does not match expected scope Thread.
+  ; CHECK-NEXT: Function: main: error: Input matrix scope 'ThreadGroup' does not match expected scope Thread.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMul.v4f32.mC9M4N8U0S2.v8f32
   %7 = call <4 x float> @dx.op.linAlgMatVecMul.v4f32.mC9M4N8U0S2.v8f32(i32 -2147483623, %dx.types.LinAlgMatrixC9M4N8U0S2 %6, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
   %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %9 = call %dx.types.LinAlgMatrixC9M4N8U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N8U1S0(i32 -2147483634, %dx.types.Handle %8, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Use 'B' does not match expected use A.
+  ; CHECK-NEXT: Function: main: error: Input matrix use 'B' does not match expected use A.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMul.v4f32.mC9M4N8U1S0.v8f32
   %10 = call <4 x float> @dx.op.linAlgMatVecMul.v4f32.mC9M4N8U1S0.v8f32(i32 -2147483623, %dx.types.LinAlgMatrixC9M4N8U1S0 %9, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
   %11 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %12 = call %dx.types.LinAlgMatrixC9M4N8U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N8U0S0(i32 -2147483634, %dx.types.Handle %11, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Input vector size '4' must be 8 for matrix with K '8' and Type 'F32'
+  ; CHECK-NEXT: Function: main: error: Input vector size '4' must be 8 for input matrix with K '8' and Type 'F32'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMul.v4f32.mC9M4N8U0S0.v4f32
   %13 = call <4 x float> @dx.op.linAlgMatVecMul.v4f32.mC9M4N8U0S0.v4f32(i32 -2147483623, %dx.types.LinAlgMatrixC9M4N8U0S0 %12, i1 true, <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, i32 9)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
   %14 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %15 = call %dx.types.LinAlgMatrixC21M4N8U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC21M4N8U0S0(i32 -2147483634, %dx.types.Handle %14, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Input vector size '8' must be 2 for matrix with K '8' and Type 'F8_E4M3FN'
+  ; CHECK-NEXT: Function: main: error: Input vector size '8' must be 2 for input matrix with K '8' and Type 'F8_E4M3FN'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMul.v4f32.mC21M4N8U0S0.v8f32
   %16 = call <4 x float> @dx.op.linAlgMatVecMul.v4f32.mC21M4N8U0S0.v8f32(i32 -2147483623, %dx.types.LinAlgMatrixC21M4N8U0S0 %15, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 21)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
 
-  ; CHECK-NEXT: Function: main: error: Output vector size '2' must match matrix M dimension '4'
+  ; CHECK-NEXT: Function: main: error: Output vector size '2' must match input matrix M dimension '4'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMul.v2f32.mC9M4N8U0S0.v8f32
   %17 = call <2 x float> @dx.op.linAlgMatVecMul.v2f32.mC9M4N8U0S0.v8f32(i32 -2147483623, %dx.types.LinAlgMatrixC9M4N8U0S0 %12, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9)  ; LinAlgMatVecMul(matrix,isOutputSigned,inputVector,interpretation)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matvecmuladd.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matvecmuladd.ll
@@ -18,37 +18,37 @@ define void @main() {
   %2 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %3 = call %dx.types.LinAlgMatrixC9M4N32U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N32U0S0(i32 -2147483634, %dx.types.Handle %2, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK: Function: main: error: Component Type 'I1' not allowed in LinAlg Matrix.
+  ; CHECK: Function: main: error: Component type 'I1' from InputInterp not allowed in LinAlg Matrix operations.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N32U0S0.v8f32.v4f32
   %4 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N32U0S0.v8f32.v4f32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N32U0S0 %3, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 1, <4 x float> <float 4.000000e+00, float 3.000000e+00, float 2.000000e+00, float 1.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
   %5 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %6 = call %dx.types.LinAlgMatrixC9M4N8U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N8U0S2(i32 -2147483634, %dx.types.Handle %5, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'ThreadGroup' does not match expected scope Thread.
+  ; CHECK-NEXT: Function: main: error: Input matrix scope 'ThreadGroup' does not match expected scope Thread.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S2.v8f32.v4f32
   %7 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S2.v8f32.v4f32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N8U0S2 %6, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9, <4 x float> <float 4.000000e+00, float 3.000000e+00, float 2.000000e+00, float 1.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
   %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %9 = call %dx.types.LinAlgMatrixC9M4N8U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N8U1S0(i32 -2147483634, %dx.types.Handle %8, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Use 'B' does not match expected use A.
+  ; CHECK-NEXT: Function: main: error: Input matrix use 'B' does not match expected use A.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U1S0.v8f32.v4f32
   %10 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U1S0.v8f32.v4f32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N8U1S0 %9, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9, <4 x float> <float 4.000000e+00, float 3.000000e+00, float 2.000000e+00, float 1.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
   %11 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %12 = call %dx.types.LinAlgMatrixC9M4N8U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N8U0S0(i32 -2147483634, %dx.types.Handle %11, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Input vector size '4' must be 8 for matrix with K '8' and Type 'F32'
+  ; CHECK-NEXT: Function: main: error: Input vector size '4' must be 8 for input matrix with K '8' and Type 'F32'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S0.v4f32.v4f32
   %13 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S0.v4f32.v4f32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N8U0S0 %12, i1 true, <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, i32 9, <4 x float> <float 4.000000e+00, float 3.000000e+00, float 2.000000e+00, float 1.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
   %14 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %15 = call %dx.types.LinAlgMatrixC21M4N8U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC21M4N8U0S0(i32 -2147483634, %dx.types.Handle %14, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Input vector size '8' must be 2 for matrix with K '8' and Type 'F8_E4M3FN'
+  ; CHECK-NEXT: Function: main: error: Input vector size '8' must be 2 for input matrix with K '8' and Type 'F8_E4M3FN'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC21M4N8U0S0.v8f32.v4f32
   %16 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC21M4N8U0S0.v8f32.v4f32(i32 -2147483622, %dx.types.LinAlgMatrixC21M4N8U0S0 %15, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 21, <4 x float> <float 4.000000e+00, float 3.000000e+00, float 2.000000e+00, float 1.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
 
-  ; CHECK-NEXT: Function: main: error: Output vector size '2' must match matrix M dimension '4'
+  ; CHECK-NEXT: Function: main: error: Output vector size '2' must match input matrix M dimension '4'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v2f32.mC9M4N8U0S0.v8f32.v2f32
-  ; CHECK-NEXT: Function: main: error: Bias vector size '2' must match matrix M dimension '4'
+  ; CHECK-NEXT: Function: main: error: Bias vector size '2' must match input matrix M dimension '4'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v2f32.mC9M4N8U0S0.v8f32.v2f32
   %17 = call <2 x float> @dx.op.linAlgMatVecMulAdd.v2f32.mC9M4N8U0S0.v8f32.v2f32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N8U0S0 %12, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9, <2 x float> <float 3.000000e+00, float 5.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
 
@@ -56,7 +56,7 @@ define void @main() {
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S0.v8f32.v4f32
   %18 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S0.v8f32.v4f32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N8U0S0 %12, i1 false, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9, <4 x float> <float 4.000000e+00, float 3.000000e+00, float 2.000000e+00, float 1.000000e+00>)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
 
-  ; CHECK-NEXT: Function: main: error: Output vector element type 'float' must match Bias vector element type 'i32'
+  ; CHECK-NEXT: Function: main: error: Output vector element type 'float' must match bias vector element type 'i32'
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S0.v8f32.v4i32
   %19 = call <4 x float> @dx.op.linAlgMatVecMulAdd.v4f32.mC9M4N8U0S0.v8f32.v4i32(i32 -2147483622, %dx.types.LinAlgMatrixC9M4N8U0S0 %12, i1 true, <8 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00, float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00>, i32 9, <4 x i32> zeroinitializer)  ; LinAlgMatVecMulAdd(matrix,isOutputSigned,inputVector,inputInterpretation,biasVector)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-max-k-dim.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-max-k-dim.ll
@@ -38,13 +38,13 @@ define void @main() {
   %2 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %3 = call %dx.types.LinAlgMatrixC8M1025N1025U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N1025U2S0(i32 -2147483634, %dx.types.Handle %2, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK: Function: main: error: Metadata must be well-formed in operand count and types.
+  ; CHECK: Function: main: error: Return matrix must have well-formed metadata.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC4M16N16U0S2
   ; Matrix<I32, 16, 16, A, ThreadGroup> - missing metadata
   %4 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %5 = call %dx.types.LinAlgMatrixC4M16N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC4M16N16U0S2(i32 -2147483634, %dx.types.Handle %4, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=129 must be >= 4 and <= 128.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=129 must be >= 4 and <= 128.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U0S0
   ; Matrix<F16, 129, 16, A, Thread> - N is K so pass
   %6 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -53,7 +53,7 @@ define void @main() {
   %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %9 = call %dx.types.LinAlgMatrixC8M16N129U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U0S0(i32 -2147483634, %dx.types.Handle %8, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 128.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=3 must be >= 4 and <= 128.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S0
   ; Matrix<F16, 3, 16, A, Thread> - N is K so pass
   %10 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -62,7 +62,7 @@ define void @main() {
   %12 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %13 = call %dx.types.LinAlgMatrixC8M16N3U0S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U0S0(i32 -2147483634, %dx.types.Handle %12, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=129 must be >= 4 and <= 128.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=129 must be >= 4 and <= 128.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N16U1S0
   ; Matrix<F16, 129, 16, B, Thread> - M is K so fail
   %14 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -71,7 +71,7 @@ define void @main() {
   %16 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %17 = call %dx.types.LinAlgMatrixC8M16N129U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N129U1S0(i32 -2147483634, %dx.types.Handle %16, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=3 must be >= 4 and <= 128.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=3 must be >= 4 and <= 128.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U1S0
   ; Matrix<F16, 3, 16, B, Thread> - M is K so fail
   %18 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -80,7 +80,7 @@ define void @main() {
   %20 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %21 = call %dx.types.LinAlgMatrixC8M16N3U1S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N3U1S0(i32 -2147483634, %dx.types.Handle %20, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 1 and <= 1024.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=1025 must be >= 1 and <= 1024.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N1025U0S2
   ; Matrix<F16, 1025, 16, A, ThreadGroup> - N is K so pass
   %22 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -89,7 +89,7 @@ define void @main() {
   %24 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %25 = call %dx.types.LinAlgMatrixC8M16N1025U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N1025U0S2(i32 -2147483634, %dx.types.Handle %24, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=0 must be >= 1 and <= 1024.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=0 must be >= 1 and <= 1024.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M16N0U0S2
   ; Matrix<F16, 16, 3, A, ThreadGroup> - N is K so fail
   %26 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -98,7 +98,7 @@ define void @main() {
   %28 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %29 = call %dx.types.LinAlgMatrixC8M3N16U0S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M3N16U0S2(i32 -2147483634, %dx.types.Handle %28, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=1025 must be >= 1 and <= 1024.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=1025 must be >= 1 and <= 1024.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M1025N129U1S2
   ; Matrix<F16, 1025, 129, B, ThreadGroup> - M is K so fail
   %30 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
@@ -107,7 +107,7 @@ define void @main() {
   %32 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %33 = call %dx.types.LinAlgMatrixC8M129N1025U1S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M129N1025U1S2(i32 -2147483634, %dx.types.Handle %32, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: Matrix K Dimension out of bounds. K=0 must be >= 1 and <= 1024.
+  ; CHECK-NEXT: Function: main: error: Return matrix K dimension out of bounds. K=0 must be >= 1 and <= 1024.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M0N129U1S2
   ; Matrix<F16, 3, 129, B, ThreadGroup> - M is K so fail
   %34 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-non-thread-ops.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-non-thread-ops.ll
@@ -7,21 +7,21 @@ target triple = "dxil-ms-dx"
 %dx.types.LinAlgMatrixC8M4N4U2S0 = type { i8* }
 
 define void @main() {
-  ; CHECK: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK: Function: main: error: Return matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgFillMatrix.mC8M4N4U2S0.i32
   %1 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgFillMatrix.mC8M4N4U2S0.i32(i32 -2147483636, i32 1)  ; LinAlgFillMatrix(value)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetElement.f32.mC8M4N4U2S0
   %2 = call float @dx.op.linAlgMatrixGetElement.f32.mC8M4N4U2S0(i32 -2147483630, %dx.types.LinAlgMatrixC8M4N4U2S0 %1, i32 1)  ; LinAlgMatrixGetElement(matrix,threadLocalIndex)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Return matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32
   %3 = call %dx.types.LinAlgMatrixC8M4N4U2S0 @dx.op.linAlgMatrixSetElement.mC8M4N4U2S0.mC8M4N4U2S0.f32(i32 -2147483629, %dx.types.LinAlgMatrixC8M4N4U2S0 %1, i32 1, float %2)  ; LinAlgMatrixSetElement(matrix,threadLocalIndex,value)
 
-  ; CHECK-NEXT: Function: main: error: Matrix Scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixGetCoordinate.mC8M4N4U2S0
   %4 = call <2 x i32> @dx.op.linAlgMatrixGetCoordinate.mC8M4N4U2S0(i32 -2147483631, %dx.types.LinAlgMatrixC8M4N4U2S0 %3, i32 0)  ; LinAlgMatrixGetCoordinate(matrix,threadLocalIndex)
 

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8642,56 +8642,56 @@ class db_dxil(object):
             "reordercoherent requires SM 6.9 or later.",
         )
         self.add_valrule(
+            "Instr.LinAlgMetadataMissing",
+            "%0 matrix must have well-formed metadata.",
+        )
+        self.add_valrule(
             "Instr.LinAlgIllegalKDim",
-            "Matrix K Dimension out of bounds. K=%0 must be >= %1 and <= %2.",
+            "%0 matrix K dimension out of bounds. K=%1 must be >= %2 and <= %3.",
         )
         self.add_valrule(
             "Instr.LinAlgIllegalComponentType",
-            "Component Type '%0' not allowed in LinAlg Matrix.",
+            "Component type '%0' from %1 not allowed in LinAlg Matrix operations.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixScopeMismatch",
-            "Matrix Scope '%0' does not match expected scope %1.",
+            "%0 matrix scope '%1' does not match expected scope %2.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixScopeMismatch2",
-            "Matrix Scope '%0' does not match expected scope %1 or %2.",
-        )
-        self.add_valrule(
-            "Instr.LinAlgMatrixDimMismatch",
-            "Matrix Dimension '%0x%1' does not match expected dimension %2x%3.",
+            "%0 matrix scope '%1' does not match expected scope %2 or %3.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixUseMismatch",
-            "Matrix Use '%0' does not match expected use %1.",
+            "%0 matrix use '%1' does not match expected use %2.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixUseMismatch2",
-            "Matrix Use '%0' does not match expected use %1 or %2.",
+            "%0 matrix use '%1' does not match expected use %2 or %3.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixNotExactMatch",
-            "Matrix '%0' must exactly match matrix '%1'.",
+            "%0 matrix '%1' must exactly match %2 matrix '%3'.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixScopeReqLayout2",
-            "Matrix scope '%0' requires layout %1 or %2.",
+            "%0 matrix with scope '%1' requires layout %2 or %3 for %4.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixLayoutReqStride",
-            "Matrix layout '%0' requires stride 0.",
+            "%0 with layout '%1' requires stride 0.",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixDimVectorMismatch",
-            "%0 vector size '%1' must match matrix %2 dimension '%3'",
+            "%0 vector size '%1' must match input matrix M dimension '%2'",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixDimKVecKMismatch",
-            "%0 vector size '%1' must be %2 for matrix with K '%3' and Type '%4'",
+            "%0 vector size '%1' must be %2 for input matrix with K '%3' and Type '%4'",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixOutputBiasVecMismatch",
-            "Output vector element type '%0' must match Bias vector element type '%1'",
+            "Output vector element type '%0' must match bias vector element type '%1'",
         )
         self.add_valrule(
             "Instr.LinAlgMatrixUnsignedFloatTypeNotAllowed",
@@ -8708,6 +8708,10 @@ class db_dxil(object):
         self.add_valrule(
             "Instr.LinAlgMatrixRequiresLayout2",
             "%0 requires layout %1 or %2.",
+        )
+        self.add_valrule(
+            "Instr.LinAlgMatrix2PartsMustMatch",
+            "%0 matrix %1 '%2' must match %3 matrix %4 '%5'.",
         )
 
         # Some legacy rules:


### PR DESCRIPTION
Fixes #8768

Updates error messages to name specific things such as the failing matrix so that an operation with multiple failures on different matrices won't repeat an identical failure message each time