### PR TITLE
[HLSL] Fix GroupSharedLimit preview guard

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -212,11 +212,11 @@ public:
   TEST_METHOD(WaveSizeRangeTest);
   // TODO(#8661): Remove me when GroupSharedLimit is available in a released
   // Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
+#if defined(DIRECT3D_PREVIEW_BUILD)
   TEST_METHOD(GroupSharedLimitTest);
   TEST_METHOD(GroupSharedLimitASTest);
   TEST_METHOD(GroupSharedLimitMSTest);
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
+#endif // defined(DIRECT3D_PREVIEW_BUILD)
   TEST_METHOD(GroupWaveIndexTest);
   TEST_METHOD(PartialDerivTest);
   TEST_METHOD(DerivativesTest);
@@ -10630,7 +10630,7 @@ void ExecutionTest::WaveSizeRangeTest() {
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
+#if defined(DIRECT3D_PREVIEW_BUILD)
 // Helper: create a SM 6.10 device with HLK-aware skip/fail logic.
 // Returns true if device was created, false if skipped.
 static bool CreateGSMLimitTestDevice(D3D12SDKSelector *D3D12SDK,
@@ -10941,7 +10941,7 @@ void ExecutionTest::GroupSharedLimitMSTest() {
         L"MS Test passed: GroupSharedLimit in mesh shader succeeded.");
   }
 }
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
+#endif // defined(DIRECT3D_PREVIEW_BUILD)
 
 void ExecutionTest::GroupWaveIndexTest() {
   WEX::TestExecution::SetVerifyOutput VerifySettings(

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -19,7 +19,7 @@
 // group shared memory capabilities from the Agility SDK runtime.
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION < 720
+#if defined(DIRECT3D_PREVIEW_BUILD) && D3D12_PREVIEW_SDK_VERSION < 720
 
 #ifndef D3D12_FEATURE_D3D12_OPTIONS_PREVIEW
 #define D3D12_FEATURE_D3D12_OPTIONS_PREVIEW ((D3D12_FEATURE)72)
@@ -1470,7 +1470,7 @@ HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
+#if defined(DIRECT3D_PREVIEW_BUILD)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
   D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
   VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
@@ -1491,7 +1491,7 @@ UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device) {
       D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupMS;
 }
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
+#endif // defined(DIRECT3D_PREVIEW_BUILD)
 
 std::unique_ptr<st::ShaderOp> createComputeOp(const char *Source,
                                               const char *Target,

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -561,11 +561,11 @@ HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(D3D12_PREVIEW_SDK_VERSION)
+#if defined(DIRECT3D_PREVIEW_BUILD)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device);
-#endif // defined(D3D12_PREVIEW_SDK_VERSION)
+#endif // defined(DIRECT3D_PREVIEW_BUILD)
 
 /// Create a ShaderOp for a compute shader dispatch.
 std::unique_ptr<st::ShaderOp>


### PR DESCRIPTION
## Summary
- guard the GroupSharedLimit execution tests and helper APIs with `DIRECT3D_PREVIEW_BUILD`
- keep the SDK version check only for the local `D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW` compatibility definition

## Testing
- built `ExecHLSLTests` with Ninja
- rebuilt the affected translation units and linked `ExecHLSLTests.dll` with `DIRECT3D_PREVIEW_BUILD` explicitly enabled