### PR TITLE
[HLSL] Key LinAlg and GroupSharedLimit tests on SDK version

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -212,11 +212,11 @@ public:
   TEST_METHOD(WaveSizeRangeTest);
   // TODO(#8661): Remove me when GroupSharedLimit is available in a released
   // Windows SDK.
-#if defined(DIRECT3D_PREVIEW_BUILD)
+#if defined(HLSLEXEC_GROUPSHARED_LIMITS)
   TEST_METHOD(GroupSharedLimitTest);
   TEST_METHOD(GroupSharedLimitASTest);
   TEST_METHOD(GroupSharedLimitMSTest);
-#endif // defined(DIRECT3D_PREVIEW_BUILD)
+#endif // defined(HLSLEXEC_GROUPSHARED_LIMITS)
   TEST_METHOD(GroupWaveIndexTest);
   TEST_METHOD(PartialDerivTest);
   TEST_METHOD(DerivativesTest);
@@ -10630,7 +10630,7 @@ void ExecutionTest::WaveSizeRangeTest() {
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(DIRECT3D_PREVIEW_BUILD)
+#if defined(HLSLEXEC_GROUPSHARED_LIMITS)
 // Helper: create a SM 6.10 device with HLK-aware skip/fail logic.
 // Returns true if device was created, false if skipped.
 static bool CreateGSMLimitTestDevice(D3D12SDKSelector *D3D12SDK,
@@ -10941,7 +10941,7 @@ void ExecutionTest::GroupSharedLimitMSTest() {
         L"MS Test passed: GroupSharedLimit in mesh shader succeeded.");
   }
 }
-#endif // defined(DIRECT3D_PREVIEW_BUILD)
+#endif // defined(HLSLEXEC_GROUPSHARED_LIMITS)
 
 void ExecutionTest::GroupWaveIndexTest() {
   WEX::TestExecution::SetVerifyOutput VerifySettings(

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -1454,22 +1454,22 @@ HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
 #if defined(HLSLEXEC_GROUPSHARED_LIMITS)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
   HlslExecGroupsharedLimits O = {};
-  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      HlslExecGroupsharedLimitsFeature, &O, sizeof(O)));
+  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(HlslExecGroupsharedLimitsFeature,
+                                               &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupCS;
 }
 
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device) {
   HlslExecGroupsharedLimits O = {};
-  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      HlslExecGroupsharedLimitsFeature, &O, sizeof(O)));
+  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(HlslExecGroupsharedLimitsFeature,
+                                               &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupAS;
 }
 
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device) {
   HlslExecGroupsharedLimits O = {};
-  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      HlslExecGroupsharedLimitsFeature, &O, sizeof(O)));
+  VERIFY_SUCCEEDED(Device->CheckFeatureSupport(HlslExecGroupsharedLimitsFeature,
+                                               &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupMS;
 }
 #endif // defined(HLSLEXEC_GROUPSHARED_LIMITS)

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.cpp
@@ -14,25 +14,6 @@
 #include <mutex>
 #include <optional>
 
-// D3D12_FEATURE_D3D12_OPTIONS_PREVIEW and its data struct are not yet in
-// the released Windows SDK. Define locally so the test can query variable
-// group shared memory capabilities from the Agility SDK runtime.
-// TODO(#8661): Remove me when GroupSharedLimit is available in a released
-// Windows SDK.
-#if defined(DIRECT3D_PREVIEW_BUILD) && D3D12_PREVIEW_SDK_VERSION < 720
-
-#ifndef D3D12_FEATURE_D3D12_OPTIONS_PREVIEW
-#define D3D12_FEATURE_D3D12_OPTIONS_PREVIEW ((D3D12_FEATURE)72)
-#endif
-
-typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW {
-  UINT MaxGroupSharedMemoryPerGroupCS;
-  UINT MaxGroupSharedMemoryPerGroupAS;
-  UINT MaxGroupSharedMemoryPerGroupMS;
-} D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW;
-
-#endif
-
 constexpr UINT KnownMultiplicationFlags = 0xf;
 constexpr UINT MatrixMultiplicationFlags =
     static_cast<UINT>(
@@ -1470,28 +1451,28 @@ HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(DIRECT3D_PREVIEW_BUILD)
+#if defined(HLSLEXEC_GROUPSHARED_LIMITS)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device) {
-  D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
+  HlslExecGroupsharedLimits O = {};
   VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
+      HlslExecGroupsharedLimitsFeature, &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupCS;
 }
 
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device) {
-  D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
+  HlslExecGroupsharedLimits O = {};
   VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
+      HlslExecGroupsharedLimitsFeature, &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupAS;
 }
 
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device) {
-  D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW O = {};
+  HlslExecGroupsharedLimits O = {};
   VERIFY_SUCCEEDED(Device->CheckFeatureSupport(
-      D3D12_FEATURE_D3D12_OPTIONS_PREVIEW, &O, sizeof(O)));
+      HlslExecGroupsharedLimitsFeature, &O, sizeof(O)));
   return O.MaxGroupSharedMemoryPerGroupMS;
 }
-#endif // defined(DIRECT3D_PREVIEW_BUILD)
+#endif // defined(HLSLEXEC_GROUPSHARED_LIMITS)
 
 std::unique_ptr<st::ShaderOp> createComputeOp(const char *Source,
                                               const char *Target,
@@ -1704,14 +1685,14 @@ void compileShader(dxc::SpecificDllLoader &DxcSupport, const char *Source,
   }
 }
 
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
 UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
                              UINT NumColumns,
                              D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
                              D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT Layout,
                              UINT Stride) {
-  CComPtr<ID3D12DevicePreview> DevicePreview;
-  VERIFY_SUCCEEDED(Device->QueryInterface(IID_PPV_ARGS(&DevicePreview)));
+  CComPtr<IHlslExecLinAlgDevice> LinAlgDevice;
+  VERIFY_SUCCEEDED(Device->QueryInterface(IID_PPV_ARGS(&LinAlgDevice)));
 
   D3D12_LINEAR_ALGEBRA_MATRIX_CONVERSION_DEST_INFO Info = {};
   Info.DestSize = 0;
@@ -1720,7 +1701,7 @@ UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
   Info.NumRows = NumRows;
   Info.NumColumns = NumColumns;
   Info.DestDataType = DataType;
-  DevicePreview->GetLinearAlgebraMatrixConversionDestinationInfo(&Info);
+  LinAlgDevice->GetLinearAlgebraMatrixConversionDestinationInfo(&Info);
   VERIFY_IS_TRUE(Info.DestSize != 0,
                  "Device reported no destination size for the requested "
                  "linear algebra matrix layout");
@@ -1733,8 +1714,8 @@ void recordLinAlgMatrixConversion(
     D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
     D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT SrcLayout, UINT SrcStride,
     D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT DestLayout, UINT DestStride) {
-  CComPtr<ID3D12GraphicsCommandListPreview> PreviewList;
-  VERIFY_SUCCEEDED(List->QueryInterface(IID_PPV_ARGS(&PreviewList)));
+  CComPtr<IHlslExecLinAlgCommandList> LinAlgList;
+  VERIFY_SUCCEEDED(List->QueryInterface(IID_PPV_ARGS(&LinAlgList)));
 
   // Per the linear-algebra spec, ConvertLinearAlgebraMatrix (legacy barriers)
   // requires the source buffer in NON_PIXEL_SHADER_RESOURCE and the destination
@@ -1763,6 +1744,6 @@ void recordLinAlgMatrixConversion(
   Info.SrcInfo.SrcStride = SrcStride;
   Info.DataDesc.DestVA = DestBuffer->GetGPUVirtualAddress();
   Info.DataDesc.SrcVA = SrcBuffer->GetGPUVirtualAddress();
-  PreviewList->ConvertLinearAlgebraMatrix(&Info, 1);
+  LinAlgList->ConvertLinearAlgebraMatrix(&Info, 1);
 }
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -38,7 +38,8 @@
 #if defined(HLSLEXEC_LINALG_CURRENT_NAMES)
 using IHlslExecLinAlgDevice = ID3D12Device18;
 using IHlslExecLinAlgCommandList = ID3D12GraphicsCommandList12;
-using HlslExecGroupsharedLimits = D3D12_FEATURE_DATA_VARIABLE_GROUPSHARED_LIMITS;
+using HlslExecGroupsharedLimits =
+    D3D12_FEATURE_DATA_VARIABLE_GROUPSHARED_LIMITS;
 constexpr D3D12_FEATURE HlslExecGroupsharedLimitsFeature =
     D3D12_FEATURE_VARIABLE_GROUPSHARED_LIMITS;
 #else
@@ -365,8 +366,9 @@ ASSERT_RUNTIME_OFFSET(
 // Headers below D3D12_SDK_VERSION 620 / D3D12_PREVIEW_SDK_VERSION 720 do not
 // declare D3D_SHADER_MODEL_6_10, released Windows SDKs included. Define it
 // locally there. Remove once a released Windows SDK declares it.
-#if !((defined(D3D12_SDK_VERSION) && D3D12_SDK_VERSION >= 620) ||              \
-      (defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION >= 720))
+#if !(                                                                         \
+    (defined(D3D12_SDK_VERSION) && D3D12_SDK_VERSION >= 620) ||                \
+    (defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION >= 720))
 static const D3D_SHADER_MODEL D3D_SHADER_MODEL_6_10 = (D3D_SHADER_MODEL)0x6a;
 #endif
 

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -13,6 +13,43 @@
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/Support/dxcapi.use.h"
 
+// These tests build against released Windows SDKs, retail Agility SDK headers
+// and preview Agility SDK headers, which disagree on how the linear algebra and
+// groupshared-limit APIs are spelled. The deployment-tier macros
+// (DIRECT3D_PREVIEW_BUILD, DIRECT3D_LINEAR_ALGEBRA) don't answer that question,
+// so key off the SDK version instead. Headers at D3D12_SDK_VERSION 621 or later
+// use the newer names; preview headers at 722 use the older ones. Earlier
+// preview drops spelled the feature query differently again and aren't
+// supported here.
+#if defined(D3D12_SDK_VERSION) && D3D12_SDK_VERSION >= 621
+#define HLSLEXEC_LINALG_CURRENT_NAMES 1
+#endif
+
+#if defined(HLSLEXEC_LINALG_CURRENT_NAMES) ||                                  \
+    (defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION >= 722)
+// This header declares the linear algebra host API (the D3D12_LINEAR_ALGEBRA_*
+// types and the matrix-conversion methods).
+#define HLSLEXEC_LINALG_HOST_API 1
+// This header declares the variable groupshared memory limits query.
+#define HLSLEXEC_GROUPSHARED_LIMITS 1
+#endif
+
+#if defined(HLSLEXEC_LINALG_HOST_API)
+#if defined(HLSLEXEC_LINALG_CURRENT_NAMES)
+using IHlslExecLinAlgDevice = ID3D12Device18;
+using IHlslExecLinAlgCommandList = ID3D12GraphicsCommandList12;
+using HlslExecGroupsharedLimits = D3D12_FEATURE_DATA_VARIABLE_GROUPSHARED_LIMITS;
+constexpr D3D12_FEATURE HlslExecGroupsharedLimitsFeature =
+    D3D12_FEATURE_VARIABLE_GROUPSHARED_LIMITS;
+#else
+using IHlslExecLinAlgDevice = ID3D12DevicePreview;
+using IHlslExecLinAlgCommandList = ID3D12GraphicsCommandListPreview;
+using HlslExecGroupsharedLimits = D3D12_FEATURE_DATA_D3D12_OPTIONS_PREVIEW;
+constexpr D3D12_FEATURE HlslExecGroupsharedLimitsFeature =
+    D3D12_FEATURE_D3D12_OPTIONS_PREVIEW;
+#endif
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
+
 // The released Windows SDK does not declare the linear algebra API yet, and
 // CheckFeatureSupport takes an untyped (void *, size) pair, so what this code
 // depends on is a runtime layout rather than a compile-time type. Everything
@@ -167,9 +204,9 @@ struct D3D12_FEATURE_DATA_LINEAR_ALGEBRA_MATRIX_OPERATION_SUPPORT {
 } // namespace linalg_abi
 
 // Everything above is pinned to the real declarations here. This only compiles
-// against a preview SDK, so it is not reached by an ordinary build; run a
-// preview-SDK compile whenever the copies above are touched.
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+// against a header that declares the linear algebra API, so run such a compile
+// whenever the copies above are touched.
+#if defined(HLSLEXEC_LINALG_HOST_API)
 
 #define ASSERT_RUNTIME_ENUM(EnumeratorName)                                    \
   static_assert(static_cast<UINT>(linalg_abi::EnumeratorName) ==               \
@@ -323,12 +360,13 @@ ASSERT_RUNTIME_OFFSET(
 
 #undef ASSERT_RUNTIME_OFFSET
 
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
 
-// D3D_SHADER_MODEL_6_10 is not yet in the released Windows SDK. Define locally
-// so the test can query 6.10 driver support. This should be removed once
-// widely supported.
-#if defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION < 720
+// Headers below D3D12_SDK_VERSION 620 / D3D12_PREVIEW_SDK_VERSION 720 do not
+// declare D3D_SHADER_MODEL_6_10, released Windows SDKs included. Define it
+// locally there. Remove once a released Windows SDK declares it.
+#if !((defined(D3D12_SDK_VERSION) && D3D12_SDK_VERSION >= 620) ||              \
+      (defined(D3D12_PREVIEW_SDK_VERSION) && D3D12_PREVIEW_SDK_VERSION >= 720))
 static const D3D_SHADER_MODEL D3D_SHADER_MODEL_6_10 = (D3D_SHADER_MODEL)0x6a;
 #endif
 
@@ -561,11 +599,11 @@ HRESULT queryAtomicAccumulateStore(ID3D12Device *Device,
 
 // TODO(#8661): Remove me when GroupSharedLimit is available in a released
 // Windows SDK.
-#if defined(DIRECT3D_PREVIEW_BUILD)
+#if defined(HLSLEXEC_GROUPSHARED_LIMITS)
 UINT getMaxGroupSharedMemoryCS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryAS(ID3D12Device *Device);
 UINT getMaxGroupSharedMemoryMS(ID3D12Device *Device);
-#endif // defined(DIRECT3D_PREVIEW_BUILD)
+#endif // defined(HLSLEXEC_GROUPSHARED_LIMITS)
 
 /// Create a ShaderOp for a compute shader dispatch.
 std::unique_ptr<st::ShaderOp>
@@ -611,13 +649,10 @@ void compileShader(dxc::SpecificDllLoader &DxcSupport, const char *Source,
                    const char *Target, const std::string &Args,
                    bool VerboseLogging = false);
 
-// Host-side linear-algebra matrix-conversion helpers. These need the D3D12
-// linear-algebra API (the D3D12_LINEAR_ALGEBRA_* types and the conversion
-// methods on ID3D12DevicePreview / ID3D12GraphicsCommandListPreview), which is
-// gated behind the preview SDK's DIRECT3D_LINEAR_ALGEBRA feature macro. When
-// absent, these helpers and the tests using them are compiled out (they Skip at
-// runtime).
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+// Host-side linear-algebra matrix-conversion helpers, which need the D3D12
+// linear-algebra API -- see HLSLEXEC_LINALG_HOST_API above. When absent, these
+// helpers and the tests using them are compiled out (they Skip at runtime).
+#if defined(HLSLEXEC_LINALG_HOST_API)
 /// Query the number of bytes required to store an NumRows x NumColumns matrix
 /// of the given datatype in the specified device layout. Fails the test if the
 /// device cannot serve the request, which it reports as a zero size.
@@ -628,7 +663,7 @@ UINT getLinAlgMatrixByteSize(ID3D12Device *Device, UINT NumRows,
                              UINT Stride);
 
 /// Record a GPU matrix layout conversion onto \p List using
-/// ID3D12GraphicsCommandListPreview::ConvertLinearAlgebraMatrix. Both
+/// IHlslExecLinAlgCommandList::ConvertLinearAlgebraMatrix. Both
 /// \p SrcBuffer (in \p SrcLayout) and \p DestBuffer (receiving \p DestLayout)
 /// must be passed in the D3D12_RESOURCE_STATE_UNORDERED_ACCESS state; the
 /// conversion requires the source in NON_PIXEL_SHADER_RESOURCE, so this helper
@@ -641,6 +676,6 @@ void recordLinAlgMatrixConversion(
     D3D12_LINEAR_ALGEBRA_DATATYPE DataType,
     D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT SrcLayout, UINT SrcStride,
     D3D12_LINEAR_ALGEBRA_MATRIX_LAYOUT DestLayout, UINT DestStride);
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
 
 #endif // HLSLEXECTESTUTILS_H

--- a/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
+++ b/tools/clang/unittests/HLSLExec/LinAlgTests.cpp
@@ -2509,7 +2509,7 @@ static void runCase(ID3D12Device *Device, dxc::SpecificDllLoader &DxcSupport,
 
   UINT MulOptimalSize = 0;
   st::ShaderOpTest::TCommandCallbackFn ConvertCallback = nullptr;
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
   if (Case.LoadFromMulOptimal) {
     const std::optional<linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE> MirrorType =
         toCapabilityDataType(Case.MatrixType);
@@ -2783,25 +2783,25 @@ static CaseData makeFP8MemoryBiasCase(ComponentType BiasType) {
   return Case;
 }
 
-#if !defined(DIRECT3D_LINEAR_ALGEBRA)
+#if !defined(HLSLEXEC_LINALG_HOST_API)
 static void reportMissingConversionApi(LPCWSTR CaseName) {
 #ifdef _HLK_CONF
   // HLK forbids skipping, so treat the missing linear-algebra matrix-conversion
   // API as a failure rather than emitting a (compiled-out) skip.
   hlsl_test::LogErrorFmt(L"%s requires the linear-algebra matrix-conversion "
-                         L"API (DIRECT3D_LINEAR_ALGEBRA), which this build "
+                         L"API (HLSLEXEC_LINALG_HOST_API), which this build "
                          L"lacks",
                          CaseName);
 #else
   hlsl_test::LogCommentFmt(
       L"Skipping %s: built against a D3D12 SDK without the linear-algebra "
-      L"matrix-conversion API (DIRECT3D_LINEAR_ALGEBRA undefined); the "
+      L"matrix-conversion API (HLSLEXEC_LINALG_HOST_API undefined); the "
       L"host-side conversion helpers are compiled out.",
       CaseName);
   WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
 #endif // _HLK_CONF
 }
-#endif // !defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // !defined(HLSLEXEC_LINALG_HOST_API)
 
 } // namespace matvec_interpretation
 // Harness self-check for the CPU oracle. Deliberately carries no Kits metadata
@@ -7095,7 +7095,7 @@ void DxilConf_SM610_LinAlg::MatVecMulAdd_Thread_4x8_F32() {
 
 // Map a DXIL ComponentType to the D3D12 linear-algebra datatype used by the
 // host-side matrix conversion API.
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
 static D3D12_LINEAR_ALGEBRA_DATATYPE toLinAlgDataType(ComponentType CT) {
   switch (CT) {
   case ComponentType::F16:
@@ -7227,10 +7227,10 @@ static void runOuterProduct(ID3D12Device *Device,
   VERIFY_IS_TRUE(verifyComponentBuffer(Params.CompType, OutData.data(),
                                        Expected, NumMatElements, Verbose));
 }
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
 
 void DxilConf_SM610_LinAlg::OuterProduct_Thread_16x16_F16() {
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
   MatrixParams Params = {};
   Params.CompType = ComponentType::F16;
   Params.M = 16;
@@ -7264,16 +7264,16 @@ void DxilConf_SM610_LinAlg::OuterProduct_Thread_16x16_F16() {
   // API as a failure rather than emitting a (compiled-out) skip.
   hlsl_test::LogErrorFmt(L"OuterProduct_Thread_16x16_F16 requires the "
                          L"linear-algebra matrix-conversion API "
-                         L"(DIRECT3D_LINEAR_ALGEBRA), which this build lacks");
+                         L"(HLSLEXEC_LINALG_HOST_API), which this build lacks");
 #else
   WEX::Logging::Log::Comment(
       L"Skipping OuterProduct_Thread_16x16_F16: built against a D3D12 SDK "
       L"without the linear-algebra matrix-conversion API "
-      L"(DIRECT3D_LINEAR_ALGEBRA undefined); the host-side conversion helpers "
+      L"(HLSLEXEC_LINALG_HOST_API undefined); the host-side conversion helpers "
       L"are compiled out.");
   WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
 #endif // _HLK_CONF
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
 }
 
 static const char QueryAccumLayoutValueShader[] = R"(
@@ -8896,7 +8896,7 @@ void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_U32_UnsignedOutput() {
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x16_F8_E4M3FN() {
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
   const matvec_interpretation::CaseData Case =
       matvec_interpretation::makeFP8MatrixCase(ComponentType::F8_E4M3FN);
   matvec_interpretation::runCapabilityChecked(
@@ -8906,11 +8906,11 @@ void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x16_F8_E4M3FN() {
 #else
   matvec_interpretation::reportMissingConversionApi(
       L"MatVecMul_Thread_4x16_F8_E4M3FN");
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x16_F8_E5M2() {
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
   const matvec_interpretation::CaseData Case =
       matvec_interpretation::makeFP8MatrixCase(ComponentType::F8_E5M2);
   matvec_interpretation::runCapabilityChecked(
@@ -8920,7 +8920,7 @@ void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x16_F8_E5M2() {
 #else
   matvec_interpretation::reportMissingConversionApi(
       L"MatVecMul_Thread_4x16_F8_E5M2");
-#endif // defined(DIRECT3D_LINEAR_ALGEBRA)
+#endif // defined(HLSLEXEC_LINALG_HOST_API)
 }
 
 void DxilConf_SM610_LinAlg::MatVecMul_Thread_4x8_F8_E4M3FN_Vector() {
@@ -9013,7 +9013,7 @@ static constexpr linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE
         linalg_abi::D3D12_LINEAR_ALGEBRA_DATATYPE_FLOAT32,
 };
 
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
 static_assert(
     static_cast<UINT>(ConvertOperationEnumerationFeature) ==
     static_cast<UINT>(D3D12_FEATURE_LINEAR_ALGEBRA_OPERATION_ENUMERATION));
@@ -9154,7 +9154,7 @@ static HRESULT queryConvertSupport(ID3D12Device *Device,
       DestinationType = toCapabilityDataType(DestinationCompType);
   if (!SourceType.has_value() || !DestinationType.has_value())
     return E_INVALIDARG;
-#if defined(DIRECT3D_LINEAR_ALGEBRA)
+#if defined(HLSLEXEC_LINALG_HOST_API)
   VERIFY_ARE_EQUAL(static_cast<UINT>(*SourceType),
                    static_cast<UINT>(toLinAlgDataType(SourceCompType)));
   VERIFY_ARE_EQUAL(static_cast<UINT>(*DestinationType),


### PR DESCRIPTION
The linear algebra and groupshared-limit APIs are spelled differently depending on the D3D12 headers being compiled against. Headers at `D3D12_SDK_VERSION` 621 or later use `D3D12_FEATURE(_DATA)_VARIABLE_GROUPSHARED_LIMITS`, `ID3D12Device18` and `ID3D12GraphicsCommandList12`; preview headers at `D3D12_PREVIEW_SDK_VERSION` 722 use `D3D12_FEATURE(_DATA)_D3D12_OPTIONS_PREVIEW`, `ID3D12DevicePreview` and `ID3D12GraphicsCommandListPreview`.

Preview 722 is the floor for the older spelling; earlier preview headers spelled the feature query differently again and were not kept compatible. That makes the local `D3D12_FEATURE_D3D12_OPTIONS_PREVIEW` shim unreachable, so it is removed.

Also fixes the `D3D_SHADER_MODEL_6_10` fallback, which only defined the enumerator when a preview header was present and older than 720.