### PR TITLE
[HLSL] Add VectorAccumulate execution coverage for LinAlg

### DIFF
--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -7541,6 +7541,10 @@ static void runVectorAccumulateDescriptor(
 
   std::vector<BYTE> InputBytes(*InputSize);
   std::vector<BYTE> InitialBytes(*OutputSize);
+  // Seed the destination with poison so the bytes the accumulation must leave
+  // alone, including everything below StartOffsetBytes, carry a known value
+  // through to readback rather than a zero the operation could also produce.
+  cpu_oracle::fillPoison(InitialBytes.data(), InitialBytes.size());
   VERIFY_IS_TRUE(cpu_oracle::writeMatrixBuffer(Input, InputLayout, InputBytes),
                  "Unable to encode vector input buffer");
   VERIFY_IS_TRUE(
@@ -7592,6 +7596,9 @@ static void runVectorAccumulateDescriptor(
       cpu_oracle::exactResult(Expected, std::move(PublicRule));
   VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(OutData.data(), OutData.size(),
                                                 OutputLayout, Oracle, Verbose));
+  VERIFY_IS_TRUE(cpu_oracle::verifyUntouchedBytes(
+      Initial.compType(), Initial.M, Initial.N, OutputLayout, OutData.data(),
+      OutData.size(), Verbose));
 }
 
 void DxilConf_SM610_LinAlg::VectorAccumulateDescriptor_Thread_F16() {

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -3177,6 +3177,8 @@ public:
 
   // Vector Accumulate
   TEST_METHOD(VectorAccumulateDescriptor_Thread_F16);
+  TEST_METHOD(VectorAccumulateDescriptor_Thread_F16_Length8_NonZero);
+  TEST_METHOD(VectorAccumulateDescriptor_Thread_F32_Length8_NonZero);
 
 private:
   CComPtr<ID3D12Device> D3DDevice;
@@ -7482,39 +7484,114 @@ void DxilConf_SM610_LinAlg::Convert() {
 }
 
 static const char VectorAccumulateDescriptorShader[] = R"(
-  RWByteAddressBuffer Output : register(u0);
+  ByteAddressBuffer Input : register(t0);
+  RWByteAddressBuffer Output : register(u1);
 
   [numthreads(1, 1, 1)]
   void main() {
-    vector<half, 4> InVec = {1.0, 2.0, 3.0, 4.0};
-    __builtin_LinAlg_VectorAccumulateToDescriptor(Output, 0, 64, InVec);
+    vector<ELEM_TYPE, VECTOR_LENGTH> InVec;
+    for (uint I = 0; I < VECTOR_LENGTH; ++I) {
+      InVec[I] = Input.Load<ELEM_TYPE>(I * ELEM_SIZE);
+    }
+    __builtin_LinAlg_VectorAccumulateToDescriptor(
+      Output, START_OFFSET, 64, InVec);
   }
 )";
 
-static void runVectorAccumulateDescriptor(ID3D12Device *Device,
-                                          dxc::SpecificDllLoader &DxcSupport,
-                                          bool Verbose) {
-  std::string Args = "-HV 2021 -enable-16bit-types";
-  MatrixDim NumElements = 4;
-  size_t BufferSize = elementSize(ComponentType::F16) * NumElements;
+static void runVectorAccumulateDescriptor(
+    ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
+    const cpu_oracle::TypedMatrix &Input,
+    const cpu_oracle::TypedMatrix &Initial,
+    const cpu_oracle::TypedMatrix &Expected, UINT StartOffsetBytes,
+    std::wstring PublicRule, bool Verbose) {
+  VERIFY_ARE_EQUAL(1u, Input.M, "Vector input must have one row");
+  VERIFY_ARE_EQUAL(Input.compType(), Initial.compType(),
+                   "Input and destination component types must match");
+  VERIFY_ARE_EQUAL(Initial.compType(), Expected.compType(),
+                   "Expected and destination component types must match");
+  VERIFY_ARE_EQUAL(Initial.M, Expected.M,
+                   "Expected and destination row counts must match");
+  VERIFY_ARE_EQUAL(Initial.N, Expected.N,
+                   "Expected and destination column counts must match");
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(
+      Initial.totalElements(), Input.totalElements(),
+      "Destination must hold the input vector and any guard elements");
+
+  const cpu_oracle::MatrixBufferLayout InputLayout = {
+      MatrixLayout::RowMajor,
+      /*OffsetBytes=*/0,
+      /*StrideBytes=*/Input.N * elementSize(Input.compType()),
+  };
+  const cpu_oracle::MatrixBufferLayout OutputLayout = {
+      MatrixLayout::RowMajor,
+      /*OffsetBytes=*/StartOffsetBytes,
+      /*StrideBytes=*/Initial.N * elementSize(Initial.compType()),
+  };
+  const std::optional<size_t> InputSize =
+      cpu_oracle::getMatrixBufferSize(Input, InputLayout);
+  const std::optional<size_t> OutputSize =
+      cpu_oracle::getMatrixBufferSize(Initial, OutputLayout);
+  VERIFY_IS_TRUE(InputSize.has_value(), "Unable to size vector input buffer");
+  VERIFY_IS_TRUE(OutputSize.has_value(),
+                 "Unable to size vector destination buffer");
+  if (!InputSize)
+    return;
+  if (!OutputSize)
+    return;
+
+  std::vector<BYTE> InputBytes(*InputSize);
+  std::vector<BYTE> InitialBytes(*OutputSize);
+  VERIFY_IS_TRUE(cpu_oracle::writeMatrixBuffer(Input, InputLayout, InputBytes),
+                 "Unable to encode vector input buffer");
+  VERIFY_IS_TRUE(
+      cpu_oracle::writeMatrixBuffer(Initial, OutputLayout, InitialBytes),
+      "Unable to encode vector destination buffer");
+
+  MatrixParams Params = {};
+  Params.CompType = Input.compType();
+  Params.M = Input.M;
+  Params.N = Input.N;
+  Params.NumThreads = 1;
+  Params.Enable16Bit = Input.compType() == ComponentType::F16;
+  std::stringstream ExtraDefs;
+  ExtraDefs << "-DVECTOR_LENGTH=" << Input.totalElements();
+  ExtraDefs << " -DSTART_OFFSET=" << StartOffsetBytes;
+  const std::string Args = buildCompilerArgs(Params, ExtraDefs.str().c_str());
 
   compileShader(DxcSupport, VectorAccumulateDescriptorShader, "cs_6_10", Args,
                 Verbose);
 
-  auto Expected = makeExpectedVec(ComponentType::F16, NumElements, 1.0);
-
   auto Op = createComputeOp(VectorAccumulateDescriptorShader, "cs_6_10",
-                            "UAV(u0)", Args.c_str());
-  addUAVBuffer(Op.get(), "Output", BufferSize, true);
-  addRootView(Op.get(), 0, "Output");
+                            "SRV(t0), UAV(u1)", Args.c_str());
+  addSRVBuffer(Op.get(), "Input", InputBytes.size(), "byname");
+  addUAVBuffer(Op.get(), "Output", InitialBytes.size(), true, "byname");
+  addRootView(Op.get(), 0, "Input");
+  addRootView(Op.get(), 1, "Output");
 
-  auto Result = runShaderOp(Device, DxcSupport, std::move(Op));
+  auto Result = runShaderOp(
+      Device, DxcSupport, std::move(Op),
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *) {
+        const std::vector<BYTE> *Source = nullptr;
+        if (strcmp(Name, "Input") == 0)
+          Source = &InputBytes;
+        else if (strcmp(Name, "Output") == 0)
+          Source = &InitialBytes;
+        VERIFY_IS_TRUE(Source != nullptr,
+                       "Unexpected vector accumulation resource initializer");
+        if (!Source)
+          return;
+        VERIFY_ARE_EQUAL(Source->size(), Data.size(),
+                         "Vector accumulation initializer size mismatch");
+        if (Source->size() == Data.size())
+          std::memcpy(Data.data(), Source->data(), Data.size());
+      });
 
   MappedData OutData;
   Result->Test->GetReadBackData("Output", &OutData);
-
-  VERIFY_IS_TRUE(verifyComponentBuffer(ComponentType::F16, OutData.data(),
-                                       Expected, NumElements, Verbose));
+  const cpu_oracle::MatrixResultOracle Oracle =
+      cpu_oracle::exactResult(Expected, std::move(PublicRule));
+  VERIFY_IS_TRUE(cpu_oracle::verifyMatrixBuffer(OutData.data(), OutData.size(),
+                                                OutputLayout, Oracle, Verbose));
 }
 
 void DxilConf_SM610_LinAlg::VectorAccumulateDescriptor_Thread_F16() {
@@ -7525,7 +7602,106 @@ void DxilConf_SM610_LinAlg::VectorAccumulateDescriptor_Thread_F16() {
           L"VectorAccumulateDescriptor_Thread_F16"))
     return;
 
-  runVectorAccumulateDescriptor(D3DDevice, DxcSupport, VerboseLogging);
+  const auto Half = [](float Value) { return HLSLHalf_t(Value); };
+  const std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeTypedMatrix<HLSLHalf_t>(
+          1, 4, {Half(1), Half(2), Half(3), Half(4)});
+  const std::optional<cpu_oracle::TypedMatrix> Initial =
+      cpu_oracle::makeTypedMatrix<HLSLHalf_t>(
+          1, 4, {Half(0), Half(0), Half(0), Half(0)});
+  const std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeTypedMatrix<HLSLHalf_t>(
+          1, 4, {Half(1), Half(2), Half(3), Half(4)});
+  VERIFY_IS_TRUE(Input.has_value());
+  VERIFY_IS_TRUE(Initial.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  if (!Input)
+    return;
+  if (!Initial)
+    return;
+  if (!Expected)
+    return;
+
+  runVectorAccumulateDescriptor(
+      D3DDevice, DxcSupport, *Input, *Initial, *Expected,
+      /*StartOffsetBytes=*/0, L"Exact F16 vector descriptor accumulation",
+      VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    VectorAccumulateDescriptor_Thread_F16_Length8_NonZero() {
+  if (!accumulateStoreApplicable(
+          D3DDevice, ComponentType::F16,
+          linalg_test::AtomicDestination::RWByteAddressBuffer,
+          L"VectorAccumulateDescriptor_Thread_F16_Length8_NonZero"))
+    return;
+
+  const auto Half = [](float Value) { return HLSLHalf_t(Value); };
+  const std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeTypedMatrix<HLSLHalf_t>(1, 8,
+                                              {Half(-3), Half(2), Half(5),
+                                               Half(-1), Half(4), Half(1),
+                                               Half(-2), Half(6)});
+  const std::optional<cpu_oracle::TypedMatrix> Initial =
+      cpu_oracle::makeTypedMatrix<HLSLHalf_t>(
+          1, 10,
+          {Half(10), Half(11), Half(12), Half(13), Half(14), Half(15), Half(16),
+           Half(17), Half(123), Half(-321)});
+  const std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeTypedMatrix<HLSLHalf_t>(
+          1, 10,
+          {Half(7), Half(13), Half(17), Half(12), Half(18), Half(16), Half(14),
+           Half(23), Half(123), Half(-321)});
+  VERIFY_IS_TRUE(Input.has_value());
+  VERIFY_IS_TRUE(Initial.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  if (!Input)
+    return;
+  if (!Initial)
+    return;
+  if (!Expected)
+    return;
+
+  runVectorAccumulateDescriptor(
+      D3DDevice, DxcSupport, *Input, *Initial, *Expected,
+      /*StartOffsetBytes=*/64,
+      L"Exact F16 length-8 accumulation at a non-zero offset onto non-zero "
+      L"values with guard lanes",
+      VerboseLogging);
+}
+
+void DxilConf_SM610_LinAlg::
+    VectorAccumulateDescriptor_Thread_F32_Length8_NonZero() {
+  if (!accumulateStoreApplicable(
+          D3DDevice, ComponentType::F32,
+          linalg_test::AtomicDestination::RWByteAddressBuffer,
+          L"VectorAccumulateDescriptor_Thread_F32_Length8_NonZero"))
+    return;
+
+  const std::optional<cpu_oracle::TypedMatrix> Input =
+      cpu_oracle::makeTypedMatrix<float>(1, 8, {6, -2, 2, 3, -5, 4, 1, -1});
+  const std::optional<cpu_oracle::TypedMatrix> Initial =
+      cpu_oracle::makeTypedMatrix<float>(
+          1, 10, {20, 21, 22, 23, 24, 25, 26, 27, 123456, -654321});
+  const std::optional<cpu_oracle::TypedMatrix> Expected =
+      cpu_oracle::makeTypedMatrix<float>(
+          1, 10, {26, 19, 24, 26, 19, 29, 27, 26, 123456, -654321});
+  VERIFY_IS_TRUE(Input.has_value());
+  VERIFY_IS_TRUE(Initial.has_value());
+  VERIFY_IS_TRUE(Expected.has_value());
+  if (!Input)
+    return;
+  if (!Initial)
+    return;
+  if (!Expected)
+    return;
+
+  runVectorAccumulateDescriptor(
+      D3DDevice, DxcSupport, *Input, *Initial, *Expected,
+      /*StartOffsetBytes=*/64,
+      L"Exact F32 length-8 accumulation at a non-zero offset onto non-zero "
+      L"values with guard lanes",
+      VerboseLogging);
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F16_NonUniform() {


### PR DESCRIPTION
This adds two SM 6.10 execution tests for `VectorAccumulateToDescriptor`. Exercise non-zero destination offset and alignement.
