### PR TITLE
[PIX] Fix debug variable storage layout

### DIFF
--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -354,51 +354,70 @@ bool DxilAnnotateWithVirtualRegister::IsAllocaRegisterWrite(
     uint32_t precedingMemberCount = 0;
     auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(pGEP->getPointerOperand());
     if (Alloca == nullptr) {
-      // In the case of vector types (floatN, matrixNxM), the pointer operand
-      // will actually point to another element pointer instruction. But this
-      // isn't a recursive thing- we only need to check these two levels.
-      if (auto *pPointerGEP = llvm::dyn_cast<llvm::GetElementPtrInst>(
-              pGEP->getPointerOperand())) {
-        Alloca =
-            llvm::dyn_cast<llvm::AllocaInst>(pPointerGEP->getPointerOperand());
-        if (Alloca == nullptr) {
+      // The pointer operand can itself be a GEP whenever the value being
+      // written is nested in more than one aggregate: a vector member of a
+      // struct (floatN, matrixNxM), or a struct member of a struct. Walk
+      // the whole chain of ancestor GEPs, outermost first, and require it
+      // to bottom out at an alloca.
+      llvm::SmallVector<llvm::GetElementPtrInst *, 4> AncestorGEPs;
+      llvm::Value *PointerOperand = pGEP->getPointerOperand();
+      while (auto *pAncestorGEP =
+                 llvm::dyn_cast<llvm::GetElementPtrInst>(PointerOperand)) {
+        AncestorGEPs.push_back(pAncestorGEP);
+        PointerOperand = pAncestorGEP->getPointerOperand();
+      }
+
+      Alloca = llvm::dyn_cast<llvm::AllocaInst>(PointerOperand);
+      if (Alloca == nullptr) {
+        return false;
+      }
+
+      // Each level contributes the flattened count of whatever members precede
+      // the one it selects, so the offsets accumulate down the chain.
+      for (auto *pAncestorGEP : AncestorGEPs) {
+        auto *pStructType = llvm::dyn_cast<llvm::StructType>(
+            pAncestorGEP->getPointerOperandType()->getPointerElementType());
+        if (pStructType == nullptr) {
+          continue;
+        }
+        if (pAncestorGEP->getNumOperands() < 3) {
+          continue;
+        }
+        auto *pStructMember =
+            llvm::dyn_cast<llvm::ConstantInt>(pAncestorGEP->getOperand(2));
+        if (pStructMember == nullptr) {
+          // A dynamically selected member has no constant offset; guessing
+          // zero would attribute the write to the wrong register.
           return false;
         }
-        // And of course the member we're after might not be at the beginning of
-        // any containing struct:
-        if (auto *pStructType = llvm::dyn_cast<llvm::StructType>(
-                pPointerGEP->getPointerOperandType()
-                    ->getPointerElementType())) {
-          auto *pStructMember =
-              llvm::dyn_cast<llvm::ConstantInt>(pPointerGEP->getOperand(2));
-          uint64_t memberIndex = pStructMember->getLimitedValue();
-          for (uint64_t i = 0; i < memberIndex; ++i) {
-            precedingMemberCount +=
-                CountStructMembers(pStructType->getStructElementType(i));
-          }
+        uint64_t memberIndex = pStructMember->getLimitedValue();
+        if (memberIndex > pStructType->getStructNumElements()) {
+          return false;
         }
+        for (uint64_t i = 0; i < memberIndex; ++i) {
+          precedingMemberCount +=
+              CountStructMembers(pStructType->getStructElementType(i));
+        }
+      }
 
-        // And the source pointer may be a vector (floatn) type,
-        // and if so, that's another offset to consider.
-        llvm::Type *DestType = pGEP->getPointerOperand()->getType();
-        // We expect this to be a pointer type (it's a GEP after all):
-        if (DestType->isPointerTy()) {
-          llvm::Type *PointedType = DestType->getPointerElementType();
-          // Being careful to check num operands too in order to avoid false
-          // positives:
-          if (PointedType->isVectorTy() && pGEP->getNumOperands() == 3) {
-            // Fetch the second deref (in operand 2).
-            // (the first derefs the pointer to the "floatn",
-            // and the second denotes the index into the floatn.)
-            llvm::Value *vectorIndex = pGEP->getOperand(2);
-            if (auto *constIntIIndex =
-                    llvm::cast<llvm::ConstantInt>(vectorIndex)) {
-              precedingMemberCount += constIntIIndex->getLimitedValue();
-            }
+      // And the source pointer may be a vector (floatn) type,
+      // and if so, that's another offset to consider.
+      llvm::Type *DestType = pGEP->getPointerOperand()->getType();
+      // We expect this to be a pointer type (it's a GEP after all):
+      if (DestType->isPointerTy()) {
+        llvm::Type *PointedType = DestType->getPointerElementType();
+        // Being careful to check num operands too in order to avoid false
+        // positives:
+        if (PointedType->isVectorTy() && pGEP->getNumOperands() == 3) {
+          // Fetch the second deref (in operand 2).
+          // (the first derefs the pointer to the "floatn",
+          // and the second denotes the index into the floatn.)
+          llvm::Value *vectorIndex = pGEP->getOperand(2);
+          if (auto *constIntIIndex =
+                  llvm::dyn_cast<llvm::ConstantInt>(vectorIndex)) {
+            precedingMemberCount += constIntIIndex->getLimitedValue();
           }
         }
-      } else {
-        return false;
       }
     }
 

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -145,6 +145,22 @@ public:
     }
   }
 
+  // Move the aligned offset forward without adding padding to the packed
+  // offset. Overlapping debug information cannot move storage mappings
+  // backward.
+  void AdvanceAlignedOffsetTo(OffsetInBits AlignedOffset) {
+    if (AlignedOffset > m_CurrentAlignedOffset) {
+      VALUE_TO_DECLARE_LOG("Advancing aligned offset from %d to %d",
+                           m_CurrentAlignedOffset, AlignedOffset);
+      m_CurrentAlignedOffset = AlignedOffset;
+    } else if (AlignedOffset < m_CurrentAlignedOffset) {
+      VALUE_TO_DECLARE_LOG("Refusing to move aligned offset back from %d to %d",
+                           m_CurrentAlignedOffset, AlignedOffset);
+      // Keep existing mappings monotonic when debug information overlaps.
+      return;
+    }
+  }
+
   // Add is used to "add" an aggregate element (struct field, array element)
   // at the current aligned/packed offsets, bumping them by Ty's size.
   Offsets Add(llvm::DIBasicType *Ty, unsigned sizeOverride) {
@@ -443,63 +459,61 @@ DescendTypeAndFindEmbeddedArrayElements(llvm::StringRef VariableName,
   } else if (auto *CompositeTy = llvm::dyn_cast<llvm::DICompositeType>(Ty)) {
     switch (CompositeTy->getTag()) {
     case llvm::dwarf::DW_TAG_array_type: {
+      // DXC flattens a multi-dimensional array to a single one-dimensional
+      // array in the module. The true array extent is the product of the
+      // dimensions.
+      uint64_t TotalElementCount = 1;
+      bool FoundSubrange = false;
       for (auto Element : CompositeTy->getElements()) {
-        // First element for an array is DISubrange
-        if (auto Subrange = llvm::dyn_cast<DISubrange>(Element)) {
-          auto ElementTy = CompositeTy->getBaseType().resolve(EmptyMap);
-          if (auto *BasicTy = llvm::dyn_cast<llvm::DIBasicType>(ElementTy)) {
-            bool CorrectLowerOffset = AccumulatedMemberOffset == OffsetToSeek;
-            bool CorrectUpperOffset =
-                AccumulatedMemberOffset +
-                    Subrange->getCount() * BasicTy->getSizeInBits() ==
-                OffsetToSeek + SizeToSeek;
-            if (BasicTy != nullptr && CorrectLowerOffset &&
-                CorrectUpperOffset) {
-              std::vector<GlobalEmbeddedArrayElementStorage> storage;
-              for (int64_t i = 0; i < Subrange->getCount(); ++i) {
-                auto ElementOffset =
-                    AccumulatedMemberOffset + i * BasicTy->getSizeInBits();
-                GlobalEmbeddedArrayElementStorage element;
-                element.Name = VariableName.str() + "." + std::to_string(i);
-                element.Offset = static_cast<OffsetInBits>(ElementOffset);
-                element.Size =
-                    static_cast<SizeInBits>(BasicTy->getSizeInBits());
-                storage.push_back(std::move(element));
-              }
-              return storage;
-            }
-          }
-
-          // If we didn't succeed and return above, then we need to process each
-          // element in the array
-          std::vector<GlobalEmbeddedArrayElementStorage> storage;
-          for (int64_t i = 0; i < Subrange->getCount(); ++i) {
-            auto elementStorage = DescendTypeAndFindEmbeddedArrayElements(
-                VariableName,
-                AccumulatedMemberOffset + ElementTy->getSizeInBits() * i,
-                ElementTy, OffsetToSeek, SizeToSeek);
-            std::move(elementStorage.begin(), elementStorage.end(),
-                      std::back_inserter(storage));
-          }
-          if (!storage.empty()) {
-            return storage;
-          }
+        if (auto *Subrange = llvm::dyn_cast<DISubrange>(Element)) {
+          TotalElementCount *= Subrange->getCount();
+          FoundSubrange = true;
         }
       }
-      for (auto Element : CompositeTy->getElements()) {
-        // First element for an array is DISubrange
-        if (auto Subrange = llvm::dyn_cast<DISubrange>(Element)) {
-          auto ElementType = CompositeTy->getBaseType().resolve(EmptyMap);
-          for (int64_t i = 0; i < Subrange->getCount(); ++i) {
-            auto storage = DescendTypeAndFindEmbeddedArrayElements(
-                VariableName,
-                AccumulatedMemberOffset + ElementType->getSizeInBits() * i,
-                ElementType, OffsetToSeek, SizeToSeek);
-            if (!storage.empty()) {
-              return storage;
-            }
+
+      if (!FoundSubrange) {
+        break;
+      }
+
+      auto ElementTy = CompositeTy->getBaseType().resolve(EmptyMap);
+      if (ElementTy == nullptr) {
+        break;
+      }
+
+      if (auto *BasicTy = llvm::dyn_cast<llvm::DIBasicType>(ElementTy)) {
+        const bool CorrectLowerOffset = AccumulatedMemberOffset == OffsetToSeek;
+        const bool CorrectUpperOffset =
+            AccumulatedMemberOffset +
+                TotalElementCount * BasicTy->getSizeInBits() ==
+            OffsetToSeek + SizeToSeek;
+        if (CorrectLowerOffset && CorrectUpperOffset) {
+          std::vector<GlobalEmbeddedArrayElementStorage> storage;
+          for (uint64_t i = 0; i < TotalElementCount; ++i) {
+            auto ElementOffset =
+                AccumulatedMemberOffset + i * BasicTy->getSizeInBits();
+            GlobalEmbeddedArrayElementStorage element;
+            element.Name = VariableName.str() + "." + std::to_string(i);
+            element.Offset = static_cast<OffsetInBits>(ElementOffset);
+            element.Size = static_cast<SizeInBits>(BasicTy->getSizeInBits());
+            storage.push_back(std::move(element));
           }
+          return storage;
         }
+      }
+
+      // The array's elements are themselves aggregates, so descend into each of
+      // them in turn looking for the sought offset.
+      std::vector<GlobalEmbeddedArrayElementStorage> storage;
+      for (uint64_t i = 0; i < TotalElementCount; ++i) {
+        auto elementStorage = DescendTypeAndFindEmbeddedArrayElements(
+            VariableName,
+            AccumulatedMemberOffset + ElementTy->getSizeInBits() * i, ElementTy,
+            OffsetToSeek, SizeToSeek);
+        std::move(elementStorage.begin(), elementStorage.end(),
+                  std::back_inserter(storage));
+      }
+      if (!storage.empty()) {
+        return storage;
       }
     } break;
     case llvm::dwarf::DW_TAG_structure_type:
@@ -554,11 +568,18 @@ GlobalStorageMap GatherGlobalEmbeddedArrayStorage(llvm::Module &M) {
         if (auto *DIGVDerivedType =
                 llvm::dyn_cast<llvm::DIDerivedType>(DIGVType)) {
           if (DIGVDerivedType->getTag() == llvm::dwarf::DW_TAG_member) {
-            // This type is embedded within the containing DIGSV type
+            // This type is embedded within the containing DIGSV type.
+            // A flattened multi-dimensional array member renames the module
+            // global but not the debug variable, so only the linkage name
+            // still identifies it.
+            llvm::StringRef GlobalName = DIGV->getLinkageName();
+            if (GlobalName.empty()) {
+              GlobalName = DIGV->getName();
+            }
             const llvm::DITypeIdentifierMap EmptyMap;
             auto *Ty = HLSLStruct->getType().resolve(EmptyMap);
             auto Storage = DescendTypeAndFindEmbeddedArrayElements(
-                DIGV->getName(), 0, Ty, DIGVDerivedType->getOffsetInBits(),
+                GlobalName, 0, Ty, DIGVDerivedType->getOffsetInBits(),
                 DIGVDerivedType->getSizeInBits());
             auto &ArrayStorage = ret[HLSLStruct].ArrayElementStorage;
             std::move(Storage.begin(), Storage.end(),
@@ -617,7 +638,8 @@ bool DxilDbgValueToDbgDeclare::runOnModule(llvm::Module &M) {
         // lists.
         for (auto &instruction : instructions) {
           if (auto *Store = llvm::dyn_cast<llvm::StoreInst>(instruction)) {
-            Changed =
+            // Preserve changes reported by every processed store.
+            Changed |=
                 handleStoreIfDestIsGlobal(M, GlobalEmbeddedArrayStorage, Store);
           }
         }
@@ -847,6 +869,33 @@ static bool IsDITypePointer(DIType *DTy,
   return false;
 }
 
+static bool HasPointerBackedCompositeCopy(llvm::DbgValueInst *DbgValue,
+                                          llvm::DIType *Ty) {
+  const llvm::DITypeIdentifierMap EmptyMap;
+  llvm::DIType *UnaliasedTy = DITypePeelTypeAlias(Ty);
+  if (!llvm::isa<llvm::Constant>(DbgValue->getValue()) ||
+      !llvm::isa<llvm::DICompositeType>(UnaliasedTy)) {
+    return false;
+  }
+
+  for (llvm::BasicBlock &Block : *DbgValue->getParent()->getParent()) {
+    for (llvm::Instruction &Instruction : Block) {
+      auto *OtherDbgValue = llvm::dyn_cast<llvm::DbgValueInst>(&Instruction);
+      if (OtherDbgValue == nullptr || OtherDbgValue == DbgValue ||
+          !llvm::isa<llvm::AllocaInst>(OtherDbgValue->getValue())) {
+        continue;
+      }
+
+      llvm::DIType *OtherTy =
+          OtherDbgValue->getVariable()->getType().resolve(EmptyMap);
+      if (OtherTy != nullptr && DITypePeelTypeAlias(OtherTy) == UnaliasedTy) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void DxilDbgValueToDbgDeclare::handleDbgValue(llvm::Module &M,
                                               llvm::DbgValueInst *DbgValue) {
   VALUE_TO_DECLARE_LOG("DbgValue named %s", DbgValue->getName().str().c_str());
@@ -908,6 +957,11 @@ void DxilDbgValueToDbgDeclare::handleDbgValue(llvm::Module &M,
     }
   }
 
+  if (HasPointerBackedCompositeCopy(DbgValue, Ty)) {
+    VALUE_TO_DECLARE_LOG("Using pointer-backed composite storage");
+    return;
+  }
+
   auto &Register = m_Registers[Variable];
   if (Register == nullptr) {
     Register.reset(new VariableRegisters(
@@ -932,6 +986,10 @@ void DxilDbgValueToDbgDeclare::handleDbgValue(llvm::Module &M,
 
   const OffsetInBits InitialOffset = PackedOffsetFromVar;
   auto *insertPt = llvm::dyn_cast<llvm::Instruction>(ValueFromDbgInst);
+  if (insertPt == nullptr) {
+    // Constants and arguments are available at the dbg.value location.
+    insertPt = DbgValue;
+  }
   if (insertPt != nullptr && !llvm::isa<TerminatorInst>(insertPt)) {
     insertPt = insertPt->getNextNode();
     // Drivers may crash if phi nodes aren't always at the top of a block,
@@ -965,11 +1023,28 @@ void DxilDbgValueToDbgDeclare::handleDbgValue(llvm::Module &M,
           continue;
         }
 
-        if (AllocaInst->getAllocatedType()->getArrayElementType() ==
-            VO.m_V->getType()) {
-          auto *GEP = B.CreateGEP(AllocaInst, {Zero, Zero});
-          B.CreateStore(VO.m_V, GEP);
+        llvm::Type *ShadowElementType =
+            AllocaInst->getAllocatedType()->getArrayElementType();
+        llvm::Value *ValueToStore = VO.m_V;
+        if (ShadowElementType != ValueToStore->getType()) {
+          // Emit a bitcast to match the shadow alloca element type when the
+          // shader reinterprets the bits without converting them.
+          const llvm::DataLayout &DataLayout = M.getDataLayout();
+          const bool SameWidth =
+              !ShadowElementType->isAggregateType() &&
+              !ValueToStore->getType()->isAggregateType() &&
+              !ShadowElementType->isPointerTy() &&
+              !ValueToStore->getType()->isPointerTy() &&
+              DataLayout.getTypeSizeInBits(ShadowElementType) ==
+                  DataLayout.getTypeSizeInBits(ValueToStore->getType());
+          if (!SameWidth) {
+            continue;
+          }
+          ValueToStore = B.CreateBitCast(ValueToStore, ShadowElementType);
         }
+
+        auto *GEP = B.CreateGEP(AllocaInst, {Zero, Zero});
+        B.CreateStore(ValueToStore, GEP);
       }
     }
   }
@@ -1158,7 +1233,13 @@ void VariableRegisters::PopulateAllocaMap(llvm::DIType *Ty) {
     case llvm::dwarf::DW_TAG_enumeration_type: {
       auto *baseType = CompositeTy->getBaseType().resolve(EmptyMap);
       if (baseType != nullptr) {
+        const OffsetInBits EnumerationStart =
+            m_Offsets.GetCurrentAlignedOffset();
         PopulateAllocaMap(baseType);
+        // Advance to the enumeration's own declared size.
+        m_Offsets.AdvanceAlignedOffsetTo(
+            EnumerationStart +
+            static_cast<SizeInBits>(CompositeTy->getSizeInBits()));
       } else {
         m_Offsets.AlignToAndAddUnhandledType(CompositeTy);
       }
@@ -1228,9 +1309,10 @@ void VariableRegisters::PopulateAllocaMap_BasicType(llvm::DIBasicType *Ty,
 
   auto *Storage = GetMetadataAsValue(llvm::ValueAsMetadata::get(Alloca));
   auto *Variable = GetMetadataAsValue(m_Variable);
-  auto *Expression = GetMetadataAsValue(
-      GetDIExpression(Ty, sizeOverride == 0 ? offsets.Aligned : offsets.Packed,
-                      GetVariableSizeInbits(m_Variable), sizeOverride));
+  // Describe the aligned offset in the bit_piece so it agrees with the
+  // debug-info field's declared offset.
+  auto *Expression = GetMetadataAsValue(GetDIExpression(
+      Ty, offsets.Aligned, GetVariableSizeInbits(m_Variable), sizeOverride));
   auto *DbgDeclare =
       m_B.CreateCall(m_DbgDeclareFn, {Storage, Variable, Expression});
   DbgDeclare->setDebugLoc(m_dbgLoc);
@@ -1261,7 +1343,6 @@ void VariableRegisters::PopulateAllocaMap_ArrayType(llvm::DICompositeType *Ty) {
   }
 
   const SizeInBits ArraySizeInBits = Ty->getSizeInBits();
-  (void)ArraySizeInBits;
 
   const llvm::DITypeIdentifierMap EmptyMap;
   llvm::DIType *ElementTy = Ty->getBaseType().resolve(EmptyMap);
@@ -1274,18 +1355,25 @@ void VariableRegisters::PopulateAllocaMap_ArrayType(llvm::DICompositeType *Ty) {
   // in bits.
   m_Offsets.AlignTo(ElementTy);
 
+  const OffsetInBits ArrayStart = m_Offsets.GetCurrentAlignedOffset();
+
   for (unsigned i = 0; i < NumElements; ++i) {
     // This is only needed if ElementTy's size is not a multiple of
     // its natural alignment.
     m_Offsets.AlignTo(ElementTy);
     PopulateAllocaMap(ElementTy);
   }
+
+  // The elements only account for the bits they occupy, which stops short
+  // of the array's real end for a padded element type. Advance to the end.
+  m_Offsets.AdvanceAlignedOffsetTo(ArrayStart + ArraySizeInBits);
 }
 
 void VariableRegisters::PopulateAllocaMap_StructType(
     llvm::DICompositeType *Ty) {
   VALUE_TO_DECLARE_LOG("Struct type : %s, size %d", Ty->getName().str().c_str(),
                        Ty->getSizeInBits());
+  const SizeInBits StructSizeInBits = Ty->getSizeInBits();
   std::map<OffsetInBits, llvm::DIDerivedType *> SortedMembers;
   if (!SortMembers(Ty, &SortedMembers)) {
     m_Offsets.AlignToAndAddUnhandledType(Ty);
@@ -1294,7 +1382,6 @@ void VariableRegisters::PopulateAllocaMap_StructType(
 
   m_Offsets.AlignTo(Ty);
   const OffsetInBits StructStart = m_Offsets.GetCurrentAlignedOffset();
-  (void)StructStart;
   const llvm::DITypeIdentifierMap EmptyMap;
 
   for (auto OffsetAndMember : SortedMembers) {
@@ -1310,6 +1397,10 @@ void VariableRegisters::PopulateAllocaMap_StructType(
       // than the type in which it resides). If we were to take
       // the base type, then the information about the member's
       // size would be lost
+      //
+      // The AlignTo above is a no-op for a bitfield, so snap to the declared
+      // offset here to ensure it aligns with the debug info.
+      m_Offsets.AdvanceAlignedOffsetTo(StructStart + OffsetAndMember.first);
       PopulateAllocaMap(OffsetAndMember.second);
     } else {
       if (OffsetAndMember.second->getAlignInBits() ==
@@ -1326,6 +1417,11 @@ void VariableRegisters::PopulateAllocaMap_StructType(
       }
     }
   }
+
+  // The members between them only account for the bits they occupy, which stops
+  // short of the struct's real end whenever the struct's alignment requires
+  // tail padding. Advance to the struct's full size.
+  m_Offsets.AdvanceAlignedOffsetTo(StructStart + StructSizeInBits);
 }
 
 // HLSL Change: remove unused function

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -235,6 +235,7 @@ struct InstructionAndType {
   DebugShaderModifierRecordType Type;
   std::uint32_t RegisterNumber;
   std::uint32_t AllocaBase;
+  std::uint32_t AllocaRegisterSize = 0;
   Value *AllocaWriteIndex = nullptr;
   std::optional<uint64_t> ConstantAllocaStoreValue;
 };
@@ -993,11 +994,10 @@ std::optional<InstructionAndType>
 DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext *BC,
                                                  StoreInst *Inst) {
   std::uint32_t ValueOrdinalBase;
-  std::uint32_t UnusedValueOrdinalSize;
+  std::uint32_t ValueOrdinalSize;
   llvm::Value *ValueOrdinalIndex;
-  if (!pix_dxil::PixAllocaRegWrite::FromInst(Inst, &ValueOrdinalBase,
-                                             &UnusedValueOrdinalSize,
-                                             &ValueOrdinalIndex)) {
+  if (!pix_dxil::PixAllocaRegWrite::FromInst(
+          Inst, &ValueOrdinalBase, &ValueOrdinalSize, &ValueOrdinalIndex)) {
     return std::nullopt;
   }
 
@@ -1019,6 +1019,7 @@ DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext *BC,
         ret.Type = *Type;
         ret.RegisterNumber = RegNum;
         ret.AllocaBase = ValueOrdinalBase;
+        ret.AllocaRegisterSize = ValueOrdinalSize;
         ret.AllocaWriteIndex = ValueOrdinalIndex;
         return ret;
       }
@@ -1029,6 +1030,7 @@ DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext *BC,
       ret.InstructionOrdinal = InstNum;
       ret.Type = *Type;
       ret.AllocaBase = ValueOrdinalBase;
+      ret.AllocaRegisterSize = ValueOrdinalSize;
       ret.AllocaWriteIndex = ValueOrdinalIndex;
 
       switch (ValueAsConst->getType()->getTypeID()) {
@@ -1356,21 +1358,18 @@ DxilDebugInstrumentation::FindInstrumentableInstructionsInBlock(
           IndexingToken = "s"; // static indexing, no debug output required
         } else {
           IndexingToken = "d"; // dynamic indexing
-          int MaxArraySize = 1;
-          if (auto *Store = dyn_cast<StoreInst>(&Inst)) {
-            if (auto *GEP =
-                    dyn_cast<GetElementPtrInst>(Store->getPointerOperand())) {
-              if (auto *Alloca =
-                      dyn_cast<AllocaInst>(GEP->getPointerOperand())) {
-                MaxArraySize =
-                    Alloca->getAllocatedType()->getArrayNumElements();
-              }
-            }
-          }
+          // The register span for a dynamic write comes from the
+          // !pix-alloca-reg-write metadata the annotation pass attached to
+          // this instruction, so it always matches the virtual-register
+          // numbering the annotation pass assigned.
+          uint32_t MaxArraySize = std::max(1u, IandT->AllocaRegisterSize);
           RegisterOrStaticIndex = std::to_string(IandT->AllocaBase) + "-" +
                                   std::to_string(MaxArraySize);
           DebugOutputForThisInstruction.ValueToWriteToDebugMemory =
               IandT->AllocaWriteIndex;
+          // Dynamic alloca records store the i32 index as a four-byte payload.
+          DebugOutputForThisInstruction.ValueType =
+              DebugShaderModifierRecordTypeDXILStepUint32;
         }
       } else {
         IndexingToken = "a"; // meaning an SSA assignment

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_16bit_bitfields.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_16bit_bitfields.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -Tcs_6_6 -enable-16bit-types -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify that 16-bit and 32-bit bitfields use their declared storage units.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct HalfBitfield
+{
+    uint16_t Small : 5;
+    uint32_t Wide : 20;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 5)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 32, 20)
+
+// CHECK: store i16 %{{[^,]+}}, i16*
+// CHECK: store i32 %{{[^,]+}}, i32*
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    HalfBitfield bitfield;
+    bitfield.Small = (uint16_t)RawUAV.Load(2 * 4);
+    bitfield.Wide = RawUAV.Load(3 * 4);
+
+    RawUAV.Store(0, bitfield.Small + bitfield.Wide);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_16bit_tail_padding.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_16bit_tail_padding.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -Tcs_6_6 -enable-16bit-types -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify a 16-bit member after a tail-padded 64-bit struct.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct HalfTail
+{
+    float Wide;
+    float16_t Small;
+};
+
+struct Holder
+{
+    HalfTail Padded;
+    float16_t Trailing;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 32, 16)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 16)
+
+// CHECK: store float
+// CHECK: store half
+// CHECK: store half
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    Holder holder;
+    holder.Padded.Wide = (float)RawUAV.Load(2 * 4);
+    holder.Padded.Small = (float16_t)RawUAV.Load(3 * 4);
+    holder.Trailing = (float16_t)RawUAV.Load(4 * 4);
+
+    RawUAV.Store(0, holder.Padded.Wide + (float)holder.Padded.Small +
+                        (float)holder.Trailing);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_aggregate_tail_padding.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_aggregate_tail_padding.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc -Tcs_6_6 -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify a member after a 128-bit struct with 32 bits of tail padding.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct TailPadded
+{
+    double Wide;
+    float Narrow;
+};
+
+struct Holder
+{
+    TailPadded Padded;
+    float Trailing;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 128, 32)
+
+// CHECK: store double
+// CHECK: store float
+// CHECK: store float
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    Holder holder;
+    holder.Padded.Wide = (double)RawUAV.Load(2 * 4);
+    holder.Padded.Narrow = (float)RawUAV.Load(3 * 4);
+    holder.Trailing = (float)RawUAV.Load(7 * 4);
+
+    RawUAV.Store(0, (float)holder.Padded.Wide + holder.Padded.Narrow + holder.Trailing);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_array_of_padded_structs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_array_of_padded_structs.hlsl
@@ -1,0 +1,44 @@
+// RUN: %dxc -Tcs_6_6 -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify an array of 128-bit padded structs followed by another member.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct TailPadded
+{
+    double Wide;
+    float Narrow;
+};
+
+struct Holder
+{
+    TailPadded Elements[2];
+    float Trailing;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 128, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 192, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 256, 32)
+
+// CHECK: store double
+// CHECK: store float
+// CHECK: store double
+// CHECK: store float
+// CHECK: store float
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    Holder holder;
+    holder.Elements[0].Wide = (double)RawUAV.Load(2 * 4);
+    holder.Elements[0].Narrow = (float)RawUAV.Load(3 * 4);
+    holder.Elements[1].Wide = (double)RawUAV.Load(4 * 4);
+    holder.Elements[1].Narrow = (float)RawUAV.Load(5 * 4);
+    holder.Trailing = (float)RawUAV.Load(7 * 4);
+
+    RawUAV.Store(0, (float)holder.Elements[0].Wide + holder.Elements[0].Narrow +
+                        (float)holder.Elements[1].Wide + holder.Elements[1].Narrow +
+                        holder.Trailing);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_constant_local.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_constant_local.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T cs_6_0 -Od -Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    float bias = 0.5;
+    bool hitFlag = true;
+    RawUAV.Store(0, asuint(bias + (hitFlag ? 2.0 : 3.0)));
+}
+
+// CHECK: %[[hitFlag:.*]] = alloca [1 x i32]
+// CHECK: %[[bias:.*]] = alloca [1 x float]
+// CHECK: %[[bias_gep:.*]] = getelementptr [1 x float], [1 x float]* %[[bias]], i32 0, i32 0
+// CHECK: store float 5.000000e-01, float* %[[bias_gep]]
+// CHECK: %[[hitFlag_gep:.*]] = getelementptr [1 x i32], [1 x i32]* %[[hitFlag]], i32 0, i32 0
+// CHECK: store i32 1, i32* %[[hitFlag_gep]]

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_front_and_tail_padding.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_front_and_tail_padding.hlsl
@@ -1,0 +1,50 @@
+// RUN: %dxc -Tcs_6_6 -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify declared offsets for front-padded and tail-padded structs.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct FrontPadded
+{
+    float Narrow;
+    double Wide;
+};
+
+struct TailPadded
+{
+    double Wide;
+    float Narrow;
+};
+
+struct Holder
+{
+    FrontPadded Front;
+    TailPadded Tail;
+    float Trailing;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 128, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 192, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 256, 32)
+
+// CHECK: store float
+// CHECK: store double
+// CHECK: store double
+// CHECK: store float
+// CHECK: store float
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    Holder holder;
+    holder.Front.Narrow = (float)RawUAV.Load(2 * 4);
+    holder.Front.Wide = (double)RawUAV.Load(3 * 4);
+    holder.Tail.Wide = (double)RawUAV.Load(4 * 4);
+    holder.Tail.Narrow = (float)RawUAV.Load(5 * 4);
+    holder.Trailing = (float)RawUAV.Load(6 * 4);
+
+    RawUAV.Store(0, holder.Front.Narrow + (float)holder.Front.Wide +
+                        (float)holder.Tail.Wide + holder.Tail.Narrow + holder.Trailing);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_matrix_after_padding.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_matrix_after_padding.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -Tcs_6_6 -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify matrix offsets after a 128-bit tail-padded struct.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct TailPadded
+{
+    double Wide;
+    float Narrow;
+};
+
+struct Holder
+{
+    TailPadded Padded;
+    float2x2 Mat;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 128, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 160, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 192, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 224, 32)
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    Holder holder;
+    holder.Padded.Wide = (double)RawUAV.Load(2 * 4);
+    holder.Padded.Narrow = (float)RawUAV.Load(3 * 4);
+    holder.Mat = float2x2(RawUAV.Load(4 * 4), RawUAV.Load(5 * 4),
+                          RawUAV.Load(6 * 4), RawUAV.Load(7 * 4));
+
+    RawUAV.Store(0, (float)holder.Padded.Wide + holder.Padded.Narrow +
+                        holder.Mat._11 + holder.Mat._22);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_mixed_width_bitfields.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_mixed_width_bitfields.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -Tcs_6_6 -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify that mixed-width bitfields use their declared storage units.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct MixedWidthBitfield
+{
+    uint32_t Leading : 5;
+    uint64_t Middle : 59;
+    uint32_t Trailing : 5;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 5)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 59)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 128, 5)
+
+// CHECK: store i32 %{{[^,]+}}, i32*
+// CHECK: store i64 %{{[^,]+}}, i64*
+// CHECK: store i32 %{{[^,]+}}, i32*
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    MixedWidthBitfield bitfield;
+    bitfield.Leading = RawUAV.Load(9 * 4);
+    bitfield.Middle = RawUAV.Load(21 * 4);
+    bitfield.Trailing = RawUAV.Load(13 * 4);
+
+    RawUAV.Store(0, (uint)(bitfield.Leading + bitfield.Middle + bitfield.Trailing));
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_multidim_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_multidim_array.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T cs_6_0 -Od -Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+static float MyArray[2][2] = {
+    { 1.0, 2.0 },
+    { 3.0, 4.0 }
+};
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID)
+{
+    RawUAV.Store(0, asuint(MyArray[tid.x][tid.y]));
+}
+
+// Verify stores for every flattened element of the multidimensional array.
+// CHECK: store float 2.000000e+00, float*
+// CHECK: store float 3.000000e+00, float*
+// CHECK: store float 4.000000e+00, float*

--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_nested_aggregate_padding.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare_nested_aggregate_padding.hlsl
@@ -1,0 +1,46 @@
+// RUN: %dxc -Tcs_6_6 -Emain /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s
+
+// Verify declared offsets across nested tail-padded aggregates.
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+struct Leaf
+{
+    double Wide;
+    float Narrow;
+};
+
+struct Middle
+{
+    Leaf Nested;
+    float AfterNested;
+};
+
+struct Root
+{
+    Middle Inner;
+    float Trailing;
+};
+
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 0, 64)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 64, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 128, 32)
+// CHECK: dbg.declare{{.*}}!DIExpression(DW_OP_bit_piece, 192, 32)
+
+// CHECK: store double
+// CHECK: store float
+// CHECK: store float
+// CHECK: store float
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    Root root;
+    root.Inner.Nested.Wide = (double)RawUAV.Load(2 * 4);
+    root.Inner.Nested.Narrow = (float)RawUAV.Load(3 * 4);
+    root.Inner.AfterNested = (float)RawUAV.Load(4 * 4);
+    root.Trailing = (float)RawUAV.Load(5 * 4);
+
+    RawUAV.Store(0, (float)root.Inner.Nested.Wide + root.Inner.Nested.Narrow +
+                        root.Inner.AfterNested + root.Trailing);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/DebugInstrumentation_dynamic_index_span.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugInstrumentation_dynamic_index_span.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_0 -Od -Zi %s | %opt -S -dxil-annotate-with-virtual-regs -hlsl-dxil-debug-instrumentation,UAVSize=1048576 | %FileCheck %s -check-prefix=SIZE
+// RUN: %dxc -T cs_6_0 -Od -Zi %s | %opt -S -dxil-annotate-with-virtual-regs -hlsl-dxil-debug-instrumentation,UAVSize=1048576 | %FileCheck %s -check-prefix=NO-OLD
+
+RWByteAddressBuffer RawUAV : register(u0);
+
+[numthreads(1, 1, 1)] void main() {
+  double local_array[4];
+  uint index = RawUAV.Load(0);
+  double value = asdouble(RawUAV.Load(4), RawUAV.Load(8));
+  if (index < 4) {
+    local_array[index] = value;
+  }
+  RawUAV.Store(12, asuint((float)local_array[0]));
+}
+
+// The store block reserves a 12-byte header and a 4-byte index payload.
+// SIZE-LABEL: define void @main()
+// SIZE: getelementptr inbounds [4 x double], [4 x double]* %{{[a-zA-Z0-9._]+}}, i32 0, i32 %{{[a-zA-Z0-9._]+}}
+// SIZE: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle {{.*}}, i32 0, i32 {{.*}}, i32 undef, i32 undef, i32 16)
+// SIZE-LABEL: declare double @dx.op.makeDouble.f64
+
+// NO-OLD-LABEL: define void @main()
+// NO-OLD-NOT: i32 undef, i32 undef, i32 20)
+// NO-OLD-LABEL: declare double @dx.op.makeDouble.f64

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -37,6 +37,7 @@
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilSubobject.h"
+#include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 
 #include "dxc/Test/DxcTestUtils.h"
 #include "dxc/Test/HLSLTestData.h"
@@ -52,6 +53,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/AsmParser/Parser.h"
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Instructions.h"
@@ -61,10 +63,12 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/Pass.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MSFileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
 #include <fstream>
 
 #include <../lib/DxilDia/DxcPixLiveVariables_FragmentIterator.h>
@@ -147,6 +151,11 @@ public:
   TEST_METHOD(PixStructAnnotation_Inheritance)
   TEST_METHOD(PixStructAnnotation_ResourceAsMember)
   TEST_METHOD(PixStructAnnotation_WheresMyDbgValue)
+  TEST_METHOD(DbgValueToDbgDeclare_BackwardLayout)
+  TEST_METHOD(DebugInstrumentation_DynamicIndexSpanMatchesAllocaRegisterCount)
+  TEST_METHOD(PixDbgValueToDbgDeclare_MultiDimensionalStaticGlobalArray)
+  TEST_METHOD(AllocaRegisterWrite_DeepAggregateChainIsAnnotated)
+  TEST_METHOD(EntryBlockInjection_HandlesLabelledAndUnlabelledFirstBlock)
 
   TEST_METHOD(VirtualRegisters_InstructionCounts)
   TEST_METHOD(VirtualRegisters_AlignedOffsets)
@@ -305,6 +314,42 @@ public:
     CComPtr<IDxcBlob> Module;
     std::vector<std::string> Lines;
   };
+
+  // Runs the virtual-register annotation pass over textual IR and returns the
+  // pass report. Textual IR builds a module shape that HLSL does not express.
+  std::vector<std::string> RunAnnotationPassOnText(const std::string &irText) {
+    CComPtr<IDxcBlobEncoding> pSource;
+    CreateBlobFromText(m_dllSupport, irText.c_str(), &pSource);
+
+    CComPtr<IDxcOptimizer> pOptimizer;
+    VERIFY_SUCCEEDED(
+        m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &pOptimizer));
+    std::vector<LPCWSTR> Options;
+    Options.push_back(L"-S");
+    Options.push_back(L"-opt-mod-passes");
+    Options.push_back(L"-dxil-annotate-with-virtual-regs");
+
+    CComPtr<IDxcBlob> pOptimizedModule;
+    CComPtr<IDxcBlobEncoding> pText;
+    VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
+        pSource, Options.data(), Options.size(), &pOptimizedModule, &pText));
+
+    return Tokenize(BlobToUtf8(pText).c_str(), "\n");
+  }
+
+  // Replaces the one occurrence of needle, and fails the test when the text
+  // does not hold exactly one.
+  static std::string ReplaceOnlyOccurrence(const std::string &text,
+                                           const std::string &needle,
+                                           const std::string &replacement) {
+    auto position = text.find(needle);
+    VERIFY_IS_TRUE(position != std::string::npos);
+    VERIFY_IS_TRUE(text.find(needle, position + needle.size()) ==
+                   std::string::npos);
+    std::string result = text;
+    result.replace(position, needle.size(), replacement);
+    return result;
+  }
 
   SinglePassOutput RunSinglePass(IDxcBlob *dxil, LPCWSTR passOption) {
     CComPtr<IDxcOptimizer> pOptimizer;
@@ -2095,9 +2140,9 @@ void main()
 
     auto Testables = TestStructAnnotationCase(hlsl, optimization);
 
-    // 2 in unoptimized case (one for each instance of smallPayload)
-    // 1 in optimized case (cuz p2 aliases over p)
-    VERIFY_IS_TRUE(Testables.OffsetAndSizes.size() >= 1);
+    // Each unoptimized source variable has storage. Optimized copies alias.
+    const size_t ExpectedCount = choice.IsOptimized ? 1u : 2u;
+    VERIFY_ARE_EQUAL(ExpectedCount, Testables.OffsetAndSizes.size());
 
     for (const auto &os : Testables.OffsetAndSizes) {
       VERIFY_ARE_EQUAL(1u, os.countOfMembers);
@@ -2105,8 +2150,76 @@ void main()
       VERIFY_ARE_EQUAL(32u, os.size);
     }
 
-    VERIFY_ARE_EQUAL(1u, Testables.AllocaWrites.size());
+    VERIFY_ARE_EQUAL(ExpectedCount, Testables.AllocaWrites.size());
+    for (size_t i = 0; i < ExpectedCount; ++i) {
+      ValidateAllocaWrite(Testables.AllocaWrites, i, "dummy");
+    }
   }
+}
+
+TEST_F(PixTest, DbgValueToDbgDeclare_BackwardLayout) {
+  const char *IR = R"(
+  %BadStruct = type { i64, i32 }
+
+  define void @main() !dbg !5 {
+  entry:
+    %var = alloca %BadStruct, align 4
+    call void @llvm.dbg.value(metadata %BadStruct* %var, i64 0, metadata !10, metadata !15), !dbg !16
+    ret void
+  }
+
+  declare void @llvm.dbg.value(metadata, i64, metadata, metadata)
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3, !4}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: 1, subprograms: !2)
+  !1 = !DIFile(filename: "test.hlsl", directory: "/")
+  !2 = !{!5}
+  !3 = !{i32 2, !"Dwarf Version", i32 4}
+  !4 = !{i32 2, !"Debug Info Version", i32 3}
+  !5 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !6, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, function: void ()* @main)
+  !6 = !DISubroutineType(types: !7)
+  !7 = !{null}
+  !8 = !DIBasicType(name: "int64", size: 64, align: 32, encoding: DW_ATE_signed)
+  !9 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)
+  !10 = !DILocalVariable(tag: DW_TAG_auto_variable, name: "var", scope: !5, file: !1, line: 2, type: !11)
+  !11 = !DICompositeType(tag: DW_TAG_structure_type, name: "BadStruct", file: !1, line: 1, size: 96, align: 32, elements: !12)
+  !12 = !{!13, !14}
+  !13 = !DIDerivedType(tag: DW_TAG_member, name: "First", scope: !11, file: !1, line: 2, baseType: !8, size: 64, align: 32, offset: 0)
+  !14 = !DIDerivedType(tag: DW_TAG_member, name: "Second", scope: !11, file: !1, line: 3, baseType: !9, size: 16, align: 32, offset: 32)
+  !15 = !DIExpression()
+  !16 = !DILocation(line: 2, column: 1, scope: !5)
+  )";
+
+  llvm::LLVMContext Context;
+  llvm::SMDiagnostic Error;
+  std::unique_ptr<llvm::Module> Module =
+      llvm::parseAssemblyString(IR, Error, Context);
+  VERIFY_IS_NOT_NULL(Module.get());
+
+  std::unique_ptr<llvm::ModulePass> Pass(
+      llvm::createDxilDbgValueToDbgDeclarePass());
+  VERIFY_IS_TRUE(Pass->runOnModule(*Module));
+
+  std::vector<std::pair<uint64_t, uint64_t>> Pieces;
+  for (llvm::BasicBlock &Block : *Module->getFunction("main")) {
+    for (llvm::Instruction &Instruction : Block) {
+      if (auto *Declare = llvm::dyn_cast<llvm::DbgDeclareInst>(&Instruction)) {
+        llvm::DIExpression *Expression = Declare->getExpression();
+        VERIFY_IS_TRUE(Expression->isBitPiece());
+        Pieces.emplace_back(Expression->getBitPieceOffset(),
+                            Expression->getBitPieceSize());
+      }
+    }
+  }
+
+  std::sort(Pieces.begin(), Pieces.end());
+  VERIFY_ARE_EQUAL(size_t(2), Pieces.size());
+  VERIFY_ARE_EQUAL(uint64_t(0), Pieces[0].first);
+  VERIFY_ARE_EQUAL(uint64_t(64), Pieces[0].second);
+  VERIFY_ARE_EQUAL(uint64_t(64), Pieces[1].first);
+  VERIFY_ARE_EQUAL(uint64_t(16), Pieces[1].second);
 }
 
 TEST_F(PixTest, PixStructAnnotation_MixedSizes) {
@@ -4744,4 +4857,279 @@ float4 main(float4 pos : SV_Position) : SV_Target
   auto output = RunShaderAccessTrackingPass(compiled);
   VerifyInstrumentedModuleIsValid(
       output.blob, "shader access tracking of a dynamically indexed resource");
+}
+
+// Pulls the register span out of every dynamically-indexed alloca write the
+// debug instrumentation pass reported. The per-block records it emits are
+// semicolon-separated and a dynamic alloca write looks like
+//
+//   <instruction ordinal>,<type>,<register>,d,<alloca base>-<register span>
+//
+// where the span is how many virtual registers the write could land in.
+static std::vector<int>
+FindDynamicAllocaWriteSpans(std::vector<std::string> const &passOutputLines) {
+  std::vector<int> spans;
+  for (auto const &line : passOutputLines) {
+    for (auto const &record : Split(line, ';')) {
+      auto tokens = Split(record, ',');
+      if (tokens.size() < 5 || tokens[3] != "d") {
+        continue;
+      }
+      auto const dash = tokens[4].find('-');
+      if (dash == std::string::npos) {
+        continue;
+      }
+      spans.push_back(atoi(tokens[4].substr(dash + 1).c_str()));
+    }
+  }
+  return spans;
+}
+
+// PIX clamps a dynamic index to the span this record reports, so a span that
+// undercounts the alloca hides every element past it. The span comes from the
+// !pix-alloca-reg-write metadata the annotation pass attaches to the
+// instruction, not from the alloca's LLVM array length, so it always matches
+// the virtual-register numbering.
+//
+// DXC's SROA flattens every aggregate the front end emits, so today's shapes
+// keep both derivations in agreement. This test guards against that ceasing
+// to be true.
+TEST_F(PixTest,
+       DebugInstrumentation_DynamicIndexSpanMatchesAllocaRegisterCount) {
+  struct Case {
+    char const *description;
+    char const *source;
+    int expectedSpan;
+  };
+
+  const Case cases[] = {
+      {"one-dimensional float array", R"x(
+RWByteAddressBuffer RawUAV : register(u0);
+[numthreads(1, 1, 1)]
+void main()
+{
+    float values[8];
+    for (uint i = 0; i < 8; ++i) values[i] = 0;
+    values[RawUAV.Load(0)] = 7;
+    RawUAV.Store(4, asuint(values[RawUAV.Load(8)]));
+})x",
+       8},
+      {"two-dimensional array is flattened to one register run", R"x(
+RWByteAddressBuffer RawUAV : register(u0);
+[numthreads(1, 1, 1)]
+void main()
+{
+    float m[4][4];
+    for (uint i = 0; i < 4; ++i) for (uint j = 0; j < 4; ++j) m[i][j] = 0;
+    m[RawUAV.Load(0)][RawUAV.Load(4)] = 7;
+    RawUAV.Store(8, asuint(m[RawUAV.Load(12)][RawUAV.Load(16)]));
+})x",
+       16},
+      {"array member of a struct", R"x(
+RWByteAddressBuffer RawUAV : register(u0);
+struct Container { float before; float values[8]; float after; };
+[numthreads(1, 1, 1)]
+void main()
+{
+    Container c;
+    c.before = 1;
+    c.after = 2;
+    for (uint i = 0; i < 8; ++i) c.values[i] = 0;
+    c.values[RawUAV.Load(0)] = 7;
+    RawUAV.Store(4, asuint(c.values[RawUAV.Load(8)] + c.before + c.after));
+})x",
+       8},
+      {"dynamically indexed vector", R"x(
+RWByteAddressBuffer RawUAV : register(u0);
+[numthreads(1, 1, 1)]
+void main()
+{
+    float3 v = float3(1, 2, 3);
+    v[RawUAV.Load(0)] = 7;
+    RawUAV.Store(4, asuint(v.x + v.y + v.z));
+})x",
+       3},
+  };
+
+  for (auto const &testCase : cases) {
+    WEX::Logging::Log::Comment(
+        WEX::Common::String().Format(L"%S", testCase.description));
+
+    auto compiled = Compile(m_dllSupport, testCase.source, L"cs_6_0", {L"-Od"});
+    auto output = RunDebugPass(compiled);
+    auto spans = FindDynamicAllocaWriteSpans(output.lines);
+
+    // If DXC ever stops emitting a dynamically-indexed alloca store for these
+    // shaders the test would otherwise quietly become a test of nothing.
+    VERIFY_IS_TRUE(spans.size() > 0);
+    for (int span : spans) {
+      VERIFY_ARE_EQUAL(testCase.expectedSpan, span);
+    }
+  }
+}
+
+// Counts stores of the given value into a shadow alloca, i.e. stores whose
+// destination is a local pointer rather than a module-scope global.
+static uint32_t
+CountStoresToAllocaOfValue(std::vector<std::string> const &disassemblyLines,
+                           const char *value) {
+  uint32_t count = 0;
+  for (auto const &line : disassemblyLines) {
+    if (line.find("store ") == std::string::npos) {
+      continue;
+    }
+    if (line.find(value) == std::string::npos) {
+      continue;
+    }
+    // A store into the original global names the global; the shadow stores this
+    // pass emits target an alloca reached through a local GEP.
+    if (line.find('@') != std::string::npos) {
+      continue;
+    }
+    count++;
+  }
+  return count;
+}
+
+// A flattened multi-dimensional array member renames the module global but
+// not the debug variable, so the pass gathers shadow storage by linkage
+// name. Keying it on the debug name instead loses the shadow store for every
+// write into the flattened array.
+TEST_F(PixTest, PixDbgValueToDbgDeclare_MultiDimensionalStaticGlobalArray) {
+  const char *source = R"x(
+RWByteAddressBuffer RawUAV : register(u0);
+struct StaticGlobalHolder
+{
+    float twoD[2][3];
+    float oneD[3];
+    float count;
+};
+static StaticGlobalHolder g_staticGlobalHolder;
+[numthreads(1, 1, 1)]
+void main()
+{
+    g_staticGlobalHolder.oneD[0] = 4.0;
+    g_staticGlobalHolder.oneD[1] = 5.0;
+    g_staticGlobalHolder.oneD[2] = 6.0;
+    g_staticGlobalHolder.twoD[1][0] = 40.0;
+    g_staticGlobalHolder.twoD[1][2] = 42.0;
+    g_staticGlobalHolder.count = 1;
+
+    float accumulator = 0;
+    uint index = 0;
+    [loop]
+    while (true)
+    {
+        accumulator += g_staticGlobalHolder.twoD[index % 2][index % 3];
+        accumulator += g_staticGlobalHolder.oneD[index % 3];
+        if (index++ == 4)
+        {
+            break;
+        }
+    }
+    RawUAV.Store(64, asuint(accumulator + g_staticGlobalHolder.count));
+})x";
+
+  auto compiled = Compile(m_dllSupport, source, L"cs_6_0", {L"-Od"});
+  CComPtr<IDxcBlob> dxilPart = FindModule(DFCC_ShaderDebugInfoDXIL, compiled);
+  auto output = RunValueToDeclarePass(dxilPart);
+  auto lines = Split(Disassemble(output.blob), '\n');
+
+  // The one-dimensional array in the same struct is the control: it is handled
+  // correctly whether or not the multi-dimensional case is.
+  VERIFY_ARE_EQUAL(1u, CountStoresToAllocaOfValue(lines, "4.000000e+00"));
+  // The two writes into the two-dimensional array are the point of the test.
+  VERIFY_ARE_EQUAL(1u, CountStoresToAllocaOfValue(lines, "4.000000e+01"));
+  VERIFY_ARE_EQUAL(1u, CountStoresToAllocaOfValue(lines, "4.200000e+01"));
+}
+
+// Returns the module with the given instructions at the start of the entry
+// point's first block. The disassembler prints a label for that block only
+// when the block is named, and instructions placed ahead of a label would form
+// a block with no terminator, so the injection follows the label when there is
+// one and the definition's brace when there is not.
+static std::string InjectIntoEntryBlock(const std::string &disassembly,
+                                        const std::string &instructions) {
+  const std::string definition = "define void @main() {";
+  const std::string labelledDefinition = definition + "\nentry:";
+  const std::string &anchor =
+      disassembly.find(labelledDefinition) != std::string::npos
+          ? labelledDefinition
+          : definition;
+  return PixTest::ReplaceOnlyOccurrence(disassembly, anchor,
+                                        anchor + "\n" + instructions);
+}
+
+// Whether the disassembler labels an entry point's first block depends on
+// whether the module kept the block's name, so the injection below pins its
+// point against both forms rather than against the one this build produces.
+TEST_F(PixTest, EntryBlockInjection_HandlesLabelledAndUnlabelledFirstBlock) {
+  const std::string instruction = "  %injected = alloca float";
+
+  const std::string labelled = "define void @main() {\nentry:\n  ret void\n}\n";
+  VERIFY_ARE_EQUAL("define void @main() {\nentry:\n" + instruction +
+                       "\n  ret void\n}\n",
+                   InjectIntoEntryBlock(labelled, instruction));
+
+  const std::string unlabelled = "define void @main() {\n  ret void\n}\n";
+  VERIFY_ARE_EQUAL("define void @main() {\n" + instruction +
+                       "\n  ret void\n}\n",
+                   InjectIntoEntryBlock(unlabelled, instruction));
+}
+
+// A value nested three GEPs below the alloca needs the annotator to walk the
+// whole ancestor chain, not just one level, before it can record the store's
+// !pix-alloca-reg-write. DXC's SROA flattens aggregates before this pass
+// runs, so this shape does not arise from HLSL; the module is constructed
+// directly here.
+TEST_F(PixTest, AllocaRegisterWrite_DeepAggregateChainIsAnnotated) {
+  auto compiled = Compile(m_dllSupport, R"x(
+RWByteAddressBuffer RawUAV : register(u0);
+[numthreads(1, 1, 1)]
+void main()
+{
+    RawUAV.Store(0, 0);
+})x",
+                          L"cs_6_0", {L"-Od"});
+  std::string disassembly = Disassemble(compiled);
+
+  // An alloca of a struct nested three levels deep, then a GEP chain that
+  // descends every level to select a scalar, then a store into it. The store's
+  // pointer is three GEPs removed from the alloca.
+  std::string withDeepStore = InjectIntoEntryBlock(
+      disassembly,
+      "  %deep = alloca { { { float, float } } }\n"
+      "  %deep.l0 = getelementptr { { { float, float } } }, { { { "
+      "float, float } } }* %deep, i32 0, i32 0\n"
+      "  %deep.l1 = getelementptr { { float, float } }, { { float, "
+      "float } }* %deep.l0, i32 0, i32 0\n"
+      "  %deep.l2 = getelementptr { float, float }, { float, float "
+      "}* %deep.l1, i32 0, i32 1\n"
+      "  store float 1.000000e+00, float* %deep.l2\n");
+
+  std::vector<std::string> lines = RunAnnotationPassOnText(withDeepStore);
+
+  bool allocaRegistered = false;
+  bool storeFound = false;
+  bool storeAnnotated = false;
+  for (const std::string &line : lines) {
+    if (line.find("%deep = alloca") != std::string::npos &&
+        line.find("pix-alloca-reg") != std::string::npos) {
+      allocaRegistered = true;
+    }
+    if (line.find("store float 1.000000e+00, float* %deep.l2") !=
+        std::string::npos) {
+      storeFound = true;
+      if (line.find("pix-alloca-reg-write") != std::string::npos) {
+        storeAnnotated = true;
+      }
+    }
+  }
+
+  // The alloca is registered, so the shape reached the pass and the store below
+  // is the thing under test rather than an artifact of it being skipped.
+  VERIFY_IS_TRUE(allocaRegistered);
+  VERIFY_IS_TRUE(storeFound);
+  // The store three GEPs deep still carries its alloca-register-write.
+  VERIFY_IS_TRUE(storeAnnotated);
 }


### PR DESCRIPTION
> Part 10 of 14 in the PIX instrumentation stack. It targets `users/damyanp/pix-fixes-09`. Its content depends on PR 2 for the shared helpers.

The debug passes tell PIX where each variable lives in the shadow storage. Four defects make that information disagree with the shader.

The offset calculation ignores the full extent of an array, the padding in an aggregate, the position of a bitfield, and the layout of a matrix. An offset can therefore point into the storage of another variable.

A dynamically indexed write to an alloca takes its register span from the length of the array. DxilAnnotateWithVirtualRegister records the true span in !pix-alloca-reg-write. The two values disagree for an array of aggregates, so a dynamic index can be limited against the wrong bound.

IsAllocaRegisterWrite examines only one level of the ancestor GEP chain. A value three or more aggregates deep receives no metadata, so the debugger shows a stale value or no value. The function also uses a member index without a bound check and without a safe cast.

The pass finds the storage of an embedded array by the name of the debug variable. DXC can flatten a multi-dimensional array and rename the module global. The debug variable keeps its name, so the lookup misses the global and every shadow store for that array is dropped.

Two decisions are worth attention. IsAllocaRegisterWrite returns false for a member index that is not constant or is out of range, because a guess would attach metadata the debug record cannot honour. A backward move of the layout writes a message and continues, and a debug build does not stop the process.

Assisted-by: Copilot

> This changes only the PIX instrumentation, so it needs no release note.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>