### PR TITLE
Add a code-review agent skill

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -58,11 +58,11 @@ This applies **everywhere in the diff**, including:
 
 Report these categories:
 
-- **Spelling errors and typos**, for example `bellow` → `below`,
-  `recieve` → `receive`, `seperate` → `separate`.
+- **Spelling errors and typos**, for example `recieve` → `receive`,
+  `seperate` → `separate`, `occured` → `occurred`.
 - **Grammar errors**, for example subject/verb disagreement such as
-  "the release branch don't exist" → "the release branch doesn't exist", or
-  awkward prepositions such as "kept into sync" → "kept in sync".
+  "the values is validated" → "the values are validated", or awkward
+  prepositions such as "compatible to" → "compatible with".
 - **Terminology and brand capitalization**, using the table below.
 - **Punctuation and formatting inconsistency within a single list, table, or
   block** — for example a checklist where some items end in a period and others

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: code-review
+description: Pull request review guidance for the DirectX Shader Compiler. Use when reviewing a pull request in this repository. Sets review priorities (correctness, memory safety, compiler compatibility, tests, design, conventions), and specifies that wording, spelling, grammar, and terminology findings should be reported as inline comments rather than suppressed. Also covers when release notes are required.
+---
+
+# Reviewing pull requests in DirectXShaderCompiler
+
+## Priorities
+
+This skill *adds* to your normal review; it does not replace it. Continue to
+apply your full correctness, security, and design analysis. The wording rules
+below are an addition at the bottom of the priority list, never a substitute for
+the rest.
+
+Review in this order, and let the earlier categories dominate the review:
+
+1. **Correctness and behavior.** Miscompiles, wrong codegen, incorrect
+   diagnostics, broken or missing validation, logic errors, off-by-one errors,
+   incorrect control flow.
+2. **Memory and lifetime safety.** Null and uninitialized dereferences, buffer
+   and index overruns, use-after-free, leaks, ownership mistakes, unchecked
+   casts, and misuse of LLVM ADT and `Value`/`Instruction` lifetimes.
+3. **Compatibility and compiler contracts.** Changes to accepted HLSL, shader
+   model gating, DXIL validator version constraints, SPIR-V codegen behavior,
+   command-line option semantics, and anything that silently changes output for
+   existing shaders.
+4. **Test coverage.** Whether the change is tested, and whether the tests
+   actually exercise the new behavior rather than just running it.
+5. **Design and maintainability.** Layering violations, duplicated logic,
+   misplaced abstractions, and code that conflicts with surrounding patterns.
+6. **Project conventions.** LLVM Coding Standards and clang-format compliance
+   for changed C and C++ code, per `CONTRIBUTING.md` and
+   `docs/CodingStandards.rst`; HLSL-specific guidance in `docs/HLSLChanges.rst`.
+7. **Release notes.** See the section at the end of this file.
+8. **Wording.** Spelling, grammar, terminology, and punctuation consistency, as
+   described next.
+
+If a pull request has correctness problems, lead with those. Wording comments
+must never crowd out or delay a substantive finding.
+
+## Report wording issues instead of suppressing them
+
+This repository *wants* small wording feedback. Do not filter out spelling,
+grammar, terminology, or punctuation-consistency findings on the grounds that
+they are low impact, cosmetic, or "nitpicks". If you would otherwise place such
+a finding in a "Suppressed comments" section of the review summary, post it as a
+normal inline review comment instead.
+
+This applies **everywhere in the diff**, including:
+
+- Markdown and reStructuredText docs (`docs/`, `README.md`, `CONTRIBUTING.md`)
+- Issue and pull request templates (`.github/ISSUE_TEMPLATE/`)
+- Code comments and Doxygen blocks in C, C++, and HLSL sources
+- Identifiers: type, function, variable, and macro names
+- User-facing strings: diagnostic and error messages, command-line help text,
+  and `-help` / usage output
+- Test file comments and RUN/CHECK line descriptions
+
+Report these categories:
+
+- **Spelling errors and typos**, for example `bellow` → `below`,
+  `recieve` → `receive`, `seperate` → `separate`.
+- **Grammar errors**, for example subject/verb disagreement such as
+  "the release branch don't exist" → "the release branch doesn't exist", or
+  awkward prepositions such as "kept into sync" → "kept in sync".
+- **Terminology and brand capitalization**, using the table below.
+- **Punctuation and formatting inconsistency within a single list, table, or
+  block** — for example a checklist where some items end in a period and others
+  do not, or a bullet list with inconsistent capitalization of the first word.
+
+Prefer a GitHub suggested change so the author can apply the fix in one click.
+
+### Terminology and capitalization
+
+| Use | Not |
+| --- | --- |
+| `NuGet` | `Nuget`, `nuget` (outside package IDs and CLI invocations) |
+| `GitHub` | `github`, `Github` (outside URLs, paths, and org/repo names) |
+| `SPIR-V` | `SPIRV`, `Spir-V`, `spirv` (outside identifiers and file paths) |
+| `HLSL` | `hlsl` (outside file extensions and paths) |
+| `DXIL` | `Dxil`, `dxil` (outside identifiers, file names, and paths) |
+| `DXC` | `dxc` when referring to the project rather than the executable |
+| `DirectX` | `Directx`, `directx` |
+| `LunarG` | `Lunarg`, `lunarg` |
+| `Vulkan` | `vulkan` |
+| `LLVM` / `Clang` | `llvm` / `clang` when referring to the projects in prose |
+| `macOS` | `MacOS`, `OSX` |
+
+Do not flag a casing "violation" when the lowercase form is load-bearing: URLs,
+file paths, file extensions, code identifiers, CLI flags, environment variables,
+and literal command invocations must be left exactly as written.
+
+### Keep wording comments proportionate
+
+Report these findings, but keep them clearly secondary to correctness:
+
+- Mark wording comments as minor, for example by prefixing them with `Nit:`.
+- Group repeats. If the same typo or casing issue appears more than three times
+  in one file, leave one comment naming the pattern and the affected lines
+  rather than one comment per occurrence.
+- Comment only on lines the pull request actually adds or modifies. Do not
+  flag pre-existing wording in untouched context lines.
+- Do not rewrite intentional style. This project follows the
+  [LLVM Coding Standards](../../../docs/CodingStandards.rst); do not propose
+  wording changes that conflict with the conventions already used in the file.
+
+## Release notes
+
+Check whether `docs/ReleaseNotes.md` should be updated, following the "Release
+Notes" policy in `CONTRIBUTING.md`.
+
+- Release notes are expected for user-visible, significant compiler behavior
+  changes: new language or hardware features, new compiler options, important
+  isolated bug fixes, and changes in default behavior.
+- Release notes are usually not needed for refactors, test-only updates, or
+  infrastructure-only changes, unless user-visible behavior changes.
+- Account for multi-pull-request efforts. If a pull request is one part of a
+  larger tracked effort, a single shared release note may be intentional;
+  confirm coverage exists or is planned across the effort rather than requiring
+  a duplicate entry per pull request.
+
+Do **not** leave a release note comment when the pull request already updates
+`docs/ReleaseNotes.md`, is docs-only, or is a dependency bump such as a
+"Bump ..." pull request.
+
+When a release note is clearly warranted and missing, say so directly and point
+to `docs/ReleaseNotes.md`. When it is not obvious, ask only the gentle version:
+**"Did you consider adding a release note?"**

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Pull request review guidance for the DirectX Shader Compiler. Use when reviewing a pull request in this repository. Sets review priorities (correctness, memory safety, compiler compatibility, tests, design, conventions), and specifies that wording, spelling, grammar, and terminology findings should be reported as inline comments rather than suppressed. Also covers when release notes are required.
+description: Pull request review guidance for the DirectX Shader Compiler. Use when reviewing a pull request in this repository. Sets review priorities (correctness, memory safety, compiler compatibility, tests, design, conventions), and specifies that wording, spelling, grammar, and terminology findings should be reported as inline comments rather than suppressed. Defers to CONTRIBUTING.md and .github/copilot-instructions.md for release note policy.
 ---
 
 # Reviewing pull requests in DirectXShaderCompiler
@@ -106,23 +106,26 @@ Report these findings, but keep them clearly secondary to correctness:
 
 ## Release notes
 
-Check whether `docs/ReleaseNotes.md` should be updated, following the "Release
-Notes" policy in `CONTRIBUTING.md`.
+Check whether `docs/ReleaseNotes.md` should be updated.
 
-- Release notes are expected for user-visible, significant compiler behavior
-  changes: new language or hardware features, new compiler options, important
-  isolated bug fixes, and changes in default behavior.
-- Release notes are usually not needed for refactors, test-only updates, or
-  infrastructure-only changes, unless user-visible behavior changes.
-- Account for multi-pull-request efforts. If a pull request is one part of a
-  larger tracked effort, a single shared release note may be intentional;
-  confirm coverage exists or is planned across the effort rather than requiring
-  a duplicate entry per pull request.
+The release notes policy is defined in two places, and both take precedence over
+this skill:
 
-Do **not** leave a release note comment when the pull request already updates
-`docs/ReleaseNotes.md`, is docs-only, or is a dependency bump such as a
-"Bump ..." pull request.
+- `CONTRIBUTING.md`, section "Release Notes", for when a note is required and
+  the rules for writing an entry.
+- `.github/copilot-instructions.md`, section "Pull request review guidance",
+  for how to review and comment on release notes, including when a note is
+  expected, how to handle multi-pull-request efforts, when to skip the comment,
+  how to review an entry that already exists, and what tone to use.
 
-When a release note is clearly warranted and missing, say so directly and point
-to `docs/ReleaseNotes.md`. When it is not obvious, ask only the gentle version:
-**"Did you consider adding a release note?"**
+Follow those files directly. Do not substitute a summary of them, and if this
+skill ever appears to disagree with them, they win.
+
+Two points worth restating, because they are easy to get wrong:
+
+- A pull request that **already updates** `docs/ReleaseNotes.md` should still
+  have its entry reviewed for placement and content. Only the prompt asking for
+  a missing note is skipped, not review of the entry itself.
+- Review the entry as it would land **merged with the current base branch**, not
+  just as it appears on the head branch. A head branch that is behind or
+  diverged can make the entry's final placement ambiguous or wrong.


### PR DESCRIPTION
Adds `.github/skills/code-review/SKILL.md`, an agent skill that Copilot code review picks up when reviewing pull requests in this repository.

### Motivation

Copilot code review applies a confidence and usefulness filter to its findings. Comments that fall below the threshold are not posted inline; they are listed in a collapsed **"Suppressed comments"** block in the review summary, under a header that otherwise reads "generated no new comments".

In practice this means small wording problems in docs, templates, and comments are reported in a place nobody looks, and cannot be applied as one-click suggested changes. Typos, brand capitalization, and grammar slips in review-visible text routinely end up suppressed rather than surfaced.

We want that feedback, so this skill asks for it explicitly.

### What the skill does

**Sets review priorities first.** The skill opens by stating that it augments rather than replaces the default review, then ranks what to look at: correctness and behavior, memory and lifetime safety, compatibility and compiler contracts, test coverage, design, project conventions, release notes, and only then wording. Wording is explicitly last, and the skill states that wording comments must never crowd out or delay a substantive finding.

**Asks for wording findings inline rather than suppressed.** Spelling, grammar, terminology, and within-block punctuation consistency, across docs, issue templates, code comments, identifiers, diagnostics and help text, and test comments.

**Constrains the noise.** Correctness first, `Nit:` prefix, one grouped comment when a pattern repeats more than three times in a file, changed lines only, and deference to the conventions already used in the file.

**Adds a terminology table.** `NuGet`, `GitHub`, `SPIR-V`, `HLSL`, `DXIL`, `DXC`, `DirectX`, `LunarG`, `Vulkan`, `LLVM`/`Clang`, `macOS` — with an explicit carve-out so URLs, file paths, extensions, identifiers, CLI flags, environment variables, and literal command invocations are left alone.

**Defers on release notes.** `CONTRIBUTING.md` and `.github/copilot-instructions.md` remain canonical; the skill points at them and states that they win on any disagreement, rather than restating the policy.

### Notes for reviewers

- The skill originally restated the release note policy, and review caught that the restatement had already drifted from `.github/copilot-instructions.md` — most importantly by saying not to comment at all when a pull request already updates `docs/ReleaseNotes.md`, when the instructions ask for the entry's placement and content to be reviewed in that case. That restatement is now replaced by a pointer to the canonical files, which should prevent the same drift recurring.
- Copilot reads skills from the **head branch**, so any review on this pull request exercises the skill being added. If it works, this PR should get inline nits rather than suppressed ones.
- No release note for this change: it is repository tooling with no user-visible compiler behavior change.

_Assisted by GitHub Copilot._
