### PR TITLE
[SM6.10][Bugfix] Fix GS Mem Validation Rules

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3212,7 +3212,7 @@ INSTR.INBOUNDSACCESS                                  Access to out-of-bounds me
 INSTR.LINALGILLEGALCOMPONENTTYPE                      Component type '%0' from %1 not allowed in LinAlg Matrix operations.
 INSTR.LINALGILLEGALKDIM                               %0 matrix K dimension out of bounds. K=%1 must be >= %2 and <= %3.
 INSTR.LINALGMATRIX2PARTSMUSTMATCH                     %0 matrix %1 '%2' must match %3 matrix %4 '%5'.
-INSTR.LINALGMATRIXBYTEWISEMUSTBEMULTIPLE              Byte width of parameter '%0' must be a multiple of %1, got %2 (%3 * %4).
+INSTR.LINALGMATRIXBYTEWISEMUSTBEMULTIPLE              Parameter '%0' in bytes must be a multiple of %1, got %2 (%3 elements * %4 bytes per element).
 INSTR.LINALGMATRIXDIMKVECKMISMATCH                    %0 vector size '%1' must be %2 for input matrix with K '%3' and Type '%4'
 INSTR.LINALGMATRIXDIMVECTORMISMATCH                   %0 vector size '%1' must match input matrix M dimension '%2'
 INSTR.LINALGMATRIXGSMEMMUSTBELARGEENOUGH              Groupshared memory holds '%0' scalars but must hold at least '%1' scalars.

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3212,6 +3212,7 @@ INSTR.INBOUNDSACCESS                                  Access to out-of-bounds me
 INSTR.LINALGILLEGALCOMPONENTTYPE                      Component type '%0' from %1 not allowed in LinAlg Matrix operations.
 INSTR.LINALGILLEGALKDIM                               %0 matrix K dimension out of bounds. K=%1 must be >= %2 and <= %3.
 INSTR.LINALGMATRIX2PARTSMUSTMATCH                     %0 matrix %1 '%2' must match %3 matrix %4 '%5'.
+INSTR.LINALGMATRIXBYTEWISEMUSTBEMULTIPLE              Byte width of parameter '%0' must be a multiple of %1, got %2 (%3 * %4).
 INSTR.LINALGMATRIXDIMKVECKMISMATCH                    %0 vector size '%1' must be %2 for input matrix with K '%3' and Type '%4'
 INSTR.LINALGMATRIXDIMVECTORMISMATCH                   %0 vector size '%1' must match input matrix M dimension '%2'
 INSTR.LINALGMATRIXGSMEMMUSTBELARGEENOUGH              Groupshared memory holds '%0' scalars but must hold at least '%1' scalars.

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1096,6 +1096,33 @@ static unsigned ComponentTypeElementsPerScalar(DXIL::ComponentType CT) {
   }
 }
 
+static unsigned ComponentTypeByteCount(DXIL::ComponentType CT) {
+  switch (CT) {
+  case DXIL::ComponentType::I8:
+  case DXIL::ComponentType::U8:
+  case DXIL::ComponentType::F8_E4M3FN:
+  case DXIL::ComponentType::F8_E5M2:
+    return 1;
+  case DXIL::ComponentType::F16:
+  case DXIL::ComponentType::U16:
+  case DXIL::ComponentType::I16:
+  case DXIL::ComponentType::BFloat16:
+    return 2;
+  case DXIL::ComponentType::I32:
+  case DXIL::ComponentType::U32:
+  case DXIL::ComponentType::F32:
+    return 4;
+  case DXIL::ComponentType::I64:
+  case DXIL::ComponentType::U64:
+  case DXIL::ComponentType::F64:
+    return 8;
+  // All other ComponentTypes are illegal to use in LinAlg Matrix. Their usage
+  // is detected and reported in other parts on the validator
+  default:
+    return 1;
+  }
+}
+
 static std::optional<LinAlgTargetType>
 GetCheckedLATT(Type *Ty, ValidationContext &ValCtx) {
   assert(dxilutil::IsHLSLLinAlgMatrixType(Ty) &&
@@ -1273,20 +1300,30 @@ static void ValidateLinAlgMatrixStoreToMemory(CallInst *CI,
         CI, ValidationRule::InstrLinAlgMatrixGSMemMustBeLargeEnough,
         {std::to_string(GSScalarCount), std::to_string(ExpectedScalarCount)});
 
+  // gs memory ops have the parameter in element count so it must be scaled
+  unsigned ByteCount = ComponentTypeByteCount(Mat->Type);
+
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
-    if (Offset % 128 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Offset", "128", std::to_string(Offset)});
+    unsigned OffsetBytes = Offset * ByteCount;
+    if (OffsetBytes % 128 != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
+          {"Offset", "128", std::to_string(OffsetBytes), std::to_string(Offset),
+           std::to_string(ByteCount)});
   }
 
   // if it is constant then stride must be 16-byte aligned
+  // gs memory ops have the parameter in element count so it msut be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
-    if (Stride % 16 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Stride", "16", std::to_string(Stride)});
+    unsigned StrideBytes = Stride * ByteCount;
+    if (StrideBytes % 16 != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
+          {"Stride", "16", std::to_string(StrideBytes), std::to_string(Stride),
+           std::to_string(ByteCount)});
   }
 }
 
@@ -1530,20 +1567,30 @@ static void ValidateLinAlgMatrixAccumulateToMemory(CallInst *CI,
            ComponentTypeToString(Target)});
   }
 
+  // gs memory ops have the parameter in element count so it must be scaled
+  unsigned ByteCount = ComponentTypeByteCount(Mat->Type);
+
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
-    if (Offset % 128 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Offset", "128", std::to_string(Offset)});
+    unsigned OffsetBytes = Offset * ByteCount;
+    if (OffsetBytes % 128 != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
+          {"Offset", "128", std::to_string(OffsetBytes), std::to_string(Offset),
+           std::to_string(ByteCount)});
   }
 
   // if it is constant then stride must be 16-byte aligned
+  // gs memory ops have the parameter in element count so it msut be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
-    if (Stride % 16 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Stride", "16", std::to_string(Stride)});
+    unsigned StrideBytes = Stride * ByteCount;
+    if (StrideBytes % 16 != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
+          {"Stride", "16", std::to_string(StrideBytes), std::to_string(Stride),
+           std::to_string(ByteCount)});
   }
 }
 
@@ -1726,20 +1773,30 @@ static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
         CI, ValidationRule::InstrLinAlgMatrixGSMemMustBeLargeEnough,
         {std::to_string(GSScalarCount), std::to_string(ExpectedScalarCount)});
 
+  // gs memory ops have the parameter in element count so it must be scaled
+  unsigned ByteCount = ComponentTypeByteCount(RetMat->Type);
+
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
-    if (Offset % 128 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Offset", "128", std::to_string(Offset)});
+    unsigned OffsetBytes = Offset * ByteCount;
+    if (OffsetBytes % 128 != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
+          {"Offset", "128", std::to_string(OffsetBytes), std::to_string(Offset),
+           std::to_string(ByteCount)});
   }
 
   // if it is constant then stride must be 16-byte aligned
+  // gs memory ops have the parameter in element count so it msut be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
-    if (Stride % 16 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Stride", "16", std::to_string(Stride)});
+    unsigned StrideBytes = Stride * ByteCount;
+    if (StrideBytes % 16 != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
+          {"Stride", "16", std::to_string(StrideBytes), std::to_string(Stride),
+           std::to_string(ByteCount)});
   }
 }
 

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1091,7 +1091,7 @@ static unsigned ComponentTypeElementsPerScalar(DXIL::ComponentType CT) {
   case DXIL::ComponentType::F8_E5M2:
     return 4;
   // All other ComponentTypes are illegal to use in LinAlg Matrix. Their usage
-  // is detected and reported in other parts on the validator
+  // is detected and reported in other parts of the validator
   default:
     return 4;
   }
@@ -1316,7 +1316,6 @@ static void ValidateLinAlgMatrixStoreToMemory(CallInst *CI,
   }
 
   // if it is constant then stride must be 16-byte aligned
-  // gs memory ops have the parameter in element count so it must be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
     uint64_t StrideBytes = Stride * ByteCount;
@@ -1583,7 +1582,6 @@ static void ValidateLinAlgMatrixAccumulateToMemory(CallInst *CI,
   }
 
   // if it is constant then stride must be 16-byte aligned
-  // gs memory ops have the parameter in element count so it must be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
     uint64_t StrideBytes = Stride * ByteCount;
@@ -1789,7 +1787,6 @@ static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
   }
 
   // if it is constant then stride must be 16-byte aligned
-  // gs memory ops have the parameter in element count so it must be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
     uint64_t StrideBytes = Stride * ByteCount;

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1118,7 +1118,7 @@ static unsigned ComponentTypeByteCount(DXIL::ComponentType CT) {
   case DXIL::ComponentType::F64:
     return 8;
   // All other ComponentTypes are illegal to use in LinAlg Matrix. Their usage
-  // is detected and reported in other parts on the validator
+  // is detected and reported in other parts of the validator
   default:
     return 1;
   }

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -50,6 +50,7 @@
 #include "DxilValidationUtils.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <deque>
 #include <optional>
 #include <string>
@@ -1306,7 +1307,7 @@ static void ValidateLinAlgMatrixStoreToMemory(CallInst *CI,
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
-    unsigned OffsetBytes = Offset * ByteCount;
+    uint64_t OffsetBytes = Offset * ByteCount;
     if (OffsetBytes % 128 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
@@ -1315,10 +1316,10 @@ static void ValidateLinAlgMatrixStoreToMemory(CallInst *CI,
   }
 
   // if it is constant then stride must be 16-byte aligned
-  // gs memory ops have the parameter in element count so it msut be scaled
+  // gs memory ops have the parameter in element count so it must be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
-    unsigned StrideBytes = Stride * ByteCount;
+    uint64_t StrideBytes = Stride * ByteCount;
     if (StrideBytes % 16 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
@@ -1573,7 +1574,7 @@ static void ValidateLinAlgMatrixAccumulateToMemory(CallInst *CI,
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
-    unsigned OffsetBytes = Offset * ByteCount;
+    uint64_t OffsetBytes = Offset * ByteCount;
     if (OffsetBytes % 128 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
@@ -1582,10 +1583,10 @@ static void ValidateLinAlgMatrixAccumulateToMemory(CallInst *CI,
   }
 
   // if it is constant then stride must be 16-byte aligned
-  // gs memory ops have the parameter in element count so it msut be scaled
+  // gs memory ops have the parameter in element count so it must be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
-    unsigned StrideBytes = Stride * ByteCount;
+    uint64_t StrideBytes = Stride * ByteCount;
     if (StrideBytes % 16 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
@@ -1779,7 +1780,7 @@ static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
-    unsigned OffsetBytes = Offset * ByteCount;
+    uint64_t OffsetBytes = Offset * ByteCount;
     if (OffsetBytes % 128 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
@@ -1788,10 +1789,10 @@ static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
   }
 
   // if it is constant then stride must be 16-byte aligned
-  // gs memory ops have the parameter in element count so it msut be scaled
+  // gs memory ops have the parameter in element count so it must be scaled
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
-    unsigned StrideBytes = Stride * ByteCount;
+    uint64_t StrideBytes = Stride * ByteCount;
     if (StrideBytes % 16 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,

--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1302,7 +1302,7 @@ static void ValidateLinAlgMatrixStoreToMemory(CallInst *CI,
         {std::to_string(GSScalarCount), std::to_string(ExpectedScalarCount)});
 
   // gs memory ops have the parameter in element count so it must be scaled
-  unsigned ByteCount = ComponentTypeByteCount(Mat->Type);
+  uint64_t ByteCount = ComponentTypeByteCount(Mat->Type);
 
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
@@ -1569,7 +1569,7 @@ static void ValidateLinAlgMatrixAccumulateToMemory(CallInst *CI,
   }
 
   // gs memory ops have the parameter in element count so it must be scaled
-  unsigned ByteCount = ComponentTypeByteCount(Mat->Type);
+  uint64_t ByteCount = ComponentTypeByteCount(Mat->Type);
 
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
@@ -1775,7 +1775,7 @@ static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
         {std::to_string(GSScalarCount), std::to_string(ExpectedScalarCount)});
 
   // gs memory ops have the parameter in element count so it must be scaled
-  unsigned ByteCount = ComponentTypeByteCount(RetMat->Type);
+  uint64_t ByteCount = ComponentTypeByteCount(RetMat->Type);
 
   // if it is constant then offset must be 128-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetomemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetomemory.ll
@@ -41,14 +41,14 @@ define void @main() {
   ; okay
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 128, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 
-  ; CHECK: Function: main: error: Byte width of parameter 'Offset' must be a multiple of 128, got 516 (129 * 4).
+  ; CHECK: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 128, got 516 (129 elements * 4 bytes per element).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 129, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 
   ; okay only if offset accounts for byte width of component type
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 32, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: Byte width of parameter 'Stride' must be a multiple of 16, got 68 (17 * 4).
+  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 16, got 68 (17 elements * 4 bytes per element).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 128, i32 17, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetomemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetomemory.ll
@@ -41,13 +41,19 @@ define void @main() {
   ; okay
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 128, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 
-  ; CHECK: Function: main: error: parameter 'Offset' must be a multiple of 128, got 129
+  ; CHECK: Function: main: error: Byte width of parameter 'Offset' must be a multiple of 128, got 516 (129 * 4).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 129, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: parameter 'Stride' must be a multiple of 16, got 17
+  ; okay only if offset accounts for byte width of component type
+  call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 32, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Byte width of parameter 'Stride' must be a multiple of 16, got 68 (17 * 4).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 128, i32 17, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
+
+  ; okay only if stride accounts for byte width of component type
+  call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 9, i32 128, i32 4, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,targetType,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory inner type 'float' must match target type 'I64'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfrommemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfrommemory.ll
@@ -18,43 +18,49 @@ define void @main() {
   ; okay
   %1 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: parameter 'Offset' must be a multiple of 128, got 129
+  ; CHECK: Function: main: error: Byte width of parameter 'Offset' must be a multiple of 128, got 516 (129 * 4).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32
   %2 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: parameter 'Stride' must be a multiple of 16, got 17
+  ; okay only if offset accounts for byte width of component type
+  %3 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Byte width of parameter 'Stride' must be a multiple of 16, got 68 (17 * 4).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32
-  %3 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %4 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+
+  ; okay only if stride accounts for byte width of component type
+  %5 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 4, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Return matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S0.f32
-  %4 = call %dx.types.LinAlgMatrixC9M4N4U0S0 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S0.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %6 = call %dx.types.LinAlgMatrixC9M4N4U0S0 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S0.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory inner type 'float' must match return matrix type 'I64'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC6M4N4U0S2.f32
-  %5 = call %dx.types.LinAlgMatrixC6M4N4U0S2 @dx.op.linAlgMatrixLoadFromMemory.mC6M4N4U0S2.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %7 = call %dx.types.LinAlgMatrixC6M4N4U0S2 @dx.op.linAlgMatrixLoadFromMemory.mC6M4N4U0S2.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; okay
-  %6 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %8 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.f32
-  %7 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %9 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.f32
-  %8 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %10 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; okay
-  %9 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %11 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.v4f32
-  %10 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %12 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32
-  %11 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %13 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Validation failed.
   ret void
@@ -102,7 +108,7 @@ attributes #0 = { nounwind }
 !3 = !{%dx.types.LinAlgMatrixC9M8N8U0S1 undef, i32 9, i32 8, i32 8, i32 0, i32 1}
 !4 = !{%dx.types.LinAlgMatrixC9M9N8U0S1 undef, i32 9, i32 9, i32 8, i32 0, i32 1}
 !5 = !{%dx.types.LinAlgMatrixC9M8N9U0S1 undef, i32 9, i32 8, i32 9, i32 0, i32 1}
-!6 = !{!"dxc(private) 1.9.0.5467 (linalg-vali-matrixaccumulatetomemory, 37b85f973-dirty)"}
+!6 = !{!"dxc(private) 1.9.0.5493 (linalg-vali-convert, 0787c0d7b-dirty)"}
 !7 = !{i32 1, i32 10}
 !8 = !{!"cs", i32 6, i32 10}
 !9 = !{void ()* @main, !"main", null, null, !10}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfrommemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfrommemory.ll
@@ -18,14 +18,14 @@ define void @main() {
   ; okay
   %1 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: Byte width of parameter 'Offset' must be a multiple of 128, got 516 (129 * 4).
+  ; CHECK: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 128, got 516 (129 elements * 4 bytes per element).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32
   %2 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; okay only if offset accounts for byte width of component type
   %3 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: Byte width of parameter 'Stride' must be a multiple of 16, got 68 (17 * 4).
+  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 16, got 68 (17 elements * 4 bytes per element).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32
   %4 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretomemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretomemory.ll
@@ -36,13 +36,19 @@ define void @main() {
   ; okay
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: parameter 'Offset' must be a multiple of 128, got 129
+  ; CHECK: Function: main: error: Byte width of parameter 'Offset' must be a multiple of 128, got 516 (129 * 4).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: parameter 'Stride' must be a multiple of 16, got 17
+  ; okay only if offset accounts for byte width of component type
+  call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Byte width of parameter 'Stride' must be a multiple of 16, got 68 (17 * 4).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
+
+  ; okay only if stride accounts for byte width of component type
+  call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 4, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S0.f32

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretomemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretomemory.ll
@@ -36,14 +36,14 @@ define void @main() {
   ; okay
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: Byte width of parameter 'Offset' must be a multiple of 128, got 516 (129 * 4).
+  ; CHECK: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 128, got 516 (129 elements * 4 bytes per element).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
   ; okay only if offset accounts for byte width of component type
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: Byte width of parameter 'Stride' must be a multiple of 16, got 68 (17 * 4).
+  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 16, got 68 (17 elements * 4 bytes per element).
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8755,6 +8755,10 @@ class db_dxil(object):
             "Instr.LinAlgMatrixVecElemCountMismatch",
             "Return vector size '%0' must match size '%1' derived from input vector size and type.",
         )
+        self.add_valrule(
+            "Instr.LinAlgMatrixBytewiseMustBeMultiple",
+            "Byte width of parameter '%0' must be a multiple of %1, got %2 (%3 * %4).",
+        )
 
         # Some legacy rules:
         # - space is only supported for shader targets 5.1 and higher

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -8757,7 +8757,7 @@ class db_dxil(object):
         )
         self.add_valrule(
             "Instr.LinAlgMatrixBytewiseMustBeMultiple",
-            "Byte width of parameter '%0' must be a multiple of %1, got %2 (%3 * %4).",
+            "Parameter '%0' in bytes must be a multiple of %1, got %2 (%3 elements * %4 bytes per element).",
         )
 
         # Some legacy rules:

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -6327,12 +6327,12 @@ class db_dxil(object):
                 db_dxil_param(
                     2, "$x_gs1", "memory", "groupshared array to fill matrix with"
                 ),
-                db_dxil_param(3, "i32", "offset", "starting offset in the array"),
+                db_dxil_param(3, "i32", "offset", "starting offset in the array in elements"),
                 db_dxil_param(
                     4,
                     "i32",
                     "stride",
-                    "number of bytes between the start of each row or column",
+                    "number of elements between the start of each row or column",
                 ),
                 db_dxil_param(5, "i32", "layout", "memory layout of matrix elements"),
             ],
@@ -6430,12 +6430,12 @@ class db_dxil(object):
                 db_dxil_param(
                     3, "$x_gs1", "memory", "groupshared array to store into"
                 ),
-                db_dxil_param(4, "i32", "offset", "starting offset in the array"),
+                db_dxil_param(4, "i32", "offset", "starting offset in the array in elements"),
                 db_dxil_param(
                     5,
                     "i32",
                     "stride",
-                    "number of bytes between the start of each row or column",
+                    "number of elements between the start of each row or column",
                 ),
                 db_dxil_param(6, "i32", "layout", "memory layout of matrix elements"),
             ],
@@ -6548,12 +6548,12 @@ class db_dxil(object):
                     3, "$x_gs1", "memory", "groupshared array to accumulate into"
                 ),
                 db_dxil_param(4, "i32", "targetType", "data type of the array"),
-                db_dxil_param(5, "i32", "offset", "starting offset in the array"),
+                db_dxil_param(5, "i32", "offset", "starting offset in the array in elements"),
                 db_dxil_param(
                     6,
                     "i32",
                     "stride",
-                    "number of bytes between the start of each row or column",
+                    "number of elements between the start of each row or column",
                 ),
                 db_dxil_param(7, "i32", "layout", "memory layout of matrix elements"),
             ],


### PR DESCRIPTION
Previously the validation rules for groupshared memory failed to account for the fact that the alignment rules are bytewise while the parameters are elementwise causing valid uses to be rejected for misalignment.

This PR updates the rule to scale the element count by the byte width of the matrix type per the spec.