### PR TITLE
Require attribution for content posted on a user's behalf

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,3 +31,29 @@ Comment tone:
 - Use a stronger ask when the PR clearly appears to be a user-visible bug fix or feature.
 - If release-note coverage may come in a related PR (including a future PR), ask the author to point to that planned coverage.
 - If uncertain, prefer the gentle **"Did you consider adding a release note?"** wording.
+
+## Attribution for content posted on a user's behalf
+
+This section applies to any agent acting through a user's GitHub account, including the Copilot CLI, the Copilot app, and the Copilot cloud agent. It does not apply to bots that post under their own identity, such as `copilot-pull-request-reviewer[bot]`, which are already attributed.
+
+Never publish AI-authored content under a user's name without saying that it was AI-assisted. Readers cannot tell the difference, and leaving them to assume a human wrote it misrepresents authorship.
+
+Add the following as the last line of the body:
+
+```
+_Assisted by GitHub Copilot._
+```
+
+Apply this to:
+- Pull request descriptions
+- Issue bodies
+- Review comments and replies in review threads
+- Pull request and issue comments
+- Discussion posts
+
+Notes:
+- Git commit messages are already covered by the `Co-authored-by` trailer, so no additional line is needed there.
+- Write the content in the user's voice, as them. The trailer records that assistance was used; it does not turn the content into a report about the agent.
+- When editing existing content that does not have the trailer, add it.
+- If the user explicitly asks for no attribution on a specific item, follow that.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,15 +34,17 @@ Comment tone:
 
 ## Attribution for content posted on a user's behalf
 
-This section applies to any agent acting through a user's GitHub account, including the Copilot CLI, the Copilot app, and the Copilot cloud agent. It does not apply to bots that post under their own identity, such as `copilot-pull-request-reviewer[bot]`, which are already attributed.
+This section applies to any AI agent acting through a user's GitHub account, whatever the vendor or product — for example the Copilot CLI, the Copilot app, or the Copilot cloud agent. It does not apply to bots that post under their own identity, such as `copilot-pull-request-reviewer[bot]`, which are already attributed by their username.
 
 Never publish AI-authored content under a user's name without saying that it was AI-assisted. Readers cannot tell the difference, and leaving them to assume a human wrote it misrepresents authorship.
 
-Add the following as the last line of the body:
+Add the following as the last line of the body, naming the agent that actually produced the content:
 
 ```
-_Assisted by GitHub Copilot._
+_Assisted by <agent>._
 ```
+
+For example, `_Assisted by GitHub Copilot._`. Name the agent you are, not a generic label and not another vendor's product. If you do not have a specific product name to use, write `_Assisted by an AI agent._` rather than guessing or naming something else.
 
 Apply this to:
 - Pull request descriptions


### PR DESCRIPTION
Adds a section to `.github/copilot-instructions.md` requiring that AI-authored content posted through a user's GitHub account is identified as such.

### Motivation

Agents acting through a contributor's account — the Copilot CLI, the Copilot app, the Copilot cloud agent — can open pull requests, write descriptions, and reply in review threads. All of that appears under the contributor's name, with nothing to distinguish it from text they wrote themselves.

Commits are already handled: the `Co-authored-by` trailer records the assistance. Content posted through the API has no equivalent, so authorship is misrepresented by default rather than by mistake.

This came up because it happened. While working on another pull request in this repository, an agent posted a review thread reply under a maintainer's identity with no indication it was AI-authored.

### The rule

Add `_Assisted by GitHub Copilot._` as the last line of the body, for:

- Pull request descriptions
- Issue bodies
- Review comments and replies in review threads
- Pull request and issue comments
- Discussion posts

With these qualifications:

- **Bots posting under their own identity are out of scope.** `copilot-pull-request-reviewer[bot]` and similar are already attributed by their username; adding a trailer would be noise.
- **Commit messages are out of scope**, being covered by `Co-authored-by`.
- **Content is still written in the contributor's voice, as them.** The trailer records that assistance was used; it does not turn the text into a report about the agent.
- **Existing content gains the trailer when edited**, so the policy converges rather than leaving a permanent unmarked backlog.
- **An explicit request for no attribution on a specific item is honored.**

### Notes for reviewers

This is a repository-wide policy about how contributors' accounts are represented, so it is deliberately separate from #8788, which is a code review tuning change. It is worth discussing on its own terms.

Two things reviewers may want to weigh in on: whether `_Assisted by GitHub Copilot._` is the right wording, and whether the policy belongs in `.github/copilot-instructions.md` or in a root `AGENTS.md`, which this repository does not currently have. Repository custom instructions are read by agents working in the repository, so this location does take effect, but `AGENTS.md` may be the more discoverable home for guidance aimed at humans as well.

No release note: repository tooling, with no user-visible compiler behavior change.

_Assisted by GitHub Copilot._
