### PR TITLE
[Win] Add opt-in Release size optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ mark_as_advanced(DXC_DISABLE_ALLOCATOR_OVERRIDES)
 option(DXC_CODEGEN_EXCEPTIONS_TRAP "An exception in code generation generates a trap, ending the compiler process" OFF)
 mark_as_advanced(DXC_CODEGEN_EXCEPTIONS_TRAP)
 
+option(DXC_OPTIMIZE_FOR_SIZE "Favor smaller Windows Release binaries over compiler throughput" OFF)
+
 # adjust link option to enable debugging from kernel mode; not compatible with incremental linking
 if(NOT CMAKE_VERSION VERSION_LESS "3.13" AND MSVC AND NOT CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64EC")
   add_link_options(/DEBUGTYPE:CV,FIXUP,PDATA /INCREMENTAL:NO)

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -370,6 +370,10 @@ if( MSVC )
     append("/DEBUG /OPT:REF" CMAKE_EXE_LINKER_FLAGS_RELEASE)
   endif()
 
+  if (DXC_OPTIMIZE_FOR_SIZE)
+    append("/Os" CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE)
+  endif()
+
   # HLSL Changes End
 
   # Enable warnings


### PR DESCRIPTION
Add an opt-in size policy for Windows Release builds.

- Add `DXC_OPTIMIZE_FOR_SIZE`, defaulting to `OFF`, so existing developer and CI builds keep their current throughput-oriented behavior.
- Add `/Os` to C and C++ Release flags when the option is enabled.
- Keep this as a focused CMake option rather than introducing an `OfficialRelease.cmake` preset; distribution pipelines can opt in without coupling unrelated release policy.

Testing:
- Configured an x64 build with Visual Studio 18 2026 and `DXC_OPTIMIZE_FOR_SIZE=ON`.
- Verified the generated Release `llvm-tblgen.vcxproj` contains `<FavorSizeOrSpeed>Size</FavorSizeOrSpeed>`.
- Built the Release `llvm-tblgen` target successfully.

This is a draft because the binary-size benefit should be weighed against DXC throughput before enabling it in a shipping pipeline. No release note is needed because the option is disabled by default and changes build configuration rather than compiler-visible behavior.