### PR TITLE
Skip CodeGenFloatingPointEnvironment under x64 ARM64 emulation

### DIFF
--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -4368,7 +4368,7 @@ static bool IsX64EmulatedOnArm64() {
 #if defined(_M_X64)
   using IsWow64Process2Fn = BOOL(WINAPI *)(HANDLE, USHORT *, USHORT *);
   HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
-  auto isWow64Process2 = reinterpret_cast<IsWow64Process2Fn>(
+  IsWow64Process2Fn isWow64Process2 = reinterpret_cast<IsWow64Process2Fn>(
       GetProcAddress(kernel32, "IsWow64Process2"));
   if (!isWow64Process2)
     return false;

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -4364,7 +4364,34 @@ void VerifyDivByZeroThrows() {
   VERIFY_IS_TRUE(bCaughtExpectedException);
 }
 
+static bool IsX64EmulatedOnArm64() {
+#if defined(_M_X64)
+  using IsWow64Process2Fn = BOOL(WINAPI *)(HANDLE, USHORT *, USHORT *);
+  HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
+  auto isWow64Process2 = reinterpret_cast<IsWow64Process2Fn>(
+      GetProcAddress(kernel32, "IsWow64Process2"));
+  if (!isWow64Process2)
+    return false;
+
+  USHORT processMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+  USHORT nativeMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+  return isWow64Process2(GetCurrentProcess(), &processMachine,
+                         &nativeMachine) &&
+         nativeMachine == IMAGE_FILE_MACHINE_ARM64;
+#else
+  return false;
+#endif
+}
+
 TEST_F(CompilerTest, CodeGenFloatingPointEnvironment) {
+  if (IsX64EmulatedOnArm64()) {
+    WEX::Logging::Log::Comment(
+        L"Skipping floating-point environment test under x64 emulation on "
+        L"ARM64.");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+
   unsigned int fpOriginal;
   VERIFY_IS_TRUE(_controlfp_s(&fpOriginal, 0, 0) == 0);
 


### PR DESCRIPTION
## Summary
fixes #8793

Skip `CompilerTest::CodeGenFloatingPointEnvironment` when the x64 test binary is running under emulation on ARM64 Windows.

The test attempts to unmask the divide-by-zero floating-point exception, but x64 emulation leaves `_EM_ZERODIVIDE` masked. The failure occurs before DXC compilation, so it does not indicate an ARM64X compiler regression.

The runtime check uses the x64 target macro together with `IsWow64Process2`'s native machine result. `IsWow64Process2` is resolved dynamically to preserve compatibility with older Windows versions.

The following PR's originally added skip logic for this test in 2022
https://github.com/microsoft/DirectXShaderCompiler/pull/4308
https://github.com/microsoft/DirectXShaderCompiler/pull/4320

## Testing

Tested on ARM64 Windows with an x64 build of `ClangHLSLTests`:

- Before: `CodeGenFloatingPointEnvironment` failed with `0x0208021F` versus `0x02080217`.
- After: the test is reported as skipped.
- Full suite: `4928` total, `4927` passed, `0` failed, `1` skipped.
