### PR TITLE
Run CI for PRs targeting user branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ trigger:
 pr: 
   - main
   - release*
+  - users/*
   
 resources:
 - repo: self


### PR DESCRIPTION
Include `users/*` base branches in the Azure Pipelines PR trigger so we get CI coverage for stacked PRs.