### PR TITLE
[HLSL] Fix LinAlg stride and group-shared offset preconditions

### DIFF
--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -81,6 +81,16 @@ static uint8_t elementSize(ComponentType CT) {
   }
 }
 
+// Proposal 0035 requires matrix strides in memory to be a multiple of 16 bytes
+// and non-zero matrix start offsets to be 128-byte aligned.
+static constexpr size_t MatrixStrideAlignmentBytes = 16;
+static constexpr size_t MatrixOffsetAlignmentBytes = 128;
+
+static constexpr size_t alignMatrixStride(size_t PackedStrideBytes) {
+  return (PackedStrideBytes + MatrixStrideAlignmentBytes - 1) /
+         MatrixStrideAlignmentBytes * MatrixStrideAlignmentBytes;
+}
+
 struct MatrixParams {
   ComponentType CompType;
   MatrixDim M;
@@ -95,9 +105,9 @@ struct MatrixParams {
   size_t strideBytes() const {
     uint32_t ES = elementSize(CompType);
     if (Layout == MatrixLayout::RowMajor)
-      return N * ES;
+      return alignMatrixStride(N * ES);
     if (Layout == MatrixLayout::ColumnMajor)
-      return M * ES;
+      return alignMatrixStride(M * ES);
     // If not Row/Col major, spec says to use 0
     return 0;
   }
@@ -2089,8 +2099,6 @@ encodePackedVector(ComponentType Type, const std::vector<int64_t> &Values) {
   return Bytes;
 }
 
-static constexpr size_t MatrixStrideAlignmentBytes = 16;
-
 static std::optional<size_t> matrixStrideBytes(const CaseData &Case) {
   const std::optional<size_t> ComponentSize =
       componentByteSize(Case.MatrixType);
@@ -2098,9 +2106,7 @@ static std::optional<size_t> matrixStrideBytes(const CaseData &Case) {
     return std::nullopt;
   const size_t MinorCount =
       Case.Layout == MatrixLayout::RowMajor ? Case.N : Case.M;
-  const size_t PackedStride = MinorCount * *ComponentSize;
-  return (PackedStride + MatrixStrideAlignmentBytes - 1) /
-         MatrixStrideAlignmentBytes * MatrixStrideAlignmentBytes;
+  return alignMatrixStride(MinorCount * *ComponentSize);
 }
 
 static std::optional<std::vector<BYTE>>
@@ -3876,7 +3882,7 @@ static cpu_oracle::MatrixBufferLayout packedLayout(const MatrixParams &Params) {
 
 // Where the padded cases put the matrix. Independent of the alignment above,
 // which is the contract rather than a placement, but constrained by it.
-static constexpr size_t DescriptorAlignedOffset = 128;
+static constexpr size_t DescriptorAlignedOffset = MatrixOffsetAlignmentBytes;
 static_assert(DescriptorAlignedOffset % DescriptorDeclaredAlignment == 0,
               "descriptor offset must keep the first element aligned");
 
@@ -7665,6 +7671,13 @@ getGroupSharedBufferDescription(const MatrixParams &Params,
   if (*RequiredBytes % ElementBytes != 0)
     return false;
 
+  // Proposal 0035 requires a 16-byte aligned stride and a 128-byte aligned
+  // matrix start for group-shared Load, Store and Accumulate.
+  if (Layout.StrideBytes % MatrixStrideAlignmentBytes != 0)
+    return false;
+  if (Layout.OffsetBytes % MatrixOffsetAlignmentBytes != 0)
+    return false;
+
   // Safely compute the GuardBytes and BufferSize.
   if (!cpu_oracle::checkedMultiply(GroupSharedTrailingGuardElements,
                                    ElementBytes, GuardBytes))
@@ -7949,13 +7962,13 @@ void DxilConf_SM610_LinAlg::
 
   const cpu_oracle::MatrixBufferLayout Target = {
       MatrixLayout::RowMajor,
-      /*OffsetBytes=*/8,
-      /*StrideBytes=*/24,
+      /*OffsetBytes=*/128,
+      /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
       MatrixLayout::ColumnMajor,
       /*OffsetBytes=*/0,
-      /*StrideBytes=*/8,
+      /*StrideBytes=*/16,
   };
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
                                       Canonical, VerboseLogging,
@@ -7983,8 +7996,8 @@ void DxilConf_SM610_LinAlg::
 
   const cpu_oracle::MatrixBufferLayout Target = {
       MatrixLayout::ColumnMajor,
-      /*OffsetBytes=*/16,
-      /*StrideBytes=*/24,
+      /*OffsetBytes=*/128,
+      /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
       MatrixLayout::RowMajor,
@@ -8015,8 +8028,8 @@ void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
 
   const cpu_oracle::MatrixBufferLayout Target = {
       MatrixLayout::ColumnMajor,
-      /*OffsetBytes=*/8,
-      /*StrideBytes=*/12,
+      /*OffsetBytes=*/128,
+      /*StrideBytes=*/32,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
       MatrixLayout::RowMajor,
@@ -8289,8 +8302,8 @@ static void runPaddedGroupSharedAccumulateCase(
 
   const cpu_oracle::MatrixBufferLayout Memory = {
       MatrixLayout::RowMajor,
-      /*OffsetBytes=*/8,
-      /*StrideBytes=*/24,
+      /*OffsetBytes=*/128,
+      /*StrideBytes=*/48,
   };
   runGroupSharedAccumulate(Device, DxcSupport, Params, Memory,
                            /*InitialValue=*/12,
@@ -8326,8 +8339,9 @@ static void runGroupSharedAccumulateContention(
   const size_t ElementBytes = elementSize(CompType);
   const cpu_oracle::MatrixBufferLayout Memory = {
       MatrixLayout::RowMajor,
-      /*OffsetBytes=*/4 * ElementBytes,
-      /*StrideBytes=*/Params.N * ElementBytes + 8,
+      /*OffsetBytes=*/MatrixOffsetAlignmentBytes,
+      /*StrideBytes=*/alignMatrixStride(Params.N * ElementBytes) +
+          MatrixStrideAlignmentBytes,
   };
   runGroupSharedAccumulate(Device, DxcSupport, Params, Memory,
                            /*InitialValue=*/7,

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -2089,6 +2089,8 @@ encodePackedVector(ComponentType Type, const std::vector<int64_t> &Values) {
   return Bytes;
 }
 
+static constexpr size_t MatrixStrideAlignmentBytes = 16;
+
 static std::optional<size_t> matrixStrideBytes(const CaseData &Case) {
   const std::optional<size_t> ComponentSize =
       componentByteSize(Case.MatrixType);
@@ -2096,7 +2098,9 @@ static std::optional<size_t> matrixStrideBytes(const CaseData &Case) {
     return std::nullopt;
   const size_t MinorCount =
       Case.Layout == MatrixLayout::RowMajor ? Case.N : Case.M;
-  return MinorCount * *ComponentSize;
+  const size_t PackedStride = MinorCount * *ComponentSize;
+  return (PackedStride + MatrixStrideAlignmentBytes - 1) /
+         MatrixStrideAlignmentBytes * MatrixStrideAlignmentBytes;
 }
 
 static std::optional<std::vector<BYTE>>
@@ -2190,6 +2194,10 @@ static bool isCaseValid(const CaseData &Case) {
     if (!storageTypeName(Case.BiasInputType))
       return false;
   }
+
+  const std::optional<size_t> Stride = matrixStrideBytes(Case);
+  if (!Stride || *Stride % MatrixStrideAlignmentBytes != 0)
+    return false;
 
   const bool ExpectedSigned = Case.ResultType != ComponentType::U32;
   return Case.OutputSigned == ExpectedSigned;

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -7960,15 +7960,17 @@ void DxilConf_SM610_LinAlg::
           SelectedWaveSize))
     return;
 
+  const size_t ElementBytes = elementSize(Params.CompType);
   const cpu_oracle::MatrixBufferLayout Target = {
       MatrixLayout::RowMajor,
-      /*OffsetBytes=*/128,
-      /*StrideBytes=*/32,
+      /*OffsetBytes=*/MatrixOffsetAlignmentBytes,
+      /*StrideBytes=*/alignMatrixStride(Params.N * ElementBytes) +
+          MatrixStrideAlignmentBytes,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
       MatrixLayout::ColumnMajor,
       /*OffsetBytes=*/0,
-      /*StrideBytes=*/16,
+      /*StrideBytes=*/alignMatrixStride(Params.M * ElementBytes),
   };
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
                                       Canonical, VerboseLogging,
@@ -7994,15 +7996,17 @@ void DxilConf_SM610_LinAlg::
           SelectedWaveSize))
     return;
 
+  const size_t ElementBytes = elementSize(Params.CompType);
   const cpu_oracle::MatrixBufferLayout Target = {
       MatrixLayout::ColumnMajor,
-      /*OffsetBytes=*/128,
-      /*StrideBytes=*/32,
+      /*OffsetBytes=*/MatrixOffsetAlignmentBytes,
+      /*StrideBytes=*/alignMatrixStride(Params.M * ElementBytes) +
+          MatrixStrideAlignmentBytes,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
       MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
-      /*StrideBytes=*/32,
+      /*StrideBytes=*/alignMatrixStride(Params.N * ElementBytes),
   };
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
                                       Canonical, VerboseLogging,
@@ -8026,15 +8030,17 @@ void DxilConf_SM610_LinAlg::LoadStoreMemory_ThreadGroup_4x8_F16() {
                                     SelectedWaveSize))
     return;
 
+  const size_t ElementBytes = elementSize(Params.CompType);
   const cpu_oracle::MatrixBufferLayout Target = {
       MatrixLayout::ColumnMajor,
-      /*OffsetBytes=*/128,
-      /*StrideBytes=*/32,
+      /*OffsetBytes=*/MatrixOffsetAlignmentBytes,
+      /*StrideBytes=*/alignMatrixStride(Params.M * ElementBytes) +
+          MatrixStrideAlignmentBytes,
   };
   const cpu_oracle::MatrixBufferLayout Canonical = {
       MatrixLayout::RowMajor,
       /*OffsetBytes=*/0,
-      /*StrideBytes=*/16,
+      /*StrideBytes=*/alignMatrixStride(Params.N * ElementBytes),
   };
   runBidirectionalGroupSharedTransfer(D3DDevice, DxcSupport, Params, Target,
                                       Canonical, VerboseLogging,
@@ -8300,10 +8306,12 @@ static void runPaddedGroupSharedAccumulateCase(
     return;
   }
 
+  const size_t ElementBytes = elementSize(Params.CompType);
   const cpu_oracle::MatrixBufferLayout Memory = {
       MatrixLayout::RowMajor,
-      /*OffsetBytes=*/128,
-      /*StrideBytes=*/48,
+      /*OffsetBytes=*/MatrixOffsetAlignmentBytes,
+      /*StrideBytes=*/alignMatrixStride(Params.N * ElementBytes) +
+          2 * MatrixStrideAlignmentBytes,
   };
   runGroupSharedAccumulate(Device, DxcSupport, Params, Memory,
                            /*InitialValue=*/12,


### PR DESCRIPTION
Proposal 0035 requires linear algebra matrix memory strides to be a multiple of 16 bytes and group-shared matrix starts to be 128-byte aligned, but ten cases were passing illegal operands and only passing because WARP is more permissive than the specification requires.

Assisted-by: GitHub Copilot
