### PR TITLE
[SM6.10] LinAlg: Adjust Wave/TG Alignment Requirements

### DIFF
--- a/lib/DxilValidation/DxilValidation.cpp
+++ b/lib/DxilValidation/DxilValidation.cpp
@@ -1240,16 +1240,16 @@ static void ValidateLinAlgMatrixStoreToDescriptor(CallInst *CI,
                                 ValidationRule::InstrLinAlgMatrixRequiresRWBAB,
                                 {"LinAlgMatrixStoreToDescriptor"});
 
-  // Align must be an imm constant that is a multiple of 128 greater than 0
+  // Align must be an imm constant that is a multiple of 4 greater than 0
   std::optional<uint64_t> Align = ValidateConstantIntGetValue(
       CI, Op.get_align(), ValCtx, "Align", "LinAlgMatrixStoreToDescriptor");
   if (Align) {
     if (*Align == 0)
       ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMinimumValue,
                                   {"Align", "0", std::to_string(*Align)});
-    if (*Align % 128 != 0)
+    if (*Align % 4 != 0)
       ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Align", "128", std::to_string(*Align)});
+                                  {"Align", "4", std::to_string(*Align)});
   }
 }
 
@@ -1304,25 +1304,25 @@ static void ValidateLinAlgMatrixStoreToMemory(CallInst *CI,
   // gs memory ops have the parameter in element count so it must be scaled
   uint64_t ByteCount = ComponentTypeByteCount(Mat->Type);
 
-  // if it is constant then offset must be 128-byte aligned
+  // if it is constant then offset must be 4-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
     uint64_t OffsetBytes = Offset * ByteCount;
-    if (OffsetBytes % 128 != 0)
+    if (OffsetBytes % 4 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
-          {"Offset", "128", std::to_string(OffsetBytes), std::to_string(Offset),
+          {"Offset", "4", std::to_string(OffsetBytes), std::to_string(Offset),
            std::to_string(ByteCount)});
   }
 
-  // if it is constant then stride must be 16-byte aligned
+  // if it is constant then stride must be 4-byte aligned
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
     uint64_t StrideBytes = Stride * ByteCount;
-    if (StrideBytes % 16 != 0)
+    if (StrideBytes % 4 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
-          {"Stride", "16", std::to_string(StrideBytes), std::to_string(Stride),
+          {"Stride", "4", std::to_string(StrideBytes), std::to_string(Stride),
            std::to_string(ByteCount)});
   }
 }
@@ -1481,7 +1481,9 @@ ValidateLinAlgMatrixAccumulateToDescriptor(CallInst *CI,
                                 ValidationRule::InstrLinAlgMatrixRequiresRWBAB,
                                 {"LinAlgMatrixAccumulateToDescriptor"});
 
-  // Align must be an imm constant that is a multiple of 128 greater than 0
+  uint64_t RequiredAlignment =
+      Mat->Scope == DXIL::MatrixScope::Thread ? 128 : 4;
+  // Align must be an imm constant with the scope's required alignment
   std::optional<uint64_t> Align =
       ValidateConstantIntGetValue(CI, Op.get_align(), ValCtx, "Align",
                                   "LinAlgMatrixAccumulateToDescriptor");
@@ -1489,9 +1491,10 @@ ValidateLinAlgMatrixAccumulateToDescriptor(CallInst *CI,
     if (*Align == 0)
       ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMinimumValue,
                                   {"Align", "0", std::to_string(*Align)});
-    if (*Align % 128 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Align", "128", std::to_string(*Align)});
+    if (*Align % RequiredAlignment != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrParamMultiple,
+          {"Align", std::to_string(RequiredAlignment), std::to_string(*Align)});
   }
 }
 
@@ -1552,25 +1555,25 @@ static void ValidateLinAlgMatrixAccumulateToMemory(CallInst *CI,
   // gs memory ops have the parameter in element count so it must be scaled
   uint64_t ByteCount = ComponentTypeByteCount(Mat->Type);
 
-  // if it is constant then offset must be 128-byte aligned
+  // if it is constant then offset must be 4-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
     uint64_t OffsetBytes = Offset * ByteCount;
-    if (OffsetBytes % 128 != 0)
+    if (OffsetBytes % 4 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
-          {"Offset", "128", std::to_string(OffsetBytes), std::to_string(Offset),
+          {"Offset", "4", std::to_string(OffsetBytes), std::to_string(Offset),
            std::to_string(ByteCount)});
   }
 
-  // if it is constant then stride must be 16-byte aligned
+  // if it is constant then stride must be 4-byte aligned
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
     uint64_t StrideBytes = Stride * ByteCount;
-    if (StrideBytes % 16 != 0)
+    if (StrideBytes % 4 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
-          {"Stride", "16", std::to_string(StrideBytes), std::to_string(Stride),
+          {"Stride", "4", std::to_string(StrideBytes), std::to_string(Stride),
            std::to_string(ByteCount)});
   }
 }
@@ -1757,25 +1760,25 @@ static void ValidateLinAlgMatrixLoadFromMemory(CallInst *CI,
   // gs memory ops have the parameter in element count so it must be scaled
   uint64_t ByteCount = ComponentTypeByteCount(RetMat->Type);
 
-  // if it is constant then offset must be 128-byte aligned
+  // if it is constant then offset must be 4-byte aligned
   if (ConstantInt *OffsetV = dyn_cast<ConstantInt>(Op.get_offset())) {
     unsigned Offset = OffsetV->getLimitedValue();
     uint64_t OffsetBytes = Offset * ByteCount;
-    if (OffsetBytes % 128 != 0)
+    if (OffsetBytes % 4 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
-          {"Offset", "128", std::to_string(OffsetBytes), std::to_string(Offset),
+          {"Offset", "4", std::to_string(OffsetBytes), std::to_string(Offset),
            std::to_string(ByteCount)});
   }
 
-  // if it is constant then stride must be 16-byte aligned
+  // if it is constant then stride must be 4-byte aligned
   if (ConstantInt *StrideV = dyn_cast<ConstantInt>(Op.get_stride())) {
     unsigned Stride = StrideV->getLimitedValue();
     uint64_t StrideBytes = Stride * ByteCount;
-    if (StrideBytes % 16 != 0)
+    if (StrideBytes % 4 != 0)
       ValCtx.EmitInstrFormatError(
           CI, ValidationRule::InstrLinAlgMatrixBytewiseMustBeMultiple,
-          {"Stride", "16", std::to_string(StrideBytes), std::to_string(Stride),
+          {"Stride", "4", std::to_string(StrideBytes), std::to_string(Stride),
            std::to_string(ByteCount)});
   }
 }
@@ -2089,16 +2092,19 @@ static void ValidateLinAlgMatrixLoadFromDescriptor(CallInst *CI,
           {"LinAlgMatrixLoadFromDescriptor", MatrixLayoutToString(Layout)});
   }
 
-  // Align must be an imm constant that is a multiple of 128 greater than 0
+  uint64_t RequiredAlignment =
+      RetMat->Scope == DXIL::MatrixScope::Thread ? 128 : 4;
+  // Align must be an imm constant with the scope's required alignment
   std::optional<uint64_t> Align = ValidateConstantIntGetValue(
       CI, Op.get_align(), ValCtx, "Align", "LinAlgMatrixLoadFromDescriptor");
   if (Align) {
     if (*Align == 0)
       ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMinimumValue,
                                   {"Align", "0", std::to_string(*Align)});
-    if (*Align % 128 != 0)
-      ValCtx.EmitInstrFormatError(CI, ValidationRule::InstrParamMultiple,
-                                  {"Align", "128", std::to_string(*Align)});
+    if (*Align % RequiredAlignment != 0)
+      ValCtx.EmitInstrFormatError(
+          CI, ValidationRule::InstrParamMultiple,
+          {"Align", std::to_string(RequiredAlignment), std::to_string(*Align)});
   }
 
   // Thread matrix may only load from SRV ByteAddressBuffer

--- a/tools/clang/lib/Headers/hlsl/dx/linalg.h
+++ b/tools/clang/lib/Headers/hlsl/dx/linalg.h
@@ -193,6 +193,17 @@ struct ScalarCountFromPackedComponents {
       (PackedComponentCount + ElementsPerScalar - 1) / ElementsPerScalar;
 };
 
+template <ComponentEnum ElementType, SIZE_TYPE M, SIZE_TYPE N>
+struct DefaultAlign {
+  enum {
+    MinDim = M < N ? M : N,
+    ScalarCount = ScalarCountFromPackedComponents<ElementType, MinDim>::Value,
+    ByteAlign = ScalarCount * 4,
+    MinByteAlign = ByteAlign < 4 ? 4 : ByteAlign,
+    Value = MinByteAlign < 16 ? MinByteAlign : 16
+  };
+};
+
 } // namespace __detail
 
 template <ComponentEnum ElementType, uint DimA> struct VectorRef {
@@ -270,7 +281,7 @@ class Matrix {
     return Result;
   }
 
-  template <uint Align = 128>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   [[nodiscard]] static Matrix Load(ByteAddressBuffer Res, uint StartOffset,
                                    uint Stride, MatrixLayoutEnum Layout) {
     Matrix Result;
@@ -279,7 +290,7 @@ class Matrix {
     return Result;
   }
 
-  template <uint Align = 128>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   [[nodiscard]] static Matrix Load(RWByteAddressBuffer Res, uint StartOffset,
                                    uint Stride, MatrixLayoutEnum Layout) {
     Matrix Result;
@@ -333,7 +344,7 @@ class Matrix {
     __builtin_LinAlg_MatrixSetElement(__handle, __handle, Index, Value);
   }
 
-  template <uint Align = 128>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value>
   void Store(RWByteAddressBuffer Res, uint StartOffset, uint Stride,
              MatrixLayoutEnum Layout) {
     __builtin_LinAlg_MatrixStoreToDescriptor(__handle, Res, StartOffset, Stride,
@@ -354,7 +365,8 @@ class Matrix {
   }
 
   // Accumulate methods
-  template <uint Align = 128, MatrixUseEnum UseLocal = Use>
+  template <uint Align = __detail::DefaultAlign<ComponentTy, M, N>::Value,
+            MatrixUseEnum UseLocal = Use>
   typename hlsl::enable_if<Use == MatrixUse::Accumulator && UseLocal == Use,
                            void>::type
   InterlockedAccumulate(RWByteAddressBuffer Res, uint StartOffset, uint Stride,

--- a/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/linalg/api/matrix-class.hlsl
@@ -58,7 +58,7 @@ void main(uint ID : SV_GroupID)
 //
 // CHECK: %[[MATA2:.*]] = call %dx.types.LinAlgMatrixC9M4N4U0S1
 // CHECK-SAME: @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N4U0S1(i32 -2147483634,
-// CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 128)
+// CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 16)
 // CHECK-SAME: ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   MatrixATy MatA2 = MatrixATy::Load(BAB, 0, 16, MatrixLayoutEnum::ColMajor);
 
@@ -66,7 +66,7 @@ void main(uint ID : SV_GroupID)
 //
 // CHECK: %[[MATB2:.*]] = call %dx.types.LinAlgMatrixC9M4N4U1S1
 // CHECK-SAME: @dx.op.linAlgMatrixLoadFromDescriptor.mC9M4N4U1S1(i32 -2147483634,
-// CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 256, i32 16, i32 1, i32 128)
+// CHECK-SAME: %dx.types.Handle %{{[0-9]+}}, i32 256, i32 16, i32 1, i32 16)
 // CHECK-SAME: ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   MatrixBTy MatB2;
   MatB2 = MatrixBTy::Load(RWBAB, 256, 16, MatrixLayoutEnum::ColMajor);
@@ -121,7 +121,7 @@ void main(uint ID : SV_GroupID)
 //
 // CHECK: call void @dx.op.linAlgMatrixStoreToDescriptor.mC9M4N4U1S1(i32 -2147483628,
 // CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U1S1 %[[MATB1_2]], %dx.types.Handle %{{[0-9]+}},
-// CHECK-SAME: i32 256, i32 16, i32 1, i32 128)  ;
+// CHECK-SAME: i32 256, i32 16, i32 1, i32 16)  ;
 // CHECK-SAME: LinAlgMatrixStoreToDescriptor(matrix,handle,offset,stride,layout,align)
   MatB1.Store(RWBAB, 256, 16, MatrixLayoutEnum::ColMajor);
 
@@ -148,7 +148,7 @@ void main(uint ID : SV_GroupID)
 // Matrix::InterlockedAccumulate to resource descriptor
 //
 // CHECK: call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC9M4N4U2S1(i32 -2147483621,
-// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM0]], %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 128)
+// CHECK-SAME: %dx.types.LinAlgMatrixC9M4N4U2S1 %[[ACCUM0]], %dx.types.Handle %{{[0-9]+}}, i32 0, i32 16, i32 1, i32 16)
 // CHECK-SAME: ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
   AccMat1.InterlockedAccumulate(RWBAB, 0, 16, MatrixLayoutEnum::ColMajor);
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetodescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetodescriptor.ll
@@ -72,10 +72,19 @@ define void @main() {
   %20 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
   call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S1(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S1 %6, %dx.types.Handle %20, i32 0, i32 0, i32 3, i32 256)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
+  ; No error expected for 4-byte alignment on a Wave matrix.
+  %21 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S1(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S1 %6, %dx.types.Handle %21, i32 0, i32 4, i32 0, i32 4)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+
+  ; CHECK-NEXT: Function: main: error: parameter 'Align' must be a multiple of 4, got 6
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S1
+  %22 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U2S1(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U2S1 %6, %dx.types.Handle %22, i32 0, i32 4, i32 0, i32 6)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+
   ; CHECK-NEXT: Function: main: error: Input matrix use 'A' does not match expected use Accumulator.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U0S0
-  %21 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
-  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U0S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U0S0 %8, %dx.types.Handle %21, i32 0, i32 0, i32 4, i32 128)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
+  %23 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
+  call void @dx.op.linAlgMatrixAccumulateToDescriptor.mC8M4N4U0S0(i32 -2147483621, %dx.types.LinAlgMatrixC8M4N4U0S0 %8, %dx.types.Handle %23, i32 0, i32 0, i32 4, i32 128)  ; LinAlgMatrixAccumulateToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; CHECK-NEXT: Validation failed.
   ret void

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetomemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixaccumulatetomemory.ll
@@ -14,6 +14,7 @@ target triple = "dxil-ms-dx"
 %dx.types.LinAlgMatrixC9M8N8U2S1 = type { i8* }
 %dx.types.LinAlgMatrixC9M9N8U2S1 = type { i8* }
 %dx.types.LinAlgMatrixC9M8N9U2S1 = type { i8* }
+%dx.types.LinAlgMatrixC19M4N4U2S1 = type { i8* }
 %dx.types.ResRet.i32 = type { i32, i32, i32, i32, i32 }
 %struct.ByteAddressBuffer = type { i32 }
 
@@ -37,20 +38,13 @@ define void @main() {
   %13 = call %dx.types.LinAlgMatrixC9M9N8U2S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M9N8U2S1(i32 -2147483634, %dx.types.Handle %12, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   %14 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %15 = call %dx.types.LinAlgMatrixC9M8N9U2S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M8N9U2S1(i32 -2147483634, %dx.types.Handle %14, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
+  %i8_matrix = call %dx.types.LinAlgMatrixC19M4N4U2S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC19M4N4U2S1(i32 -2147483634, %dx.types.Handle %2, i32 0, i32 4, i32 0, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
   ; okay
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 128, got 516 (129 elements * 4 bytes per element).
-  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32
-  call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
-
   ; okay only if offset accounts for byte width of component type
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
-
-  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 16, got 68 (17 elements * 4 bytes per element).
-  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32
-  call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
 
   ; okay only if stride accounts for byte width of component type
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 4, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
@@ -58,7 +52,7 @@ define void @main() {
   ; okay: i32 groupshared memory may hold any matrix element type
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.i32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S1 %7, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S0.f32
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S0.f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M4N4U2S0 %3, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
 
@@ -92,6 +86,14 @@ define void @main() {
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC9M8N9U2S1.v4f32
   call void @dx.op.linAlgMatrixAccumulateToMemory.mC9M8N9U2S1.v4f32(i32 -2147483620, %dx.types.LinAlgMatrixC9M8N9U2S1 %15, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
 
+  ; CHECK-NEXT: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 4, got 2 (2 elements * 1 bytes per element).
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC19M4N4U2S1.i32
+  call void @dx.op.linAlgMatrixAccumulateToMemory.mC19M4N4U2S1.i32(i32 -2147483620, %dx.types.LinAlgMatrixC19M4N4U2S1 %i8_matrix, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 2, i32 4, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 4, got 2 (2 elements * 1 bytes per element).
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixAccumulateToMemory.mC19M4N4U2S1.i32
+  call void @dx.op.linAlgMatrixAccumulateToMemory.mC19M4N4U2S1.i32(i32 -2147483620, %dx.types.LinAlgMatrixC19M4N4U2S1 %i8_matrix, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 4, i32 2, i32 0)  ; LinAlgMatrixAccumulateToMemory(matrix,memory,offset,stride,layout)
+
   ; CHECK-NEXT: Validation failed.
   ret void
 }
@@ -116,6 +118,9 @@ declare %dx.types.LinAlgMatrixC9M9N8U2S1 @dx.op.linAlgMatrixLoadFromDescriptor.m
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC9M8N9U2S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M8N9U2S1(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC19M4N4U2S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC19M4N4U2S1(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare void @dx.op.linAlgMatrixAccumulateToMemory.mC9M4N4U2S1.f32(i32, %dx.types.LinAlgMatrixC9M4N4U2S1, float addrspace(3)*, i32, i32, i32) #0
@@ -150,6 +155,9 @@ declare void @dx.op.linAlgMatrixAccumulateToMemory.mC9M9N8U2S1.v4f32(i32, %dx.ty
 ; Function Attrs: nounwind
 declare void @dx.op.linAlgMatrixAccumulateToMemory.mC9M8N9U2S1.v4f32(i32, %dx.types.LinAlgMatrixC9M8N9U2S1, <4 x float> addrspace(3)*, i32, i32, i32) #0
 
+; Function Attrs: nounwind
+declare void @dx.op.linAlgMatrixAccumulateToMemory.mC19M4N4U2S1.i32(i32, %dx.types.LinAlgMatrixC19M4N4U2S1, i32 addrspace(3)*, i32, i32, i32) #0
+
 ; Function Attrs: nounwind readnone
 declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #1
 
@@ -159,7 +167,7 @@ declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
 
-!dx.targetTypes = !{!0, !1, !2, !3, !4, !5, !6}
+!dx.targetTypes = !{!0, !1, !2, !3, !4, !5, !6, !16}
 !llvm.ident = !{!7}
 !dx.version = !{!8}
 !dx.valver = !{!8}
@@ -183,3 +191,4 @@ attributes #1 = { nounwind readnone }
 !13 = !{void ()* @main, !"main", null, !10, !14}
 !14 = !{i32 0, i64 2199031644176, i32 4, !15}
 !15 = !{i32 1, i32 1, i32 1}
+!16 = !{%dx.types.LinAlgMatrixC19M4N4U2S1 undef, i32 19, i32 4, i32 4, i32 2, i32 1}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfromdescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfromdescriptor.ll
@@ -58,7 +58,6 @@ define void @main() {
   %16 = call %dx.types.LinAlgMatrixC8M4N8U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N8U2S0(i32 -2147483634, %dx.types.Handle %15, i32 0, i32 %10, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   %17 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
 
-
   ; CHECK-NEXT: Function: main: error: parameter 'Align' must be a multiple of 128, got 215
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N8U2S0
   %18 = call %dx.types.LinAlgMatrixC8M4N8U2S0 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N8U2S0(i32 -2147483634, %dx.types.Handle %17, i32 0, i32 0, i32 0, i32 215)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfromdescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfromdescriptor.ll
@@ -30,6 +30,16 @@ define void @main() {
   ; CHECK: Function: main: error: Return matrix with scope 'ThreadGroup' requires layout RowMajor or ColumnMajor for LinAlgMatrixLoadFromDescriptor.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2
   %5 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2(i32 -2147483634, %dx.types.Handle %4, i32 0, i32 0, i32 4, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
+  %threadgroup_align4_anno = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
+
+
+  ; No error expected for 4-byte alignment on a ThreadGroup matrix.
+  %threadgroup_align4 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2(i32 -2147483634, %dx.types.Handle %threadgroup_align4_anno, i32 0, i32 4, i32 0, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
+  %threadgroup_align6_anno = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
+
+  ; CHECK-NEXT: Function: main: error: parameter 'Align' must be a multiple of 4, got 6
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2
+  %threadgroup_align6 = call %dx.types.LinAlgMatrixC8M4N4U2S2 @dx.op.linAlgMatrixLoadFromDescriptor.mC8M4N4U2S2(i32 -2147483634, %dx.types.Handle %threadgroup_align6_anno, i32 0, i32 4, i32 0, i32 6)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   %6 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
 
 

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfrommemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixloadfrommemory.ll
@@ -10,57 +10,59 @@ target triple = "dxil-ms-dx"
 %dx.types.LinAlgMatrixC9M8N8U0S1 = type { i8* }
 %dx.types.LinAlgMatrixC9M9N8U0S1 = type { i8* }
 %dx.types.LinAlgMatrixC9M8N9U0S1 = type { i8* }
+%dx.types.LinAlgMatrixC19M4N4U0S1 = type { i8* }
 
 @"\01?SharedArr@@3PAMA" = external addrspace(3) global [64 x float], align 4
 @"\01?SharedVecArr@@3PAV?$vector@M$03@@A" = external addrspace(3) global [16 x <4 x float>], align 4
+@"\01?SharedIntArr@@3PAIA" = external addrspace(3) global [64 x i32], align 4
 
 define void @main() {
   ; okay
   %1 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 128, got 516 (129 elements * 4 bytes per element).
-  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32
-  %2 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
-
   ; okay only if offset accounts for byte width of component type
-  %3 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
-
-  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 16, got 68 (17 elements * 4 bytes per element).
-  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32
-  %4 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %2 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; okay only if stride accounts for byte width of component type
-  %5 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 4, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %3 = call %dx.types.LinAlgMatrixC9M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 4, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: Return matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK: Function: main: error: Return matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S0.f32
-  %6 = call %dx.types.LinAlgMatrixC9M4N4U0S0 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S0.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %4 = call %dx.types.LinAlgMatrixC9M4N4U0S0 @dx.op.linAlgMatrixLoadFromMemory.mC9M4N4U0S0.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory inner type 'float' must match return matrix type 'I64'.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC6M4N4U0S2.f32
-  %7 = call %dx.types.LinAlgMatrixC6M4N4U0S2 @dx.op.linAlgMatrixLoadFromMemory.mC6M4N4U0S2.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %5 = call %dx.types.LinAlgMatrixC6M4N4U0S2 @dx.op.linAlgMatrixLoadFromMemory.mC6M4N4U0S2.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; okay
-  %8 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %6 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.f32
-  %9 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %7 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.f32
-  %10 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %8 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.f32(i32 -2147483633, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; okay
-  %11 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %9 = call %dx.types.LinAlgMatrixC9M8N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.v4f32
-  %12 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %10 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9N8U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Function: main: error: Groupshared memory holds '64' scalars but must hold at least '72' scalars.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32
-  %13 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+  %11 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32(i32 -2147483633, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 4, got 2 (2 elements * 1 bytes per element).
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC19M4N4U0S1.i32
+  %12 = call %dx.types.LinAlgMatrixC19M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC19M4N4U0S1.i32(i32 -2147483633, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 2, i32 4, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 4, got 2 (2 elements * 1 bytes per element).
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixLoadFromMemory.mC19M4N4U0S1.i32
+  %13 = call %dx.types.LinAlgMatrixC19M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC19M4N4U0S1.i32(i32 -2147483633, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 4, i32 2, i32 0)  ; LinAlgMatrixLoadFromMemory(memory,offset,stride,layout)
 
   ; CHECK-NEXT: Validation failed.
   ret void
@@ -93,9 +95,12 @@ declare %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M9
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC9M8N9U0S1.v4f32(i32, <4 x float> addrspace(3)*, i32, i32, i32) #0
 
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC19M4N4U0S1 @dx.op.linAlgMatrixLoadFromMemory.mC19M4N4U0S1.i32(i32, i32 addrspace(3)*, i32, i32, i32) #0
+
 attributes #0 = { nounwind }
 
-!dx.targetTypes = !{!0, !1, !2, !3, !4, !5}
+!dx.targetTypes = !{!0, !1, !2, !3, !4, !5, !12}
 !llvm.ident = !{!6}
 !dx.version = !{!7}
 !dx.valver = !{!7}
@@ -114,3 +119,4 @@ attributes #0 = { nounwind }
 !9 = !{void ()* @main, !"main", null, null, !10}
 !10 = !{i32 0, i64 2199031644160, i32 4, !11}
 !11 = !{i32 1, i32 1, i32 1}
+!12 = !{%dx.types.LinAlgMatrixC19M4N4U0S1 undef, i32 19, i32 4, i32 4, i32 0, i32 1}

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretodescriptor.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretodescriptor.ll
@@ -28,10 +28,10 @@ define void @main() {
   %6 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %2, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   call void @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U0S1(i32 -2147483628, %dx.types.LinAlgMatrixC8M4N4U0S1 %4, %dx.types.Handle %6, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixStoreToDescriptor(matrix,handle,offset,stride,layout,align)
 
-  ; CHECK-NEXT: Function: main: error: parameter 'Align' must be a multiple of 128, got 296
+  ; CHECK-NEXT: Function: main: error: parameter 'Align' must be a multiple of 4, got 298
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U0S1
   %7 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 4107, i32 0 })  ; AnnotateHandle(res,props)  resource: RWByteAddressBuffer
-  call void @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U0S1(i32 -2147483628, %dx.types.LinAlgMatrixC8M4N4U0S1 %4, %dx.types.Handle %7, i32 0, i32 0, i32 0, i32 296)  ; LinAlgMatrixStoreToDescriptor(matrix,handle,offset,stride,layout,align)
+  call void @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U0S1(i32 -2147483628, %dx.types.LinAlgMatrixC8M4N4U0S1 %4, %dx.types.Handle %7, i32 0, i32 0, i32 0, i32 298)  ; LinAlgMatrixStoreToDescriptor(matrix,handle,offset,stride,layout,align)
 
   ; CHECK-NEXT: Function: main: error: parameter 'Align' must be greater than 0, got 0
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToDescriptor.mC8M4N4U0S1

--- a/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretomemory.ll
+++ b/tools/clang/test/LitDXILValidation/LinAlgMatrix/linalgmatrix-matrixstoretomemory.ll
@@ -13,10 +13,12 @@ target triple = "dxil-ms-dx"
 %dx.types.LinAlgMatrixC9M8N8U0S1 = type { i8* }
 %dx.types.LinAlgMatrixC9M9N8U0S1 = type { i8* }
 %dx.types.LinAlgMatrixC9M8N9U0S1 = type { i8* }
+%dx.types.LinAlgMatrixC19M4N4U0S1 = type { i8* }
 %struct.ByteAddressBuffer = type { i32 }
 
 @"\01?SharedArr@@3PAMA" = external addrspace(3) global [64 x float], align 4
 @"\01?SharedVecArr@@3PAV?$vector@M$03@@A" = external addrspace(3) global [16 x <4 x float>], align 4
+@"\01?SharedIntArr@@3PAIA" = external addrspace(3) global [64 x i32], align 4
 
 define void @main() {
   %1 = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
@@ -32,25 +34,18 @@ define void @main() {
   %11 = call %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M9N8U0S1(i32 -2147483634, %dx.types.Handle %10, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
   %12 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 11, i32 0 })  ; AnnotateHandle(res,props)  resource: ByteAddressBuffer
   %13 = call %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M8N9U0S1(i32 -2147483634, %dx.types.Handle %12, i32 0, i32 0, i32 0, i32 128)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
+  %i8_matrix = call %dx.types.LinAlgMatrixC19M4N4U0S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC19M4N4U0S1(i32 -2147483634, %dx.types.Handle %2, i32 0, i32 4, i32 0, i32 4)  ; LinAlgMatrixLoadFromDescriptor(handle,offset,stride,layout,align)
 
   ; okay
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 128, got 516 (129 elements * 4 bytes per element).
-  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32
-  call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 129, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
-
   ; okay only if offset accounts for byte width of component type
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 32, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
-
-  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 16, got 68 (17 elements * 4 bytes per element).
-  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32
-  call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 17, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
   ; okay only if stride accounts for byte width of component type
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S1 %5, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 4, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
-  ; CHECK-NEXT: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
+  ; CHECK: Function: main: error: Input matrix scope 'Thread' does not match expected scope Wave or ThreadGroup.
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S0.f32
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S0.f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M4N4U0S0 %3, float addrspace(3)* getelementptr inbounds ([64 x float], [64 x float] addrspace(3)* @"\01?SharedArr@@3PAMA", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
@@ -80,6 +75,14 @@ define void @main() {
   ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC9M8N9U0S1.v4f32
   call void @dx.op.linAlgMatrixStoreToMemory.mC9M8N9U0S1.v4f32(i32 -2147483627, %dx.types.LinAlgMatrixC9M8N9U0S1 %13, <4 x float> addrspace(3)* getelementptr inbounds ([16 x <4 x float>], [16 x <4 x float>] addrspace(3)* @"\01?SharedVecArr@@3PAV?$vector@M$03@@A", i32 0, i32 0), i32 128, i32 16, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
 
+  ; CHECK-NEXT: Function: main: error: Parameter 'Offset' in bytes must be a multiple of 4, got 2 (2 elements * 1 bytes per element).
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC19M4N4U0S1.i32
+  call void @dx.op.linAlgMatrixStoreToMemory.mC19M4N4U0S1.i32(i32 -2147483627, %dx.types.LinAlgMatrixC19M4N4U0S1 %i8_matrix, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 2, i32 4, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
+
+  ; CHECK-NEXT: Function: main: error: Parameter 'Stride' in bytes must be a multiple of 4, got 2 (2 elements * 1 bytes per element).
+  ; CHECK-NEXT: note: at {{.*}} @dx.op.linAlgMatrixStoreToMemory.mC19M4N4U0S1.i32
+  call void @dx.op.linAlgMatrixStoreToMemory.mC19M4N4U0S1.i32(i32 -2147483627, %dx.types.LinAlgMatrixC19M4N4U0S1 %i8_matrix, i32 addrspace(3)* getelementptr inbounds ([64 x i32], [64 x i32] addrspace(3)* @"\01?SharedIntArr@@3PAIA", i32 0, i32 0), i32 4, i32 2, i32 0)  ; LinAlgMatrixStoreToMemory(matrix,memory,offset,stride,layout)
+
   ; CHECK-NEXT: Validation failed.
   ret void
 }
@@ -101,6 +104,9 @@ declare %dx.types.LinAlgMatrixC9M9N8U0S1 @dx.op.linAlgMatrixLoadFromDescriptor.m
 
 ; Function Attrs: nounwind
 declare %dx.types.LinAlgMatrixC9M8N9U0S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC9M8N9U0S1(i32, %dx.types.Handle, i32, i32, i32, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.LinAlgMatrixC19M4N4U0S1 @dx.op.linAlgMatrixLoadFromDescriptor.mC19M4N4U0S1(i32, %dx.types.Handle, i32, i32, i32, i32) #0
 
 ; Function Attrs: nounwind
 declare void @dx.op.linAlgMatrixStoreToMemory.mC9M4N4U0S1.f32(i32, %dx.types.LinAlgMatrixC9M4N4U0S1, float addrspace(3)*, i32, i32, i32) #0
@@ -129,6 +135,9 @@ declare void @dx.op.linAlgMatrixStoreToMemory.mC9M9N8U0S1.v4f32(i32, %dx.types.L
 ; Function Attrs: nounwind
 declare void @dx.op.linAlgMatrixStoreToMemory.mC9M8N9U0S1.v4f32(i32, %dx.types.LinAlgMatrixC9M8N9U0S1, <4 x float> addrspace(3)*, i32, i32, i32) #0
 
+; Function Attrs: nounwind
+declare void @dx.op.linAlgMatrixStoreToMemory.mC19M4N4U0S1.i32(i32, %dx.types.LinAlgMatrixC19M4N4U0S1, i32 addrspace(3)*, i32, i32, i32) #0
+
 ; Function Attrs: nounwind readnone
 declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #1
 
@@ -138,7 +147,7 @@ declare %dx.types.Handle @dx.op.createHandleFromBinding(i32, %dx.types.ResBind, 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
 
-!dx.targetTypes = !{!0, !1, !2, !3, !4, !5}
+!dx.targetTypes = !{!0, !1, !2, !3, !4, !5, !15}
 !llvm.ident = !{!6}
 !dx.version = !{!7}
 !dx.valver = !{!7}
@@ -161,3 +170,4 @@ attributes #1 = { nounwind readnone }
 !12 = !{void ()* @main, !"main", null, !9, !13}
 !13 = !{i32 0, i64 2199031644176, i32 4, !14}
 !14 = !{i32 1, i32 1, i32 1}
+!15 = !{%dx.types.LinAlgMatrixC19M4N4U0S1 undef, i32 19, i32 4, i32 4, i32 0, i32 1}


### PR DESCRIPTION
Fixes #8896

Addresses the spec changes from https://github.com/microsoft/hlsl-specs/pull/924
- Updates the header to allow smaller alignment with a useful default
- Updates the validator to allow the smaller alignments

Co-authored-by: Copilot [223556219+Copilot@users.noreply.github.com](mailto:223556219+Copilot@users.noreply.github.com)