### PR TITLE
Update retail LinAlg interface names

### DIFF
--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -36,7 +36,7 @@
 
 #if defined(HLSLEXEC_LINALG_HOST_API)
 #if defined(HLSLEXEC_LINALG_CURRENT_NAMES)
-using IHlslExecLinAlgDevice = ID3D12Device18;
+using IHlslExecLinAlgDevice = ID3D12Device17;
 using IHlslExecLinAlgCommandList = ID3D12GraphicsCommandList13;
 using HlslExecGroupsharedLimits =
     D3D12_FEATURE_DATA_VARIABLE_GROUPSHARED_LIMITS;

--- a/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
+++ b/tools/clang/unittests/HLSLExec/HlslExecTestUtils.h
@@ -37,7 +37,7 @@
 #if defined(HLSLEXEC_LINALG_HOST_API)
 #if defined(HLSLEXEC_LINALG_CURRENT_NAMES)
 using IHlslExecLinAlgDevice = ID3D12Device18;
-using IHlslExecLinAlgCommandList = ID3D12GraphicsCommandList12;
+using IHlslExecLinAlgCommandList = ID3D12GraphicsCommandList13;
 using HlslExecGroupsharedLimits =
     D3D12_FEATURE_DATA_VARIABLE_GROUPSHARED_LIMITS;
 constexpr D3D12_FEATURE HlslExecGroupsharedLimitsFeature =


### PR DESCRIPTION
`ID3D12GraphicsCommandList12` will have an earlier ship vehicle, need to bump this out one more. `ID3D12Device17` is no longer reserved by an earlier ship vehicle, so LinAlg slots in there instead.