### PR TITLE
[NFC] Fix two uninitialized variable warnings

### DIFF
--- a/tools/clang/unittests/HLSL/SystemValueTest.cpp
+++ b/tools/clang/unittests/HLSL/SystemValueTest.cpp
@@ -109,7 +109,7 @@ public:
       IFT(library->CreateBlobFromFile(path.c_str(), nullptr, &m_pSource));
     }
 
-    LPCWSTR entry, profile;
+    LPCWSTR entry = nullptr, profile = nullptr;
     wchar_t profile_buf[] = L"vs_6_1";
     switch (shaderKind) {
     case DXIL::ShaderKind::Vertex:
@@ -149,6 +149,7 @@ public:
       assert(!"invalid shaderKind");
       break;
     }
+    VERIFY_IS_TRUE(entry != nullptr && profile != nullptr);
     if (Major == 0) {
       Major = m_HighestMajor;
       Minor = m_HighestMinor;

--- a/utils/unittest/googletest/src/gtest-death-test.cc
+++ b/utils/unittest/googletest/src/gtest-death-test.cc
@@ -1004,7 +1004,7 @@ void StackLowerThanAddress(const void* ptr, bool* result) {
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0; // HLSL Change - silence uninitialized variable warning.
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
This addresses some uninitialized variable warnings to silence the compiler.