### PR TITLE
[PIX] Fix shared instrumentation resource handling

### DIFF
--- a/lib/DxilPIXPasses/DxilDebugBreakInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugBreakInstrumentation.cpp
@@ -120,10 +120,8 @@ bool DxilDebugBreakInstrumentation::runOnModule(Module &M) {
     CI->eraseFromParent();
   }
 
-  // Clean up the now-unused declaration. Not strictly required for
-  // correctness, but keeps the module free of dead references.
-  if (DebugBreakFunc->use_empty())
-    DebugBreakFunc->eraseFromParent();
+  PIXPassHelpers::EraseIfUnused(DM, DebugBreakFunc);
+  PIXPassHelpers::EraseIfUnused(DM, AtomicOpFunc);
 
   const bool modified = (PixUAVResource != nullptr);
 

--- a/lib/DxilPIXPasses/DxilDebugBreakInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugBreakInstrumentation.cpp
@@ -120,8 +120,8 @@ bool DxilDebugBreakInstrumentation::runOnModule(Module &M) {
     CI->eraseFromParent();
   }
 
-  PIXPassHelpers::EraseIfUnused(DM, DebugBreakFunc);
-  PIXPassHelpers::EraseIfUnused(DM, AtomicOpFunc);
+  PIXPassHelpers::eraseIfUnused(DM, DebugBreakFunc);
+  PIXPassHelpers::eraseIfUnused(DM, AtomicOpFunc);
 
   const bool modified = (PixUAVResource != nullptr);
 

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -1436,23 +1436,6 @@ bool DxilDebugInstrumentation::RunOnFunction(Module &M, DxilModule &DM,
 
   auto &values = m_FunctionToValues[BC.Builder.GetInsertBlock()->getParent()];
 
-  // PIX binds two UAVs when running this instrumentation: one for raygen
-  // shaders and another for the hitgroups and miss shaders. Since PIX invokes
-  // this pass at the library level, which may contain examples of both types,
-  // PIX can't really specify which UAV index to use per-shader. This pass
-  // therefore just has to know this:
-  constexpr unsigned int RayGenUAVRegister = 0;
-  constexpr unsigned int HitGroupAndMissUAVRegister = 1;
-  unsigned int UAVRegisterId = RayGenUAVRegister;
-  switch (shaderKind) {
-  case DXIL::ShaderKind::ClosestHit:
-  case DXIL::ShaderKind::Intersection:
-  case DXIL::ShaderKind::AnyHit:
-  case DXIL::ShaderKind::Miss:
-    UAVRegisterId = HitGroupAndMissUAVRegister;
-    break;
-  }
-
   values.UAVHandle = PIXPassHelpers::CreateHandleForResource(
       DM, Builder, uav, "PIX_DebugUAV_Handle");
 

--- a/lib/DxilPIXPasses/DxilNonUniformResourceIndexInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilNonUniformResourceIndexInstrumentation.cpp
@@ -149,6 +149,9 @@ bool DxilNonUniformResourceIndexInstrumentation::runOnModule(Module &M) {
 
   const bool modified = (PixUAVResource != nullptr);
 
+  PIXPassHelpers::EraseIfUnused(DM, WaveActiveAllEqualFunc);
+  PIXPassHelpers::EraseIfUnused(DM, AtomicOpFunc);
+
   if (modified) {
     DM.ReEmitDxilResources();
 

--- a/lib/DxilPIXPasses/DxilNonUniformResourceIndexInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilNonUniformResourceIndexInstrumentation.cpp
@@ -149,8 +149,8 @@ bool DxilNonUniformResourceIndexInstrumentation::runOnModule(Module &M) {
 
   const bool modified = (PixUAVResource != nullptr);
 
-  PIXPassHelpers::EraseIfUnused(DM, WaveActiveAllEqualFunc);
-  PIXPassHelpers::EraseIfUnused(DM, AtomicOpFunc);
+  PIXPassHelpers::eraseIfUnused(DM, WaveActiveAllEqualFunc);
+  PIXPassHelpers::eraseIfUnused(DM, AtomicOpFunc);
 
   if (modified) {
     DM.ReEmitDxilResources();

--- a/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
+++ b/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
@@ -125,8 +125,8 @@ bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
       [&hasIntOutputs](CallInst *) { hasIntOutputs = true; });
 
   if (!hasFloatOutputs && !hasIntOutputs) {
-    PIXPassHelpers::EraseIfUnused(DM, FloatOutputFunction);
-    PIXPassHelpers::EraseIfUnused(DM, IntOutputFunction);
+    PIXPassHelpers::eraseIfUnused(DM, FloatOutputFunction);
+    PIXPassHelpers::eraseIfUnused(DM, IntOutputFunction);
     return false;
   }
 
@@ -253,8 +253,8 @@ bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
         });
   }
 
-  PIXPassHelpers::EraseIfUnused(DM, FloatOutputFunction);
-  PIXPassHelpers::EraseIfUnused(DM, IntOutputFunction);
+  PIXPassHelpers::eraseIfUnused(DM, FloatOutputFunction);
+  PIXPassHelpers::eraseIfUnused(DM, IntOutputFunction);
 
   return Modified;
 }

--- a/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
+++ b/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
@@ -125,6 +125,8 @@ bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
       [&hasIntOutputs](CallInst *) { hasIntOutputs = true; });
 
   if (!hasFloatOutputs && !hasIntOutputs) {
+    PIXPassHelpers::EraseIfUnused(DM, FloatOutputFunction);
+    PIXPassHelpers::EraseIfUnused(DM, IntOutputFunction);
     return false;
   }
 
@@ -250,6 +252,9 @@ bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
               ReplacementColors[*OutputColumn.getRawData()]);
         });
   }
+
+  PIXPassHelpers::EraseIfUnused(DM, FloatOutputFunction);
+  PIXPassHelpers::EraseIfUnused(DM, IntOutputFunction);
 
   return Modified;
 }

--- a/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
+++ b/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
@@ -187,7 +187,7 @@ bool DxilPIXAddTidToAmplificationShaderPayload::runOnModule(Module &M) {
           cast<CallInst>(&*I)->getCalledFunction();
       I->removeFromParent();
       delete &*I;
-      PIXPassHelpers::EraseIfUnused(DM, OriginalDispatchMeshFn);
+      PIXPassHelpers::eraseIfUnused(DM, OriginalDispatchMeshFn);
       // Validation requires exactly one DispatchMesh in an AS, so we can exit
       // after the first one:
       DM.ReEmitDxilResources();

--- a/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
+++ b/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
@@ -183,8 +183,11 @@ bool DxilPIXAddTidToAmplificationShaderPayload::runOnModule(Module &M) {
                    {DispatchMeshOpcode, DispatchMesh.get_threadGroupCountX(),
                     DispatchMesh.get_threadGroupCountY(),
                     DispatchMesh.get_threadGroupCountZ(), NewStructAlloca});
+      llvm::Function *OriginalDispatchMeshFn =
+          cast<CallInst>(&*I)->getCalledFunction();
       I->removeFromParent();
       delete &*I;
+      PIXPassHelpers::EraseIfUnused(DM, OriginalDispatchMeshFn);
       // Validation requires exactly one DispatchMesh in an AS, so we can exit
       // after the first one:
       DM.ReEmitDxilResources();

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -310,6 +310,8 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
     }
 
     if (getMeshPayloadInstructions != nullptr) {
+      llvm::Function *OriginalGetMeshPayloadFunction =
+          cast<CallInst>(getMeshPayloadInstructions)->getCalledFunction();
 
       Function *DxilFunc = HlslOP->GetOpFunc(
           OP::OpCode::GetMeshPayload, expanded.ExpandedPayloadStructPtrType);
@@ -326,6 +328,7 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
       ReplaceAllUsesOfInstructionWithNewValueAndDeleteInstruction(
           getMeshPayloadInstructions, payload,
           expanded.ExpandedPayloadStructType);
+      PIXPassHelpers::EraseIfUnused(DM, OriginalGetMeshPayloadFunction);
     }
   }
 
@@ -378,9 +381,11 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
       {Type::getInt16Ty(Ctx), int16ValueIndicator},
       {Type::getFloatTy(Ctx), floatValueIndicator},
       {Type::getHalfTy(Ctx), float16ValueIndicator}};
+  SmallVector<Function *, 4> StoreVertexOutputFunctions;
 
   for (auto const &Overload : StoreVertexOutputOverloads) {
     F = HlslOP->GetOpFunc(DXIL::OpCode::StoreVertexOutput, Overload.type);
+    StoreVertexOutputFunctions.push_back(F);
     FunctionUses = F->uses();
     for (auto FI = FunctionUses.begin(); FI != FunctionUses.end();) {
       auto &FunctionUse = *FI++;
@@ -417,6 +422,10 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
                  Call->getOperand(1), Call->getOperand(2), ColumnIndex,
                  CoercedValue, Call->getOperand(5));
     }
+  }
+
+  for (Function *StoreVertexOutputFunction : StoreVertexOutputFunctions) {
+    PIXPassHelpers::EraseIfUnused(DM, StoreVertexOutputFunction);
   }
 
   DM.ReEmitDxilResources();

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -328,7 +328,7 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
       ReplaceAllUsesOfInstructionWithNewValueAndDeleteInstruction(
           getMeshPayloadInstructions, payload,
           expanded.ExpandedPayloadStructType);
-      PIXPassHelpers::EraseIfUnused(DM, OriginalGetMeshPayloadFunction);
+      PIXPassHelpers::eraseIfUnused(DM, OriginalGetMeshPayloadFunction);
     }
   }
 
@@ -425,7 +425,7 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M) {
   }
 
   for (Function *StoreVertexOutputFunction : StoreVertexOutputFunctions) {
-    PIXPassHelpers::EraseIfUnused(DM, StoreVertexOutputFunction);
+    PIXPassHelpers::eraseIfUnused(DM, StoreVertexOutputFunction);
   }
 
   DM.ReEmitDxilResources();

--- a/lib/DxilPIXPasses/DxilRemoveDiscards.cpp
+++ b/lib/DxilPIXPasses/DxilRemoveDiscards.cpp
@@ -55,7 +55,7 @@ bool DxilRemoveDiscards::runOnModule(Module &M) {
     Modified = true;
   }
 
-  PIXPassHelpers::EraseIfUnused(DM, DiscardFunction);
+  PIXPassHelpers::eraseIfUnused(DM, DiscardFunction);
 
   return Modified;
 }

--- a/lib/DxilPIXPasses/DxilRemoveDiscards.cpp
+++ b/lib/DxilPIXPasses/DxilRemoveDiscards.cpp
@@ -17,6 +17,8 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
 
+#include "PixPassHelpers.h"
+
 using namespace llvm;
 using namespace hlsl;
 
@@ -52,6 +54,8 @@ bool DxilRemoveDiscards::runOnModule(Module &M) {
     instruction->eraseFromParent();
     Modified = true;
   }
+
+  PIXPassHelpers::EraseIfUnused(DM, DiscardFunction);
 
   return Modified;
 }

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -198,8 +198,9 @@ static std::vector<uint8_t> SerializeRootSignatureToVector(
 
 constexpr uint32_t toolsRegisterSpace = static_cast<uint32_t>(-2);
 
+// Returns whether a parameter was appended.
 template <typename RootSigDesc, typename RootParameterDesc>
-void ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
+bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
   auto *existingParams = rootSigDesc.pParameters;
   for (uint32_t i = 0; i < rootSigDesc.NumParameters; ++i) {
     if (rootSigDesc.pParameters[i].ParameterType ==
@@ -209,7 +210,7 @@ void ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
           rootSigDesc.pParameters[i].Descriptor.ShaderRegister ==
               toolsUAVRegister) {
         // Already added
-        return;
+        return false;
       }
     }
   }
@@ -229,6 +230,7 @@ void ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
   rootSigDesc.pParameters[rootSigDesc.NumParameters].ShaderVisibility =
       DxilShaderVisibility::All;
   rootSigDesc.NumParameters++;
+  return true;
 }
 
 static std::vector<uint8_t>
@@ -243,10 +245,11 @@ AddUAVParamterToRootSignature(const void *Data, uint32_t Size,
                                                             toolsUAVRegister);
     break;
   case DxilRootSignatureVersion::Version_1_1:
-    ExtendRootSig<DxilRootSignatureDesc1, DxilRootParameter1>(rs->Desc_1_1,
-                                                              toolsUAVRegister);
-    rs->Desc_1_1.pParameters[rs->Desc_1_1.NumParameters - 1].Descriptor.Flags =
-        hlsl::DxilRootDescriptorFlags::None;
+    if (ExtendRootSig<DxilRootSignatureDesc1, DxilRootParameter1>(
+            rs->Desc_1_1, toolsUAVRegister)) {
+      rs->Desc_1_1.pParameters[rs->Desc_1_1.NumParameters - 1]
+          .Descriptor.Flags = hlsl::DxilRootDescriptorFlags::None;
+    }
     break;
   }
   return SerializeRootSignatureToVector(rs);

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -185,6 +185,9 @@ static std::vector<uint8_t> SerializeRootSignatureToVector(
   SerializeRootSignature(rootSignature, &serializedRootSignature, &errorBlob,
                          allowReservedRegisterSpace);
   std::vector<uint8_t> ret;
+  if (serializedRootSignature == nullptr) {
+    return ret;
+  }
   auto const *serializedData = reinterpret_cast<const uint8_t *>(
       serializedRootSignature->GetBufferPointer());
   ret.assign(serializedData,
@@ -194,10 +197,9 @@ static std::vector<uint8_t> SerializeRootSignatureToVector(
 }
 
 constexpr uint32_t toolsRegisterSpace = static_cast<uint32_t>(-2);
-constexpr uint32_t toolsUAVRegister = 0;
 
 template <typename RootSigDesc, typename RootParameterDesc>
-void ExtendRootSig(RootSigDesc &rootSigDesc) {
+void ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
   auto *existingParams = rootSigDesc.pParameters;
   for (uint32_t i = 0; i < rootSigDesc.NumParameters; ++i) {
     if (rootSigDesc.pParameters[i].ParameterType ==
@@ -229,17 +231,20 @@ void ExtendRootSig(RootSigDesc &rootSigDesc) {
   rootSigDesc.NumParameters++;
 }
 
-static std::vector<uint8_t> AddUAVParamterToRootSignature(const void *Data,
-                                                          uint32_t Size) {
+static std::vector<uint8_t>
+AddUAVParamterToRootSignature(const void *Data, uint32_t Size,
+                              uint32_t toolsUAVRegister) {
   DxilVersionedRootSignature rootSignature;
   DeserializeRootSignature(Data, Size, rootSignature.get_address_of());
   auto *rs = rootSignature.get_mutable();
   switch (rootSignature->Version) {
   case DxilRootSignatureVersion::Version_1_0:
-    ExtendRootSig<DxilRootSignatureDesc, DxilRootParameter>(rs->Desc_1_0);
+    ExtendRootSig<DxilRootSignatureDesc, DxilRootParameter>(rs->Desc_1_0,
+                                                            toolsUAVRegister);
     break;
   case DxilRootSignatureVersion::Version_1_1:
-    ExtendRootSig<DxilRootSignatureDesc1, DxilRootParameter1>(rs->Desc_1_1);
+    ExtendRootSig<DxilRootSignatureDesc1, DxilRootParameter1>(rs->Desc_1_1,
+                                                              toolsUAVRegister);
     rs->Desc_1_1.pParameters[rs->Desc_1_1.NumParameters - 1].Descriptor.Flags =
         hlsl::DxilRootDescriptorFlags::None;
     break;
@@ -247,16 +252,26 @@ static std::vector<uint8_t> AddUAVParamterToRootSignature(const void *Data,
   return SerializeRootSignatureToVector(rs);
 }
 
-static void AddUAVToShaderAttributeRootSignature(DxilModule &DM) {
+static void AddUAVToShaderAttributeRootSignature(DxilModule &DM,
+                                                 uint32_t toolsUAVRegister) {
   auto rs = DM.GetSerializedRootSignature();
   if (!rs.empty()) {
     std::vector<uint8_t> asVector = AddUAVParamterToRootSignature(
-        rs.data(), static_cast<uint32_t>(rs.size()));
-    DM.ResetSerializedRootSignature(asVector);
+        rs.data(), static_cast<uint32_t>(rs.size()), toolsUAVRegister);
+    if (!asVector.empty()) {
+      DM.ResetSerializedRootSignature(asVector);
+    }
   }
 }
 
-static void AddUAVToDxilDefinedGlobalRootSignatures(DxilModule &DM) {
+static void AddUAVToDxilDefinedGlobalRootSignatures(DxilModule &DM,
+                                                    uint32_t toolsUAVRegister) {
+  struct ReplacementRootSignature {
+    std::string Name;
+    std::vector<uint8_t> Data;
+  };
+
+  std::vector<ReplacementRootSignature> replacementRootSignatures;
   auto *subObjects = DM.GetSubobjects();
   if (subObjects != nullptr) {
     for (auto const &subObject : subObjects->GetSubobjects()) {
@@ -267,15 +282,23 @@ static void AddUAVToDxilDefinedGlobalRootSignatures(DxilModule &DM) {
         constexpr bool notALocalRS = false;
         if (subObject.second->GetRootSignature(notALocalRS, Data, Size,
                                                nullptr)) {
-          auto extendedRootSig = AddUAVParamterToRootSignature(Data, Size);
-          auto rootSignatureSubObjectName = subObject.first;
-          subObjects->RemoveSubobject(rootSignatureSubObjectName);
-          subObjects->CreateRootSignature(
-              rootSignatureSubObjectName, notALocalRS, extendedRootSig.data(),
-              static_cast<uint32_t>(extendedRootSig.size()));
-          break;
+          std::vector<uint8_t> extended =
+              AddUAVParamterToRootSignature(Data, Size, toolsUAVRegister);
+          if (!extended.empty()) {
+            replacementRootSignatures.push_back(
+                {subObject.first.str(), std::move(extended)});
+          }
         }
       }
+    }
+
+    constexpr bool notALocalRS = false;
+    for (auto const &replacementRootSignature : replacementRootSignatures) {
+      subObjects->RemoveSubobject(replacementRootSignature.Name);
+      subObjects->CreateRootSignature(
+          replacementRootSignature.Name, notALocalRS,
+          replacementRootSignature.Data.data(),
+          static_cast<uint32_t>(replacementRootSignature.Data.size()));
     }
   }
 }
@@ -286,6 +309,13 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
                                             const char *name) {
   LLVMContext &Ctx = DM.GetModule()->getContext();
 
+  for (auto const &existingUAV : DM.GetUAVs()) {
+    if (existingUAV->GetSpaceID() == toolsRegisterSpace &&
+        existingUAV->GetLowerBound() == hlslBindIndex) {
+      return existingUAV.get();
+    }
+  }
+
   const char *PIXStructTypeName = ShaderModelHandleTypeName(DM);
   llvm::StructType *UAVStructTy =
       DM.GetModule()->getTypeByName(PIXStructTypeName);
@@ -295,10 +325,8 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
     UAVStructTy = llvm::StructType::create(Elements, PIXStructTypeName);
   }
 
-  // Since this function should only be called once per module,
-  // we can modify the root sig at the same time:
-  AddUAVToDxilDefinedGlobalRootSignatures(DM);
-  AddUAVToShaderAttributeRootSignature(DM);
+  AddUAVToDxilDefinedGlobalRootSignatures(DM, hlslBindIndex);
+  AddUAVToShaderAttributeRootSignature(DM, hlslBindIndex);
 
   unsigned int Id = static_cast<unsigned int>(DM.GetUAVs().size());
   std::unique_ptr<DxilResource> pUAV = llvm::make_unique<DxilResource>();
@@ -320,8 +348,7 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
   }
   pUAV->SetGlobalName(name);
   pUAV->SetRW(true); // sets UAV class
-  pUAV->SetSpaceID(
-      (unsigned int)-2);   // This is the reserved-for-tools register space
+  pUAV->SetSpaceID(toolsRegisterSpace); // reserved-for-tools register space
   pUAV->SetSampleCount(0); // This is what compiler generates for a raw UAV
   pUAV->SetGloballyCoherent(false);
   pUAV->SetReorderCoherent(false);
@@ -351,7 +378,15 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
 
   auto *ret = pUAV.get();
   DM.AddUAV(std::move(pUAV));
+  DM.CollectShaderFlagsForModule();
   return ret;
+}
+
+void EraseIfUnused(hlsl::DxilModule &DM, llvm::Function *OpFunction) {
+  if (OpFunction != nullptr && OpFunction->user_empty()) {
+    DM.GetOP()->RemoveFunction(OpFunction);
+    OpFunction->eraseFromParent();
+  }
 }
 
 // Set up a UAV with structure of a single int
@@ -399,18 +434,6 @@ hlsl::DXIL::ShaderKind GetFunctionShaderKind(hlsl::DxilModule &DM,
     shaderKind = props.shaderKind;
   }
   return shaderKind;
-}
-
-std::vector<llvm::BasicBlock *> GetAllBlocks(hlsl::DxilModule &DM) {
-  std::vector<llvm::BasicBlock *> ret;
-  auto entryPoints = DM.GetExportedFunctions();
-  for (auto &fn : entryPoints) {
-    auto &blocks = fn->getBasicBlockList();
-    for (auto &block : blocks) {
-      ret.push_back(&block);
-    }
-  }
-  return ret;
 }
 
 ExpandedStruct ExpandStructType(LLVMContext &Ctx,
@@ -547,6 +570,24 @@ void ForEachDynamicallyIndexedResource(
 
   auto CreateHandleFn =
       HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
+  auto CreateHandleFromBindingFn = HlslOP->GetOpFunc(
+      DXIL::OpCode::CreateHandleFromBinding, Type::getVoidTy(Ctx));
+  auto CreateHandleFromHeapFn = HlslOP->GetOpFunc(
+      DXIL::OpCode::CreateHandleFromHeap, Type::getVoidTy(Ctx));
+
+  struct UnusedDeclarationCleanup {
+    hlsl::DxilModule &DM;
+    llvm::Function *CreateHandleFn;
+    llvm::Function *CreateHandleFromBindingFn;
+    llvm::Function *CreateHandleFromHeapFn;
+    ~UnusedDeclarationCleanup() {
+      EraseIfUnused(DM, CreateHandleFn);
+      EraseIfUnused(DM, CreateHandleFromBindingFn);
+      EraseIfUnused(DM, CreateHandleFromHeapFn);
+    }
+  } cleanup{DM, CreateHandleFn, CreateHandleFromBindingFn,
+            CreateHandleFromHeapFn};
+
   for (auto FI = CreateHandleFn->user_begin();
        FI != CreateHandleFn->user_end();) {
     auto *FunctionUser = *FI++;
@@ -562,8 +603,6 @@ void ForEachDynamicallyIndexedResource(
     }
   }
 
-  auto CreateHandleFromBindingFn = HlslOP->GetOpFunc(
-      DXIL::OpCode::CreateHandleFromBinding, Type::getVoidTy(Ctx));
   for (auto FI = CreateHandleFromBindingFn->user_begin();
        FI != CreateHandleFromBindingFn->user_end();) {
     auto *FunctionUser = *FI++;
@@ -579,8 +618,6 @@ void ForEachDynamicallyIndexedResource(
     }
   }
 
-  auto CreateHandleFromHeapFn = HlslOP->GetOpFunc(
-      DXIL::OpCode::CreateHandleFromHeap, Type::getVoidTy(Ctx));
   for (auto FI = CreateHandleFromHeapFn->user_begin();
        FI != CreateHandleFromHeapFn->user_end();) {
     auto *FunctionUser = *FI++;

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -200,36 +200,36 @@ constexpr uint32_t toolsRegisterSpace = static_cast<uint32_t>(-2);
 
 // Returns whether a parameter was appended.
 template <typename RootSigDesc, typename RootParameterDesc>
-bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t ToolsUAVRegister) {
-  auto *existingParams = rootSigDesc.pParameters;
-  for (uint32_t i = 0; i < rootSigDesc.NumParameters; ++i) {
-    if (rootSigDesc.pParameters[i].ParameterType ==
+bool ExtendRootSig(RootSigDesc &RootSignatureDesc, uint32_t ToolsUAVRegister) {
+  auto *existingParams = RootSignatureDesc.pParameters;
+  for (uint32_t i = 0; i < RootSignatureDesc.NumParameters; ++i) {
+    if (RootSignatureDesc.pParameters[i].ParameterType ==
         DxilRootParameterType::UAV) {
-      if (rootSigDesc.pParameters[i].Descriptor.RegisterSpace ==
+      if (RootSignatureDesc.pParameters[i].Descriptor.RegisterSpace ==
               toolsRegisterSpace &&
-          rootSigDesc.pParameters[i].Descriptor.ShaderRegister ==
+          RootSignatureDesc.pParameters[i].Descriptor.ShaderRegister ==
               ToolsUAVRegister) {
         // Already added
         return false;
       }
     }
   }
-  auto *newParams = new RootParameterDesc[rootSigDesc.NumParameters + 1];
+  auto *newParams = new RootParameterDesc[RootSignatureDesc.NumParameters + 1];
   if (existingParams != nullptr) {
     memcpy(newParams, existingParams,
-           rootSigDesc.NumParameters * sizeof(RootParameterDesc));
+           RootSignatureDesc.NumParameters * sizeof(RootParameterDesc));
     delete[] existingParams;
   }
-  rootSigDesc.pParameters = newParams;
-  rootSigDesc.pParameters[rootSigDesc.NumParameters].ParameterType =
+  RootSignatureDesc.pParameters = newParams;
+  RootSignatureDesc.pParameters[RootSignatureDesc.NumParameters].ParameterType =
       DxilRootParameterType::UAV;
-  rootSigDesc.pParameters[rootSigDesc.NumParameters].Descriptor.RegisterSpace =
-      toolsRegisterSpace;
-  rootSigDesc.pParameters[rootSigDesc.NumParameters].Descriptor.ShaderRegister =
-      ToolsUAVRegister;
-  rootSigDesc.pParameters[rootSigDesc.NumParameters].ShaderVisibility =
-      DxilShaderVisibility::All;
-  rootSigDesc.NumParameters++;
+  RootSignatureDesc.pParameters[RootSignatureDesc.NumParameters]
+      .Descriptor.RegisterSpace = toolsRegisterSpace;
+  RootSignatureDesc.pParameters[RootSignatureDesc.NumParameters]
+      .Descriptor.ShaderRegister = ToolsUAVRegister;
+  RootSignatureDesc.pParameters[RootSignatureDesc.NumParameters]
+      .ShaderVisibility = DxilShaderVisibility::All;
+  RootSignatureDesc.NumParameters++;
   return true;
 }
 

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -296,7 +296,8 @@ static void AddUAVToDxilDefinedGlobalRootSignatures(DxilModule &DM,
     }
 
     constexpr bool notALocalRS = false;
-    for (auto const &replacementRootSignature : replacementRootSignatures) {
+    for (const ReplacementRootSignature &replacementRootSignature :
+         replacementRootSignatures) {
       subObjects->RemoveSubobject(replacementRootSignature.Name);
       subObjects->CreateRootSignature(
           replacementRootSignature.Name, notALocalRS,
@@ -312,7 +313,7 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
                                             const char *name) {
   LLVMContext &Ctx = DM.GetModule()->getContext();
 
-  for (auto const &existingUAV : DM.GetUAVs()) {
+  for (const std::unique_ptr<DxilResource> &existingUAV : DM.GetUAVs()) {
     if (existingUAV->GetSpaceID() == toolsRegisterSpace &&
         existingUAV->GetLowerBound() == hlslBindIndex) {
       return existingUAV.get();
@@ -573,9 +574,9 @@ void ForEachDynamicallyIndexedResource(
 
   auto CreateHandleFn =
       HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
-  auto CreateHandleFromBindingFn = HlslOP->GetOpFunc(
+  llvm::Function *CreateHandleFromBindingFn = HlslOP->GetOpFunc(
       DXIL::OpCode::CreateHandleFromBinding, Type::getVoidTy(Ctx));
-  auto CreateHandleFromHeapFn = HlslOP->GetOpFunc(
+  llvm::Function *CreateHandleFromHeapFn = HlslOP->GetOpFunc(
       DXIL::OpCode::CreateHandleFromHeap, Type::getVoidTy(Ctx));
 
   struct UnusedDeclarationCleanup {

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -200,7 +200,7 @@ constexpr uint32_t toolsRegisterSpace = static_cast<uint32_t>(-2);
 
 // Returns whether a parameter was appended.
 template <typename RootSigDesc, typename RootParameterDesc>
-bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
+bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t ToolsUAVRegister) {
   auto *existingParams = rootSigDesc.pParameters;
   for (uint32_t i = 0; i < rootSigDesc.NumParameters; ++i) {
     if (rootSigDesc.pParameters[i].ParameterType ==
@@ -208,7 +208,7 @@ bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
       if (rootSigDesc.pParameters[i].Descriptor.RegisterSpace ==
               toolsRegisterSpace &&
           rootSigDesc.pParameters[i].Descriptor.ShaderRegister ==
-              toolsUAVRegister) {
+              ToolsUAVRegister) {
         // Already added
         return false;
       }
@@ -226,7 +226,7 @@ bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
   rootSigDesc.pParameters[rootSigDesc.NumParameters].Descriptor.RegisterSpace =
       toolsRegisterSpace;
   rootSigDesc.pParameters[rootSigDesc.NumParameters].Descriptor.ShaderRegister =
-      toolsUAVRegister;
+      ToolsUAVRegister;
   rootSigDesc.pParameters[rootSigDesc.NumParameters].ShaderVisibility =
       DxilShaderVisibility::All;
   rootSigDesc.NumParameters++;
@@ -235,18 +235,18 @@ bool ExtendRootSig(RootSigDesc &rootSigDesc, uint32_t toolsUAVRegister) {
 
 static std::vector<uint8_t>
 AddUAVParamterToRootSignature(const void *Data, uint32_t Size,
-                              uint32_t toolsUAVRegister) {
+                              uint32_t ToolsUAVRegister) {
   DxilVersionedRootSignature rootSignature;
   DeserializeRootSignature(Data, Size, rootSignature.get_address_of());
   auto *rs = rootSignature.get_mutable();
   switch (rootSignature->Version) {
   case DxilRootSignatureVersion::Version_1_0:
     ExtendRootSig<DxilRootSignatureDesc, DxilRootParameter>(rs->Desc_1_0,
-                                                            toolsUAVRegister);
+                                                            ToolsUAVRegister);
     break;
   case DxilRootSignatureVersion::Version_1_1:
     if (ExtendRootSig<DxilRootSignatureDesc1, DxilRootParameter1>(
-            rs->Desc_1_1, toolsUAVRegister)) {
+            rs->Desc_1_1, ToolsUAVRegister)) {
       rs->Desc_1_1.pParameters[rs->Desc_1_1.NumParameters - 1]
           .Descriptor.Flags = hlsl::DxilRootDescriptorFlags::None;
     }
@@ -256,11 +256,11 @@ AddUAVParamterToRootSignature(const void *Data, uint32_t Size,
 }
 
 static void AddUAVToShaderAttributeRootSignature(DxilModule &DM,
-                                                 uint32_t toolsUAVRegister) {
+                                                 uint32_t ToolsUAVRegister) {
   auto rs = DM.GetSerializedRootSignature();
   if (!rs.empty()) {
     std::vector<uint8_t> asVector = AddUAVParamterToRootSignature(
-        rs.data(), static_cast<uint32_t>(rs.size()), toolsUAVRegister);
+        rs.data(), static_cast<uint32_t>(rs.size()), ToolsUAVRegister);
     if (!asVector.empty()) {
       DM.ResetSerializedRootSignature(asVector);
     }
@@ -268,13 +268,13 @@ static void AddUAVToShaderAttributeRootSignature(DxilModule &DM,
 }
 
 static void AddUAVToDxilDefinedGlobalRootSignatures(DxilModule &DM,
-                                                    uint32_t toolsUAVRegister) {
+                                                    uint32_t ToolsUAVRegister) {
   struct ReplacementRootSignature {
     std::string Name;
     std::vector<uint8_t> Data;
   };
 
-  std::vector<ReplacementRootSignature> replacementRootSignatures;
+  std::vector<ReplacementRootSignature> ReplacementRootSignatures;
   auto *subObjects = DM.GetSubobjects();
   if (subObjects != nullptr) {
     for (auto const &subObject : subObjects->GetSubobjects()) {
@@ -285,24 +285,23 @@ static void AddUAVToDxilDefinedGlobalRootSignatures(DxilModule &DM,
         constexpr bool notALocalRS = false;
         if (subObject.second->GetRootSignature(notALocalRS, Data, Size,
                                                nullptr)) {
-          std::vector<uint8_t> extended =
-              AddUAVParamterToRootSignature(Data, Size, toolsUAVRegister);
-          if (!extended.empty()) {
-            replacementRootSignatures.push_back(
-                {subObject.first.str(), std::move(extended)});
+          std::vector<uint8_t> ExtendedRootSignature =
+              AddUAVParamterToRootSignature(Data, Size, ToolsUAVRegister);
+          if (!ExtendedRootSignature.empty()) {
+            ReplacementRootSignatures.push_back(
+                {subObject.first.str(), std::move(ExtendedRootSignature)});
           }
         }
       }
     }
 
-    constexpr bool notALocalRS = false;
-    for (const ReplacementRootSignature &replacementRootSignature :
-         replacementRootSignatures) {
-      subObjects->RemoveSubobject(replacementRootSignature.Name);
+    constexpr bool NotALocalRootSignature = false;
+    for (const ReplacementRootSignature &Replacement :
+         ReplacementRootSignatures) {
+      subObjects->RemoveSubobject(Replacement.Name);
       subObjects->CreateRootSignature(
-          replacementRootSignature.Name, notALocalRS,
-          replacementRootSignature.Data.data(),
-          static_cast<uint32_t>(replacementRootSignature.Data.size()));
+          Replacement.Name, NotALocalRootSignature, Replacement.Data.data(),
+          static_cast<uint32_t>(Replacement.Data.size()));
     }
   }
 }
@@ -313,10 +312,10 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
                                             const char *name) {
   LLVMContext &Ctx = DM.GetModule()->getContext();
 
-  for (const std::unique_ptr<DxilResource> &existingUAV : DM.GetUAVs()) {
-    if (existingUAV->GetSpaceID() == toolsRegisterSpace &&
-        existingUAV->GetLowerBound() == hlslBindIndex) {
-      return existingUAV.get();
+  for (const std::unique_ptr<DxilResource> &ExistingUAV : DM.GetUAVs()) {
+    if (ExistingUAV->GetSpaceID() == toolsRegisterSpace &&
+        ExistingUAV->GetLowerBound() == hlslBindIndex) {
+      return ExistingUAV.get();
     }
   }
 
@@ -386,7 +385,7 @@ hlsl::DxilResource *CreateGlobalUAVResource(hlsl::DxilModule &DM,
   return ret;
 }
 
-void EraseIfUnused(hlsl::DxilModule &DM, llvm::Function *OpFunction) {
+void eraseIfUnused(hlsl::DxilModule &DM, llvm::Function *OpFunction) {
   if (OpFunction != nullptr && OpFunction->user_empty()) {
     DM.GetOP()->RemoveFunction(OpFunction);
     OpFunction->eraseFromParent();
@@ -585,11 +584,11 @@ void ForEachDynamicallyIndexedResource(
     llvm::Function *CreateHandleFromBindingFn;
     llvm::Function *CreateHandleFromHeapFn;
     ~UnusedDeclarationCleanup() {
-      EraseIfUnused(DM, CreateHandleFn);
-      EraseIfUnused(DM, CreateHandleFromBindingFn);
-      EraseIfUnused(DM, CreateHandleFromHeapFn);
+      eraseIfUnused(DM, CreateHandleFn);
+      eraseIfUnused(DM, CreateHandleFromBindingFn);
+      eraseIfUnused(DM, CreateHandleFromHeapFn);
     }
-  } cleanup{DM, CreateHandleFn, CreateHandleFromBindingFn,
+  } Cleanup{DM, CreateHandleFn, CreateHandleFromBindingFn,
             CreateHandleFromHeapFn};
 
   for (auto FI = CreateHandleFn->user_begin();

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -48,7 +48,7 @@ llvm::CallInst *CreateHandleForResource(hlsl::DxilModule &DM,
                                         hlsl::DxilResourceBase *resource,
                                         const char *name);
 llvm::Function *GetEntryFunction(hlsl::DxilModule &DM);
-std::vector<llvm::BasicBlock *> GetAllBlocks(hlsl::DxilModule &DM);
+void EraseIfUnused(hlsl::DxilModule &DM, llvm::Function *OpFunction);
 std::vector<llvm::Function *>
 GetAllInstrumentableFunctions(hlsl::DxilModule &DM);
 hlsl::DXIL::ShaderKind GetFunctionShaderKind(hlsl::DxilModule &DM,

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -48,7 +48,7 @@ llvm::CallInst *CreateHandleForResource(hlsl::DxilModule &DM,
                                         hlsl::DxilResourceBase *resource,
                                         const char *name);
 llvm::Function *GetEntryFunction(hlsl::DxilModule &DM);
-void EraseIfUnused(hlsl::DxilModule &DM, llvm::Function *OpFunction);
+void eraseIfUnused(hlsl::DxilModule &DM, llvm::Function *OpFunction);
 std::vector<llvm::Function *>
 GetAllInstrumentableFunctions(hlsl::DxilModule &DM);
 hlsl::DXIL::ShaderKind GetFunctionShaderKind(hlsl::DxilModule &DM,

--- a/tools/clang/test/HLSLFileCheck/pix/pixelCounterEarlyZ.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/pixelCounterEarlyZ.hlsl
@@ -3,9 +3,11 @@
 // Check the write to the UAV was emitted:
 // CHECK: %UAVIncResult = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 0, i32 %ByteIndex, i32 undef, i32 undef, i32 1)
 
-// Early z flag value is 8. The flags are stored in an entry in the entry function description record. See:
+// The flags are stored in an entry in the entry function description record. See:
 // https://github.com/Microsoft/DirectXShaderCompiler/blob/main/docs/DXIL.rst#shader-properties-and-capabilities
-// CHECK: !{i32 0, i64 8}
+// 8 is force-early-z. 16 is EnableRawAndStructuredBuffers, set for the
+// RWByteAddressBuffer counter this pass adds. 8 | 16 = 24.
+// CHECK: !{i32 0, i64 24}
 
 float4 main(float4 pos : SV_Position) : SV_Target {
   return pos;

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -3663,8 +3663,10 @@ float main() : SV_Target
   // Virtual-register annotation adds metadata that DXIL does not consume,
   // so this module only validates because that metadata is one of the
   // four known PIX kinds.
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  auto output = RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput output =
+      RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
   VerifyInstrumentedModuleIsValid(
       output.Module,
       "virtual-register annotation of a trivial pixel shader (validation "
@@ -3678,14 +3680,16 @@ float main() : SV_Target
     return 0;
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  auto output = RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput output =
+      RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
 
   // Mislabel the shader stage, so the container carries both the
   // harness's permitted PIX metadata and a real defect.
   std::string disassembly = Disassemble(output.Module);
   const std::string shaderKindTag = "!\"ps\",";
-  auto tagPosition = disassembly.find(shaderKindTag);
+  std::string::size_type tagPosition = disassembly.find(shaderKindTag);
   VERIFY_IS_TRUE(tagPosition != std::string::npos);
   disassembly.replace(tagPosition, shaderKindTag.size(), "!\"vs\",");
 

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -50,6 +50,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Bitcode/ReaderWriter.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -165,6 +166,7 @@ public:
   TEST_METHOD(Validation_ControlValidModulePasses)
   TEST_METHOD(Validation_ControlInvalidModuleFails)
   TEST_METHOD(Validation_ControlNonPixUnusedMetadataIsRejected)
+  TEST_METHOD(Validation_ControlInvalidPixMetadataIsRejected)
 
   dxc::DxCompilerDllLoader m_dllSupport;
   VersionSupportInfo m_ver;
@@ -341,16 +343,83 @@ public:
       pix_dxil::PixDxilInstNum::MDName, pix_dxil::PixDxilReg::MDName,
       pix_dxil::PixAllocaReg::MDName, pix_dxil::PixAllocaRegWrite::MDName};
 
-  // Removes the known PIX metadata kinds from every function and instruction.
+  // Checks that known PIX metadata has the expected location and payload.
+  static bool hasValidKnownPixVirtualRegisterMetadata(llvm::Module &M) {
+    llvm::LLVMContext &Ctx = M.getContext();
+    unsigned InstNumKindID = Ctx.getMDKindID(pix_dxil::PixDxilInstNum::MDName);
+    unsigned RegKindID = Ctx.getMDKindID(pix_dxil::PixDxilReg::MDName);
+    unsigned AllocaRegKindID = Ctx.getMDKindID(pix_dxil::PixAllocaReg::MDName);
+    unsigned AllocaRegWriteKindID =
+        Ctx.getMDKindID(pix_dxil::PixAllocaRegWrite::MDName);
+
+    for (llvm::Function &F : M) {
+      for (const char *Kind : KnownPixVirtualRegisterMetadataKinds) {
+        if (F.getMetadata(Ctx.getMDKindID(Kind)) != nullptr) {
+          return false;
+        }
+      }
+
+      for (llvm::BasicBlock &BB : F) {
+        for (llvm::Instruction &I : BB) {
+          if (I.getMetadata(InstNumKindID) != nullptr) {
+            std::uint32_t InstNum;
+            if (!pix_dxil::PixDxilInstNum::FromInst(&I, &InstNum)) {
+              return false;
+            }
+          }
+
+          if (I.getMetadata(RegKindID) != nullptr) {
+            std::uint32_t RegNum;
+            if (!pix_dxil::PixDxilReg::FromInst(&I, &RegNum)) {
+              return false;
+            }
+          }
+
+          if (I.getMetadata(AllocaRegKindID) != nullptr) {
+            llvm::AllocaInst *Alloca = llvm::dyn_cast<llvm::AllocaInst>(&I);
+            std::uint32_t RegBase;
+            std::uint32_t RegSize;
+            if (Alloca == nullptr ||
+                !pix_dxil::PixAllocaReg::FromInst(Alloca, &RegBase, &RegSize)) {
+              return false;
+            }
+          }
+
+          if (I.getMetadata(AllocaRegWriteKindID) != nullptr) {
+            llvm::StoreInst *Store = llvm::dyn_cast<llvm::StoreInst>(&I);
+            std::uint32_t RegBase;
+            std::uint32_t RegSize;
+            llvm::Value *Index;
+            if (Store == nullptr || !pix_dxil::PixAllocaRegWrite::FromInst(
+                                        Store, &RegBase, &RegSize, &Index)) {
+              return false;
+            }
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  // Removes valid PIX metadata from its documented instruction types.
   static void stripKnownPixVirtualRegisterMetadata(llvm::Module &M) {
     llvm::LLVMContext &Ctx = M.getContext();
-    for (const char *Kind : KnownPixVirtualRegisterMetadataKinds) {
-      unsigned KindID = Ctx.getMDKindID(Kind);
-      for (llvm::Function &F : M) {
-        F.setMetadata(KindID, nullptr);
-        for (llvm::BasicBlock &BB : F) {
-          for (llvm::Instruction &I : BB) {
-            I.setMetadata(KindID, nullptr);
+    unsigned InstNumKindID = Ctx.getMDKindID(pix_dxil::PixDxilInstNum::MDName);
+    unsigned RegKindID = Ctx.getMDKindID(pix_dxil::PixDxilReg::MDName);
+    unsigned AllocaRegKindID = Ctx.getMDKindID(pix_dxil::PixAllocaReg::MDName);
+    unsigned AllocaRegWriteKindID =
+        Ctx.getMDKindID(pix_dxil::PixAllocaRegWrite::MDName);
+
+    for (llvm::Function &F : M) {
+      for (llvm::BasicBlock &BB : F) {
+        for (llvm::Instruction &I : BB) {
+          I.setMetadata(InstNumKindID, nullptr);
+          I.setMetadata(RegKindID, nullptr);
+          if (llvm::isa<llvm::AllocaInst>(&I)) {
+            I.setMetadata(AllocaRegKindID, nullptr);
+          }
+          if (llvm::isa<llvm::StoreInst>(&I)) {
+            I.setMetadata(AllocaRegWriteKindID, nullptr);
           }
         }
       }
@@ -395,8 +464,17 @@ public:
     // from any other unsupported metadata. Strip only the known PIX kinds
     // and revalidate. If this fixes the module, PIX metadata was the only
     // cause.
-    CComPtr<IDxcBlob> StrippedContainer =
-        cloneModuleAndMutate(Container, stripKnownPixVirtualRegisterMetadata);
+    bool KnownPixMetadataIsValid = false;
+    CComPtr<IDxcBlob> StrippedContainer = cloneModuleAndMutate(
+        Container, [&KnownPixMetadataIsValid](llvm::Module &M) {
+          KnownPixMetadataIsValid = hasValidKnownPixVirtualRegisterMetadata(M);
+          if (KnownPixMetadataIsValid) {
+            stripKnownPixVirtualRegisterMetadata(M);
+          }
+        });
+    if (!KnownPixMetadataIsValid) {
+      return DirectResult;
+    }
     if (runValidator(StrippedContainer).Valid) {
       return {true, {}};
     }
@@ -3749,4 +3827,78 @@ float main() : SV_Target
 
   ValidationResult Result = validateInstrumentedModule(WithForeignMetadata);
   VERIFY_IS_FALSE(Result.Valid);
+}
+
+TEST_F(PixTest, Validation_ControlInvalidPixMetadataIsRejected) {
+  const char *Source = R"x(
+float main() : SV_Target
+{
+    return 0;
+})x";
+
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      runSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> Container = normalizeToContainer(Output.Module);
+
+  bool AddedFunctionMetadata = false;
+  CComPtr<IDxcBlob> WithFunctionMetadata = cloneModuleAndMutate(
+      Container, [&AddedFunctionMetadata](llvm::Module &M) {
+        for (llvm::Function &F : M) {
+          if (F.isDeclaration()) {
+            continue;
+          }
+          F.setMetadata(pix_dxil::PixDxilInstNum::MDName,
+                        llvm::MDNode::get(M.getContext(), {}));
+          AddedFunctionMetadata = true;
+          break;
+        }
+      });
+  VERIFY_IS_TRUE(AddedFunctionMetadata);
+  VERIFY_IS_FALSE(validateInstrumentedModule(WithFunctionMetadata).Valid);
+
+  bool AddedMisplacedMetadata = false;
+  CComPtr<IDxcBlob> WithMisplacedMetadata = cloneModuleAndMutate(
+      Container, [&AddedMisplacedMetadata](llvm::Module &M) {
+        llvm::LLVMContext &Ctx = M.getContext();
+        llvm::Type *Int32Ty = llvm::Type::getInt32Ty(Ctx);
+        llvm::MDNode *ValidAllocaReg = llvm::MDNode::get(
+            Ctx,
+            {llvm::ConstantAsMetadata::get(
+                 llvm::ConstantInt::get(Int32Ty, pix_dxil::PixAllocaReg::ID)),
+             llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(Int32Ty, 0)),
+             llvm::ConstantAsMetadata::get(
+                 llvm::ConstantInt::get(Int32Ty, 1))});
+        for (llvm::Function &F : M) {
+          for (llvm::BasicBlock &BB : F) {
+            for (llvm::Instruction &I : BB) {
+              if (!llvm::isa<llvm::AllocaInst>(&I)) {
+                I.setMetadata(pix_dxil::PixAllocaReg::MDName, ValidAllocaReg);
+                AddedMisplacedMetadata = true;
+                return;
+              }
+            }
+          }
+        }
+      });
+  VERIFY_IS_TRUE(AddedMisplacedMetadata);
+  VERIFY_IS_FALSE(validateInstrumentedModule(WithMisplacedMetadata).Valid);
+
+  bool AddedMalformedMetadata = false;
+  CComPtr<IDxcBlob> WithMalformedMetadata = cloneModuleAndMutate(
+      Container, [&AddedMalformedMetadata](llvm::Module &M) {
+        for (llvm::Function &F : M) {
+          for (llvm::BasicBlock &BB : F) {
+            for (llvm::Instruction &I : BB) {
+              I.setMetadata(pix_dxil::PixDxilInstNum::MDName,
+                            llvm::MDNode::get(M.getContext(), {}));
+              AddedMalformedMetadata = true;
+              return;
+            }
+          }
+        }
+      });
+  VERIFY_IS_TRUE(AddedMalformedMetadata);
+  VERIFY_IS_FALSE(validateInstrumentedModule(WithMalformedMetadata).Valid);
 }

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -578,12 +578,12 @@ public:
   }
 
   void ValidateAccessTrackingMods(const char *hlsl, bool modsExpected);
-  void LoadSubobjectsFromContainerIntoModule(IDxcBlob *container,
+  void loadSubobjectsFromContainerIntoModule(IDxcBlob *Container,
                                              DxilModule &DM);
-  void VerifyGlobalRootSignaturesHaveToolsUAVs(
-      DxilSubobjects *subObjects,
-      const std::vector<std::string> &expectedRootSignatureNames,
-      const std::vector<uint32_t> &expectedShaderRegisters);
+  void verifyGlobalRootSignaturesHaveToolsUAVs(
+      DxilSubobjects *Subobjects,
+      const std::vector<std::string> &ExpectedRootSignatureNames,
+      const std::vector<uint32_t> &ExpectedShaderRegisters);
 
   class ModuleAndHangersOn {
     std::unique_ptr<llvm::LLVMContext> llvmContext;
@@ -689,50 +689,52 @@ bool PixTest::InitSupport() {
   return true;
 }
 
-static unsigned CountToolsUAVs(DxilModule &DM) {
-  unsigned count = 0;
-  for (const std::unique_ptr<DxilResource> &uav : DM.GetUAVs()) {
-    if (uav->GetSpaceID() == static_cast<uint32_t>(-2)) {
-      count++;
+static unsigned countToolsUAVs(DxilModule &DM) {
+  unsigned Count = 0;
+  for (const std::unique_ptr<DxilResource> &UAV : DM.GetUAVs()) {
+    if (UAV->GetSpaceID() == static_cast<uint32_t>(-2)) {
+      Count++;
     }
   }
-  return count;
+  return Count;
 }
 
-static int CountToolsUAVRecords(std::vector<std::string> const &lines) {
-  int count = 0;
-  for (const std::string &line : lines) {
-    if (!line.empty() && line[0] == '!' &&
-        line.find(", i32 -2, i32 ") != std::string::npos) {
-      count++;
+static int countToolsUAVRecords(std::vector<std::string> const &Lines) {
+  int Count = 0;
+  for (const std::string &Line : Lines) {
+    if (!Line.empty() && Line[0] == '!' &&
+        Line.find(", i32 -2, i32 ") != std::string::npos) {
+      Count++;
     }
   }
-  return count;
+  return Count;
 }
 
 static bool
-RootSignatureHasToolsUAV(const DxilVersionedRootSignatureDesc *rootSignature,
-                         uint32_t shaderRegister) {
-  switch (rootSignature->Version) {
+rootSignatureHasToolsUAV(const DxilVersionedRootSignatureDesc *RootSignature,
+                         uint32_t ShaderRegister) {
+  switch (RootSignature->Version) {
   case DxilRootSignatureVersion::Version_1_0: {
-    const DxilRootSignatureDesc &desc = rootSignature->Desc_1_0;
-    for (uint32_t i = 0; i < desc.NumParameters; ++i) {
-      const DxilRootParameter &param = desc.pParameters[i];
-      if (param.ParameterType == DxilRootParameterType::UAV &&
-          param.Descriptor.RegisterSpace == static_cast<uint32_t>(-2) &&
-          param.Descriptor.ShaderRegister == shaderRegister) {
+    const DxilRootSignatureDesc &Desc = RootSignature->Desc_1_0;
+    for (uint32_t ParameterIndex = 0; ParameterIndex < Desc.NumParameters;
+         ++ParameterIndex) {
+      const DxilRootParameter &Parameter = Desc.pParameters[ParameterIndex];
+      if (Parameter.ParameterType == DxilRootParameterType::UAV &&
+          Parameter.Descriptor.RegisterSpace == static_cast<uint32_t>(-2) &&
+          Parameter.Descriptor.ShaderRegister == ShaderRegister) {
         return true;
       }
     }
     break;
   }
   case DxilRootSignatureVersion::Version_1_1: {
-    const DxilRootSignatureDesc1 &desc = rootSignature->Desc_1_1;
-    for (uint32_t i = 0; i < desc.NumParameters; ++i) {
-      const DxilRootParameter1 &param = desc.pParameters[i];
-      if (param.ParameterType == DxilRootParameterType::UAV &&
-          param.Descriptor.RegisterSpace == static_cast<uint32_t>(-2) &&
-          param.Descriptor.ShaderRegister == shaderRegister) {
+    const DxilRootSignatureDesc1 &Desc = RootSignature->Desc_1_1;
+    for (uint32_t ParameterIndex = 0; ParameterIndex < Desc.NumParameters;
+         ++ParameterIndex) {
+      const DxilRootParameter1 &Parameter = Desc.pParameters[ParameterIndex];
+      if (Parameter.ParameterType == DxilRootParameterType::UAV &&
+          Parameter.Descriptor.RegisterSpace == static_cast<uint32_t>(-2) &&
+          Parameter.Descriptor.ShaderRegister == ShaderRegister) {
         return true;
       }
     }
@@ -742,67 +744,67 @@ RootSignatureHasToolsUAV(const DxilVersionedRootSignatureDesc *rootSignature,
   return false;
 }
 
-void PixTest::LoadSubobjectsFromContainerIntoModule(IDxcBlob *container,
+void PixTest::loadSubobjectsFromContainerIntoModule(IDxcBlob *Container,
                                                     DxilModule &DM) {
-  const char *blobContent =
-      reinterpret_cast<const char *>(container->GetBufferPointer());
-  const unsigned blobSize = container->GetBufferSize();
-  const hlsl::DxilContainerHeader *containerHeader =
-      hlsl::IsDxilContainerLike(blobContent, blobSize);
-  VERIFY_ARE_NOT_EQUAL(containerHeader, nullptr);
+  const char *BlobContent =
+      reinterpret_cast<const char *>(Container->GetBufferPointer());
+  const unsigned BlobSize = Container->GetBufferSize();
+  const hlsl::DxilContainerHeader *ContainerHeader =
+      hlsl::IsDxilContainerLike(BlobContent, BlobSize);
+  VERIFY_ARE_NOT_EQUAL(ContainerHeader, nullptr);
 
-  const hlsl::DxilPartHeader *partHeader =
-      GetDxilPartByType(containerHeader, hlsl::DFCC_RuntimeData);
-  VERIFY_ARE_NOT_EQUAL(partHeader, nullptr);
+  const hlsl::DxilPartHeader *PartHeader =
+      GetDxilPartByType(ContainerHeader, hlsl::DFCC_RuntimeData);
+  VERIFY_ARE_NOT_EQUAL(PartHeader, nullptr);
 
-  hlsl::RDAT::DxilRuntimeData rdat(GetDxilPartData(partHeader),
-                                   partHeader->PartSize);
-  std::unique_ptr<DxilSubobjects> subObjects(new DxilSubobjects());
-  VERIFY_IS_TRUE(LoadSubobjectsFromRDAT(*subObjects, rdat));
-  DM.ResetSubobjects(subObjects.release());
+  hlsl::RDAT::DxilRuntimeData RuntimeData(GetDxilPartData(PartHeader),
+                                          PartHeader->PartSize);
+  std::unique_ptr<DxilSubobjects> Subobjects(new DxilSubobjects());
+  VERIFY_IS_TRUE(LoadSubobjectsFromRDAT(*Subobjects, RuntimeData));
+  DM.ResetSubobjects(Subobjects.release());
 }
 
-void PixTest::VerifyGlobalRootSignaturesHaveToolsUAVs(
-    DxilSubobjects *subObjects,
-    const std::vector<std::string> &expectedRootSignatureNames,
-    const std::vector<uint32_t> &expectedShaderRegisters) {
-  VERIFY_IS_NOT_NULL(subObjects);
+void PixTest::verifyGlobalRootSignaturesHaveToolsUAVs(
+    DxilSubobjects *Subobjects,
+    const std::vector<std::string> &ExpectedRootSignatureNames,
+    const std::vector<uint32_t> &ExpectedShaderRegisters) {
+  VERIFY_IS_NOT_NULL(Subobjects);
 
-  std::map<std::string, bool> foundRootSignatures;
-  for (const std::string &rootSignatureName : expectedRootSignatureNames) {
-    foundRootSignatures[rootSignatureName] = false;
+  std::map<std::string, bool> FoundRootSignatures;
+  for (const std::string &RootSignatureName : ExpectedRootSignatureNames) {
+    FoundRootSignatures[RootSignatureName] = false;
   }
 
-  for (auto const &subObject : subObjects->GetSubobjects()) {
-    if (subObject.second->GetKind() !=
+  for (auto const &Subobject : Subobjects->GetSubobjects()) {
+    if (Subobject.second->GetKind() !=
         hlsl::DXIL::SubobjectKind::GlobalRootSignature) {
       continue;
     }
 
-    const std::string subObjectName = subObject.first.str();
-    if (foundRootSignatures.find(subObjectName) == foundRootSignatures.end()) {
+    const std::string SubobjectName = Subobject.first.str();
+    if (FoundRootSignatures.find(SubobjectName) == FoundRootSignatures.end()) {
       continue;
     }
 
-    const void *data = nullptr;
-    uint32_t size = 0;
-    constexpr bool notALocalRS = false;
-    VERIFY_IS_TRUE(
-        subObject.second->GetRootSignature(notALocalRS, data, size, nullptr));
+    const void *Data = nullptr;
+    uint32_t Size = 0;
+    constexpr bool NotALocalRootSignature = false;
+    VERIFY_IS_TRUE(Subobject.second->GetRootSignature(NotALocalRootSignature,
+                                                      Data, Size, nullptr));
 
-    DxilVersionedRootSignatureDesc const *rootSignature = nullptr;
-    DeserializeRootSignature(data, size, &rootSignature);
-    for (uint32_t expectedShaderRegister : expectedShaderRegisters) {
+    DxilVersionedRootSignatureDesc const *RootSignature = nullptr;
+    DeserializeRootSignature(Data, Size, &RootSignature);
+    for (uint32_t ExpectedShaderRegister : ExpectedShaderRegisters) {
       VERIFY_IS_TRUE(
-          RootSignatureHasToolsUAV(rootSignature, expectedShaderRegister));
+          rootSignatureHasToolsUAV(RootSignature, ExpectedShaderRegister));
     }
-    DeleteRootSignature(rootSignature);
-    foundRootSignatures[subObjectName] = true;
+    DeleteRootSignature(RootSignature);
+    FoundRootSignatures[SubobjectName] = true;
   }
 
-  for (const std::map<std::string, bool>::value_type &foundRootSignature :
-       foundRootSignatures) {
-    VERIFY_IS_TRUE(foundRootSignature.second);
+  for (const std::map<std::string, bool>::value_type &FoundRootSignature :
+       FoundRootSignatures) {
+    VERIFY_IS_TRUE(FoundRootSignature.second);
   }
 }
 
@@ -1039,10 +1041,10 @@ PassOutput PixTest::RunDxilNonUniformResourceIndexInstrumentation(
 
   outputText = BlobToUtf8(pText);
 
-  PassOutput result;
-  result.blob = pOptimizedModule;
-  result.lines = Tokenize(Disassemble(pOptimizedModule), "\n");
-  return result;
+  PassOutput Result;
+  Result.blob = pOptimizedModule;
+  Result.lines = Tokenize(Disassemble(pOptimizedModule), "\n");
+  return Result;
 }
 
 CComPtr<IDxcBlob>
@@ -1064,12 +1066,12 @@ PixTest::RunDxilPIXAddTidToAmplificationShaderPayloadPass(IDxcBlob *blob) {
   return pOptimizedModule;
 }
 
-static bool HasDeclaration(const std::string &disassembly,
-                           const std::string &functionName);
-static std::string FindDeclarationLine(const std::string &disassembly,
-                                       const std::string &functionName);
-static bool HasDeclarationLine(const std::string &disassembly,
-                               const std::string &declaration);
+static bool hasDeclaration(const std::string &Disassembly,
+                           const std::string &FunctionName);
+static std::string findDeclarationLine(const std::string &Disassembly,
+                                       const std::string &FunctionName);
+static bool hasDeclarationLine(const std::string &Disassembly,
+                               const std::string &Declaration);
 
 TEST_F(PixTest, AddToASPayload) {
 
@@ -1112,30 +1114,30 @@ void MSMain(
   )";
 
   auto as = Compile(m_dllSupport, hlsl, L"as_6_6", {}, L"ASMain");
-  const std::string originalDispatchMeshDeclaration =
-      FindDeclarationLine(Disassemble(as), "dx.op.dispatchMesh");
-  VERIFY_IS_FALSE(originalDispatchMeshDeclaration.empty());
+  const std::string OriginalDispatchMeshDeclaration =
+      findDeclarationLine(Disassemble(as), "dx.op.dispatchMesh");
+  VERIFY_IS_FALSE(OriginalDispatchMeshDeclaration.empty());
 
-  CComPtr<IDxcBlob> asOutput =
+  CComPtr<IDxcBlob> ASOutput =
       RunDxilPIXAddTidToAmplificationShaderPayloadPass(as);
-  VERIFY_IS_FALSE(HasDeclarationLine(Disassemble(asOutput),
-                                     originalDispatchMeshDeclaration));
+  VERIFY_IS_FALSE(hasDeclarationLine(Disassemble(ASOutput),
+                                     OriginalDispatchMeshDeclaration));
 
   auto ms = Compile(m_dllSupport, hlsl, L"ms_6_6", {}, L"MSMain");
-  const std::string originalGetMeshPayloadDeclaration =
-      FindDeclarationLine(Disassemble(ms), "dx.op.getMeshPayload");
-  VERIFY_IS_FALSE(originalGetMeshPayloadDeclaration.empty());
+  const std::string OriginalGetMeshPayloadDeclaration =
+      findDeclarationLine(Disassemble(ms), "dx.op.getMeshPayload");
+  VERIFY_IS_FALSE(OriginalGetMeshPayloadDeclaration.empty());
 
-  CComPtr<IDxcBlob> msOutput = RunDxilPIXMeshShaderOutputPass(ms);
-  const std::string meshDisassembly = Disassemble(msOutput);
+  CComPtr<IDxcBlob> MSOutput = RunDxilPIXMeshShaderOutputPass(ms);
+  const std::string MeshDisassembly = Disassemble(MSOutput);
   VERIFY_IS_FALSE(
-      HasDeclarationLine(meshDisassembly, originalGetMeshPayloadDeclaration));
+      hasDeclarationLine(MeshDisassembly, OriginalGetMeshPayloadDeclaration));
   VERIFY_IS_FALSE(
-      HasDeclaration(meshDisassembly, "dx.op.storeVertexOutput.i32"));
+      hasDeclaration(MeshDisassembly, "dx.op.storeVertexOutput.i32"));
   VERIFY_IS_FALSE(
-      HasDeclaration(meshDisassembly, "dx.op.storeVertexOutput.i16"));
+      hasDeclaration(MeshDisassembly, "dx.op.storeVertexOutput.i16"));
   VERIFY_IS_FALSE(
-      HasDeclaration(meshDisassembly, "dx.op.storeVertexOutput.f16"));
+      hasDeclaration(MeshDisassembly, "dx.op.storeVertexOutput.f16"));
 }
 unsigned FindOrAddVSInSignatureElementForInstanceOrVertexID(
     hlsl::DxilSignature &InputSignature, hlsl::DXIL::SemanticKind semanticKind);
@@ -3214,7 +3216,7 @@ float4 main(int i : A, float j : B) : SV_TARGET
 }
 
 TEST_F(PixTest, ToolsUav_TwoPixPassesShareOneResource) {
-  const char *source = R"x(
+  const char *Source = R"x(
 RWByteAddressBuffer output : register(u0);
 
 [numthreads(1, 1, 1)]
@@ -3223,20 +3225,20 @@ void main(uint3 tid : SV_DispatchThreadID)
     output.Store(4 * tid.x, tid.x);
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
-  PassOutput debugOutput = RunDebugPass(compiled);
-  PassOutput accessOutput = RunShaderAccessTrackingPass(debugOutput.blob);
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"cs_6_2", {L"-Od"});
+  PassOutput DebugOutput = RunDebugPass(Compiled);
+  PassOutput AccessOutput = RunShaderAccessTrackingPass(DebugOutput.blob);
 
-  ModuleAndHangersOn moduleEtc(accessOutput.blob);
-  VERIFY_ARE_EQUAL(1u, CountToolsUAVs(moduleEtc.GetDxilModule()));
-  VerifyInstrumentedModuleIsValid(
-      accessOutput.blob,
+  ModuleAndHangersOn ModuleEtc(AccessOutput.blob);
+  VERIFY_ARE_EQUAL(1u, countToolsUAVs(ModuleEtc.GetDxilModule()));
+  verifyInstrumentedModuleIsValid(
+      AccessOutput.blob,
       "debug instrumentation followed by shader access tracking");
 }
 
 TEST_F(PixTest, ToolsUav_LibraryWithTwoEntryPointsCreatesOnePair) {
-  const char *source = R"x(
+  const char *Source = R"x(
 struct [raypayload] MyPayload
 {
     float2 barycentrics : read(caller) : write(caller,anyhit);
@@ -3256,15 +3258,15 @@ void MissTwo(inout MyPayload payload)
 }
 )x";
 
-  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
-  CComPtr<IDxcBlob> output = RunDxilPIXDXRInvocationsLog(compiled);
+  CComPtr<IDxcBlob> Compiled = Compile(m_dllSupport, Source, L"lib_6_6", {});
+  CComPtr<IDxcBlob> Output = RunDxilPIXDXRInvocationsLog(Compiled);
 
-  std::vector<std::string> lines = Tokenize(Disassemble(output), "\n");
-  VERIFY_ARE_EQUAL(2, CountToolsUAVRecords(lines));
+  std::vector<std::string> Lines = Tokenize(Disassemble(Output), "\n");
+  VERIFY_ARE_EQUAL(2, countToolsUAVRecords(Lines));
 }
 
 TEST_F(PixTest, ToolsUav_ExtendsEveryGlobalRootSignatureSubobject) {
-  const char *source = R"x(
+  const char *Source = R"x(
 GlobalRootSignature firstRootSignature = {"CBV(b0)"};
 GlobalRootSignature secondRootSignature = {"SRV(t0)"};
 
@@ -3302,249 +3304,249 @@ void MyMiss(inout MyPayload payload)
 }
 )x";
 
-  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
-  ModuleAndHangersOn moduleEtc(compiled);
-  DxilModule &DM = moduleEtc.GetDxilModule();
-  LoadSubobjectsFromContainerIntoModule(compiled, DM);
+  CComPtr<IDxcBlob> Compiled = Compile(m_dllSupport, Source, L"lib_6_6", {});
+  ModuleAndHangersOn ModuleEtc(Compiled);
+  DxilModule &DM = ModuleEtc.GetDxilModule();
+  loadSubobjectsFromContainerIntoModule(Compiled, DM);
   PIXPassHelpers::CreateGlobalUAVResource(DM, 0, "PIX_CountUAV_Handle");
   PIXPassHelpers::CreateGlobalUAVResource(DM, 1, "PIX_LogUAV_Handle");
 
-  VerifyGlobalRootSignaturesHaveToolsUAVs(
+  verifyGlobalRootSignaturesHaveToolsUAVs(
       DM.GetSubobjects(), {"firstRootSignature", "secondRootSignature"},
       {0, 1});
 }
 
 TEST_F(PixTest, DebugInstrumentation_RawBufferShaderFlagDeclared) {
-  const char *source = R"x(
+  const char *Source = R"x(
 [numthreads(1, 1, 1)]
 void main(uint threadId : SV_DispatchThreadID)
 {
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
-  PassOutput output = RunDebugPass(compiled);
-  std::vector<std::string> lines = Tokenize(Disassemble(output.blob), "\n");
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"cs_6_2", {L"-Od"});
+  PassOutput Output = RunDebugPass(Compiled);
+  std::vector<std::string> Lines = Tokenize(Disassemble(Output.blob), "\n");
 
   constexpr uint64_t EnableRawAndStructuredBuffers = 0x10;
-  bool foundShaderFlags = false;
-  uint64_t shaderFlags = 0;
-  const std::string tagPrefix = "!{i32 0, i64 ";
-  for (const std::string &line : lines) {
-    const std::string::size_type tagStart = line.find(tagPrefix);
-    if (tagStart == std::string::npos) {
+  bool FoundShaderFlags = false;
+  uint64_t ShaderFlags = 0;
+  const std::string TagPrefix = "!{i32 0, i64 ";
+  for (const std::string &Line : Lines) {
+    const std::string::size_type TagStart = Line.find(TagPrefix);
+    if (TagStart == std::string::npos) {
       continue;
     }
-    shaderFlags =
-        strtoull(line.c_str() + tagStart + tagPrefix.length(), nullptr, 10);
-    foundShaderFlags = true;
+    ShaderFlags =
+        strtoull(Line.c_str() + TagStart + TagPrefix.length(), nullptr, 10);
+    FoundShaderFlags = true;
     break;
   }
 
-  VERIFY_IS_TRUE(foundShaderFlags);
+  VERIFY_IS_TRUE(FoundShaderFlags);
   VERIFY_ARE_EQUAL(EnableRawAndStructuredBuffers,
-                   shaderFlags & EnableRawAndStructuredBuffers);
-  VerifyInstrumentedModuleIsValid(output.blob,
+                   ShaderFlags & EnableRawAndStructuredBuffers);
+  verifyInstrumentedModuleIsValid(Output.blob,
                                   "debug instrumentation shader flags");
 }
 
 TEST_F(PixTest, ToolsUav_RootSignatureSerializationFailurePreservesSignature) {
-  const char *source = R"x(
+  const char *Source = R"x(
 [numthreads(1, 1, 1)]
 void main()
 {
 })x";
 
-  DxilDescriptorRange range = {};
-  range.RangeType = DxilDescriptorRangeType::UAV;
-  range.NumDescriptors = 1;
-  range.BaseShaderRegister = 0;
-  range.RegisterSpace = static_cast<uint32_t>(-2);
-  range.OffsetInDescriptorsFromTableStart = DxilDescriptorRangeOffsetAppend;
+  DxilDescriptorRange Range = {};
+  Range.RangeType = DxilDescriptorRangeType::UAV;
+  Range.NumDescriptors = 1;
+  Range.BaseShaderRegister = 0;
+  Range.RegisterSpace = static_cast<uint32_t>(-2);
+  Range.OffsetInDescriptorsFromTableStart = DxilDescriptorRangeOffsetAppend;
 
-  DxilRootParameter parameter = {};
-  parameter.ParameterType = DxilRootParameterType::DescriptorTable;
-  parameter.DescriptorTable.NumDescriptorRanges = 1;
-  parameter.DescriptorTable.pDescriptorRanges = &range;
-  parameter.ShaderVisibility = DxilShaderVisibility::All;
+  DxilRootParameter Parameter = {};
+  Parameter.ParameterType = DxilRootParameterType::DescriptorTable;
+  Parameter.DescriptorTable.NumDescriptorRanges = 1;
+  Parameter.DescriptorTable.pDescriptorRanges = &Range;
+  Parameter.ShaderVisibility = DxilShaderVisibility::All;
 
-  DxilVersionedRootSignatureDesc rootSignature = {};
-  rootSignature.Version = DxilRootSignatureVersion::Version_1_0;
-  rootSignature.Desc_1_0.NumParameters = 1;
-  rootSignature.Desc_1_0.pParameters = &parameter;
-  rootSignature.Desc_1_0.Flags = DxilRootSignatureFlags::None;
+  DxilVersionedRootSignatureDesc RootSignature = {};
+  RootSignature.Version = DxilRootSignatureVersion::Version_1_0;
+  RootSignature.Desc_1_0.NumParameters = 1;
+  RootSignature.Desc_1_0.pParameters = &Parameter;
+  RootSignature.Desc_1_0.Flags = DxilRootSignatureFlags::None;
 
-  CComPtr<IDxcBlob> serializedRootSignature;
-  CComPtr<IDxcBlobEncoding> errorBlob;
-  SerializeRootSignature(&rootSignature, &serializedRootSignature, &errorBlob,
+  CComPtr<IDxcBlob> SerializedRootSignature;
+  CComPtr<IDxcBlobEncoding> ErrorBlob;
+  SerializeRootSignature(&RootSignature, &SerializedRootSignature, &ErrorBlob,
                          true);
-  VERIFY_IS_NOT_NULL(serializedRootSignature);
+  VERIFY_IS_NOT_NULL(SerializedRootSignature);
 
-  const uint8_t *serializedData =
-      static_cast<const uint8_t *>(serializedRootSignature->GetBufferPointer());
-  std::vector<uint8_t> originalRootSignature(
-      serializedData,
-      serializedData + serializedRootSignature->GetBufferSize());
+  const uint8_t *SerializedData =
+      static_cast<const uint8_t *>(SerializedRootSignature->GetBufferPointer());
+  std::vector<uint8_t> OriginalRootSignature(
+      SerializedData,
+      SerializedData + SerializedRootSignature->GetBufferSize());
 
-  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
-  ModuleAndHangersOn moduleEtc(compiled);
-  DxilModule &DM = moduleEtc.GetDxilModule();
-  DM.ResetSerializedRootSignature(originalRootSignature);
+  CComPtr<IDxcBlob> Compiled = Compile(m_dllSupport, Source, L"cs_6_0", {});
+  ModuleAndHangersOn ModuleEtc(Compiled);
+  DxilModule &DM = ModuleEtc.GetDxilModule();
+  DM.ResetSerializedRootSignature(OriginalRootSignature);
 
-  std::unique_ptr<DxilSubobjects> subObjects(new DxilSubobjects());
-  constexpr bool notALocalRootSignature = false;
-  subObjects->CreateRootSignature(
-      "testRootSignature", notALocalRootSignature, originalRootSignature.data(),
-      static_cast<uint32_t>(originalRootSignature.size()));
-  DM.ResetSubobjects(subObjects.release());
+  std::unique_ptr<DxilSubobjects> Subobjects(new DxilSubobjects());
+  constexpr bool NotALocalRootSignature = false;
+  Subobjects->CreateRootSignature(
+      "testRootSignature", NotALocalRootSignature, OriginalRootSignature.data(),
+      static_cast<uint32_t>(OriginalRootSignature.size()));
+  DM.ResetSubobjects(Subobjects.release());
 
   PIXPassHelpers::CreateGlobalUAVResource(DM, 0, "PIX_TestUAV");
 
-  const std::vector<uint8_t> &actualRootSignature =
+  const std::vector<uint8_t> &ActualRootSignature =
       DM.GetSerializedRootSignature();
-  VERIFY_ARE_EQUAL(originalRootSignature.size(), actualRootSignature.size());
-  VERIFY_IS_TRUE(std::equal(originalRootSignature.begin(),
-                            originalRootSignature.end(),
-                            actualRootSignature.begin()));
+  VERIFY_ARE_EQUAL(OriginalRootSignature.size(), ActualRootSignature.size());
+  VERIFY_IS_TRUE(std::equal(OriginalRootSignature.begin(),
+                            OriginalRootSignature.end(),
+                            ActualRootSignature.begin()));
 
-  bool foundRootSignature = false;
-  for (auto const &subObject : DM.GetSubobjects()->GetSubobjects()) {
-    if (subObject.first != "testRootSignature") {
+  bool FoundRootSignature = false;
+  for (auto const &Subobject : DM.GetSubobjects()->GetSubobjects()) {
+    if (Subobject.first != "testRootSignature") {
       continue;
     }
 
-    const void *data = nullptr;
-    uint32_t size = 0;
-    VERIFY_IS_TRUE(subObject.second->GetRootSignature(notALocalRootSignature,
-                                                      data, size, nullptr));
-    VERIFY_ARE_EQUAL(originalRootSignature.size(), static_cast<size_t>(size));
-    VERIFY_IS_TRUE(std::equal(originalRootSignature.begin(),
-                              originalRootSignature.end(),
-                              static_cast<const uint8_t *>(data)));
-    foundRootSignature = true;
+    const void *Data = nullptr;
+    uint32_t Size = 0;
+    VERIFY_IS_TRUE(Subobject.second->GetRootSignature(NotALocalRootSignature,
+                                                      Data, Size, nullptr));
+    VERIFY_ARE_EQUAL(OriginalRootSignature.size(), static_cast<size_t>(Size));
+    VERIFY_IS_TRUE(std::equal(OriginalRootSignature.begin(),
+                              OriginalRootSignature.end(),
+                              static_cast<const uint8_t *>(Data)));
+    FoundRootSignature = true;
   }
-  VERIFY_IS_TRUE(foundRootSignature);
+  VERIFY_IS_TRUE(FoundRootSignature);
 }
 
 TEST_F(PixTest,
        ToolsUav_ExtendingRootSignaturePreservesUnrelatedParameterFlags) {
-  const char *source = R"x(
+  const char *Source = R"x(
 [numthreads(1, 1, 1)]
 void main()
 {
 })x";
 
-  DxilRootParameter1 parameters[2] = {};
-  parameters[0].ParameterType = DxilRootParameterType::UAV;
-  parameters[0].Descriptor.RegisterSpace = static_cast<uint32_t>(-2);
-  parameters[0].Descriptor.ShaderRegister = 0;
-  parameters[0].Descriptor.Flags = DxilRootDescriptorFlags::None;
-  parameters[0].ShaderVisibility = DxilShaderVisibility::All;
+  DxilRootParameter1 Parameters[2] = {};
+  Parameters[0].ParameterType = DxilRootParameterType::UAV;
+  Parameters[0].Descriptor.RegisterSpace = static_cast<uint32_t>(-2);
+  Parameters[0].Descriptor.ShaderRegister = 0;
+  Parameters[0].Descriptor.Flags = DxilRootDescriptorFlags::None;
+  Parameters[0].ShaderVisibility = DxilShaderVisibility::All;
 
-  parameters[1].ParameterType = DxilRootParameterType::CBV;
-  parameters[1].Descriptor.RegisterSpace = 0;
-  parameters[1].Descriptor.ShaderRegister = 0;
-  parameters[1].Descriptor.Flags = DxilRootDescriptorFlags::DataVolatile;
-  parameters[1].ShaderVisibility = DxilShaderVisibility::All;
+  Parameters[1].ParameterType = DxilRootParameterType::CBV;
+  Parameters[1].Descriptor.RegisterSpace = 0;
+  Parameters[1].Descriptor.ShaderRegister = 0;
+  Parameters[1].Descriptor.Flags = DxilRootDescriptorFlags::DataVolatile;
+  Parameters[1].ShaderVisibility = DxilShaderVisibility::All;
 
-  DxilVersionedRootSignatureDesc rootSignature = {};
-  rootSignature.Version = DxilRootSignatureVersion::Version_1_1;
-  rootSignature.Desc_1_1.NumParameters = 2;
-  rootSignature.Desc_1_1.pParameters = parameters;
-  rootSignature.Desc_1_1.Flags = DxilRootSignatureFlags::None;
+  DxilVersionedRootSignatureDesc RootSignature = {};
+  RootSignature.Version = DxilRootSignatureVersion::Version_1_1;
+  RootSignature.Desc_1_1.NumParameters = 2;
+  RootSignature.Desc_1_1.pParameters = Parameters;
+  RootSignature.Desc_1_1.Flags = DxilRootSignatureFlags::None;
 
-  CComPtr<IDxcBlob> serializedRootSignature;
-  CComPtr<IDxcBlobEncoding> errorBlob;
-  SerializeRootSignature(&rootSignature, &serializedRootSignature, &errorBlob,
+  CComPtr<IDxcBlob> SerializedRootSignature;
+  CComPtr<IDxcBlobEncoding> ErrorBlob;
+  SerializeRootSignature(&RootSignature, &SerializedRootSignature, &ErrorBlob,
                          true);
-  VERIFY_IS_NOT_NULL(serializedRootSignature);
+  VERIFY_IS_NOT_NULL(SerializedRootSignature);
 
-  const uint8_t *serializedData =
-      static_cast<const uint8_t *>(serializedRootSignature->GetBufferPointer());
-  std::vector<uint8_t> originalRootSignature(
-      serializedData,
-      serializedData + serializedRootSignature->GetBufferSize());
+  const uint8_t *SerializedData =
+      static_cast<const uint8_t *>(SerializedRootSignature->GetBufferPointer());
+  std::vector<uint8_t> OriginalRootSignature(
+      SerializedData,
+      SerializedData + SerializedRootSignature->GetBufferSize());
 
-  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
-  ModuleAndHangersOn moduleEtc(compiled);
-  DxilModule &DM = moduleEtc.GetDxilModule();
-  DM.ResetSerializedRootSignature(originalRootSignature);
+  CComPtr<IDxcBlob> Compiled = Compile(m_dllSupport, Source, L"cs_6_0", {});
+  ModuleAndHangersOn ModuleEtc(Compiled);
+  DxilModule &DM = ModuleEtc.GetDxilModule();
+  DM.ResetSerializedRootSignature(OriginalRootSignature);
 
   PIXPassHelpers::CreateGlobalUAVResource(DM, 0, "PIX_TestUAV0");
 
   {
-    const std::vector<uint8_t> &bytes = DM.GetSerializedRootSignature();
-    DxilVersionedRootSignatureDesc const *afterNoOp = nullptr;
-    DeserializeRootSignature(bytes.data(), static_cast<uint32_t>(bytes.size()),
-                             &afterNoOp);
-    VERIFY_ARE_EQUAL(afterNoOp->Desc_1_1.NumParameters, 2u);
-    VERIFY_IS_TRUE(afterNoOp->Desc_1_1.pParameters[1].Descriptor.Flags ==
+    const std::vector<uint8_t> &Bytes = DM.GetSerializedRootSignature();
+    DxilVersionedRootSignatureDesc const *AfterNoOp = nullptr;
+    DeserializeRootSignature(Bytes.data(), static_cast<uint32_t>(Bytes.size()),
+                             &AfterNoOp);
+    VERIFY_ARE_EQUAL(AfterNoOp->Desc_1_1.NumParameters, 2u);
+    VERIFY_IS_TRUE(AfterNoOp->Desc_1_1.pParameters[1].Descriptor.Flags ==
                    DxilRootDescriptorFlags::DataVolatile);
-    DeleteRootSignature(afterNoOp);
+    DeleteRootSignature(AfterNoOp);
   }
 
   PIXPassHelpers::CreateGlobalUAVResource(DM, 1, "PIX_TestUAV1");
 
   {
-    const std::vector<uint8_t> &bytes = DM.GetSerializedRootSignature();
-    DxilVersionedRootSignatureDesc const *afterAdd = nullptr;
-    DeserializeRootSignature(bytes.data(), static_cast<uint32_t>(bytes.size()),
-                             &afterAdd);
-    VERIFY_ARE_EQUAL(afterAdd->Desc_1_1.NumParameters, 3u);
-    VERIFY_IS_TRUE(afterAdd->Desc_1_1.pParameters[1].Descriptor.Flags ==
+    const std::vector<uint8_t> &Bytes = DM.GetSerializedRootSignature();
+    DxilVersionedRootSignatureDesc const *AfterAdd = nullptr;
+    DeserializeRootSignature(Bytes.data(), static_cast<uint32_t>(Bytes.size()),
+                             &AfterAdd);
+    VERIFY_ARE_EQUAL(AfterAdd->Desc_1_1.NumParameters, 3u);
+    VERIFY_IS_TRUE(AfterAdd->Desc_1_1.pParameters[1].Descriptor.Flags ==
                    DxilRootDescriptorFlags::DataVolatile);
-    VERIFY_ARE_EQUAL(afterAdd->Desc_1_1.pParameters[2].Descriptor.RegisterSpace,
+    VERIFY_ARE_EQUAL(AfterAdd->Desc_1_1.pParameters[2].Descriptor.RegisterSpace,
                      static_cast<uint32_t>(-2));
     VERIFY_ARE_EQUAL(
-        afterAdd->Desc_1_1.pParameters[2].Descriptor.ShaderRegister, 1u);
-    VERIFY_IS_TRUE(afterAdd->Desc_1_1.pParameters[2].Descriptor.Flags ==
+        AfterAdd->Desc_1_1.pParameters[2].Descriptor.ShaderRegister, 1u);
+    VERIFY_IS_TRUE(AfterAdd->Desc_1_1.pParameters[2].Descriptor.Flags ==
                    DxilRootDescriptorFlags::None);
-    DeleteRootSignature(afterAdd);
+    DeleteRootSignature(AfterAdd);
   }
 }
 
-static bool HasUnusedDeclaration(std::vector<std::string> const &lines,
-                                 std::string const &functionName) {
-  bool declared = false;
-  for (const std::string &line : lines) {
-    if (line.find("declare") != std::string::npos &&
-        line.find(functionName) != std::string::npos) {
-      declared = true;
+static bool hasUnusedDeclaration(std::vector<std::string> const &Lines,
+                                 std::string const &FunctionName) {
+  bool Declared = false;
+  for (const std::string &Line : Lines) {
+    if (Line.find("declare") != std::string::npos &&
+        Line.find(FunctionName) != std::string::npos) {
+      Declared = true;
     }
-    if (line.find("call") != std::string::npos &&
-        line.find(functionName) != std::string::npos) {
+    if (Line.find("call") != std::string::npos &&
+        Line.find(FunctionName) != std::string::npos) {
       return false;
     }
   }
-  return declared;
+  return Declared;
 }
 
-static bool HasDeclaration(const std::string &disassembly,
-                           const std::string &functionName) {
-  for (const std::string &line : Tokenize(disassembly, "\n")) {
-    if (line.find("declare") != std::string::npos &&
-        line.find(functionName) != std::string::npos) {
+static bool hasDeclaration(const std::string &Disassembly,
+                           const std::string &FunctionName) {
+  for (const std::string &Line : Tokenize(Disassembly, "\n")) {
+    if (Line.find("declare") != std::string::npos &&
+        Line.find(FunctionName) != std::string::npos) {
       return true;
     }
   }
   return false;
 }
 
-static std::string FindDeclarationLine(const std::string &disassembly,
-                                       const std::string &functionName) {
-  for (const std::string &line : Tokenize(disassembly, "\n")) {
-    if (line.find("declare") != std::string::npos &&
-        line.find(functionName) != std::string::npos) {
-      return line;
+static std::string findDeclarationLine(const std::string &Disassembly,
+                                       const std::string &FunctionName) {
+  for (const std::string &Line : Tokenize(Disassembly, "\n")) {
+    if (Line.find("declare") != std::string::npos &&
+        Line.find(FunctionName) != std::string::npos) {
+      return Line;
     }
   }
   return {};
 }
 
-static bool HasDeclarationLine(const std::string &disassembly,
-                               const std::string &declaration) {
-  for (const std::string &line : Tokenize(disassembly, "\n")) {
-    if (line == declaration) {
+static bool hasDeclarationLine(const std::string &Disassembly,
+                               const std::string &Declaration) {
+  for (const std::string &Line : Tokenize(Disassembly, "\n")) {
+    if (Line == Declaration) {
       return true;
     }
   }
@@ -3552,90 +3554,90 @@ static bool HasDeclarationLine(const std::string &disassembly,
 }
 
 TEST_F(PixTest, ConstantColor_UnusedIntOverloadIsErased) {
-  const char *source = R"x(
+  const char *Source = R"x(
 float4 main() : SV_Target
 {
     return float4(1, 2, 3, 4);
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  SinglePassOutput output =
-      RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      runSinglePass(Compiled, L"-hlsl-dxil-constantColor");
 
-  VERIFY_IS_FALSE(HasUnusedDeclaration(output.Lines, "dx.op.storeOutput.i32"));
-  VerifyInstrumentedModuleIsValid(output.Module,
+  VERIFY_IS_FALSE(hasUnusedDeclaration(Output.Lines, "dx.op.storeOutput.i32"));
+  verifyInstrumentedModuleIsValid(Output.Module,
                                   "constant-colour substitution");
 }
 
 TEST_F(PixTest, ConstantColor_NoTargetOverloadsAreErased) {
-  const char *source = R"x(
+  const char *Source = R"x(
 [numthreads(1, 1, 1)]
 void main()
 {
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"cs_6_0", {L"-Od"});
-  SinglePassOutput output =
-      RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
-  const std::string disassembly = Disassemble(output.Module);
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"cs_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      runSinglePass(Compiled, L"-hlsl-dxil-constantColor");
+  const std::string Disassembly = Disassemble(Output.Module);
 
-  VerifyInstrumentedModuleIsValid(
-      output.Module, "constant-colour substitution with no target");
-  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.storeOutput.f32"));
-  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.storeOutput.i32"));
+  verifyInstrumentedModuleIsValid(
+      Output.Module, "constant-colour substitution with no target");
+  VERIFY_IS_FALSE(hasDeclaration(Disassembly, "dx.op.storeOutput.f32"));
+  VERIFY_IS_FALSE(hasDeclaration(Disassembly, "dx.op.storeOutput.i32"));
 }
 
 TEST_F(PixTest, RemoveDiscards_UnusedDiscardOverloadIsErased) {
-  const char *source = R"x(
+  const char *Source = R"x(
 float4 main() : SV_Target
 {
     return float4(1, 2, 3, 4);
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  SinglePassOutput output =
-      RunSinglePass(compiled, L"-hlsl-dxil-remove-discards");
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      runSinglePass(Compiled, L"-hlsl-dxil-remove-discards");
 
-  VERIFY_IS_FALSE(HasUnusedDeclaration(output.Lines, "dx.op.discard"));
-  VerifyInstrumentedModuleIsValid(output.Module,
+  VERIFY_IS_FALSE(hasUnusedDeclaration(Output.Lines, "dx.op.discard"));
+  verifyInstrumentedModuleIsValid(Output.Module,
                                   "discard removal with no discard");
 }
 
 TEST_F(PixTest, OperationCacheCleanup_RemovesErasedFunctions) {
-  const char *source = R"x(
+  const char *Source = R"x(
 float4 main() : SV_Target
 {
     return float4(1, 2, 3, 4);
 })x";
 
-  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"ps_6_0", {});
-  ModuleAndHangersOn moduleEtc(compiled);
-  DxilModule &DM = moduleEtc.GetDxilModule();
+  CComPtr<IDxcBlob> Compiled = Compile(m_dllSupport, Source, L"ps_6_0", {});
+  ModuleAndHangersOn ModuleEtc(Compiled);
+  DxilModule &DM = ModuleEtc.GetDxilModule();
   OP *HlslOP = DM.GetOP();
-  llvm::Function *discard =
+  llvm::Function *Discard =
       HlslOP->GetOpFunc(DXIL::OpCode::Discard,
                         llvm::Type::getVoidTy(DM.GetModule()->getContext()));
 
   VERIFY_ARE_EQUAL(1u,
                    static_cast<unsigned>(
                        HlslOP->GetOpFuncList(DXIL::OpCode::Discard).size()));
-  PIXPassHelpers::EraseIfUnused(DM, discard);
+  PIXPassHelpers::eraseIfUnused(DM, Discard);
   VERIFY_ARE_EQUAL(0u,
                    static_cast<unsigned>(
                        HlslOP->GetOpFuncList(DXIL::OpCode::Discard).size()));
 
-  llvm::Function *recreated =
+  llvm::Function *Recreated =
       HlslOP->GetOpFunc(DXIL::OpCode::Discard,
                         llvm::Type::getVoidTy(DM.GetModule()->getContext()));
-  VERIFY_IS_NOT_NULL(recreated);
-  PIXPassHelpers::EraseIfUnused(DM, recreated);
+  VERIFY_IS_NOT_NULL(Recreated);
+  PIXPassHelpers::eraseIfUnused(DM, Recreated);
 }
 
 TEST_F(PixTest, DynamicResourceCleanup_VisitorStopsEarly) {
-  const char *source = R"x(
+  const char *Source = R"x(
 Texture2D<float4> textures[] : register(t0);
 
 float4 main(float2 uv : TEXCOORD0) : SV_Target
@@ -3643,18 +3645,18 @@ float4 main(float2 uv : TEXCOORD0) : SV_Target
     return textures[(uint)uv.x].Load(int3(0, 0, 0));
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  ModuleAndHangersOn moduleEtc(compiled);
-  DxilModule &DM = moduleEtc.GetDxilModule();
-  bool visitorCalled = false;
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  ModuleAndHangersOn ModuleEtc(Compiled);
+  DxilModule &DM = ModuleEtc.GetDxilModule();
+  bool VisitorCalled = false;
   PIXPassHelpers::ForEachDynamicallyIndexedResource(
-      DM, [&visitorCalled](bool, llvm::Instruction *, llvm::Value *) {
-        visitorCalled = true;
+      DM, [&VisitorCalled](bool, llvm::Instruction *, llvm::Value *) {
+        VisitorCalled = true;
         return false;
       });
 
-  VERIFY_IS_TRUE(visitorCalled);
+  VERIFY_IS_TRUE(VisitorCalled);
   OP *HlslOP = DM.GetOP();
   VERIFY_ARE_EQUAL(
       0u,
@@ -3759,9 +3761,9 @@ void PixTest::TestNuriCase(const char *source, const wchar_t *target,
         Compile(m_dllSupport, source, target, compilationOptions);
 
     std::string outputText;
-    PassOutput output =
+    PassOutput Output =
         RunDxilNonUniformResourceIndexInstrumentation(compiledLib, outputText);
-    const std::vector<std::string> &dxilLines = output.lines;
+    const std::vector<std::string> &dxilLines = Output.lines;
 
     VERIFY_ARE_EQUAL(NuriGetWaveInstructionCount(dxilLines), expectedResult);
 
@@ -3812,7 +3814,7 @@ TEST_F(PixTest, NonUniformResourceIndex_QualifiedCleanupValidates) {
     return;
   }
 
-  const char *source = R"x(
+  const char *Source = R"x(
 Texture2D<float4> textures[] : register(t0);
 
 float4 main(float2 uv : TEXCOORD0) : SV_Target
@@ -3821,18 +3823,18 @@ float4 main(float2 uv : TEXCOORD0) : SV_Target
     return textures[NonUniformResourceIndex(index)].Load(int3(0, 0, 0));
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_6", {L"-Od"});
-  std::string outputText;
-  PassOutput output =
-      RunDxilNonUniformResourceIndexInstrumentation(compiled, outputText);
-  const std::string disassembly = Disassemble(output.blob);
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_6", {L"-Od"});
+  std::string OutputText;
+  PassOutput Output =
+      RunDxilNonUniformResourceIndexInstrumentation(Compiled, OutputText);
+  const std::string Disassembly = Disassemble(Output.blob);
 
-  VerifyInstrumentedModuleIsValid(
-      output.blob, "qualified non-uniform resource index instrumentation");
-  VERIFY_ARE_EQUAL(0u, NuriGetWaveInstructionCount(output.lines));
-  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.waveActiveAllEqual.i32"));
-  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.atomicBinOp.i32"));
+  verifyInstrumentedModuleIsValid(
+      Output.blob, "qualified non-uniform resource index instrumentation");
+  VERIFY_ARE_EQUAL(0u, NuriGetWaveInstructionCount(Output.lines));
+  VERIFY_IS_FALSE(hasDeclaration(Disassembly, "dx.op.waveActiveAllEqual.i32"));
+  VERIFY_IS_FALSE(hasDeclaration(Disassembly, "dx.op.atomicBinOp.i32"));
 }
 
 TEST_F(PixTest, NonUniformResourceIndex_DescriptorHeap) {
@@ -4247,7 +4249,7 @@ void main() {
       foundDebugBreak = true;
   }
   VERIFY_IS_FALSE(foundDebugBreak);
-  VerifyInstrumentedModuleIsValid(output.blob,
+  verifyInstrumentedModuleIsValid(output.blob,
                                   "debug-break instrumentation with no call");
 }
 

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -33,7 +33,10 @@
 #include <atlfile.h>
 #endif
 
+#include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilOperations.h"
+#include "dxc/DXIL/DxilSubobject.h"
 
 #include "dxc/Test/DxcTestUtils.h"
 #include "dxc/Test/HLSLTestData.h"
@@ -65,6 +68,7 @@
 #include <fstream>
 
 #include <../lib/DxilDia/DxcPixLiveVariables_FragmentIterator.h>
+#include <../lib/DxilPIXPasses/PixPassHelpers.h>
 #include <dxc/DxilPIXPasses/DxilPIXVirtualRegisters.h>
 
 #include "PixTestUtils.h"
@@ -143,6 +147,16 @@ public:
 
   TEST_METHOD(RootSignatureUpgrade_SubObjects)
   TEST_METHOD(RootSignatureUpgrade_Annotation)
+  TEST_METHOD(ToolsUav_TwoPixPassesShareOneResource)
+  TEST_METHOD(ToolsUav_LibraryWithTwoEntryPointsCreatesOnePair)
+  TEST_METHOD(ToolsUav_ExtendsEveryGlobalRootSignatureSubobject)
+  TEST_METHOD(DebugInstrumentation_RawBufferShaderFlagDeclared)
+  TEST_METHOD(ToolsUav_RootSignatureSerializationFailurePreservesSignature)
+  TEST_METHOD(ConstantColor_UnusedIntOverloadIsErased)
+  TEST_METHOD(ConstantColor_NoTargetOverloadsAreErased)
+  TEST_METHOD(RemoveDiscards_UnusedDiscardOverloadIsErased)
+  TEST_METHOD(OperationCacheCleanup_RemovesErasedFunctions)
+  TEST_METHOD(DynamicResourceCleanup_VisitorStopsEarly)
 
   TEST_METHOD(DxilPIXDXRInvocationsLog_SanityTest)
   TEST_METHOD(DxilPIXDXRInvocationsLog_EmbeddedRootSigs)
@@ -157,6 +171,7 @@ public:
   TEST_METHOD(DebugBreakInstrumentation_Multiple)
 
   TEST_METHOD(NonUniformResourceIndex_Resource)
+  TEST_METHOD(NonUniformResourceIndex_QualifiedCleanupValidates)
   TEST_METHOD(NonUniformResourceIndex_DescriptorHeap)
   TEST_METHOD(NonUniformResourceIndex_Raytracing)
 
@@ -283,6 +298,7 @@ public:
     std::vector<LPCWSTR> Options;
     Options.push_back(L"-opt-mod-passes");
     Options.push_back(passOption);
+    Options.push_back(L"-hlsl-dxilemit");
 
     CComPtr<IDxcBlob> pOptimizedModule;
     CComPtr<IDxcBlobEncoding> pText;
@@ -528,6 +544,12 @@ public:
   }
 
   void ValidateAccessTrackingMods(const char *hlsl, bool modsExpected);
+  void LoadSubobjectsFromContainerIntoModule(IDxcBlob *container,
+                                             DxilModule &DM);
+  void VerifyGlobalRootSignaturesHaveToolsUAVs(
+      DxilSubobjects *subObjects,
+      const std::vector<std::string> &expectedRootSignatureNames,
+      const std::vector<uint32_t> &expectedShaderRegisters);
 
   class ModuleAndHangersOn {
     std::unique_ptr<llvm::LLVMContext> llvmContext;
@@ -611,10 +633,11 @@ public:
   void ValidateAllocaWrite(std::vector<AllocaWrite> const &allocaWrites,
                            size_t index, const char *name);
   PassOutput RunShaderAccessTrackingPass(IDxcBlob *blob);
-  std::string RunDxilPIXAddTidToAmplificationShaderPayloadPass(IDxcBlob *blob);
+  CComPtr<IDxcBlob>
+  RunDxilPIXAddTidToAmplificationShaderPayloadPass(IDxcBlob *blob);
   CComPtr<IDxcBlob> RunDxilPIXMeshShaderOutputPass(IDxcBlob *blob);
   CComPtr<IDxcBlob> RunDxilPIXDXRInvocationsLog(IDxcBlob *blob);
-  std::vector<std::string>
+  PassOutput
   RunDxilNonUniformResourceIndexInstrumentation(IDxcBlob *blob,
                                                 std::string &outputText);
   void TestNuriCase(const char *source, const wchar_t *target,
@@ -630,6 +653,122 @@ bool PixTest::InitSupport() {
     m_ver.Initialize(m_dllSupport);
   }
   return true;
+}
+
+static unsigned CountToolsUAVs(DxilModule &DM) {
+  unsigned count = 0;
+  for (auto const &uav : DM.GetUAVs()) {
+    if (uav->GetSpaceID() == static_cast<uint32_t>(-2)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+static int CountToolsUAVRecords(std::vector<std::string> const &lines) {
+  int count = 0;
+  for (auto const &line : lines) {
+    if (!line.empty() && line[0] == '!' &&
+        line.find(", i32 -2, i32 ") != std::string::npos) {
+      count++;
+    }
+  }
+  return count;
+}
+
+static bool
+RootSignatureHasToolsUAV(const DxilVersionedRootSignatureDesc *rootSignature,
+                         uint32_t shaderRegister) {
+  switch (rootSignature->Version) {
+  case DxilRootSignatureVersion::Version_1_0: {
+    const DxilRootSignatureDesc &desc = rootSignature->Desc_1_0;
+    for (uint32_t i = 0; i < desc.NumParameters; ++i) {
+      const DxilRootParameter &param = desc.pParameters[i];
+      if (param.ParameterType == DxilRootParameterType::UAV &&
+          param.Descriptor.RegisterSpace == static_cast<uint32_t>(-2) &&
+          param.Descriptor.ShaderRegister == shaderRegister) {
+        return true;
+      }
+    }
+    break;
+  }
+  case DxilRootSignatureVersion::Version_1_1: {
+    const DxilRootSignatureDesc1 &desc = rootSignature->Desc_1_1;
+    for (uint32_t i = 0; i < desc.NumParameters; ++i) {
+      const DxilRootParameter1 &param = desc.pParameters[i];
+      if (param.ParameterType == DxilRootParameterType::UAV &&
+          param.Descriptor.RegisterSpace == static_cast<uint32_t>(-2) &&
+          param.Descriptor.ShaderRegister == shaderRegister) {
+        return true;
+      }
+    }
+    break;
+  }
+  }
+  return false;
+}
+
+void PixTest::LoadSubobjectsFromContainerIntoModule(IDxcBlob *container,
+                                                    DxilModule &DM) {
+  const char *blobContent =
+      reinterpret_cast<const char *>(container->GetBufferPointer());
+  const unsigned blobSize = container->GetBufferSize();
+  const hlsl::DxilContainerHeader *containerHeader =
+      hlsl::IsDxilContainerLike(blobContent, blobSize);
+  VERIFY_ARE_NOT_EQUAL(containerHeader, nullptr);
+
+  const hlsl::DxilPartHeader *partHeader =
+      GetDxilPartByType(containerHeader, hlsl::DFCC_RuntimeData);
+  VERIFY_ARE_NOT_EQUAL(partHeader, nullptr);
+
+  hlsl::RDAT::DxilRuntimeData rdat(GetDxilPartData(partHeader),
+                                   partHeader->PartSize);
+  std::unique_ptr<DxilSubobjects> subObjects(new DxilSubobjects());
+  VERIFY_IS_TRUE(LoadSubobjectsFromRDAT(*subObjects, rdat));
+  DM.ResetSubobjects(subObjects.release());
+}
+
+void PixTest::VerifyGlobalRootSignaturesHaveToolsUAVs(
+    DxilSubobjects *subObjects,
+    const std::vector<std::string> &expectedRootSignatureNames,
+    const std::vector<uint32_t> &expectedShaderRegisters) {
+  VERIFY_IS_NOT_NULL(subObjects);
+
+  std::map<std::string, bool> foundRootSignatures;
+  for (const std::string &rootSignatureName : expectedRootSignatureNames) {
+    foundRootSignatures[rootSignatureName] = false;
+  }
+
+  for (auto const &subObject : subObjects->GetSubobjects()) {
+    if (subObject.second->GetKind() !=
+        hlsl::DXIL::SubobjectKind::GlobalRootSignature) {
+      continue;
+    }
+
+    const std::string subObjectName = subObject.first.str();
+    if (foundRootSignatures.find(subObjectName) == foundRootSignatures.end()) {
+      continue;
+    }
+
+    const void *data = nullptr;
+    uint32_t size = 0;
+    constexpr bool notALocalRS = false;
+    VERIFY_IS_TRUE(
+        subObject.second->GetRootSignature(notALocalRS, data, size, nullptr));
+
+    DxilVersionedRootSignatureDesc const *rootSignature = nullptr;
+    DeserializeRootSignature(data, size, &rootSignature);
+    for (uint32_t expectedShaderRegister : expectedShaderRegisters) {
+      VERIFY_IS_TRUE(
+          RootSignatureHasToolsUAV(rootSignature, expectedShaderRegister));
+    }
+    DeleteRootSignature(rootSignature);
+    foundRootSignatures[subObjectName] = true;
+  }
+
+  for (const auto &foundRootSignature : foundRootSignatures) {
+    VERIFY_IS_TRUE(foundRootSignature.second);
+  }
 }
 
 void PixTest::TestPixUAVCase(char const *hlsl, wchar_t const *model,
@@ -846,7 +985,7 @@ CComPtr<IDxcBlob> PixTest::RunDxilPIXDXRInvocationsLog(IDxcBlob *blob) {
   return pOptimizedModule;
 }
 
-std::vector<std::string> PixTest::RunDxilNonUniformResourceIndexInstrumentation(
+PassOutput PixTest::RunDxilNonUniformResourceIndexInstrumentation(
     IDxcBlob *blob, std::string &outputText) {
 
   CComPtr<IDxcBlob> dxil = FindModule(DFCC_ShaderDebugInfoDXIL, blob);
@@ -865,11 +1004,13 @@ std::vector<std::string> PixTest::RunDxilNonUniformResourceIndexInstrumentation(
 
   outputText = BlobToUtf8(pText);
 
-  const std::string disassembly = Disassemble(pOptimizedModule);
-  return Tokenize(disassembly, "\n");
+  PassOutput result;
+  result.blob = pOptimizedModule;
+  result.lines = Tokenize(Disassemble(pOptimizedModule), "\n");
+  return result;
 }
 
-std::string
+CComPtr<IDxcBlob>
 PixTest::RunDxilPIXAddTidToAmplificationShaderPayloadPass(IDxcBlob *blob) {
   CComPtr<IDxcBlob> dxil = FindModule(DFCC_ShaderDebugInfoDXIL, blob);
   CComPtr<IDxcOptimizer> pOptimizer;
@@ -885,13 +1026,15 @@ PixTest::RunDxilPIXAddTidToAmplificationShaderPayloadPass(IDxcBlob *blob) {
   VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
       dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
 
-  std::string outputText;
-  if (pText->GetBufferSize() != 0) {
-    outputText = reinterpret_cast<const char *>(pText->GetBufferPointer());
-  }
-
-  return outputText;
+  return pOptimizedModule;
 }
+
+static bool HasDeclaration(const std::string &disassembly,
+                           const std::string &functionName);
+static std::string FindDeclarationLine(const std::string &disassembly,
+                                       const std::string &functionName);
+static bool HasDeclarationLine(const std::string &disassembly,
+                               const std::string &declaration);
 
 TEST_F(PixTest, AddToASPayload) {
 
@@ -934,10 +1077,29 @@ void MSMain(
   )";
 
   auto as = Compile(m_dllSupport, hlsl, L"as_6_6", {}, L"ASMain");
-  RunDxilPIXAddTidToAmplificationShaderPayloadPass(as);
+  const std::string originalDispatchMeshDeclaration =
+      FindDeclarationLine(Disassemble(as), "dx.op.dispatchMesh");
+  VERIFY_IS_FALSE(originalDispatchMeshDeclaration.empty());
+
+  auto asOutput = RunDxilPIXAddTidToAmplificationShaderPayloadPass(as);
+  VERIFY_IS_FALSE(HasDeclarationLine(Disassemble(asOutput),
+                                     originalDispatchMeshDeclaration));
 
   auto ms = Compile(m_dllSupport, hlsl, L"ms_6_6", {}, L"MSMain");
-  RunDxilPIXMeshShaderOutputPass(ms);
+  const std::string originalGetMeshPayloadDeclaration =
+      FindDeclarationLine(Disassemble(ms), "dx.op.getMeshPayload");
+  VERIFY_IS_FALSE(originalGetMeshPayloadDeclaration.empty());
+
+  auto msOutput = RunDxilPIXMeshShaderOutputPass(ms);
+  const std::string meshDisassembly = Disassemble(msOutput);
+  VERIFY_IS_FALSE(
+      HasDeclarationLine(meshDisassembly, originalGetMeshPayloadDeclaration));
+  VERIFY_IS_FALSE(
+      HasDeclaration(meshDisassembly, "dx.op.storeVertexOutput.i32"));
+  VERIFY_IS_FALSE(
+      HasDeclaration(meshDisassembly, "dx.op.storeVertexOutput.i16"));
+  VERIFY_IS_FALSE(
+      HasDeclaration(meshDisassembly, "dx.op.storeVertexOutput.f16"));
 }
 unsigned FindOrAddVSInSignatureElementForInstanceOrVertexID(
     hlsl::DxilSignature &InputSignature, hlsl::DXIL::SemanticKind semanticKind);
@@ -3015,6 +3177,373 @@ float4 main(int i : A, float j : B) : SV_TARGET
   VERIFY_IS_TRUE(foundGlobalRS);
 }
 
+TEST_F(PixTest, ToolsUav_TwoPixPassesShareOneResource) {
+  const char *source = R"x(
+RWByteAddressBuffer output : register(u0);
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    output.Store(4 * tid.x, tid.x);
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
+  auto debugOutput = RunDebugPass(compiled);
+  auto accessOutput = RunShaderAccessTrackingPass(debugOutput.blob);
+
+  ModuleAndHangersOn moduleEtc(accessOutput.blob);
+  VERIFY_ARE_EQUAL(1u, CountToolsUAVs(moduleEtc.GetDxilModule()));
+  VerifyInstrumentedModuleIsValid(
+      accessOutput.blob,
+      "debug instrumentation followed by shader access tracking");
+}
+
+TEST_F(PixTest, ToolsUav_LibraryWithTwoEntryPointsCreatesOnePair) {
+  const char *source = R"x(
+struct [raypayload] MyPayload
+{
+    float2 barycentrics : read(caller) : write(caller,anyhit);
+    uint primitiveIndex : read(caller) : write(caller,anyhit);
+};
+
+[shader("miss")]
+void MissOne(inout MyPayload payload)
+{
+    payload.primitiveIndex = 1;
+}
+
+[shader("miss")]
+void MissTwo(inout MyPayload payload)
+{
+    payload.primitiveIndex = 2;
+}
+)x";
+
+  auto compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
+  auto output = RunDxilPIXDXRInvocationsLog(compiled);
+
+  auto lines = Tokenize(Disassemble(output), "\n");
+  VERIFY_ARE_EQUAL(2, CountToolsUAVRecords(lines));
+}
+
+TEST_F(PixTest, ToolsUav_ExtendsEveryGlobalRootSignatureSubobject) {
+  const char *source = R"x(
+GlobalRootSignature firstRootSignature = {"CBV(b0)"};
+GlobalRootSignature secondRootSignature = {"SRV(t0)"};
+
+SubobjectToExportsAssociation firstAssociation =
+{
+    "firstRootSignature",
+    "MyClosestHit"
+};
+
+SubobjectToExportsAssociation secondAssociation =
+{
+    "secondRootSignature",
+    "MyMiss"
+};
+
+struct MyPayload
+{
+    float4 color;
+};
+
+[shader("raygeneration")]
+void MyRayGen()
+{
+}
+
+[shader("closesthit")]
+void MyClosestHit(inout MyPayload payload,
+                  in BuiltInTriangleIntersectionAttributes attr)
+{
+}
+
+[shader("miss")]
+void MyMiss(inout MyPayload payload)
+{
+}
+)x";
+
+  auto compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
+  ModuleAndHangersOn moduleEtc(compiled);
+  DxilModule &DM = moduleEtc.GetDxilModule();
+  LoadSubobjectsFromContainerIntoModule(compiled, DM);
+  PIXPassHelpers::CreateGlobalUAVResource(DM, 0, "PIX_CountUAV_Handle");
+  PIXPassHelpers::CreateGlobalUAVResource(DM, 1, "PIX_LogUAV_Handle");
+
+  VerifyGlobalRootSignaturesHaveToolsUAVs(
+      DM.GetSubobjects(), {"firstRootSignature", "secondRootSignature"},
+      {0, 1});
+}
+
+TEST_F(PixTest, DebugInstrumentation_RawBufferShaderFlagDeclared) {
+  const char *source = R"x(
+[numthreads(1, 1, 1)]
+void main(uint threadId : SV_DispatchThreadID)
+{
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
+  auto output = RunDebugPass(compiled);
+  auto lines = Tokenize(Disassemble(output.blob), "\n");
+
+  constexpr uint64_t EnableRawAndStructuredBuffers = 0x10;
+  bool foundShaderFlags = false;
+  uint64_t shaderFlags = 0;
+  const std::string tagPrefix = "!{i32 0, i64 ";
+  for (auto const &line : lines) {
+    const auto tagStart = line.find(tagPrefix);
+    if (tagStart == std::string::npos) {
+      continue;
+    }
+    shaderFlags =
+        strtoull(line.c_str() + tagStart + tagPrefix.length(), nullptr, 10);
+    foundShaderFlags = true;
+    break;
+  }
+
+  VERIFY_IS_TRUE(foundShaderFlags);
+  VERIFY_ARE_EQUAL(EnableRawAndStructuredBuffers,
+                   shaderFlags & EnableRawAndStructuredBuffers);
+  VerifyInstrumentedModuleIsValid(output.blob,
+                                  "debug instrumentation shader flags");
+}
+
+TEST_F(PixTest, ToolsUav_RootSignatureSerializationFailurePreservesSignature) {
+  const char *source = R"x(
+[numthreads(1, 1, 1)]
+void main()
+{
+})x";
+
+  DxilDescriptorRange range = {};
+  range.RangeType = DxilDescriptorRangeType::UAV;
+  range.NumDescriptors = 1;
+  range.BaseShaderRegister = 0;
+  range.RegisterSpace = static_cast<uint32_t>(-2);
+  range.OffsetInDescriptorsFromTableStart = DxilDescriptorRangeOffsetAppend;
+
+  DxilRootParameter parameter = {};
+  parameter.ParameterType = DxilRootParameterType::DescriptorTable;
+  parameter.DescriptorTable.NumDescriptorRanges = 1;
+  parameter.DescriptorTable.pDescriptorRanges = &range;
+  parameter.ShaderVisibility = DxilShaderVisibility::All;
+
+  DxilVersionedRootSignatureDesc rootSignature = {};
+  rootSignature.Version = DxilRootSignatureVersion::Version_1_0;
+  rootSignature.Desc_1_0.NumParameters = 1;
+  rootSignature.Desc_1_0.pParameters = &parameter;
+  rootSignature.Desc_1_0.Flags = DxilRootSignatureFlags::None;
+
+  CComPtr<IDxcBlob> serializedRootSignature;
+  CComPtr<IDxcBlobEncoding> errorBlob;
+  SerializeRootSignature(&rootSignature, &serializedRootSignature, &errorBlob,
+                         true);
+  VERIFY_IS_NOT_NULL(serializedRootSignature);
+
+  auto serializedData =
+      static_cast<const uint8_t *>(serializedRootSignature->GetBufferPointer());
+  std::vector<uint8_t> originalRootSignature(
+      serializedData,
+      serializedData + serializedRootSignature->GetBufferSize());
+
+  auto compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
+  ModuleAndHangersOn moduleEtc(compiled);
+  DxilModule &DM = moduleEtc.GetDxilModule();
+  DM.ResetSerializedRootSignature(originalRootSignature);
+
+  std::unique_ptr<DxilSubobjects> subObjects(new DxilSubobjects());
+  constexpr bool notALocalRootSignature = false;
+  subObjects->CreateRootSignature(
+      "testRootSignature", notALocalRootSignature, originalRootSignature.data(),
+      static_cast<uint32_t>(originalRootSignature.size()));
+  DM.ResetSubobjects(subObjects.release());
+
+  PIXPassHelpers::CreateGlobalUAVResource(DM, 0, "PIX_TestUAV");
+
+  const std::vector<uint8_t> &actualRootSignature =
+      DM.GetSerializedRootSignature();
+  VERIFY_ARE_EQUAL(originalRootSignature.size(), actualRootSignature.size());
+  VERIFY_IS_TRUE(std::equal(originalRootSignature.begin(),
+                            originalRootSignature.end(),
+                            actualRootSignature.begin()));
+
+  bool foundRootSignature = false;
+  for (auto const &subObject : DM.GetSubobjects()->GetSubobjects()) {
+    if (subObject.first != "testRootSignature") {
+      continue;
+    }
+
+    const void *data = nullptr;
+    uint32_t size = 0;
+    VERIFY_IS_TRUE(subObject.second->GetRootSignature(notALocalRootSignature,
+                                                      data, size, nullptr));
+    VERIFY_ARE_EQUAL(originalRootSignature.size(), static_cast<size_t>(size));
+    VERIFY_IS_TRUE(std::equal(originalRootSignature.begin(),
+                              originalRootSignature.end(),
+                              static_cast<const uint8_t *>(data)));
+    foundRootSignature = true;
+  }
+  VERIFY_IS_TRUE(foundRootSignature);
+}
+
+static bool HasUnusedDeclaration(std::vector<std::string> const &lines,
+                                 std::string const &functionName) {
+  bool declared = false;
+  for (auto const &line : lines) {
+    if (line.find("declare") != std::string::npos &&
+        line.find(functionName) != std::string::npos) {
+      declared = true;
+    }
+    if (line.find("call") != std::string::npos &&
+        line.find(functionName) != std::string::npos) {
+      return false;
+    }
+  }
+  return declared;
+}
+
+static bool HasDeclaration(const std::string &disassembly,
+                           const std::string &functionName) {
+  for (const std::string &line : Tokenize(disassembly, "\n")) {
+    if (line.find("declare") != std::string::npos &&
+        line.find(functionName) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static std::string FindDeclarationLine(const std::string &disassembly,
+                                       const std::string &functionName) {
+  for (const std::string &line : Tokenize(disassembly, "\n")) {
+    if (line.find("declare") != std::string::npos &&
+        line.find(functionName) != std::string::npos) {
+      return line;
+    }
+  }
+  return {};
+}
+
+static bool HasDeclarationLine(const std::string &disassembly,
+                               const std::string &declaration) {
+  for (const std::string &line : Tokenize(disassembly, "\n")) {
+    if (line == declaration) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST_F(PixTest, ConstantColor_UnusedIntOverloadIsErased) {
+  const char *source = R"x(
+float4 main() : SV_Target
+{
+    return float4(1, 2, 3, 4);
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  auto output = RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
+
+  VERIFY_IS_FALSE(HasUnusedDeclaration(output.Lines, "dx.op.storeOutput.i32"));
+  VerifyInstrumentedModuleIsValid(output.Module,
+                                  "constant-colour substitution");
+}
+
+TEST_F(PixTest, ConstantColor_NoTargetOverloadsAreErased) {
+  const char *source = R"x(
+[numthreads(1, 1, 1)]
+void main()
+{
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"cs_6_0", {L"-Od"});
+  auto output = RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
+  const std::string disassembly = Disassemble(output.Module);
+
+  VerifyInstrumentedModuleIsValid(
+      output.Module, "constant-colour substitution with no target");
+  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.storeOutput.f32"));
+  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.storeOutput.i32"));
+}
+
+TEST_F(PixTest, RemoveDiscards_UnusedDiscardOverloadIsErased) {
+  const char *source = R"x(
+float4 main() : SV_Target
+{
+    return float4(1, 2, 3, 4);
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  auto output = RunSinglePass(compiled, L"-hlsl-dxil-remove-discards");
+
+  VERIFY_IS_FALSE(HasUnusedDeclaration(output.Lines, "dx.op.discard"));
+  VerifyInstrumentedModuleIsValid(output.Module,
+                                  "discard removal with no discard");
+}
+
+TEST_F(PixTest, OperationCacheCleanup_RemovesErasedFunctions) {
+  const char *source = R"x(
+float4 main() : SV_Target
+{
+    return float4(1, 2, 3, 4);
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {});
+  ModuleAndHangersOn moduleEtc(compiled);
+  DxilModule &DM = moduleEtc.GetDxilModule();
+  OP *HlslOP = DM.GetOP();
+  llvm::Function *discard =
+      HlslOP->GetOpFunc(DXIL::OpCode::Discard,
+                        llvm::Type::getVoidTy(DM.GetModule()->getContext()));
+
+  VERIFY_ARE_EQUAL(1u,
+                   static_cast<unsigned>(
+                       HlslOP->GetOpFuncList(DXIL::OpCode::Discard).size()));
+  PIXPassHelpers::EraseIfUnused(DM, discard);
+  VERIFY_ARE_EQUAL(0u,
+                   static_cast<unsigned>(
+                       HlslOP->GetOpFuncList(DXIL::OpCode::Discard).size()));
+
+  llvm::Function *recreated =
+      HlslOP->GetOpFunc(DXIL::OpCode::Discard,
+                        llvm::Type::getVoidTy(DM.GetModule()->getContext()));
+  VERIFY_IS_NOT_NULL(recreated);
+  PIXPassHelpers::EraseIfUnused(DM, recreated);
+}
+
+TEST_F(PixTest, DynamicResourceCleanup_VisitorStopsEarly) {
+  const char *source = R"x(
+Texture2D<float4> textures[] : register(t0);
+
+float4 main(float2 uv : TEXCOORD0) : SV_Target
+{
+    return textures[(uint)uv.x].Load(int3(0, 0, 0));
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  ModuleAndHangersOn moduleEtc(compiled);
+  DxilModule &DM = moduleEtc.GetDxilModule();
+  bool visitorCalled = false;
+  PIXPassHelpers::ForEachDynamicallyIndexedResource(
+      DM, [&visitorCalled](bool, llvm::Instruction *, llvm::Value *) {
+        visitorCalled = true;
+        return false;
+      });
+
+  VERIFY_IS_TRUE(visitorCalled);
+  OP *HlslOP = DM.GetOP();
+  VERIFY_ARE_EQUAL(
+      0u,
+      static_cast<unsigned>(
+          HlslOP->GetOpFuncList(DXIL::OpCode::CreateHandleFromBinding).size()));
+  VERIFY_ARE_EQUAL(
+      0u,
+      static_cast<unsigned>(
+          HlslOP->GetOpFuncList(DXIL::OpCode::CreateHandleFromHeap).size()));
+}
+
 TEST_F(PixTest, DxilPIXDXRInvocationsLog_SanityTest) {
 
   const char *source = R"x(
@@ -3108,8 +3637,9 @@ void PixTest::TestNuriCase(const char *source, const wchar_t *target,
         Compile(m_dllSupport, source, target, compilationOptions);
 
     std::string outputText;
-    const std::vector<std::string> dxilLines =
+    PassOutput output =
         RunDxilNonUniformResourceIndexInstrumentation(compiledLib, outputText);
+    const std::vector<std::string> &dxilLines = output.lines;
 
     VERIFY_ARE_EQUAL(NuriGetWaveInstructionCount(dxilLines), expectedResult);
 
@@ -3153,6 +3683,33 @@ float4 main(float2 uv : TEXCOORD0) : SV_TARGET
 
   TestNuriCase(source, L"ps_6_6", 1);
   TestNuriCase(sourceWithNuri, L"ps_6_6", 0);
+}
+
+TEST_F(PixTest, NonUniformResourceIndex_QualifiedCleanupValidates) {
+  if (m_ver.SkipDxilVersion(1, 6)) {
+    return;
+  }
+
+  const char *source = R"x(
+Texture2D<float4> textures[] : register(t0);
+
+float4 main(float2 uv : TEXCOORD0) : SV_Target
+{
+    uint index = (uint)uv.x;
+    return textures[NonUniformResourceIndex(index)].Load(int3(0, 0, 0));
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_6", {L"-Od"});
+  std::string outputText;
+  PassOutput output =
+      RunDxilNonUniformResourceIndexInstrumentation(compiled, outputText);
+  const std::string disassembly = Disassemble(output.blob);
+
+  VerifyInstrumentedModuleIsValid(
+      output.blob, "qualified non-uniform resource index instrumentation");
+  VERIFY_ARE_EQUAL(0u, NuriGetWaveInstructionCount(output.lines));
+  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.waveActiveAllEqual.i32"));
+  VERIFY_IS_FALSE(HasDeclaration(disassembly, "dx.op.atomicBinOp.i32"));
 }
 
 TEST_F(PixTest, NonUniformResourceIndex_DescriptorHeap) {
@@ -3551,15 +4108,15 @@ void main() {
 }
 
 TEST_F(PixTest, DebugBreakInstrumentation_NoDebugBreak) {
+  if (m_ver.SkipDxilVersion(1, 10))
+    return;
 
   const char *source = R"x(
-RWByteAddressBuffer buf : register(u0);
 [numthreads(1, 1, 1)]
 void main() {
-    buf.Store(0, 1);
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
+  auto compiled = Compile(m_dllSupport, source, L"cs_6_10", {});
   auto output = RunDebugBreakPass(compiled);
   bool foundDebugBreak = false;
   for (auto const &line : output.lines) {
@@ -3567,6 +4124,8 @@ void main() {
       foundDebugBreak = true;
   }
   VERIFY_IS_FALSE(foundDebugBreak);
+  VerifyInstrumentedModuleIsValid(output.blob,
+                                  "debug-break instrumentation with no call");
 }
 
 TEST_F(PixTest, DebugBreakInstrumentation_Multiple) {

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -692,7 +692,7 @@ bool PixTest::InitSupport() {
 
 static unsigned CountToolsUAVs(DxilModule &DM) {
   unsigned count = 0;
-  for (auto const &uav : DM.GetUAVs()) {
+  for (const std::unique_ptr<DxilResource> &uav : DM.GetUAVs()) {
     if (uav->GetSpaceID() == static_cast<uint32_t>(-2)) {
       count++;
     }
@@ -702,7 +702,7 @@ static unsigned CountToolsUAVs(DxilModule &DM) {
 
 static int CountToolsUAVRecords(std::vector<std::string> const &lines) {
   int count = 0;
-  for (auto const &line : lines) {
+  for (const std::string &line : lines) {
     if (!line.empty() && line[0] == '!' &&
         line.find(", i32 -2, i32 ") != std::string::npos) {
       count++;
@@ -801,7 +801,8 @@ void PixTest::VerifyGlobalRootSignaturesHaveToolsUAVs(
     foundRootSignatures[subObjectName] = true;
   }
 
-  for (const auto &foundRootSignature : foundRootSignatures) {
+  for (const std::map<std::string, bool>::value_type &foundRootSignature :
+       foundRootSignatures) {
     VERIFY_IS_TRUE(foundRootSignature.second);
   }
 }
@@ -1116,7 +1117,8 @@ void MSMain(
       FindDeclarationLine(Disassemble(as), "dx.op.dispatchMesh");
   VERIFY_IS_FALSE(originalDispatchMeshDeclaration.empty());
 
-  auto asOutput = RunDxilPIXAddTidToAmplificationShaderPayloadPass(as);
+  CComPtr<IDxcBlob> asOutput =
+      RunDxilPIXAddTidToAmplificationShaderPayloadPass(as);
   VERIFY_IS_FALSE(HasDeclarationLine(Disassemble(asOutput),
                                      originalDispatchMeshDeclaration));
 
@@ -1125,7 +1127,7 @@ void MSMain(
       FindDeclarationLine(Disassemble(ms), "dx.op.getMeshPayload");
   VERIFY_IS_FALSE(originalGetMeshPayloadDeclaration.empty());
 
-  auto msOutput = RunDxilPIXMeshShaderOutputPass(ms);
+  CComPtr<IDxcBlob> msOutput = RunDxilPIXMeshShaderOutputPass(ms);
   const std::string meshDisassembly = Disassemble(msOutput);
   VERIFY_IS_FALSE(
       HasDeclarationLine(meshDisassembly, originalGetMeshPayloadDeclaration));
@@ -3222,9 +3224,10 @@ void main(uint3 tid : SV_DispatchThreadID)
     output.Store(4 * tid.x, tid.x);
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
-  auto debugOutput = RunDebugPass(compiled);
-  auto accessOutput = RunShaderAccessTrackingPass(debugOutput.blob);
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
+  PassOutput debugOutput = RunDebugPass(compiled);
+  PassOutput accessOutput = RunShaderAccessTrackingPass(debugOutput.blob);
 
   ModuleAndHangersOn moduleEtc(accessOutput.blob);
   VERIFY_ARE_EQUAL(1u, CountToolsUAVs(moduleEtc.GetDxilModule()));
@@ -3254,10 +3257,10 @@ void MissTwo(inout MyPayload payload)
 }
 )x";
 
-  auto compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
-  auto output = RunDxilPIXDXRInvocationsLog(compiled);
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
+  CComPtr<IDxcBlob> output = RunDxilPIXDXRInvocationsLog(compiled);
 
-  auto lines = Tokenize(Disassemble(output), "\n");
+  std::vector<std::string> lines = Tokenize(Disassemble(output), "\n");
   VERIFY_ARE_EQUAL(2, CountToolsUAVRecords(lines));
 }
 
@@ -3300,7 +3303,7 @@ void MyMiss(inout MyPayload payload)
 }
 )x";
 
-  auto compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"lib_6_6", {});
   ModuleAndHangersOn moduleEtc(compiled);
   DxilModule &DM = moduleEtc.GetDxilModule();
   LoadSubobjectsFromContainerIntoModule(compiled, DM);
@@ -3319,16 +3322,17 @@ void main(uint threadId : SV_DispatchThreadID)
 {
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
-  auto output = RunDebugPass(compiled);
-  auto lines = Tokenize(Disassemble(output.blob), "\n");
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"cs_6_2", {L"-Od"});
+  PassOutput output = RunDebugPass(compiled);
+  std::vector<std::string> lines = Tokenize(Disassemble(output.blob), "\n");
 
   constexpr uint64_t EnableRawAndStructuredBuffers = 0x10;
   bool foundShaderFlags = false;
   uint64_t shaderFlags = 0;
   const std::string tagPrefix = "!{i32 0, i64 ";
-  for (auto const &line : lines) {
-    const auto tagStart = line.find(tagPrefix);
+  for (const std::string &line : lines) {
+    const std::string::size_type tagStart = line.find(tagPrefix);
     if (tagStart == std::string::npos) {
       continue;
     }
@@ -3377,13 +3381,13 @@ void main()
                          true);
   VERIFY_IS_NOT_NULL(serializedRootSignature);
 
-  auto serializedData =
+  const uint8_t *serializedData =
       static_cast<const uint8_t *>(serializedRootSignature->GetBufferPointer());
   std::vector<uint8_t> originalRootSignature(
       serializedData,
       serializedData + serializedRootSignature->GetBufferSize());
 
-  auto compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
   ModuleAndHangersOn moduleEtc(compiled);
   DxilModule &DM = moduleEtc.GetDxilModule();
   DM.ResetSerializedRootSignature(originalRootSignature);
@@ -3503,7 +3507,7 @@ void main()
 static bool HasUnusedDeclaration(std::vector<std::string> const &lines,
                                  std::string const &functionName) {
   bool declared = false;
-  for (auto const &line : lines) {
+  for (const std::string &line : lines) {
     if (line.find("declare") != std::string::npos &&
         line.find(functionName) != std::string::npos) {
       declared = true;
@@ -3555,8 +3559,10 @@ float4 main() : SV_Target
     return float4(1, 2, 3, 4);
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  auto output = RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput output =
+      RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
 
   VERIFY_IS_FALSE(HasUnusedDeclaration(output.Lines, "dx.op.storeOutput.i32"));
   VerifyInstrumentedModuleIsValid(output.Module,
@@ -3570,8 +3576,10 @@ void main()
 {
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"cs_6_0", {L"-Od"});
-  auto output = RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"cs_6_0", {L"-Od"});
+  SinglePassOutput output =
+      RunSinglePass(compiled, L"-hlsl-dxil-constantColor");
   const std::string disassembly = Disassemble(output.Module);
 
   VerifyInstrumentedModuleIsValid(
@@ -3587,8 +3595,10 @@ float4 main() : SV_Target
     return float4(1, 2, 3, 4);
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  auto output = RunSinglePass(compiled, L"-hlsl-dxil-remove-discards");
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput output =
+      RunSinglePass(compiled, L"-hlsl-dxil-remove-discards");
 
   VERIFY_IS_FALSE(HasUnusedDeclaration(output.Lines, "dx.op.discard"));
   VerifyInstrumentedModuleIsValid(output.Module,
@@ -3602,7 +3612,7 @@ float4 main() : SV_Target
     return float4(1, 2, 3, 4);
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {});
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"ps_6_0", {});
   ModuleAndHangersOn moduleEtc(compiled);
   DxilModule &DM = moduleEtc.GetDxilModule();
   OP *HlslOP = DM.GetOP();
@@ -3634,7 +3644,8 @@ float4 main(float2 uv : TEXCOORD0) : SV_Target
     return textures[(uint)uv.x].Load(int3(0, 0, 0));
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
   ModuleAndHangersOn moduleEtc(compiled);
   DxilModule &DM = moduleEtc.GetDxilModule();
   bool visitorCalled = false;
@@ -3811,7 +3822,8 @@ float4 main(float2 uv : TEXCOORD0) : SV_Target
     return textures[NonUniformResourceIndex(index)].Load(int3(0, 0, 0));
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"ps_6_6", {L"-Od"});
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_6", {L"-Od"});
   std::string outputText;
   PassOutput output =
       RunDxilNonUniformResourceIndexInstrumentation(compiled, outputText);
@@ -4209,7 +4221,7 @@ void main() {
     DebugBreak();
 })x";
 
-  auto compiled = Compile(m_dllSupport, source, L"cs_6_10", {});
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"cs_6_10", {});
   auto output = RunDebugBreakPass(compiled);
   bool foundDebugBreak = false;
   for (auto const &line : output.lines) {

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -334,15 +334,14 @@ public:
     return {false, BlobToUtf8(pValidationErrors)};
   }
 
-  // The four metadata kinds PIX's virtual-register annotation pass
-  // intentionally leaves unused for downstream tools to consume. See
+  // The metadata kinds that PIX's virtual-register annotation pass
+  // intentionally leaves unused for downstream tools. See
   // DxilPIXVirtualRegisters.h.
   static constexpr const char *KnownPixVirtualRegisterMetadataKinds[] = {
       pix_dxil::PixDxilInstNum::MDName, pix_dxil::PixDxilReg::MDName,
       pix_dxil::PixAllocaReg::MDName, pix_dxil::PixAllocaRegWrite::MDName};
 
-  // Removes the four known PIX metadata kinds from every function and
-  // instruction.
+  // Removes the known PIX metadata kinds from every function and instruction.
   static void StripKnownPixVirtualRegisterMetadata(llvm::Module &M) {
     llvm::LLVMContext &Ctx = M.getContext();
     for (const char *kind : KnownPixVirtualRegisterMetadataKinds) {
@@ -393,9 +392,9 @@ public:
 
     // The validator's "unused metadata" diagnostic names the metadata
     // node, not the kind, so text can't separate PIX's own annotations
-    // from any other unsupported metadata. Strip only the four known PIX
-    // kinds and revalidate; if that alone fixes it, PIX metadata was the
-    // sole cause.
+    // from any other unsupported metadata. Strip only the known PIX kinds
+    // and revalidate. If this fixes the module, PIX metadata was the only
+    // cause.
     CComPtr<IDxcBlob> strippedContainer =
         CloneModuleAndMutate(pContainer, StripKnownPixVirtualRegisterMetadata);
     if (RunValidator(strippedContainer).Valid) {
@@ -3723,9 +3722,8 @@ float main() : SV_Target
       GetSignificantValidationDiagnostics(validation.Errors).empty());
 }
 
-// A foreign, unused instruction metadata kind alongside the module's own
-// permitted PIX metadata must still be rejected: stripping only the four
-// known PIX kinds leaves it behind.
+// A foreign, unused instruction metadata kind with the module's PIX metadata
+// must still be rejected. Stripping the known PIX kinds leaves it behind.
 TEST_F(PixTest, Validation_ControlNonPixUnusedMetadataIsRejected) {
   const char *source = R"x(
 float main() : SV_Target

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -160,6 +160,12 @@ public:
   TEST_METHOD(NonUniformResourceIndex_DescriptorHeap)
   TEST_METHOD(NonUniformResourceIndex_Raytracing)
 
+  // Control tests for the PIX pass validation harness below
+  // (ValidateInstrumentedModule / VerifyInstrumentedModuleIsValid).
+  TEST_METHOD(Validation_ControlValidModulePasses)
+  TEST_METHOD(Validation_ControlInvalidModuleFails)
+  TEST_METHOD(Validation_ControlBoilerplateOnlyFailureIsRejected)
+
   dxc::DxCompilerDllLoader m_dllSupport;
   VersionSupportInfo m_ver;
 
@@ -261,6 +267,142 @@ public:
 
     return {
         std::move(pOptimizedModule), {}, Tokenize(outputText.c_str(), "\n")};
+  }
+
+  // Runs one named PIX or DXIL pass and returns the resulting module and
+  // its disassembly lines.
+  struct SinglePassOutput {
+    CComPtr<IDxcBlob> Module;
+    std::vector<std::string> Lines;
+  };
+
+  SinglePassOutput RunSinglePass(IDxcBlob *dxil, LPCWSTR passOption) {
+    CComPtr<IDxcOptimizer> pOptimizer;
+    VERIFY_SUCCEEDED(
+        m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &pOptimizer));
+    std::vector<LPCWSTR> Options;
+    Options.push_back(L"-opt-mod-passes");
+    Options.push_back(passOption);
+
+    CComPtr<IDxcBlob> pOptimizedModule;
+    CComPtr<IDxcBlobEncoding> pText;
+    VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
+        dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
+
+    SinglePassOutput ret;
+    ret.Module = pOptimizedModule;
+    ret.Lines = Tokenize(BlobToUtf8(pText).c_str(), "\n");
+    return ret;
+  }
+
+  // PIX does not validate the shaders its passes instrument, so a pass
+  // that produces invalid DXIL goes undetected elsewhere. Validate here
+  // instead.
+  struct ValidationResult {
+    bool Valid;
+    std::string Errors;
+  };
+
+  ValidationResult ValidateInstrumentedModule(IDxcBlob *pModule) {
+    CComPtr<IDxcBlob> pContainer;
+
+    // Some pass runners return a bare bitcode module; others already
+    // return a container. The validator accepts only a container.
+    if (hlsl::IsDxilContainerLike(pModule->GetBufferPointer(),
+                                  pModule->GetBufferSize()) != nullptr) {
+      pContainer = pModule;
+    } else {
+      pContainer = pix_test::WrapInNewContainer(m_dllSupport, pModule);
+    }
+
+    CComPtr<IDxcValidator> pValidator;
+    VERIFY_SUCCEEDED(
+        m_dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
+
+    CComPtr<IDxcOperationResult> pValidationResult;
+    VERIFY_SUCCEEDED(pValidator->Validate(pContainer, DxcValidatorFlags_Default,
+                                          &pValidationResult));
+
+    HRESULT validationStatus;
+    VERIFY_SUCCEEDED(pValidationResult->GetStatus(&validationStatus));
+    if (SUCCEEDED(validationStatus)) {
+      return {true, {}};
+    }
+
+    CComPtr<IDxcBlobEncoding> pValidationErrors;
+    VERIFY_SUCCEEDED(pValidationResult->GetErrorBuffer(&pValidationErrors));
+    return {false, BlobToUtf8(pValidationErrors)};
+  }
+
+  // Significant holds validator diagnostics other than boilerplate and the
+  // permitted metadata exception. PermittedExceptionCount counts the
+  // exception separately.
+  struct FilteredValidationDiagnostics {
+    std::vector<std::string> Significant;
+    int PermittedExceptionCount = 0;
+  };
+
+  // Filters out boilerplate ("Validation failed.") and the permitted
+  // metadata exception: virtual-register annotation passes add metadata
+  // that DXIL does not consume, so the validator reports it as unused. Do
+  // not widen this filter.
+  FilteredValidationDiagnostics
+  GetSignificantValidationDiagnostics(const std::string &errors) {
+    FilteredValidationDiagnostics result;
+    std::stringstream errorStream(errors);
+    std::string line;
+    while (std::getline(errorStream, line)) {
+      if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+      }
+      if (line.empty() || line == "Validation failed.") {
+        continue;
+      }
+      if (line.find("All metadata must be used by dxil") != std::string::npos) {
+        result.PermittedExceptionCount++;
+        continue;
+      }
+      result.Significant.push_back(line);
+    }
+    return result;
+  }
+
+  // True only if the diagnostics contain no significant errors and at
+  // least one instance of the permitted metadata exception.
+  bool IsPermittedValidationException(
+      const FilteredValidationDiagnostics &diagnostics) {
+    return diagnostics.Significant.empty() &&
+           diagnostics.PermittedExceptionCount > 0;
+  }
+
+  // Asserts an instrumented module validates. Accepts a module whose only
+  // diagnostic is the permitted metadata exception; logs and fails on any
+  // other validator error.
+  void VerifyInstrumentedModuleIsValid(IDxcBlob *pModule,
+                                       const char *description) {
+    ValidationResult validation = ValidateInstrumentedModule(pModule);
+    if (validation.Valid) {
+      return;
+    }
+
+    FilteredValidationDiagnostics diagnostics =
+        GetSignificantValidationDiagnostics(validation.Errors);
+    if (IsPermittedValidationException(diagnostics)) {
+      return;
+    }
+
+    std::string joined;
+    if (diagnostics.Significant.empty()) {
+      joined = "(validator reported failure with no significant diagnostic "
+               "text, and no permitted metadata exception was found)";
+    } else {
+      for (auto const &significantError : diagnostics.Significant) {
+        joined += significantError + "\n";
+      }
+    }
+    WEX::Logging::Log::Error(WEX::Common::String().Format(
+        L"Validation failed after %S:\n%S", description, joined.c_str()));
+    VERIFY_FAIL();
   }
 
   CComPtr<IDxcBlob> FindModule(hlsl::DxilFourCC fourCC, IDxcBlob *pSource) {
@@ -3466,4 +3608,109 @@ void main(uint3 tid : SV_DispatchThreadID) {
     pos += strlen("DebugBreakBitSet");
   }
   VERIFY_ARE_EQUAL(debugBreakBitSetCount, 2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Control tests for the PIX pass validation harness
+// (ValidateInstrumentedModule / VerifyInstrumentedModuleIsValid).
+//
+// Both tests instrument the same trivial pixel shader with the
+// virtual-register annotation pass, so the valid and invalid cases are
+// directly comparable.
+
+TEST_F(PixTest, Validation_ControlValidModulePasses) {
+  const char *source = R"x(
+float main() : SV_Target
+{
+    return 0;
+})x";
+
+  // Virtual-register annotation adds metadata that DXIL does not consume,
+  // so this module only validates via the permitted metadata exception.
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  auto output = RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+  VerifyInstrumentedModuleIsValid(
+      output.Module,
+      "virtual-register annotation of a trivial pixel shader (validation "
+      "harness control)");
+}
+
+TEST_F(PixTest, Validation_ControlInvalidModuleFails) {
+  const char *source = R"x(
+float main() : SV_Target
+{
+    return 0;
+})x";
+
+  // Same shader and pass as Validation_ControlValidModulePasses; only the
+  // corruption below differs.
+  auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  auto output = RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+
+  // Confirm the baseline validates before corrupting it, so the failure
+  // below is caused by the corruption and nothing else.
+  VerifyInstrumentedModuleIsValid(
+      output.Module,
+      "virtual-register annotation of a trivial pixel shader, uncorrupted "
+      "baseline (validation harness control)");
+
+  // Mislabel the shader stage. The validator must reject this regardless
+  // of the permitted metadata exception.
+  std::string disassembly = Disassemble(output.Module);
+  const std::string shaderKindTag = "!\"ps\",";
+  auto tagPosition = disassembly.find(shaderKindTag);
+  VERIFY_IS_TRUE(tagPosition != std::string::npos);
+  disassembly.replace(tagPosition, shaderKindTag.size(), "!\"vs\",");
+
+  CComPtr<IDxcBlobEncoding> pDisassemblyBlob;
+  CreateBlobFromText(m_dllSupport, disassembly.c_str(), &pDisassemblyBlob);
+
+  CComPtr<IDxcAssembler> pAssembler;
+  VERIFY_SUCCEEDED(
+      m_dllSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
+  CComPtr<IDxcOperationResult> pAssembleResult;
+  VERIFY_SUCCEEDED(
+      pAssembler->AssembleToContainer(pDisassemblyBlob, &pAssembleResult));
+  HRESULT assembleStatus;
+  VERIFY_SUCCEEDED(pAssembleResult->GetStatus(&assembleStatus));
+  VERIFY_SUCCEEDED(assembleStatus);
+  CComPtr<IDxcBlob> pCorruptedContainer;
+  VERIFY_SUCCEEDED(pAssembleResult->GetResult(&pCorruptedContainer));
+
+  ValidationResult validation = ValidateInstrumentedModule(pCorruptedContainer);
+  VERIFY_IS_FALSE(validation.Valid);
+
+  // Confirm the corruption produces a real diagnostic, not just the
+  // permitted metadata exception.
+  FilteredValidationDiagnostics diagnostics =
+      GetSignificantValidationDiagnostics(validation.Errors);
+  VERIFY_IS_FALSE(diagnostics.Significant.empty());
+}
+
+// Tests that a validator failure is rejected unless its only diagnostic is
+// the permitted metadata exception. A failure with only the "Validation
+// failed." boilerplate and no exception must not pass.
+TEST_F(PixTest, Validation_ControlBoilerplateOnlyFailureIsRejected) {
+  // Boilerplate only, no permitted exception: must be rejected.
+  FilteredValidationDiagnostics boilerplateOnly =
+      GetSignificantValidationDiagnostics("Validation failed.\n");
+  VERIFY_IS_TRUE(boilerplateOnly.Significant.empty());
+  VERIFY_ARE_EQUAL(boilerplateOnly.PermittedExceptionCount, 0);
+  VERIFY_IS_FALSE(IsPermittedValidationException(boilerplateOnly));
+
+  // Permitted exception present: must be accepted.
+  FilteredValidationDiagnostics exceptionOnly =
+      GetSignificantValidationDiagnostics(
+          "Validation failed.\n"
+          "All metadata must be used by dxil's users.\n");
+  VERIFY_IS_TRUE(exceptionOnly.Significant.empty());
+  VERIFY_IS_TRUE(exceptionOnly.PermittedExceptionCount > 0);
+  VERIFY_IS_TRUE(IsPermittedValidationException(exceptionOnly));
+
+  // Real diagnostic present: must be rejected, even with the exception.
+  FilteredValidationDiagnostics realDiagnostic =
+      GetSignificantValidationDiagnostics("Validation failed.\n"
+                                          "Some real validator diagnostic.\n");
+  VERIFY_IS_FALSE(realDiagnostic.Significant.empty());
+  VERIFY_IS_FALSE(IsPermittedValidationException(realDiagnostic));
 }

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -152,6 +152,7 @@ public:
   TEST_METHOD(ToolsUav_ExtendsEveryGlobalRootSignatureSubobject)
   TEST_METHOD(DebugInstrumentation_RawBufferShaderFlagDeclared)
   TEST_METHOD(ToolsUav_RootSignatureSerializationFailurePreservesSignature)
+  TEST_METHOD(ToolsUav_ExtendingRootSignaturePreservesUnrelatedParameterFlags)
   TEST_METHOD(ConstantColor_UnusedIntOverloadIsErased)
   TEST_METHOD(ConstantColor_NoTargetOverloadsAreErased)
   TEST_METHOD(RemoveDiscards_UnusedDiscardOverloadIsErased)
@@ -3420,6 +3421,83 @@ void main()
     foundRootSignature = true;
   }
   VERIFY_IS_TRUE(foundRootSignature);
+}
+
+TEST_F(PixTest,
+       ToolsUav_ExtendingRootSignaturePreservesUnrelatedParameterFlags) {
+  const char *source = R"x(
+[numthreads(1, 1, 1)]
+void main()
+{
+})x";
+
+  DxilRootParameter1 parameters[2] = {};
+  parameters[0].ParameterType = DxilRootParameterType::UAV;
+  parameters[0].Descriptor.RegisterSpace = static_cast<uint32_t>(-2);
+  parameters[0].Descriptor.ShaderRegister = 0;
+  parameters[0].Descriptor.Flags = DxilRootDescriptorFlags::None;
+  parameters[0].ShaderVisibility = DxilShaderVisibility::All;
+
+  parameters[1].ParameterType = DxilRootParameterType::CBV;
+  parameters[1].Descriptor.RegisterSpace = 0;
+  parameters[1].Descriptor.ShaderRegister = 0;
+  parameters[1].Descriptor.Flags = DxilRootDescriptorFlags::DataVolatile;
+  parameters[1].ShaderVisibility = DxilShaderVisibility::All;
+
+  DxilVersionedRootSignatureDesc rootSignature = {};
+  rootSignature.Version = DxilRootSignatureVersion::Version_1_1;
+  rootSignature.Desc_1_1.NumParameters = 2;
+  rootSignature.Desc_1_1.pParameters = parameters;
+  rootSignature.Desc_1_1.Flags = DxilRootSignatureFlags::None;
+
+  CComPtr<IDxcBlob> serializedRootSignature;
+  CComPtr<IDxcBlobEncoding> errorBlob;
+  SerializeRootSignature(&rootSignature, &serializedRootSignature, &errorBlob,
+                         true);
+  VERIFY_IS_NOT_NULL(serializedRootSignature);
+
+  const uint8_t *serializedData =
+      static_cast<const uint8_t *>(serializedRootSignature->GetBufferPointer());
+  std::vector<uint8_t> originalRootSignature(
+      serializedData,
+      serializedData + serializedRootSignature->GetBufferSize());
+
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"cs_6_0", {});
+  ModuleAndHangersOn moduleEtc(compiled);
+  DxilModule &DM = moduleEtc.GetDxilModule();
+  DM.ResetSerializedRootSignature(originalRootSignature);
+
+  PIXPassHelpers::CreateGlobalUAVResource(DM, 0, "PIX_TestUAV0");
+
+  {
+    const std::vector<uint8_t> &bytes = DM.GetSerializedRootSignature();
+    DxilVersionedRootSignatureDesc const *afterNoOp = nullptr;
+    DeserializeRootSignature(bytes.data(), static_cast<uint32_t>(bytes.size()),
+                             &afterNoOp);
+    VERIFY_ARE_EQUAL(afterNoOp->Desc_1_1.NumParameters, 2u);
+    VERIFY_IS_TRUE(afterNoOp->Desc_1_1.pParameters[1].Descriptor.Flags ==
+                   DxilRootDescriptorFlags::DataVolatile);
+    DeleteRootSignature(afterNoOp);
+  }
+
+  PIXPassHelpers::CreateGlobalUAVResource(DM, 1, "PIX_TestUAV1");
+
+  {
+    const std::vector<uint8_t> &bytes = DM.GetSerializedRootSignature();
+    DxilVersionedRootSignatureDesc const *afterAdd = nullptr;
+    DeserializeRootSignature(bytes.data(), static_cast<uint32_t>(bytes.size()),
+                             &afterAdd);
+    VERIFY_ARE_EQUAL(afterAdd->Desc_1_1.NumParameters, 3u);
+    VERIFY_IS_TRUE(afterAdd->Desc_1_1.pParameters[1].Descriptor.Flags ==
+                   DxilRootDescriptorFlags::DataVolatile);
+    VERIFY_ARE_EQUAL(afterAdd->Desc_1_1.pParameters[2].Descriptor.RegisterSpace,
+                     static_cast<uint32_t>(-2));
+    VERIFY_ARE_EQUAL(
+        afterAdd->Desc_1_1.pParameters[2].Descriptor.ShaderRegister, 1u);
+    VERIFY_IS_TRUE(afterAdd->Desc_1_1.pParameters[2].Descriptor.Flags ==
+                   DxilRootDescriptorFlags::None);
+    DeleteRootSignature(afterAdd);
+  }
 }
 
 static bool HasUnusedDeclaration(std::vector<std::string> const &lines,

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -276,23 +276,23 @@ public:
     std::vector<std::string> Lines;
   };
 
-  SinglePassOutput RunSinglePass(IDxcBlob *dxil, LPCWSTR passOption) {
-    CComPtr<IDxcOptimizer> pOptimizer;
+  SinglePassOutput RunSinglePass(IDxcBlob *Dxil, LPCWSTR PassOption) {
+    CComPtr<IDxcOptimizer> Optimizer;
     VERIFY_SUCCEEDED(
-        m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &pOptimizer));
+        m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &Optimizer));
     std::vector<LPCWSTR> Options;
     Options.push_back(L"-opt-mod-passes");
-    Options.push_back(passOption);
+    Options.push_back(PassOption);
 
-    CComPtr<IDxcBlob> pOptimizedModule;
-    CComPtr<IDxcBlobEncoding> pText;
-    VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
-        dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
+    CComPtr<IDxcBlob> OptimizedModule;
+    CComPtr<IDxcBlobEncoding> Text;
+    VERIFY_SUCCEEDED(Optimizer->RunOptimizer(
+        Dxil, Options.data(), Options.size(), &OptimizedModule, &Text));
 
-    SinglePassOutput ret;
-    ret.Module = pOptimizedModule;
-    ret.Lines = Tokenize(BlobToUtf8(pText).c_str(), "\n");
-    return ret;
+    SinglePassOutput Result;
+    Result.Module = OptimizedModule;
+    Result.Lines = Tokenize(BlobToUtf8(Text).c_str(), "\n");
+    return Result;
   }
 
   // PIX does not validate the shaders its passes instrument, so a pass
@@ -306,32 +306,32 @@ public:
   // The validator (and the assembler, when reconstructing a container
   // from bare bitcode) both require a container; some pass runners
   // return bare bitcode instead.
-  CComPtr<IDxcBlob> NormalizeToContainer(IDxcBlob *pModule) {
-    if (hlsl::IsDxilContainerLike(pModule->GetBufferPointer(),
-                                  pModule->GetBufferSize()) != nullptr) {
-      return pModule;
+  CComPtr<IDxcBlob> NormalizeToContainer(IDxcBlob *Module) {
+    if (hlsl::IsDxilContainerLike(Module->GetBufferPointer(),
+                                  Module->GetBufferSize()) != nullptr) {
+      return Module;
     }
-    return pix_test::WrapInNewContainer(m_dllSupport, pModule);
+    return pix_test::WrapInNewContainer(m_dllSupport, Module);
   }
 
-  ValidationResult RunValidator(IDxcBlob *pContainer) {
-    CComPtr<IDxcValidator> pValidator;
+  ValidationResult RunValidator(IDxcBlob *Container) {
+    CComPtr<IDxcValidator> Validator;
     VERIFY_SUCCEEDED(
-        m_dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
+        m_dllSupport.CreateInstance(CLSID_DxcValidator, &Validator));
 
-    CComPtr<IDxcOperationResult> pValidationResult;
-    VERIFY_SUCCEEDED(pValidator->Validate(pContainer, DxcValidatorFlags_Default,
-                                          &pValidationResult));
+    CComPtr<IDxcOperationResult> OperationResult;
+    VERIFY_SUCCEEDED(Validator->Validate(Container, DxcValidatorFlags_Default,
+                                         &OperationResult));
 
-    HRESULT validationStatus;
-    VERIFY_SUCCEEDED(pValidationResult->GetStatus(&validationStatus));
-    if (SUCCEEDED(validationStatus)) {
+    HRESULT ValidationStatus;
+    VERIFY_SUCCEEDED(OperationResult->GetStatus(&ValidationStatus));
+    if (SUCCEEDED(ValidationStatus)) {
       return {true, {}};
     }
 
-    CComPtr<IDxcBlobEncoding> pValidationErrors;
-    VERIFY_SUCCEEDED(pValidationResult->GetErrorBuffer(&pValidationErrors));
-    return {false, BlobToUtf8(pValidationErrors)};
+    CComPtr<IDxcBlobEncoding> ValidationErrors;
+    VERIFY_SUCCEEDED(OperationResult->GetErrorBuffer(&ValidationErrors));
+    return {false, BlobToUtf8(ValidationErrors)};
   }
 
   // The metadata kinds that PIX's virtual-register annotation pass
@@ -344,50 +344,50 @@ public:
   // Removes the known PIX metadata kinds from every function and instruction.
   static void StripKnownPixVirtualRegisterMetadata(llvm::Module &M) {
     llvm::LLVMContext &Ctx = M.getContext();
-    for (const char *kind : KnownPixVirtualRegisterMetadataKinds) {
-      unsigned kindID = Ctx.getMDKindID(kind);
+    for (const char *Kind : KnownPixVirtualRegisterMetadataKinds) {
+      unsigned KindID = Ctx.getMDKindID(Kind);
       for (llvm::Function &F : M) {
-        F.setMetadata(kindID, nullptr);
+        F.setMetadata(KindID, nullptr);
         for (llvm::BasicBlock &BB : F) {
           for (llvm::Instruction &I : BB) {
-            I.setMetadata(kindID, nullptr);
+            I.setMetadata(KindID, nullptr);
           }
         }
       }
     }
   }
 
-  // Parses pContainer into an isolated LLVM module, applies Mutate to it,
+  // Parses Container into an isolated LLVM module, applies Mutate to it,
   // and re-serializes into a fresh validator-ready container.
   template <typename MutatorFn>
-  CComPtr<IDxcBlob> CloneModuleAndMutate(IDxcBlob *pContainer,
+  CComPtr<IDxcBlob> CloneModuleAndMutate(IDxcBlob *Container,
                                          MutatorFn Mutate) {
-    ModuleAndHangersOn moduleEtc(pContainer);
-    llvm::Module *M = moduleEtc.GetDxilModule().GetModule();
+    ModuleAndHangersOn ModuleEtc(Container);
+    llvm::Module *M = ModuleEtc.GetDxilModule().GetModule();
     Mutate(*M);
 
-    llvm::SmallVector<char, 0> bitcode;
+    llvm::SmallVector<char, 0> Bitcode;
     {
-      llvm::raw_svector_ostream OS(bitcode);
+      llvm::raw_svector_ostream OS(Bitcode);
       llvm::WriteBitcodeToFile(M, OS);
     }
 
-    CComPtr<IDxcLibrary> pLibrary;
-    VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
-    CComPtr<IDxcBlobEncoding> pBitcodeBlob;
-    VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(
-        bitcode.data(), static_cast<UINT32>(bitcode.size()), CP_ACP,
-        &pBitcodeBlob));
+    CComPtr<IDxcLibrary> Library;
+    VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &Library));
+    CComPtr<IDxcBlobEncoding> BitcodeBlob;
+    VERIFY_SUCCEEDED(Library->CreateBlobWithEncodingFromPinned(
+        Bitcode.data(), static_cast<UINT32>(Bitcode.size()), CP_ACP,
+        &BitcodeBlob));
 
-    return pix_test::WrapInNewContainer(m_dllSupport, pBitcodeBlob);
+    return pix_test::WrapInNewContainer(m_dllSupport, BitcodeBlob);
   }
 
-  ValidationResult ValidateInstrumentedModule(IDxcBlob *pModule) {
-    CComPtr<IDxcBlob> pContainer = NormalizeToContainer(pModule);
+  ValidationResult ValidateInstrumentedModule(IDxcBlob *Module) {
+    CComPtr<IDxcBlob> Container = NormalizeToContainer(Module);
 
-    ValidationResult direct = RunValidator(pContainer);
-    if (direct.Valid) {
-      return direct;
+    ValidationResult DirectResult = RunValidator(Container);
+    if (DirectResult.Valid) {
+      return DirectResult;
     }
 
     // The validator's "unused metadata" diagnostic names the metadata
@@ -395,47 +395,46 @@ public:
     // from any other unsupported metadata. Strip only the known PIX kinds
     // and revalidate. If this fixes the module, PIX metadata was the only
     // cause.
-    CComPtr<IDxcBlob> strippedContainer =
-        CloneModuleAndMutate(pContainer, StripKnownPixVirtualRegisterMetadata);
-    if (RunValidator(strippedContainer).Valid) {
+    CComPtr<IDxcBlob> StrippedContainer =
+        CloneModuleAndMutate(Container, StripKnownPixVirtualRegisterMetadata);
+    if (RunValidator(StrippedContainer).Valid) {
       return {true, {}};
     }
 
-    return direct;
+    return DirectResult;
   }
 
   // Joins diagnostic lines, skipping blanks and "Validation failed."
   // boilerplate.
   static std::string
-  GetSignificantValidationDiagnostics(const std::string &errors) {
-    std::string result;
-    std::stringstream errorStream(errors);
-    std::string line;
-    while (std::getline(errorStream, line)) {
-      if (!line.empty() && line.back() == '\r') {
-        line.pop_back();
+  GetSignificantValidationDiagnostics(const std::string &Errors) {
+    std::string Result;
+    std::stringstream ErrorStream(Errors);
+    std::string Line;
+    while (std::getline(ErrorStream, Line)) {
+      if (!Line.empty() && Line.back() == '\r') {
+        Line.pop_back();
       }
-      if (line.empty() || line == "Validation failed.") {
+      if (Line.empty() || Line == "Validation failed.") {
         continue;
       }
-      result += line + "\n";
+      Result += Line + "\n";
     }
-    return result;
+    return Result;
   }
 
-  // Asserts an instrumented module validates, allowing for the four known
-  // PIX metadata kinds being unused; logs and fails on any other
-  // validator error.
-  void VerifyInstrumentedModuleIsValid(IDxcBlob *pModule,
-                                       const char *description) {
-    ValidationResult validation = ValidateInstrumentedModule(pModule);
-    if (validation.Valid) {
+  // Asserts that an instrumented module is valid when known PIX metadata is
+  // unused. Logs and fails on any other validator error.
+  void VerifyInstrumentedModuleIsValid(IDxcBlob *Module,
+                                       const char *Description) {
+    ValidationResult Result = ValidateInstrumentedModule(Module);
+    if (Result.Valid) {
       return;
     }
 
     WEX::Logging::Log::Error(WEX::Common::String().Format(
-        L"Validation failed after %S:\n%S", description,
-        GetSignificantValidationDiagnostics(validation.Errors).c_str()));
+        L"Validation failed after %S:\n%S", Description,
+        GetSignificantValidationDiagnostics(Result.Errors).c_str()));
     VERIFY_FAIL();
   }
 
@@ -3648,97 +3647,95 @@ void main(uint3 tid : SV_DispatchThreadID) {
 // Control tests for the PIX pass validation harness
 // (ValidateInstrumentedModule / VerifyInstrumentedModuleIsValid).
 //
-// Both tests instrument the same trivial pixel shader with the
-// virtual-register annotation pass, so the valid and invalid cases are
-// directly comparable.
+// These tests use the same trivial pixel shader and virtual-register
+// annotation pass. This keeps the valid and invalid cases comparable.
 
 TEST_F(PixTest, Validation_ControlValidModulePasses) {
-  const char *source = R"x(
+  const char *Source = R"x(
 float main() : SV_Target
 {
     return 0;
 })x";
 
   // Virtual-register annotation adds metadata that DXIL does not consume,
-  // so this module only validates because that metadata is one of the
-  // four known PIX kinds.
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  SinglePassOutput output =
-      RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+  // so this module validates only because the metadata kind is known to PIX.
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      RunSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
   VerifyInstrumentedModuleIsValid(
-      output.Module,
+      Output.Module,
       "virtual-register annotation of a trivial pixel shader (validation "
       "harness control)");
 }
 
 TEST_F(PixTest, Validation_ControlInvalidModuleFails) {
-  const char *source = R"x(
+  const char *Source = R"x(
 float main() : SV_Target
 {
     return 0;
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  SinglePassOutput output =
-      RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      RunSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
 
   // Mislabel the shader stage, so the container carries both the
   // harness's permitted PIX metadata and a real defect.
-  std::string disassembly = Disassemble(output.Module);
-  const std::string shaderKindTag = "!\"ps\",";
-  std::string::size_type tagPosition = disassembly.find(shaderKindTag);
-  VERIFY_IS_TRUE(tagPosition != std::string::npos);
-  disassembly.replace(tagPosition, shaderKindTag.size(), "!\"vs\",");
+  std::string Disassembly = Disassemble(Output.Module);
+  const std::string ShaderKindTag = "!\"ps\",";
+  std::string::size_type TagPosition = Disassembly.find(ShaderKindTag);
+  VERIFY_IS_TRUE(TagPosition != std::string::npos);
+  Disassembly.replace(TagPosition, ShaderKindTag.size(), "!\"vs\",");
 
-  CComPtr<IDxcBlobEncoding> pDisassemblyBlob;
-  CreateBlobFromText(m_dllSupport, disassembly.c_str(), &pDisassemblyBlob);
+  CComPtr<IDxcBlobEncoding> DisassemblyBlob;
+  CreateBlobFromText(m_dllSupport, Disassembly.c_str(), &DisassemblyBlob);
 
-  CComPtr<IDxcAssembler> pAssembler;
+  CComPtr<IDxcAssembler> Assembler;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcAssembler, &Assembler));
+  CComPtr<IDxcOperationResult> AssembleResult;
   VERIFY_SUCCEEDED(
-      m_dllSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
-  CComPtr<IDxcOperationResult> pAssembleResult;
-  VERIFY_SUCCEEDED(
-      pAssembler->AssembleToContainer(pDisassemblyBlob, &pAssembleResult));
-  HRESULT assembleStatus;
-  VERIFY_SUCCEEDED(pAssembleResult->GetStatus(&assembleStatus));
-  VERIFY_SUCCEEDED(assembleStatus);
-  CComPtr<IDxcBlob> pCorruptedContainer;
-  VERIFY_SUCCEEDED(pAssembleResult->GetResult(&pCorruptedContainer));
+      Assembler->AssembleToContainer(DisassemblyBlob, &AssembleResult));
+  HRESULT AssembleStatus;
+  VERIFY_SUCCEEDED(AssembleResult->GetStatus(&AssembleStatus));
+  VERIFY_SUCCEEDED(AssembleStatus);
+  CComPtr<IDxcBlob> CorruptedContainer;
+  VERIFY_SUCCEEDED(AssembleResult->GetResult(&CorruptedContainer));
 
   // Direct validation's own diagnostic proves the PIX metadata is present
   // and otherwise unused, alongside rejecting for the mislabeled stage.
-  ValidationResult direct = RunValidator(pCorruptedContainer);
-  VERIFY_IS_FALSE(direct.Valid);
-  VERIFY_IS_TRUE(direct.Errors.find("All metadata must be used by dxil") !=
-                 std::string::npos);
+  ValidationResult DirectResult = RunValidator(CorruptedContainer);
+  VERIFY_IS_FALSE(DirectResult.Valid);
+  VERIFY_IS_TRUE(DirectResult.Errors.find(
+                     "All metadata must be used by dxil") != std::string::npos);
 
   // The harness must still reject it, for a reason other than the
   // permitted metadata.
-  ValidationResult validation = ValidateInstrumentedModule(pCorruptedContainer);
-  VERIFY_IS_FALSE(validation.Valid);
+  ValidationResult HarnessResult =
+      ValidateInstrumentedModule(CorruptedContainer);
+  VERIFY_IS_FALSE(HarnessResult.Valid);
   VERIFY_IS_FALSE(
-      GetSignificantValidationDiagnostics(validation.Errors).empty());
+      GetSignificantValidationDiagnostics(HarnessResult.Errors).empty());
 }
 
 // A foreign, unused instruction metadata kind with the module's PIX metadata
 // must still be rejected. Stripping the known PIX kinds leaves it behind.
 TEST_F(PixTest, Validation_ControlNonPixUnusedMetadataIsRejected) {
-  const char *source = R"x(
+  const char *Source = R"x(
 float main() : SV_Target
 {
     return 0;
 })x";
 
-  CComPtr<IDxcBlob> compiled =
-      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
-  SinglePassOutput output =
-      RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
-  CComPtr<IDxcBlob> pContainer = NormalizeToContainer(output.Module);
+  CComPtr<IDxcBlob> Compiled =
+      Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput Output =
+      RunSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> Container = NormalizeToContainer(Output.Module);
 
-  CComPtr<IDxcBlob> withForeignMetadata =
-      CloneModuleAndMutate(pContainer, [](llvm::Module &M) {
+  CComPtr<IDxcBlob> WithForeignMetadata =
+      CloneModuleAndMutate(Container, [](llvm::Module &M) {
         for (llvm::Function &F : M) {
           if (F.isDeclaration()) {
             continue;
@@ -3750,6 +3747,6 @@ float main() : SV_Target
         }
       });
 
-  ValidationResult validation = ValidateInstrumentedModule(withForeignMetadata);
-  VERIFY_IS_FALSE(validation.Valid);
+  ValidationResult Result = ValidateInstrumentedModule(WithForeignMetadata);
+  VERIFY_IS_FALSE(Result.Valid);
 }

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -361,7 +361,7 @@ public:
   // and re-serializes into a fresh validator-ready container.
   template <typename MutatorFn>
   CComPtr<IDxcBlob> CloneModuleAndMutate(IDxcBlob *pContainer,
-                                        MutatorFn Mutate) {
+                                         MutatorFn Mutate) {
     ModuleAndHangersOn moduleEtc(pContainer);
     llvm::Module *M = moduleEtc.GetDxilModule().GetModule();
     Mutate(*M);
@@ -3712,7 +3712,7 @@ float main() : SV_Target
   ValidationResult direct = RunValidator(pCorruptedContainer);
   VERIFY_IS_FALSE(direct.Valid);
   VERIFY_IS_TRUE(direct.Errors.find("All metadata must be used by dxil") !=
-                std::string::npos);
+                 std::string::npos);
 
   // The harness must still reject it, for a reason other than the
   // permitted metadata.
@@ -3731,7 +3731,8 @@ float main() : SV_Target
     return 0;
 })x";
 
-  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  CComPtr<IDxcBlob> compiled =
+      Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
   SinglePassOutput output =
       RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
   CComPtr<IDxcBlob> pContainer = NormalizeToContainer(output.Module);

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -164,7 +164,7 @@ public:
   // (ValidateInstrumentedModule / VerifyInstrumentedModuleIsValid).
   TEST_METHOD(Validation_ControlValidModulePasses)
   TEST_METHOD(Validation_ControlInvalidModuleFails)
-  TEST_METHOD(Validation_ControlBoilerplateOnlyFailureIsRejected)
+  TEST_METHOD(Validation_ControlNonPixUnusedMetadataIsRejected)
 
   dxc::DxCompilerDllLoader m_dllSupport;
   VersionSupportInfo m_ver;
@@ -303,18 +303,18 @@ public:
     std::string Errors;
   };
 
-  ValidationResult ValidateInstrumentedModule(IDxcBlob *pModule) {
-    CComPtr<IDxcBlob> pContainer;
-
-    // Some pass runners return a bare bitcode module; others already
-    // return a container. The validator accepts only a container.
+  // The validator (and the assembler, when reconstructing a container
+  // from bare bitcode) both require a container; some pass runners
+  // return bare bitcode instead.
+  CComPtr<IDxcBlob> NormalizeToContainer(IDxcBlob *pModule) {
     if (hlsl::IsDxilContainerLike(pModule->GetBufferPointer(),
                                   pModule->GetBufferSize()) != nullptr) {
-      pContainer = pModule;
-    } else {
-      pContainer = pix_test::WrapInNewContainer(m_dllSupport, pModule);
+      return pModule;
     }
+    return pix_test::WrapInNewContainer(m_dllSupport, pModule);
+  }
 
+  ValidationResult RunValidator(IDxcBlob *pContainer) {
     CComPtr<IDxcValidator> pValidator;
     VERIFY_SUCCEEDED(
         m_dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
@@ -334,21 +334,82 @@ public:
     return {false, BlobToUtf8(pValidationErrors)};
   }
 
-  // Significant holds validator diagnostics other than boilerplate and the
-  // permitted metadata exception. PermittedExceptionCount counts the
-  // exception separately.
-  struct FilteredValidationDiagnostics {
-    std::vector<std::string> Significant;
-    int PermittedExceptionCount = 0;
-  };
+  // The four metadata kinds PIX's virtual-register annotation pass
+  // intentionally leaves unused for downstream tools to consume. See
+  // DxilPIXVirtualRegisters.h.
+  static constexpr const char *KnownPixVirtualRegisterMetadataKinds[] = {
+      pix_dxil::PixDxilInstNum::MDName, pix_dxil::PixDxilReg::MDName,
+      pix_dxil::PixAllocaReg::MDName, pix_dxil::PixAllocaRegWrite::MDName};
 
-  // Filters out boilerplate ("Validation failed.") and the permitted
-  // metadata exception: virtual-register annotation passes add metadata
-  // that DXIL does not consume, so the validator reports it as unused. Do
-  // not widen this filter.
-  FilteredValidationDiagnostics
+  // Removes the four known PIX metadata kinds from every function and
+  // instruction.
+  static void StripKnownPixVirtualRegisterMetadata(llvm::Module &M) {
+    llvm::LLVMContext &Ctx = M.getContext();
+    for (const char *kind : KnownPixVirtualRegisterMetadataKinds) {
+      unsigned kindID = Ctx.getMDKindID(kind);
+      for (llvm::Function &F : M) {
+        F.setMetadata(kindID, nullptr);
+        for (llvm::BasicBlock &BB : F) {
+          for (llvm::Instruction &I : BB) {
+            I.setMetadata(kindID, nullptr);
+          }
+        }
+      }
+    }
+  }
+
+  // Parses pContainer into an isolated LLVM module, applies Mutate to it,
+  // and re-serializes into a fresh validator-ready container.
+  template <typename MutatorFn>
+  CComPtr<IDxcBlob> CloneModuleAndMutate(IDxcBlob *pContainer,
+                                        MutatorFn Mutate) {
+    ModuleAndHangersOn moduleEtc(pContainer);
+    llvm::Module *M = moduleEtc.GetDxilModule().GetModule();
+    Mutate(*M);
+
+    llvm::SmallVector<char, 0> bitcode;
+    {
+      llvm::raw_svector_ostream OS(bitcode);
+      llvm::WriteBitcodeToFile(M, OS);
+    }
+
+    CComPtr<IDxcLibrary> pLibrary;
+    VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
+    CComPtr<IDxcBlobEncoding> pBitcodeBlob;
+    VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(
+        bitcode.data(), static_cast<UINT32>(bitcode.size()), CP_ACP,
+        &pBitcodeBlob));
+
+    return pix_test::WrapInNewContainer(m_dllSupport, pBitcodeBlob);
+  }
+
+  ValidationResult ValidateInstrumentedModule(IDxcBlob *pModule) {
+    CComPtr<IDxcBlob> pContainer = NormalizeToContainer(pModule);
+
+    ValidationResult direct = RunValidator(pContainer);
+    if (direct.Valid) {
+      return direct;
+    }
+
+    // The validator's "unused metadata" diagnostic names the metadata
+    // node, not the kind, so text can't separate PIX's own annotations
+    // from any other unsupported metadata. Strip only the four known PIX
+    // kinds and revalidate; if that alone fixes it, PIX metadata was the
+    // sole cause.
+    CComPtr<IDxcBlob> strippedContainer =
+        CloneModuleAndMutate(pContainer, StripKnownPixVirtualRegisterMetadata);
+    if (RunValidator(strippedContainer).Valid) {
+      return {true, {}};
+    }
+
+    return direct;
+  }
+
+  // Joins diagnostic lines, skipping blanks and "Validation failed."
+  // boilerplate.
+  static std::string
   GetSignificantValidationDiagnostics(const std::string &errors) {
-    FilteredValidationDiagnostics result;
+    std::string result;
     std::stringstream errorStream(errors);
     std::string line;
     while (std::getline(errorStream, line)) {
@@ -358,26 +419,14 @@ public:
       if (line.empty() || line == "Validation failed.") {
         continue;
       }
-      if (line.find("All metadata must be used by dxil") != std::string::npos) {
-        result.PermittedExceptionCount++;
-        continue;
-      }
-      result.Significant.push_back(line);
+      result += line + "\n";
     }
     return result;
   }
 
-  // True only if the diagnostics contain no significant errors and at
-  // least one instance of the permitted metadata exception.
-  bool IsPermittedValidationException(
-      const FilteredValidationDiagnostics &diagnostics) {
-    return diagnostics.Significant.empty() &&
-           diagnostics.PermittedExceptionCount > 0;
-  }
-
-  // Asserts an instrumented module validates. Accepts a module whose only
-  // diagnostic is the permitted metadata exception; logs and fails on any
-  // other validator error.
+  // Asserts an instrumented module validates, allowing for the four known
+  // PIX metadata kinds being unused; logs and fails on any other
+  // validator error.
   void VerifyInstrumentedModuleIsValid(IDxcBlob *pModule,
                                        const char *description) {
     ValidationResult validation = ValidateInstrumentedModule(pModule);
@@ -385,23 +434,9 @@ public:
       return;
     }
 
-    FilteredValidationDiagnostics diagnostics =
-        GetSignificantValidationDiagnostics(validation.Errors);
-    if (IsPermittedValidationException(diagnostics)) {
-      return;
-    }
-
-    std::string joined;
-    if (diagnostics.Significant.empty()) {
-      joined = "(validator reported failure with no significant diagnostic "
-               "text, and no permitted metadata exception was found)";
-    } else {
-      for (auto const &significantError : diagnostics.Significant) {
-        joined += significantError + "\n";
-      }
-    }
     WEX::Logging::Log::Error(WEX::Common::String().Format(
-        L"Validation failed after %S:\n%S", description, joined.c_str()));
+        L"Validation failed after %S:\n%S", description,
+        GetSignificantValidationDiagnostics(validation.Errors).c_str()));
     VERIFY_FAIL();
   }
 
@@ -3626,7 +3661,8 @@ float main() : SV_Target
 })x";
 
   // Virtual-register annotation adds metadata that DXIL does not consume,
-  // so this module only validates via the permitted metadata exception.
+  // so this module only validates because that metadata is one of the
+  // four known PIX kinds.
   auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
   auto output = RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
   VerifyInstrumentedModuleIsValid(
@@ -3642,20 +3678,11 @@ float main() : SV_Target
     return 0;
 })x";
 
-  // Same shader and pass as Validation_ControlValidModulePasses; only the
-  // corruption below differs.
   auto compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
   auto output = RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
 
-  // Confirm the baseline validates before corrupting it, so the failure
-  // below is caused by the corruption and nothing else.
-  VerifyInstrumentedModuleIsValid(
-      output.Module,
-      "virtual-register annotation of a trivial pixel shader, uncorrupted "
-      "baseline (validation harness control)");
-
-  // Mislabel the shader stage. The validator must reject this regardless
-  // of the permitted metadata exception.
+  // Mislabel the shader stage, so the container carries both the
+  // harness's permitted PIX metadata and a real defect.
   std::string disassembly = Disassemble(output.Module);
   const std::string shaderKindTag = "!\"ps\",";
   auto tagPosition = disassembly.find(shaderKindTag);
@@ -3677,40 +3704,49 @@ float main() : SV_Target
   CComPtr<IDxcBlob> pCorruptedContainer;
   VERIFY_SUCCEEDED(pAssembleResult->GetResult(&pCorruptedContainer));
 
+  // Direct validation's own diagnostic proves the PIX metadata is present
+  // and otherwise unused, alongside rejecting for the mislabeled stage.
+  ValidationResult direct = RunValidator(pCorruptedContainer);
+  VERIFY_IS_FALSE(direct.Valid);
+  VERIFY_IS_TRUE(direct.Errors.find("All metadata must be used by dxil") !=
+                std::string::npos);
+
+  // The harness must still reject it, for a reason other than the
+  // permitted metadata.
   ValidationResult validation = ValidateInstrumentedModule(pCorruptedContainer);
   VERIFY_IS_FALSE(validation.Valid);
-
-  // Confirm the corruption produces a real diagnostic, not just the
-  // permitted metadata exception.
-  FilteredValidationDiagnostics diagnostics =
-      GetSignificantValidationDiagnostics(validation.Errors);
-  VERIFY_IS_FALSE(diagnostics.Significant.empty());
+  VERIFY_IS_FALSE(
+      GetSignificantValidationDiagnostics(validation.Errors).empty());
 }
 
-// Tests that a validator failure is rejected unless its only diagnostic is
-// the permitted metadata exception. A failure with only the "Validation
-// failed." boilerplate and no exception must not pass.
-TEST_F(PixTest, Validation_ControlBoilerplateOnlyFailureIsRejected) {
-  // Boilerplate only, no permitted exception: must be rejected.
-  FilteredValidationDiagnostics boilerplateOnly =
-      GetSignificantValidationDiagnostics("Validation failed.\n");
-  VERIFY_IS_TRUE(boilerplateOnly.Significant.empty());
-  VERIFY_ARE_EQUAL(boilerplateOnly.PermittedExceptionCount, 0);
-  VERIFY_IS_FALSE(IsPermittedValidationException(boilerplateOnly));
+// A foreign, unused instruction metadata kind alongside the module's own
+// permitted PIX metadata must still be rejected: stripping only the four
+// known PIX kinds leaves it behind.
+TEST_F(PixTest, Validation_ControlNonPixUnusedMetadataIsRejected) {
+  const char *source = R"x(
+float main() : SV_Target
+{
+    return 0;
+})x";
 
-  // Permitted exception present: must be accepted.
-  FilteredValidationDiagnostics exceptionOnly =
-      GetSignificantValidationDiagnostics(
-          "Validation failed.\n"
-          "All metadata must be used by dxil's users.\n");
-  VERIFY_IS_TRUE(exceptionOnly.Significant.empty());
-  VERIFY_IS_TRUE(exceptionOnly.PermittedExceptionCount > 0);
-  VERIFY_IS_TRUE(IsPermittedValidationException(exceptionOnly));
+  CComPtr<IDxcBlob> compiled = Compile(m_dllSupport, source, L"ps_6_0", {L"-Od"});
+  SinglePassOutput output =
+      RunSinglePass(compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> pContainer = NormalizeToContainer(output.Module);
 
-  // Real diagnostic present: must be rejected, even with the exception.
-  FilteredValidationDiagnostics realDiagnostic =
-      GetSignificantValidationDiagnostics("Validation failed.\n"
-                                          "Some real validator diagnostic.\n");
-  VERIFY_IS_FALSE(realDiagnostic.Significant.empty());
-  VERIFY_IS_FALSE(IsPermittedValidationException(realDiagnostic));
+  CComPtr<IDxcBlob> withForeignMetadata =
+      CloneModuleAndMutate(pContainer, [](llvm::Module &M) {
+        for (llvm::Function &F : M) {
+          if (F.isDeclaration()) {
+            continue;
+          }
+          llvm::Instruction &I = *F.begin()->begin();
+          I.setMetadata("not-a-pix-kind",
+                        llvm::MDNode::get(M.getContext(), {}));
+          break;
+        }
+      });
+
+  ValidationResult validation = ValidateInstrumentedModule(withForeignMetadata);
+  VERIFY_IS_FALSE(validation.Valid);
 }

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -161,7 +161,7 @@ public:
   TEST_METHOD(NonUniformResourceIndex_Raytracing)
 
   // Control tests for the PIX pass validation harness below
-  // (ValidateInstrumentedModule / VerifyInstrumentedModuleIsValid).
+  // (validateInstrumentedModule / verifyInstrumentedModuleIsValid).
   TEST_METHOD(Validation_ControlValidModulePasses)
   TEST_METHOD(Validation_ControlInvalidModuleFails)
   TEST_METHOD(Validation_ControlNonPixUnusedMetadataIsRejected)
@@ -276,7 +276,7 @@ public:
     std::vector<std::string> Lines;
   };
 
-  SinglePassOutput RunSinglePass(IDxcBlob *Dxil, LPCWSTR PassOption) {
+  SinglePassOutput runSinglePass(IDxcBlob *Dxil, LPCWSTR PassOption) {
     CComPtr<IDxcOptimizer> Optimizer;
     VERIFY_SUCCEEDED(
         m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &Optimizer));
@@ -306,7 +306,7 @@ public:
   // The validator (and the assembler, when reconstructing a container
   // from bare bitcode) both require a container; some pass runners
   // return bare bitcode instead.
-  CComPtr<IDxcBlob> NormalizeToContainer(IDxcBlob *Module) {
+  CComPtr<IDxcBlob> normalizeToContainer(IDxcBlob *Module) {
     if (hlsl::IsDxilContainerLike(Module->GetBufferPointer(),
                                   Module->GetBufferSize()) != nullptr) {
       return Module;
@@ -314,7 +314,7 @@ public:
     return pix_test::WrapInNewContainer(m_dllSupport, Module);
   }
 
-  ValidationResult RunValidator(IDxcBlob *Container) {
+  ValidationResult runValidator(IDxcBlob *Container) {
     CComPtr<IDxcValidator> Validator;
     VERIFY_SUCCEEDED(
         m_dllSupport.CreateInstance(CLSID_DxcValidator, &Validator));
@@ -342,7 +342,7 @@ public:
       pix_dxil::PixAllocaReg::MDName, pix_dxil::PixAllocaRegWrite::MDName};
 
   // Removes the known PIX metadata kinds from every function and instruction.
-  static void StripKnownPixVirtualRegisterMetadata(llvm::Module &M) {
+  static void stripKnownPixVirtualRegisterMetadata(llvm::Module &M) {
     llvm::LLVMContext &Ctx = M.getContext();
     for (const char *Kind : KnownPixVirtualRegisterMetadataKinds) {
       unsigned KindID = Ctx.getMDKindID(Kind);
@@ -360,7 +360,7 @@ public:
   // Parses Container into an isolated LLVM module, applies Mutate to it,
   // and re-serializes into a fresh validator-ready container.
   template <typename MutatorFn>
-  CComPtr<IDxcBlob> CloneModuleAndMutate(IDxcBlob *Container,
+  CComPtr<IDxcBlob> cloneModuleAndMutate(IDxcBlob *Container,
                                          MutatorFn Mutate) {
     ModuleAndHangersOn ModuleEtc(Container);
     llvm::Module *M = ModuleEtc.GetDxilModule().GetModule();
@@ -382,10 +382,10 @@ public:
     return pix_test::WrapInNewContainer(m_dllSupport, BitcodeBlob);
   }
 
-  ValidationResult ValidateInstrumentedModule(IDxcBlob *Module) {
-    CComPtr<IDxcBlob> Container = NormalizeToContainer(Module);
+  ValidationResult validateInstrumentedModule(IDxcBlob *Module) {
+    CComPtr<IDxcBlob> Container = normalizeToContainer(Module);
 
-    ValidationResult DirectResult = RunValidator(Container);
+    ValidationResult DirectResult = runValidator(Container);
     if (DirectResult.Valid) {
       return DirectResult;
     }
@@ -396,8 +396,8 @@ public:
     // and revalidate. If this fixes the module, PIX metadata was the only
     // cause.
     CComPtr<IDxcBlob> StrippedContainer =
-        CloneModuleAndMutate(Container, StripKnownPixVirtualRegisterMetadata);
-    if (RunValidator(StrippedContainer).Valid) {
+        cloneModuleAndMutate(Container, stripKnownPixVirtualRegisterMetadata);
+    if (runValidator(StrippedContainer).Valid) {
       return {true, {}};
     }
 
@@ -407,7 +407,7 @@ public:
   // Joins diagnostic lines, skipping blanks and "Validation failed."
   // boilerplate.
   static std::string
-  GetSignificantValidationDiagnostics(const std::string &Errors) {
+  getSignificantValidationDiagnostics(const std::string &Errors) {
     std::string Result;
     std::stringstream ErrorStream(Errors);
     std::string Line;
@@ -425,16 +425,16 @@ public:
 
   // Asserts that an instrumented module is valid when known PIX metadata is
   // unused. Logs and fails on any other validator error.
-  void VerifyInstrumentedModuleIsValid(IDxcBlob *Module,
+  void verifyInstrumentedModuleIsValid(IDxcBlob *Module,
                                        const char *Description) {
-    ValidationResult Result = ValidateInstrumentedModule(Module);
+    ValidationResult Result = validateInstrumentedModule(Module);
     if (Result.Valid) {
       return;
     }
 
     WEX::Logging::Log::Error(WEX::Common::String().Format(
         L"Validation failed after %S:\n%S", Description,
-        GetSignificantValidationDiagnostics(Result.Errors).c_str()));
+        getSignificantValidationDiagnostics(Result.Errors).c_str()));
     VERIFY_FAIL();
   }
 
@@ -3645,7 +3645,7 @@ void main(uint3 tid : SV_DispatchThreadID) {
 
 ///////////////////////////////////////////////////////////////////////////////
 // Control tests for the PIX pass validation harness
-// (ValidateInstrumentedModule / VerifyInstrumentedModuleIsValid).
+// (validateInstrumentedModule / verifyInstrumentedModuleIsValid).
 //
 // These tests use the same trivial pixel shader and virtual-register
 // annotation pass. This keeps the valid and invalid cases comparable.
@@ -3662,8 +3662,8 @@ float main() : SV_Target
   CComPtr<IDxcBlob> Compiled =
       Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
   SinglePassOutput Output =
-      RunSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
-  VerifyInstrumentedModuleIsValid(
+      runSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
+  verifyInstrumentedModuleIsValid(
       Output.Module,
       "virtual-register annotation of a trivial pixel shader (validation "
       "harness control)");
@@ -3679,7 +3679,7 @@ float main() : SV_Target
   CComPtr<IDxcBlob> Compiled =
       Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
   SinglePassOutput Output =
-      RunSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
+      runSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
 
   // Mislabel the shader stage, so the container carries both the
   // harness's permitted PIX metadata and a real defect.
@@ -3705,7 +3705,7 @@ float main() : SV_Target
 
   // Direct validation's own diagnostic proves the PIX metadata is present
   // and otherwise unused, alongside rejecting for the mislabeled stage.
-  ValidationResult DirectResult = RunValidator(CorruptedContainer);
+  ValidationResult DirectResult = runValidator(CorruptedContainer);
   VERIFY_IS_FALSE(DirectResult.Valid);
   VERIFY_IS_TRUE(DirectResult.Errors.find(
                      "All metadata must be used by dxil") != std::string::npos);
@@ -3713,10 +3713,10 @@ float main() : SV_Target
   // The harness must still reject it, for a reason other than the
   // permitted metadata.
   ValidationResult HarnessResult =
-      ValidateInstrumentedModule(CorruptedContainer);
+      validateInstrumentedModule(CorruptedContainer);
   VERIFY_IS_FALSE(HarnessResult.Valid);
   VERIFY_IS_FALSE(
-      GetSignificantValidationDiagnostics(HarnessResult.Errors).empty());
+      getSignificantValidationDiagnostics(HarnessResult.Errors).empty());
 }
 
 // A foreign, unused instruction metadata kind with the module's PIX metadata
@@ -3731,11 +3731,11 @@ float main() : SV_Target
   CComPtr<IDxcBlob> Compiled =
       Compile(m_dllSupport, Source, L"ps_6_0", {L"-Od"});
   SinglePassOutput Output =
-      RunSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
-  CComPtr<IDxcBlob> Container = NormalizeToContainer(Output.Module);
+      runSinglePass(Compiled, L"-dxil-annotate-with-virtual-regs");
+  CComPtr<IDxcBlob> Container = normalizeToContainer(Output.Module);
 
   CComPtr<IDxcBlob> WithForeignMetadata =
-      CloneModuleAndMutate(Container, [](llvm::Module &M) {
+      cloneModuleAndMutate(Container, [](llvm::Module &M) {
         for (llvm::Function &F : M) {
           if (F.isDeclaration()) {
             continue;
@@ -3747,6 +3747,6 @@ float main() : SV_Target
         }
       });
 
-  ValidationResult Result = ValidateInstrumentedModule(WithForeignMetadata);
+  ValidationResult Result = validateInstrumentedModule(WithForeignMetadata);
   VERIFY_IS_FALSE(Result.Valid);
 }


### PR DESCRIPTION
> Part 2 of 14 in the PIX instrumentation stack. It targets `users/damyanp/pix-fixes-01`, which supplies the validation helpers. Eleven later layers use the helpers this layer changes, so please review it with care.

More than one PIX pass can run on the same module. Each pass adds its own tools UAV, so a pipeline with two passes makes two resources at the same register and space.

The code that adds this UAV to a root signature has three unsafe paths. Root signature serialization can fail and give a null blob, which the code then reads. An empty result can replace a correct root signature. Only the first global root-signature subobject gets the new parameter, so a state object that declares more than one is left in a mixed state.

The tools UAV is a raw buffer, so it changes the shader flags of the module. The code does not compute the flags again. Some passes make a dx.op overload declaration and then find no callers for it. They leave the declaration in the module, and the validator refuses a module that has an unused declaration.

When serialization fails, the helpers keep the original root signature. A valid signature is better than an empty one.

Assisted-by: Copilot

> This changes only the PIX instrumentation, so it needs no release note.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>