### PR TITLE
Cherry Pick: Modify gen_version.py to handle vpack versioning (#8760)

### DIFF
--- a/utils/version/gen_version.py
+++ b/utils/version/gen_version.py
@@ -77,7 +77,10 @@ class VersionGen():
             "dxcoob" if self.options.official else "dxc(private)")
 
     def rc_version_field_1(self):
-        return self.latest_release_info["version"]["major"]
+        major = int(self.latest_release_info["version"]["major"])
+        if self.options.vpack:
+            major += 100
+        return str(major)
 
     def rc_version_field_2(self):
         return self.latest_release_info["version"]["minor"]
@@ -147,6 +150,7 @@ def main():
     p = argparse.ArgumentParser("gen_version")
     p.add_argument("--no-commit-sha", action='store_true')
     p.add_argument("--official", action="store_true")
+    p.add_argument("--vpack", action="store_true")
     args = p.parse_args()
 
     VersionGen(args).print_version() 


### PR DESCRIPTION
Wintools generates versions for vpacks differently from other release
formats. Originally this was handled in a combination of CMake and
PowerShell, orchestrated in `mm release`. In order to have the same
solution in DXCBuild the simplest solution is to modify `gen_version.py`
so it handles this logic within it.

Co-authored-by: Joao Saffran <jderezende@microsoft.com>
(cherry picked from commit b5cf89c6d00e170b268f76785ffa04f9c30271e1)