### PR TITLE
[NFC] Refactor IsTypeDeducibleWithAuto into HlslTypes

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -545,6 +545,7 @@ bool DoesTypeDefineOverloadedOperator(clang::QualType typeWithOperator,
                                       clang::OverloadedOperatorKind opc,
                                       clang::QualType paramType);
 bool IsPatchConstantFunctionDecl(const clang::FunctionDecl *FD);
+bool IsTypeDeducibleWithAuto(clang::QualType type);
 
 #ifdef ENABLE_SPIRV_CODEGEN
 bool IsVKBufferPointerType(clang::QualType type);

--- a/tools/clang/include/clang/Sema/SemaHLSL.h
+++ b/tools/clang/include/clang/Sema/SemaHLSL.h
@@ -93,10 +93,6 @@ bool DiagnoseTypeElements(clang::Sema &S, clang::SourceLocation Loc,
                           TypeDiagContext LongVecDiagContext,
                           const clang::FieldDecl *FD = nullptr);
 
-// Returns true if 'auto' is allowed to deduce the given type. Container types
-// are deducible only when the type they wrap is deducible.
-bool IsTypeDeducibleWithAuto(clang::Sema &S, clang::QualType Ty);
-
 void DiagnoseControlFlowConditionForHLSL(clang::Sema *self,
                                          clang::Expr *condExpr,
                                          llvm::StringRef StmtName);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -981,4 +981,24 @@ HLSLScalarType MakeUnsigned(HLSLScalarType T) {
   return T;
 }
 
+bool IsTypeDeducibleWithAuto(QualType type) {
+  if (type.isNull())
+    return false;
+
+  if (hlsl::IsStringType(type) || hlsl::IsStringLiteralType(type))
+    return false;
+
+  if (const CXXRecordDecl *recordDecl =
+          GetStructuralForm(type)->getAsCXXRecordDecl()) {
+    if (!recordDecl->hasAttr<HLSLNonAutoDeducibleAttr>())
+      if (const CXXRecordDecl *pattern =
+              recordDecl->getTemplateInstantiationPattern())
+        recordDecl = pattern;
+    if (recordDecl->hasAttr<HLSLNonAutoDeducibleAttr>())
+      return false;
+  }
+
+  return true;
+}
+
 } // namespace hlsl

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -9055,7 +9055,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init,
       // A dependent deduced type cannot be classified yet; defer the check to
       // instantiation, when 'auto' is re-deduced to a concrete type.
       if (!DeducedType->isDependentType() &&
-          !hlsl::IsTypeDeducibleWithAuto(*this, DeducedType)) {
+          !hlsl::IsTypeDeducibleWithAuto(DeducedType)) {
         Diag(VDecl->getLocation(), diag::err_hlsl_auto_undeducible_type)
             << DeducedType;
         VDecl->setInvalidDecl();

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -25,6 +25,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/EvaluatedExprVisitor.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/AST/HlslTypes.h" // HLSL Change
 #include "clang/AST/StmtCXX.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/PartialDiagnostic.h"

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4804,26 +4804,6 @@ public:
     return type;
   }
 
-  bool IsTypeDeducibleWithAuto(QualType type) {
-    if (type.isNull())
-      return false;
-
-    if (hlsl::IsStringType(type) || hlsl::IsStringLiteralType(type))
-      return false;
-
-    if (const CXXRecordDecl *recordDecl =
-            GetStructuralForm(type)->getAsCXXRecordDecl()) {
-      if (!recordDecl->hasAttr<HLSLNonAutoDeducibleAttr>())
-        if (const CXXRecordDecl *pattern =
-                recordDecl->getTemplateInstantiationPattern())
-          recordDecl = pattern;
-      if (recordDecl->hasAttr<HLSLNonAutoDeducibleAttr>())
-        return false;
-    }
-
-    return true;
-  }
-
   /// <summary>Given a Clang type, return the ArBasicKind classification for its
   /// contents.</summary>
   ArBasicKind GetTypeElementKind(QualType type) {
@@ -12888,10 +12868,6 @@ bool hlsl::DiagnoseTypeElements(Sema &S, SourceLocation Loc, QualType Ty,
   llvm::SmallPtrSet<const RecordDecl *, 8> CheckedDecls;
   return DiagnoseElementTypes(S, Loc, Ty, Empty, ObjDiagContext,
                               LongVecDiagContext, CheckedDecls, FD);
-}
-
-bool hlsl::IsTypeDeducibleWithAuto(Sema &S, QualType Ty) {
-  return HLSLExternalSource::FromSema(&S)->IsTypeDeducibleWithAuto(Ty);
 }
 
 bool hlsl::DiagnoseNodeStructArgument(Sema *self, TemplateArgumentLoc ArgLoc,


### PR DESCRIPTION
This function really should be one of the standalone type query functions rather than being on Sema, and since it doesn't depend on sema in any way it was a bit odd to have it that way to begin with.