### PR TITLE
Only download prebuilt DXC releases on Windows

### DIFF
--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -137,20 +137,20 @@ function(add_released_dxc name version)
   )
 endfunction()
 
-# Iterate over releases
-list(LENGTH DXC_RELEASES DXC_RELEASES_LENGTH)
-math(EXPR num_pairs "${DXC_RELEASES_LENGTH} / 2")
-math(EXPR loop_end "${num_pairs} - 1")
-foreach(i RANGE 0 ${loop_end})
-  math(EXPR idx_name "${i}*2")
-  math(EXPR idx_version "${i}*2 + 1")  
+if(WIN32)
+  # Iterate over releases
+  list(LENGTH DXC_RELEASES DXC_RELEASES_LENGTH)
+  math(EXPR num_pairs "${DXC_RELEASES_LENGTH} / 2")
+  math(EXPR loop_end "${num_pairs} - 1")
+  foreach(i RANGE 0 ${loop_end})
+    math(EXPR idx_name "${i}*2")
+    math(EXPR idx_version "${i}*2 + 1")
 
-  list(GET DXC_RELEASES ${idx_name} name)
-  list(GET DXC_RELEASES ${idx_version} version)
+    list(GET DXC_RELEASES ${idx_name} name)
+    list(GET DXC_RELEASES ${idx_version} version)
 
-  add_released_dxc(${name} ${version})
+    add_released_dxc(${name} ${version})
 
-  if(WIN32)
   # Determine target architecture for DXC binaries
     if(CMAKE_GENERATOR MATCHES "Visual Studio")
         # Multi-config generators (VS/Xcode)
@@ -197,8 +197,8 @@ foreach(i RANGE 0 ${loop_end})
       DEPENDS ${CLANG_TEST_DEPS} ${name}
       ARGS ${CLANG_TEST_EXTRA_ARGS}
     )
-  endif()
-endforeach()
+  endforeach()
+endif()
 # -------------------------------------------------------------------------
 
 set(CLANG_TEST_PARAMS


### PR DESCRIPTION
The DXIL backward compatibility section downloads four release archives from github and then uses them exclusively from inside an `if(WIN32)` block, because what it wants out of them is bin/<arch>/dxil.dll -- a Windows binary that has no equivalent, and no consumer, on other platforms.

The download itself was outside that guard, and `ExternalProject_Add` adds its download target to ALL, so every Linux and macOS build fetched all four archives for nothing. It also makes an ordinary build depend on network access, which breaks offline and distribution builds.

Move the `add_released_dxc()` call inside the existing if(WIN32), matching what taef_exec/DownloadWarp.cmake already does for the WARP package.