### PR TITLE
Fix hang/write-back drop for inout structs bitcast

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,6 +33,10 @@ line upon naming the release. Refer to previous for appropriate section names.
 - Fix a crash generating DXIL from sources containing a dynamic resource heap
   access that was discarded. Identified during development of SPIR-V support for
   [descriptor heaps](https://github.com/microsoft/DirectXShaderCompiler/pull/8517#discussion_r3752113078).
+- Fixed a dropped `inout` write-back when an argument is passed to an `inout`
+  parameter of a struct type with an identical layout.
+- Fixed a compiler hang when an argument is passed to an `inout` parameter of a
+  struct type with a different layout.
 
 #### HLSL Language
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -2721,7 +2721,7 @@ void SROA_Helper::RewriteBitCast(BitCastInst *BCI) {
 
   bool bTypeMatch = false;
   unsigned level = 0;
-  while (SrcST) {
+  while (SrcST && SrcST->getNumElements()) {
     level++;
     Type *EltTy = SrcST->getElementType(0);
     if (EltTy == DstST) {

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1533,6 +1533,39 @@ static bool isUDTIntrinsicArg(CallInst *CI, unsigned OpIdx) {
   return false;
 }
 
+/// isSafeBitCastForScalarRepl - Check if a bitcast can be handled for scalar
+/// replacement.  A struct to struct pointer cast is only rewritable when the
+/// destination is reachable through the leading elements of the source, or
+/// when both structs have an identical layout.
+static bool isSafeBitCastForScalarRepl(BitCastInst *BCI) {
+  // Unused bitcast may be leftover from temporary memcpy
+  if (BCI->use_empty())
+    return true;
+
+  Type *DstTy = BCI->getType();
+  Type *SrcTy = BCI->getOperand(0)->getType();
+
+  if (!DstTy->isPointerTy() || !SrcTy->isPointerTy())
+    return true;
+
+  StructType *DstST = dyn_cast<StructType>(DstTy->getPointerElementType());
+  StructType *SrcST = dyn_cast<StructType>(SrcTy->getPointerElementType());
+
+  // A non-struct destination is rewritten per llvm.lifetime.* intrinsic user
+  // A non-struct source never reaches the struct to struct rewrite
+  if (!DstST || !SrcST)
+    return true;
+
+  for (StructType *ST = SrcST; ST && ST->getNumElements();) {
+    Type *EltTy = ST->getElementType(0);
+    if (EltTy == DstST)
+      return true;
+    ST = dyn_cast<StructType>(EltTy);
+  }
+
+  return SrcST->isLayoutIdentical(DstST);
+}
+
 /// isSafeForScalarRepl - Check if instruction I is a safe use with regard to
 /// performing scalar replacement of alloca AI.  The results are flagged in
 /// the Info parameter.  Offset indicates the position within AI that is
@@ -1548,6 +1581,8 @@ void isSafeForScalarRepl(Instruction *I, uint64_t Offset, AllocaInfo &Info) {
     Instruction *User = cast<Instruction>(U.getUser());
 
     if (BitCastInst *BC = dyn_cast<BitCastInst>(User)) {
+      if (!isSafeBitCastForScalarRepl(BC))
+        return MarkUnsafe(Info, User);
       isSafeForScalarRepl(BC, Offset, Info);
     } else if (GetElementPtrInst *GEPI = dyn_cast<GetElementPtrInst>(User)) {
       uint64_t GEPOffset = Offset;
@@ -2687,7 +2722,10 @@ void SROA_Helper::RewriteBitCast(BitCastInst *BCI) {
       BCI->eraseFromParent();
       return;
     }
-    assert(0 && "Type mismatch.");
+    dxilutil::EmitErrorOnInstruction(
+        BCI, "Unsupported cast between struct types with different layouts.");
+    BCI->replaceAllUsesWith(UndefValue::get(BCI->getType()));
+    BCI->eraseFromParent();
     return;
   }
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -4395,8 +4395,6 @@ public:
   static char ID; // Pass identification, replacement for typeid
   explicit SROA_Parameter_HLSL() : ModulePass(ID) {}
   StringRef getPassName() const override { return "SROA Parameter HLSL"; }
-  static void RewriteBitcastWithIdenticalStructs(Function *F);
-  static void RewriteBitcastWithIdenticalStructs(BitCastInst *BCI);
   static bool DeleteSimpleStoreOnlyAlloca(AllocaInst *AI);
   static bool IsSimpleStoreOnlyAlloca(AllocaInst *AI);
 
@@ -4464,7 +4462,6 @@ public:
     while (!WorkList.empty()) {
       Function *F = WorkList.front();
       WorkList.pop_front();
-      RewriteBitcastWithIdenticalStructs(F);
       createFlattenedFunction(F);
     }
 
@@ -4609,28 +4606,6 @@ INITIALIZE_PASS(SROA_Parameter_HLSL, "scalarrepl-param-hlsl",
                 "Scalar Replacement of Aggregates HLSL (parameters)", false,
                 false)
 
-void SROA_Parameter_HLSL::RewriteBitcastWithIdenticalStructs(Function *F) {
-  if (F->isDeclaration())
-    return;
-  // Gather list of bitcast involving src and dest structs with identical layout
-  std::vector<BitCastInst *> worklist;
-  for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
-    if (BitCastInst *BCI = dyn_cast<BitCastInst>(&*I)) {
-      Type *DstTy = BCI->getDestTy();
-      Type *SrcTy = BCI->getSrcTy();
-      if (ArePointersToStructsOfIdenticalLayouts(DstTy, SrcTy))
-        worklist.push_back(BCI);
-    }
-  }
-
-  // Replace bitcast involving src and dest structs with identical layout
-  while (!worklist.empty()) {
-    BitCastInst *BCI = worklist.back();
-    worklist.pop_back();
-    RewriteBitcastWithIdenticalStructs(BCI);
-  }
-}
-
 bool SROA_Parameter_HLSL::IsSimpleStoreOnlyAlloca(AllocaInst *AI) {
   if (!AI->getAllocatedType()->isSingleValueType())
     return false;
@@ -4659,23 +4634,6 @@ bool SROA_Parameter_HLSL::DeleteSimpleStoreOnlyAlloca(AllocaInst *AI) {
 
   AI->eraseFromParent();
   return true;
-}
-
-void SROA_Parameter_HLSL::RewriteBitcastWithIdenticalStructs(BitCastInst *BCI) {
-  StructType *srcStTy =
-      cast<StructType>(BCI->getSrcTy()->getPointerElementType());
-  StructType *destStTy =
-      cast<StructType>(BCI->getDestTy()->getPointerElementType());
-  Value *srcPtr = BCI->getOperand(0);
-  IRBuilder<> AllocaBuilder(
-      dxilutil::FindAllocaInsertionPt(BCI->getParent()->getParent()));
-  AllocaInst *destPtr = AllocaBuilder.CreateAlloca(destStTy);
-  IRBuilder<> InstBuilder(BCI);
-  std::vector<unsigned> idxlist = {0};
-  CopyElementsOfStructsWithIdenticalLayout(InstBuilder, destPtr, srcPtr,
-                                           srcStTy, idxlist);
-  BCI->replaceAllUsesWith(destPtr);
-  BCI->eraseFromParent();
 }
 
 /// DeleteDeadInstructions - Erase instructions on the DeadInstrs list,

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1537,13 +1537,13 @@ static bool isUDTIntrinsicArg(CallInst *CI, unsigned OpIdx) {
 /// replacement.  A struct to struct pointer cast is only rewritable when the
 /// destination is reachable through the leading elements of the source, or
 /// when both structs have an identical layout.
-static bool isSafeBitCastForScalarRepl(BitCastInst *BCI) {
+static bool isSafeBitCastForScalarRepl(BitCastOperator *BC) {
   // Unused bitcast may be leftover from temporary memcpy
-  if (BCI->use_empty())
+  if (BC->use_empty())
     return true;
 
-  Type *DstTy = BCI->getType();
-  Type *SrcTy = BCI->getOperand(0)->getType();
+  Type *DstTy = BC->getDestTy();
+  Type *SrcTy = BC->getSrcTy();
 
   if (!DstTy->isPointerTy() || !SrcTy->isPointerTy())
     return true;
@@ -1581,7 +1581,7 @@ void isSafeForScalarRepl(Instruction *I, uint64_t Offset, AllocaInfo &Info) {
     Instruction *User = cast<Instruction>(U.getUser());
 
     if (BitCastInst *BC = dyn_cast<BitCastInst>(User)) {
-      if (!isSafeBitCastForScalarRepl(BC))
+      if (!isSafeBitCastForScalarRepl(cast<BitCastOperator>(BC)))
         return MarkUnsafe(Info, User);
       isSafeForScalarRepl(BC, Offset, Info);
     } else if (GetElementPtrInst *GEPI = dyn_cast<GetElementPtrInst>(User)) {
@@ -1702,6 +1702,24 @@ bool isSafeAllocaToScalarRepl(AllocaInst *AI) {
       HasPadding(AI->getAllocatedType(), DL))
     return false;
 
+  return true;
+}
+
+/// isSafeGlobalToScalarRepl - Check if a global can be broken down into
+/// elements.  Recursively walks the pointer producing users, which for a global
+/// may be constant expressions rather than instructions, and returns false when
+/// any of them cannot be rewritten.
+bool isSafeGlobalToScalarRepl(Value *V) {
+  for (User *U : V->users()) {
+    if (BitCastOperator *BC = dyn_cast<BitCastOperator>(U)) {
+      if (!isSafeBitCastForScalarRepl(BC))
+        return false;
+    } else if (!isa<GEPOperator>(U)) {
+      continue;
+    }
+    if (!isSafeGlobalToScalarRepl(U))
+      return false;
+  }
   return true;
 }
 } // namespace
@@ -6641,7 +6659,8 @@ public:
       } else {
         EltTy = dxilutil::GetArrayEltTy(EltTy);
         // Lower static [array of] resources
-        if (dxilutil::IsHLSLObjectType(EltTy) || EltTy == handleTy) {
+        if (dxilutil::IsHLSLObjectType(EltTy) || EltTy == handleTy ||
+            !isSafeGlobalToScalarRepl(&GV)) {
           staticGVs.emplace_back(&GV);
         }
       }

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param-strictudt.hlsl
@@ -1,0 +1,42 @@
+// RUN: %dxc -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2021 -DSTATIC_GLOBAL %s | FileCheck %s
+
+// Validate that the copy-out of an inout argument survives a cast between two
+// structs of identical layout.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 2.000000e+00)
+
+struct S {
+  float a;
+  int b;
+};
+
+struct T {
+  float c;
+  int d;
+};
+
+void f(inout S s) {
+  s.a = 1;
+  s.b = 2;
+}
+
+#ifdef STATIC_GLOBAL
+
+static T g;
+
+float4 main() : SV_Target {
+  f((S)g);
+  return float4(g.c, g.d, 0, 0);
+}
+
+#else
+
+float4 main() : SV_Target {
+  T t = (T)0;
+  f((S)t);
+  return float4(t.c, t.d, 0, 0);
+}
+
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param.hlsl
@@ -1,0 +1,42 @@
+// RUN: %dxc -T ps_6_0 -HV 2018 %s | FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2018 -DSTATIC_GLOBAL %s | FileCheck %s
+
+// Validate that the copy-out of an inout argument survives a cast between two
+// structs of identical layout.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 2.000000e+00)
+
+struct S {
+  float a;
+  int b;
+};
+
+struct T {
+  float c;
+  int d;
+};
+
+void f(inout S s) {
+  s.a = 1;
+  s.b = 2;
+}
+
+#ifdef STATIC_GLOBAL
+
+static T g;
+
+float4 main() : SV_Target {
+  f(g);
+  return float4(g.c, g.d, 0, 0);
+}
+
+#else
+
+float4 main() : SV_Target {
+  T t = (T)0;
+  f(t);
+  return float4(t.c, t.d, 0, 0);
+}
+
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param_empty_base-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param_empty_base-strictudt.hlsl
@@ -1,0 +1,46 @@
+// RUN: %dxc -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2021 -DSTATIC_GLOBAL %s | FileCheck %s
+
+// Validate that a cast between two structs of identical layout whose leading
+// members bottom out in an empty struct does not crash the compiler.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+
+struct Empty {};
+
+struct Inner {
+  Empty e;
+};
+
+struct S {
+  Inner i;
+  float a;
+};
+
+struct T {
+  Inner i;
+  float a;
+};
+
+void f(inout S s) {
+  s.a = 1;
+}
+
+#ifdef STATIC_GLOBAL
+
+static T g;
+
+float4 main() : SV_Target {
+  f((S)g);
+  return g.a;
+}
+
+#else
+
+float4 main() : SV_Target {
+  T t = (T)0;
+  f((S)t);
+  return t.a;
+}
+
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param_empty_base.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/cast_as_func_inout_param_empty_base.hlsl
@@ -1,0 +1,46 @@
+// RUN: %dxc -T ps_6_0 -HV 2018 %s | FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2018 -DSTATIC_GLOBAL %s | FileCheck %s
+
+// Validate that a cast between two structs of identical layout whose leading
+// members bottom out in an empty struct does not crash the compiler.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+
+struct Empty {};
+
+struct Inner {
+  Empty e;
+};
+
+struct S {
+  Inner i;
+  float a;
+};
+
+struct T {
+  Inner i;
+  float a;
+};
+
+void f(inout S s) {
+  s.a = 1;
+}
+
+#ifdef STATIC_GLOBAL
+
+static T g;
+
+float4 main() : SV_Target {
+  f(g);
+  return g.a;
+}
+
+#else
+
+float4 main() : SV_Target {
+  T t = (T)0;
+  f(t);
+  return t.a;
+}
+
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param-lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param-lib.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+
+// Validate that passing a static global to an inout parameter of a differently
+// laid out struct is diagnosed rather than hanging the compiler, when the
+// global is used from an exported library function.
+
+// CHECK: error: Unsupported cast between struct types with different layouts.
+
+struct S {
+  float2 v;
+};
+
+struct T {
+  float x, y;
+};
+
+static T g;
+
+void f(inout S s) {
+  s.v.x = 1;
+}
+
+export float4 fn(float y) {
+  g.y = y;
+  f((S)g);
+  return float4(g.x, g.y, 0, 0);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param-strictudt.hlsl
@@ -1,0 +1,40 @@
+// RUN: %dxc -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2021 -DSTATIC_GLOBAL %s | FileCheck %s -check-prefix=STATIC_GLOBAL
+
+// Validate that passing a struct to an inout parameter of a differently laid
+// out struct does not hang the compiler.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+
+// STATIC_GLOBAL: error: Unsupported cast between struct types with different layouts.
+
+struct S {
+  float2 v;
+};
+
+struct T {
+  float x, y;
+};
+
+void f(inout S s) {
+  s.v.x = 1;
+}
+
+#ifdef STATIC_GLOBAL
+
+static T g;
+
+float4 main() : SV_Target {
+  f((S)g);
+  return g.x;
+}
+
+#else
+
+float4 main() : SV_Target {
+  T t = (T)0;
+  f((S)t);
+  return t.x;
+}
+
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param-strictudt.hlsl
@@ -1,12 +1,11 @@
 // RUN: %dxc -T ps_6_0 -HV 2021 %s | FileCheck %s
-// RUN: %dxc -T ps_6_0 -HV 2021 -DSTATIC_GLOBAL %s | FileCheck %s -check-prefix=STATIC_GLOBAL
+// RUN: %dxc -T ps_6_0 -HV 2021 -DSTATIC_GLOBAL %s | FileCheck %s
 
 // Validate that passing a struct to an inout parameter of a differently laid
-// out struct does not hang the compiler.
+// out struct does not hang the compiler, and that the write-back of the inout
+// argument survives, whether the argument is a local or a static global.
 
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
-
-// STATIC_GLOBAL: error: Unsupported cast between struct types with different layouts.
 
 struct S {
   float2 v;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param.hlsl
@@ -1,11 +1,11 @@
 // RUN: %dxc -T ps_6_0 -HV 2018 %s | FileCheck %s
-// RUN: %dxc -T ps_6_0 -HV 2018 -DSTATIC_GLOBAL %s | FileCheck %s -check-prefix=STATIC_GLOBAL
+// RUN: %dxc -T ps_6_0 -HV 2018 -DSTATIC_GLOBAL %s | FileCheck %s
 
 // Validate that passing a struct to an inout parameter of a differently laid
-// out struct does not hang the compiler.
+// out struct does not hang the compiler, and that the write-back of the inout
+// argument survives, whether the argument is a local or a static global.
 
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
-// STATIC_GLOBAL: error: Unsupported cast between struct types with different layouts.
 
 struct S {
   float2 v;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/similar_layout_structs/cast_as_func_inout_param.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -T ps_6_0 -HV 2018 %s | FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2018 -DSTATIC_GLOBAL %s | FileCheck %s -check-prefix=STATIC_GLOBAL
+
+// Validate that passing a struct to an inout parameter of a differently laid
+// out struct does not hang the compiler.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+// STATIC_GLOBAL: error: Unsupported cast between struct types with different layouts.
+
+struct S {
+  float2 v;
+};
+
+struct T {
+  float x, y;
+};
+
+void f(inout S s) {
+  s.v.x = 1;
+}
+
+#ifdef STATIC_GLOBAL
+
+static T g;
+
+float4 main() : SV_Target {
+  f(g);
+  return g.x;
+}
+
+#else
+
+float4 main() : SV_Target {
+  T t = (T)0;
+  f(t);
+  return t.x;
+}
+
+#endif


### PR DESCRIPTION
Fix two SROA bugs casting between struct types in inout arguments

Both come from the same place: passing a struct to an inout parameter of a *different* struct type makes CodeGen coerce the argument with a pointer bitcast. `SROA_Helper::RewriteBitCast` has to handle that cast, and whether the two layouts are `isLayoutIdentical` decides which bug you hit.

### 1. inout write-back dropped on an identical layout

`SROA_Parameter_HLSL` ran a pre-pass that replaced the bitcast with a one-way copy into fresh storage; the callee wrote into the copy and nothing copied back. The fix is to delete obsolete prepass (#1718) and rely on correct aliasing-preserving rewrite (#2745).

### 2. hang on a layout mismatch

`RewriteBitCast` can redirect the cast in three cases: the destination is reachable through the source's leading elements, the layouts are identical, or the cast is unused. Otherwise the fall-through returned with the bitcast still using the value being replaced. That breaks the invariant `RewriteForScalarRepl` drives on - every user must be erased or stop using the value - so it spins forever (asserts in Debug in both `RewriteBitCast` type mismatch check and `RewriteForScalarRepl` infinite loop guard).

New `isSafeBitCastForScalarRepl` mirrors the three shapes the rewrite supports, so analysis and rewrite agree on what is handleable. Anything else keeps the alloca whole, which preserves the bitcast and the `inout` copy-out. For values that check does not cover the dead end becomes a diagnostic that also drops the use (static global variable).

*Note:* this is the first error emission in this module, however I'm not sure how to gracefully handle static global case.

---
Did not find any open issues related to this fixes. #4614 reports hang in the same pass, but from an empty base struct, and is *not* fixed here. #1718 and #2745 were revalidated, additional test cases were added.
