### PR TITLE
[SM6.10] Define and Dump LinAlg PSV0 runtime data

### DIFF
--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -175,8 +175,107 @@ struct PSVRuntimeInfo3 : public PSVRuntimeInfo2 {
   uint32_t EntryFunctionName;
 };
 
+enum class PSVRuntimeInfo4Flag : uint32_t {
+  None = 0x00000000,
+  // Indicates use of LinAlg operations beyond the Tier 1 required set, thus
+  // the presence of the PSVLinAlgRuntimeInfo structure with usage details.
+  LinAlgRuntimeInfoPresent = 0x00000001,
+};
+
 struct PSVRuntimeInfo4 : public PSVRuntimeInfo3 {
   uint32_t NumBytesGroupSharedMemory;
+  uint32_t Flags; // PSVRuntimeInfo4Flag
+};
+
+struct PSVLinAlgRuntimeInfo0 {
+  // Presence of each table is indicated by a non-zero count.
+  // Tables are serialized in this order, with each starting with the record
+  // stride in bytes, followed by the records.
+  uint32_t MatrixOperationShapeCount;
+  uint32_t MatrixConstructionCount;
+  uint32_t ThreadMatrixVectorMultiplyCount;
+  uint32_t WaveMatrixMultiplyCount;
+  uint32_t ThreadGroupMatrixMultiplyCount;
+  uint32_t OuterProductCount;
+  uint32_t AccumulateStoreCount;
+};
+
+struct PSVLinAlgMatrixOperationShape0 {
+  // For each dimension, unused == 0.
+  // For MatrixConstruction, the unused dimension depends on the matrix use.
+  uint32_t M; // Rows in matrix A / Accumulator
+  uint32_t N; // Columns in matrix B / Accumulator
+  uint32_t K; // Columns in matrix A / Rows in matrix B
+};
+
+struct PSVLinAlgMatrixShapeArrayReference {
+  uint32_t ShapesIndex; // Index into SemanticIndexTable where the array of
+                        // LinAlgMatrixOperationShape table indexes is located.
+  uint32_t Count;
+};
+
+struct PSVLinAlgMatrixConstruction0 {
+  // Each shape collects only the dimensions needed for a single matrix use.
+  // For instance, an Accumulator only uses M and N, so K will be set to 0.
+  // Different matrix use types are not combined to avoid implying uses that
+  // aren't present.
+  PSVLinAlgMatrixShapeArrayReference OperationShapes;
+  uint8_t MatrixType;
+  uint8_t Reserved[3];
+};
+
+enum class PSVLinAlgThreadMatrixVectorMultiplyFlag : uint8_t {
+  None = 0,
+  // If neither flag is set, the matrix is only loaded from MulOptimal layout.
+  // The matrix is loaded from MulOptimalTranspose layout.
+  MatrixTransposed = 1 << 0,
+  // The matrix is loaded from a non-MulOptimal layout.
+  MatrixNonMulOptimalLayout = 1 << 1,
+};
+
+struct PSVLinAlgThreadMatrixVectorMultiply0 {
+  uint8_t ResultType;
+  uint8_t MatrixType;
+  uint8_t VectorInputType;
+  uint8_t Flags; // PSVLinAlgThreadMatrixVectorMultiplyFlag
+};
+
+struct PSVLinAlgWaveMatrixMultiply0 {
+  PSVLinAlgMatrixShapeArrayReference OperationShapes;
+  uint8_t AccumulatorType;
+  uint8_t MatrixAType;
+  uint8_t MatrixBType;
+  uint8_t Reserved;
+};
+
+// This matches PSVLinAlgWaveMatrixMultiply0 for now, but remains a separate
+// structure in case the final wave and thread-group records diverge.
+struct PSVLinAlgThreadGroupMatrixMultiply0 {
+  PSVLinAlgMatrixShapeArrayReference OperationShapes;
+  uint8_t AccumulatorType;
+  uint8_t MatrixAType;
+  uint8_t MatrixBType;
+  uint8_t Reserved;
+};
+
+struct PSVLinAlgOuterProduct0 {
+  uint8_t ResultType;
+  uint8_t VectorInputType;
+  uint8_t Reserved[2];
+};
+
+enum class PSVLinAlgAccumulateStoreFlag : uint8_t {
+  None = 0,
+  // Accumulate is to a raw buffer, for all scopes.
+  RawBuffer = 1 << 0,
+  // Accumulate is to groupshared memory, for wave/group scope only.
+  GroupShared = 1 << 1,
+};
+
+struct PSVLinAlgAccumulateStore0 {
+  uint8_t AccumulatorType;
+  uint8_t Flags; // PSVLinAlgAccumulateStoreFlag
+  uint8_t Reserved[2];
 };
 
 enum class PSVResourceType {
@@ -494,6 +593,30 @@ struct PSVInitInfo {
   uint8_t SigInputVectors = 0;
   uint8_t SigPatchConstOrPrimVectors = 0;
   uint8_t SigOutputVectors[PSV_GS_MAX_STREAMS] = {0, 0, 0, 0};
+  const PSVLinAlgMatrixOperationShape0 *LinAlgMatrixOperationShapes = nullptr;
+  uint32_t LinAlgMatrixOperationShapeCount = 0;
+  const PSVLinAlgMatrixConstruction0 *LinAlgMatrixConstructions = nullptr;
+  uint32_t LinAlgMatrixConstructionCount = 0;
+  const PSVLinAlgThreadMatrixVectorMultiply0
+      *LinAlgThreadMatrixVectorMultiplies = nullptr;
+  uint32_t LinAlgThreadMatrixVectorMultiplyCount = 0;
+  const PSVLinAlgWaveMatrixMultiply0 *LinAlgWaveMatrixMultiplies = nullptr;
+  uint32_t LinAlgWaveMatrixMultiplyCount = 0;
+  const PSVLinAlgThreadGroupMatrixMultiply0 *LinAlgThreadGroupMatrixMultiplies =
+      nullptr;
+  uint32_t LinAlgThreadGroupMatrixMultiplyCount = 0;
+  const PSVLinAlgOuterProduct0 *LinAlgOuterProducts = nullptr;
+  uint32_t LinAlgOuterProductCount = 0;
+  const PSVLinAlgAccumulateStore0 *LinAlgAccumulateStores = nullptr;
+  uint32_t LinAlgAccumulateStoreCount = 0;
+
+  bool HasLinAlgRuntimeInfo() const {
+    return LinAlgMatrixConstructionCount ||
+           LinAlgThreadMatrixVectorMultiplyCount ||
+           LinAlgWaveMatrixMultiplyCount ||
+           LinAlgThreadGroupMatrixMultiplyCount || LinAlgOuterProductCount ||
+           LinAlgAccumulateStoreCount;
+  }
 
   static_assert(MAX_PSV_VERSION == 4, "otherwise this needs updating.");
   uint32_t RuntimeInfoSize() const {
@@ -542,6 +665,22 @@ class DxilPipelineStateValidation {
                                                          nullptr, nullptr};
   uint32_t *m_pInputToPCOutputTable = nullptr;
   uint32_t *m_pPCInputToOutputTable = nullptr;
+  uint32_t m_uPSVLinAlgRuntimeInfoSize = 0;
+  PSVLinAlgRuntimeInfo0 *m_pPSVLinAlgRuntimeInfo0 = nullptr;
+  uint32_t m_uPSVLinAlgMatrixOperationShapeSize = 0;
+  void *m_pPSVLinAlgMatrixOperationShapes = nullptr;
+  uint32_t m_uPSVLinAlgMatrixConstructionSize = 0;
+  void *m_pPSVLinAlgMatrixConstructions = nullptr;
+  uint32_t m_uPSVLinAlgThreadMatrixVectorMultiplySize = 0;
+  void *m_pPSVLinAlgThreadMatrixVectorMultiplies = nullptr;
+  uint32_t m_uPSVLinAlgWaveMatrixMultiplySize = 0;
+  void *m_pPSVLinAlgWaveMatrixMultiplies = nullptr;
+  uint32_t m_uPSVLinAlgThreadGroupMatrixMultiplySize = 0;
+  void *m_pPSVLinAlgThreadGroupMatrixMultiplies = nullptr;
+  uint32_t m_uPSVLinAlgOuterProductSize = 0;
+  void *m_pPSVLinAlgOuterProducts = nullptr;
+  uint32_t m_uPSVLinAlgAccumulateStoreSize = 0;
+  void *m_pPSVLinAlgAccumulateStores = nullptr;
 
 public:
   DxilPipelineStateValidation() {}
@@ -642,6 +781,101 @@ public:
   PSVRuntimeInfo3 *GetPSVRuntimeInfo3() const { return m_pPSVRuntimeInfo3; }
 
   PSVRuntimeInfo4 *GetPSVRuntimeInfo4() const { return m_pPSVRuntimeInfo4; }
+
+  PSVLinAlgRuntimeInfo0 *GetPSVLinAlgRuntimeInfo0() const {
+    return m_pPSVLinAlgRuntimeInfo0;
+  }
+
+  uint32_t GetPSVLinAlgMatrixOperationShapeCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->MatrixOperationShapeCount
+               : 0;
+  }
+
+  PSVLinAlgMatrixOperationShape0 *
+  GetPSVLinAlgMatrixOperationShape(uint32_t index) const {
+    return GetRecord<PSVLinAlgMatrixOperationShape0>(
+        m_pPSVLinAlgMatrixOperationShapes, m_uPSVLinAlgMatrixOperationShapeSize,
+        GetPSVLinAlgMatrixOperationShapeCount(), index);
+  }
+
+  uint32_t GetPSVLinAlgMatrixConstructionCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->MatrixConstructionCount
+               : 0;
+  }
+
+  PSVLinAlgMatrixConstruction0 *
+  GetPSVLinAlgMatrixConstruction(uint32_t index) const {
+    return GetRecord<PSVLinAlgMatrixConstruction0>(
+        m_pPSVLinAlgMatrixConstructions, m_uPSVLinAlgMatrixConstructionSize,
+        GetPSVLinAlgMatrixConstructionCount(), index);
+  }
+
+  uint32_t GetPSVLinAlgThreadMatrixVectorMultiplyCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->ThreadMatrixVectorMultiplyCount
+               : 0;
+  }
+
+  PSVLinAlgThreadMatrixVectorMultiply0 *
+  GetPSVLinAlgThreadMatrixVectorMultiply(uint32_t index) const {
+    return GetRecord<PSVLinAlgThreadMatrixVectorMultiply0>(
+        m_pPSVLinAlgThreadMatrixVectorMultiplies,
+        m_uPSVLinAlgThreadMatrixVectorMultiplySize,
+        GetPSVLinAlgThreadMatrixVectorMultiplyCount(), index);
+  }
+
+  uint32_t GetPSVLinAlgWaveMatrixMultiplyCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->WaveMatrixMultiplyCount
+               : 0;
+  }
+
+  PSVLinAlgWaveMatrixMultiply0 *
+  GetPSVLinAlgWaveMatrixMultiply(uint32_t index) const {
+    return GetRecord<PSVLinAlgWaveMatrixMultiply0>(
+        m_pPSVLinAlgWaveMatrixMultiplies, m_uPSVLinAlgWaveMatrixMultiplySize,
+        GetPSVLinAlgWaveMatrixMultiplyCount(), index);
+  }
+
+  uint32_t GetPSVLinAlgThreadGroupMatrixMultiplyCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->ThreadGroupMatrixMultiplyCount
+               : 0;
+  }
+
+  PSVLinAlgThreadGroupMatrixMultiply0 *
+  GetPSVLinAlgThreadGroupMatrixMultiply(uint32_t index) const {
+    return GetRecord<PSVLinAlgThreadGroupMatrixMultiply0>(
+        m_pPSVLinAlgThreadGroupMatrixMultiplies,
+        m_uPSVLinAlgThreadGroupMatrixMultiplySize,
+        GetPSVLinAlgThreadGroupMatrixMultiplyCount(), index);
+  }
+
+  uint32_t GetPSVLinAlgOuterProductCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->OuterProductCount
+               : 0;
+  }
+
+  PSVLinAlgOuterProduct0 *GetPSVLinAlgOuterProduct(uint32_t index) const {
+    return GetRecord<PSVLinAlgOuterProduct0>(
+        m_pPSVLinAlgOuterProducts, m_uPSVLinAlgOuterProductSize,
+        GetPSVLinAlgOuterProductCount(), index);
+  }
+
+  uint32_t GetPSVLinAlgAccumulateStoreCount() const {
+    return m_pPSVLinAlgRuntimeInfo0
+               ? m_pPSVLinAlgRuntimeInfo0->AccumulateStoreCount
+               : 0;
+  }
+
+  PSVLinAlgAccumulateStore0 *GetPSVLinAlgAccumulateStore(uint32_t index) const {
+    return GetRecord<PSVLinAlgAccumulateStore0>(
+        m_pPSVLinAlgAccumulateStores, m_uPSVLinAlgAccumulateStoreSize,
+        GetPSVLinAlgAccumulateStoreCount(), index);
+  }
 
   uint32_t GetBindCount() const { return m_uResourceCount; }
 
@@ -938,6 +1172,12 @@ inline void DxilPipelineStateValidation::CheckedReaderWriter::Clear() {
 //      PSVComputeInputOutputTableDwords(SigPatchConstOrPrimVectors,
 //      SigOutputVectors[0]) }
 //        - Outputs affected by patch constant inputs as a table of bitmasks
+// If PSVRuntimeInfo4::Flags has LinAlgRuntimeInfoPresent:
+//    uint32_t PSVLinAlgRuntimeInfo_size
+//    { PSVLinAlgRuntimeInfoN structure }
+//    For each non-empty LinAlg record table, in declaration order:
+//      uint32_t record_size
+//      { record } * record_count
 // returns true if no errors occurred.
 inline bool
 DxilPipelineStateValidation::ReadOrWrite(const void *pBits, uint32_t *pSize,
@@ -963,10 +1203,21 @@ DxilPipelineStateValidation::ReadOrWrite(const void *pBits, uint32_t *pSize,
 
   // In RWMode::CalcSize, use temp runtime info to hold needed values from
   // initInfo
-  PSVRuntimeInfo1 tempRuntimeInfo = {};
+  PSVRuntimeInfo4 tempRuntimeInfo = {};
   if (mode == RWMode::CalcSize && initInfo.PSVVersion > 0) {
     m_pPSVRuntimeInfo1 = &tempRuntimeInfo;
+    if (initInfo.PSVVersion > 1)
+      m_pPSVRuntimeInfo2 = &tempRuntimeInfo;
+    if (initInfo.PSVVersion > 2)
+      m_pPSVRuntimeInfo3 = &tempRuntimeInfo;
+    if (initInfo.PSVVersion > 3)
+      m_pPSVRuntimeInfo4 = &tempRuntimeInfo;
   }
+
+  if (mode != RWMode::Read && m_pPSVRuntimeInfo4 &&
+      initInfo.HasLinAlgRuntimeInfo())
+    m_pPSVRuntimeInfo4->Flags |=
+        static_cast<uint32_t>(PSVRuntimeInfo4Flag::LinAlgRuntimeInfoPresent);
 
   PSV_RETB(rw.MapValue(&m_uResourceCount, initInfo.ResourceCount));
 
@@ -1092,9 +1343,90 @@ DxilPipelineStateValidation::ReadOrWrite(const void *pBits, uint32_t *pSize,
     }
   }
 
+  bool HasLinAlgRuntimeInfo =
+      m_pPSVRuntimeInfo4 &&
+      (m_pPSVRuntimeInfo4->Flags &
+       static_cast<uint32_t>(PSVRuntimeInfo4Flag::LinAlgRuntimeInfoPresent));
+  PSVLinAlgRuntimeInfo0 tempLinAlgRuntimeInfo = {};
+  if (HasLinAlgRuntimeInfo) {
+    PSV_RETB(rw.MapValue(&m_uPSVLinAlgRuntimeInfoSize,
+                         static_cast<uint32_t>(sizeof(PSVLinAlgRuntimeInfo0))));
+    PSV_RETB(sizeof(PSVLinAlgRuntimeInfo0) <= m_uPSVLinAlgRuntimeInfoSize);
+    PSV_RETB(
+        rw.MapArray(&m_pPSVLinAlgRuntimeInfo0, 1, m_uPSVLinAlgRuntimeInfoSize));
+    if (mode == RWMode::CalcSize)
+      m_pPSVLinAlgRuntimeInfo0 = &tempLinAlgRuntimeInfo;
+
+    if (mode != RWMode::Read) {
+      m_pPSVLinAlgRuntimeInfo0->MatrixOperationShapeCount =
+          initInfo.LinAlgMatrixOperationShapeCount;
+      m_pPSVLinAlgRuntimeInfo0->MatrixConstructionCount =
+          initInfo.LinAlgMatrixConstructionCount;
+      m_pPSVLinAlgRuntimeInfo0->ThreadMatrixVectorMultiplyCount =
+          initInfo.LinAlgThreadMatrixVectorMultiplyCount;
+      m_pPSVLinAlgRuntimeInfo0->WaveMatrixMultiplyCount =
+          initInfo.LinAlgWaveMatrixMultiplyCount;
+      m_pPSVLinAlgRuntimeInfo0->ThreadGroupMatrixMultiplyCount =
+          initInfo.LinAlgThreadGroupMatrixMultiplyCount;
+      m_pPSVLinAlgRuntimeInfo0->OuterProductCount =
+          initInfo.LinAlgOuterProductCount;
+      m_pPSVLinAlgRuntimeInfo0->AccumulateStoreCount =
+          initInfo.LinAlgAccumulateStoreCount;
+    }
+
+#define PSV_MAP_LINALG_TABLE(Record, CountField, SizeField, DataField,         \
+                             InitData)                                         \
+  if (m_pPSVLinAlgRuntimeInfo0->CountField) {                                  \
+    PSV_RETB(rw.MapValue(&SizeField, static_cast<uint32_t>(sizeof(Record))));  \
+    PSV_RETB(sizeof(Record) <= SizeField);                                     \
+    PSV_RETB(rw.MapArray(&DataField, m_pPSVLinAlgRuntimeInfo0->CountField,     \
+                         SizeField));                                          \
+    if (mode == RWMode::Write) {                                               \
+      PSV_RETB(InitData != nullptr);                                           \
+      memcpy(DataField, InitData,                                              \
+             sizeof(Record) * m_pPSVLinAlgRuntimeInfo0->CountField);           \
+    }                                                                          \
+  }
+
+    PSV_MAP_LINALG_TABLE(
+        PSVLinAlgMatrixOperationShape0, MatrixOperationShapeCount,
+        m_uPSVLinAlgMatrixOperationShapeSize, m_pPSVLinAlgMatrixOperationShapes,
+        initInfo.LinAlgMatrixOperationShapes);
+    PSV_MAP_LINALG_TABLE(PSVLinAlgMatrixConstruction0, MatrixConstructionCount,
+                         m_uPSVLinAlgMatrixConstructionSize,
+                         m_pPSVLinAlgMatrixConstructions,
+                         initInfo.LinAlgMatrixConstructions);
+    PSV_MAP_LINALG_TABLE(PSVLinAlgThreadMatrixVectorMultiply0,
+                         ThreadMatrixVectorMultiplyCount,
+                         m_uPSVLinAlgThreadMatrixVectorMultiplySize,
+                         m_pPSVLinAlgThreadMatrixVectorMultiplies,
+                         initInfo.LinAlgThreadMatrixVectorMultiplies);
+    PSV_MAP_LINALG_TABLE(PSVLinAlgWaveMatrixMultiply0, WaveMatrixMultiplyCount,
+                         m_uPSVLinAlgWaveMatrixMultiplySize,
+                         m_pPSVLinAlgWaveMatrixMultiplies,
+                         initInfo.LinAlgWaveMatrixMultiplies);
+    PSV_MAP_LINALG_TABLE(PSVLinAlgThreadGroupMatrixMultiply0,
+                         ThreadGroupMatrixMultiplyCount,
+                         m_uPSVLinAlgThreadGroupMatrixMultiplySize,
+                         m_pPSVLinAlgThreadGroupMatrixMultiplies,
+                         initInfo.LinAlgThreadGroupMatrixMultiplies);
+    PSV_MAP_LINALG_TABLE(
+        PSVLinAlgOuterProduct0, OuterProductCount, m_uPSVLinAlgOuterProductSize,
+        m_pPSVLinAlgOuterProducts, initInfo.LinAlgOuterProducts);
+    PSV_MAP_LINALG_TABLE(PSVLinAlgAccumulateStore0, AccumulateStoreCount,
+                         m_uPSVLinAlgAccumulateStoreSize,
+                         m_pPSVLinAlgAccumulateStores,
+                         initInfo.LinAlgAccumulateStores);
+#undef PSV_MAP_LINALG_TABLE
+  }
+
   if (mode == RWMode::CalcSize) {
     *pSize = rw.GetSize();
-    m_pPSVRuntimeInfo1 = nullptr; // clear ptr to tempRuntimeInfo
+    m_pPSVRuntimeInfo1 = nullptr;
+    m_pPSVRuntimeInfo2 = nullptr;
+    m_pPSVRuntimeInfo3 = nullptr;
+    m_pPSVRuntimeInfo4 = nullptr;
+    m_pPSVLinAlgRuntimeInfo0 = nullptr;
   }
   return true;
 }

--- a/lib/DxilContainer/DxilPipelineStateValidation.cpp
+++ b/lib/DxilContainer/DxilPipelineStateValidation.cpp
@@ -911,6 +911,13 @@ void hlsl::PrintPSVRuntimeInfo(llvm::raw_ostream &OS, PSVRuntimeInfo0 *pInfo0,
   }
   if (pInfo3)
     OS << Comment << " EntryFunctionName: " << EntryName << "\n";
+  if (pInfo4)
+    OS << Comment << " LinAlgRuntimeInfoPresent: "
+       << ((pInfo4->Flags & static_cast<uint32_t>(
+                                PSVRuntimeInfo4Flag::LinAlgRuntimeInfoPresent))
+               ? "true"
+               : "false")
+       << "\n";
 }
 
 void DxilPipelineStateValidation::PrintPSVRuntimeInfo(
@@ -985,6 +992,99 @@ void DxilPipelineStateValidation::Print(raw_ostream &OS,
                                         uint8_t ShaderKind) const {
   OS << "DxilPipelineStateValidation:\n";
   PrintPSVRuntimeInfo(OS, ShaderKind, "");
+
+  if (m_pPSVLinAlgRuntimeInfo0) {
+    OS << "PSVLinAlgRuntimeInfo:\n";
+    OS << " MatrixOperationShapeCount: "
+       << m_pPSVLinAlgRuntimeInfo0->MatrixOperationShapeCount << "\n";
+    OS << " MatrixConstructionCount: "
+       << m_pPSVLinAlgRuntimeInfo0->MatrixConstructionCount << "\n";
+    OS << " ThreadMatrixVectorMultiplyCount: "
+       << m_pPSVLinAlgRuntimeInfo0->ThreadMatrixVectorMultiplyCount << "\n";
+    OS << " WaveMatrixMultiplyCount: "
+       << m_pPSVLinAlgRuntimeInfo0->WaveMatrixMultiplyCount << "\n";
+    OS << " ThreadGroupMatrixMultiplyCount: "
+       << m_pPSVLinAlgRuntimeInfo0->ThreadGroupMatrixMultiplyCount << "\n";
+    OS << " OuterProductCount: " << m_pPSVLinAlgRuntimeInfo0->OuterProductCount
+       << "\n";
+    OS << " AccumulateStoreCount: "
+       << m_pPSVLinAlgRuntimeInfo0->AccumulateStoreCount << "\n";
+
+    auto PrintShapes = [&](const PSVLinAlgMatrixShapeArrayReference &ShapeRef) {
+      OS << "[";
+      if (ShapeRef.ShapesIndex > m_SemanticIndexTable.Entries ||
+          ShapeRef.Count >
+              m_SemanticIndexTable.Entries - ShapeRef.ShapesIndex) {
+        OS << "invalid]";
+        return;
+      }
+      const uint32_t *Indexes = m_SemanticIndexTable.Get(ShapeRef.ShapesIndex);
+      for (uint32_t I = 0; I < ShapeRef.Count; ++I) {
+        if (I)
+          OS << ", ";
+        PSVLinAlgMatrixOperationShape0 *Shape =
+            Indexes ? GetPSVLinAlgMatrixOperationShape(Indexes[I]) : nullptr;
+        if (Shape)
+          OS << "(" << Shape->M << "," << Shape->N << "," << Shape->K << ")";
+        else
+          OS << "invalid";
+      }
+      OS << "]";
+    };
+
+    for (uint32_t I = 0; I < GetPSVLinAlgMatrixConstructionCount(); ++I) {
+      auto *Record = GetPSVLinAlgMatrixConstruction(I);
+      OS << " MatrixConstruction[" << I
+         << "]: MatrixType=" << static_cast<uint32_t>(Record->MatrixType)
+         << ", Shapes=";
+      PrintShapes(Record->OperationShapes);
+      OS << "\n";
+    }
+    for (uint32_t I = 0; I < GetPSVLinAlgThreadMatrixVectorMultiplyCount();
+         ++I) {
+      auto *Record = GetPSVLinAlgThreadMatrixVectorMultiply(I);
+      OS << " ThreadMatrixVectorMultiply[" << I
+         << "]: ResultType=" << static_cast<uint32_t>(Record->ResultType)
+         << ", MatrixType=" << static_cast<uint32_t>(Record->MatrixType)
+         << ", VectorInputType="
+         << static_cast<uint32_t>(Record->VectorInputType)
+         << ", Flags=" << static_cast<uint32_t>(Record->Flags) << "\n";
+    }
+    for (uint32_t I = 0; I < GetPSVLinAlgWaveMatrixMultiplyCount(); ++I) {
+      auto *Record = GetPSVLinAlgWaveMatrixMultiply(I);
+      OS << " WaveMatrixMultiply[" << I << "]: AccumulatorType="
+         << static_cast<uint32_t>(Record->AccumulatorType)
+         << ", MatrixAType=" << static_cast<uint32_t>(Record->MatrixAType)
+         << ", MatrixBType=" << static_cast<uint32_t>(Record->MatrixBType)
+         << ", Shapes=";
+      PrintShapes(Record->OperationShapes);
+      OS << "\n";
+    }
+    for (uint32_t I = 0; I < GetPSVLinAlgThreadGroupMatrixMultiplyCount();
+         ++I) {
+      auto *Record = GetPSVLinAlgThreadGroupMatrixMultiply(I);
+      OS << " ThreadGroupMatrixMultiply[" << I << "]: AccumulatorType="
+         << static_cast<uint32_t>(Record->AccumulatorType)
+         << ", MatrixAType=" << static_cast<uint32_t>(Record->MatrixAType)
+         << ", MatrixBType=" << static_cast<uint32_t>(Record->MatrixBType)
+         << ", Shapes=";
+      PrintShapes(Record->OperationShapes);
+      OS << "\n";
+    }
+    for (uint32_t I = 0; I < GetPSVLinAlgOuterProductCount(); ++I) {
+      auto *Record = GetPSVLinAlgOuterProduct(I);
+      OS << " OuterProduct[" << I
+         << "]: ResultType=" << static_cast<uint32_t>(Record->ResultType)
+         << ", VectorInputType="
+         << static_cast<uint32_t>(Record->VectorInputType) << "\n";
+    }
+    for (uint32_t I = 0; I < GetPSVLinAlgAccumulateStoreCount(); ++I) {
+      auto *Record = GetPSVLinAlgAccumulateStore(I);
+      OS << " AccumulateStore[" << I << "]: AccumulatorType="
+         << static_cast<uint32_t>(Record->AccumulatorType)
+         << ", Flags=" << static_cast<uint32_t>(Record->Flags) << "\n";
+    }
+  }
 
   OS << "ResourceCount : " << m_uResourceCount << "\n ";
   if (m_uResourceCount) {

--- a/tools/clang/test/DXC/dumpPSV_AS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_AS.hlsl
@@ -19,6 +19,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 0
 
 #define NUM_THREADS 32

--- a/tools/clang/test/DXC/dumpPSV_CS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_CS.hlsl
@@ -19,6 +19,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 3
 // CHECK-NEXT:  PSVResourceBindInfo:
 // CHECK-NEXT:   Space: 0

--- a/tools/clang/test/DXC/dumpPSV_DS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_DS.hlsl
@@ -18,6 +18,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 0
 // CHECK-NEXT:  PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:

--- a/tools/clang/test/DXC/dumpPSV_GS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_GS.hlsl
@@ -21,6 +21,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 1
 // CHECK-NEXT:  PSVResourceBindInfo:
 // CHECK-NEXT:   Space: 0

--- a/tools/clang/test/DXC/dumpPSV_HS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_HS.hlsl
@@ -21,6 +21,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 0
 // CHECK-NEXT:  PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:

--- a/tools/clang/test/DXC/dumpPSV_MS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_MS.hlsl
@@ -20,6 +20,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 0
 // CHECK-NEXT:  PSVSignatureElement:
 // CHECK-NEXT:   SemanticName:

--- a/tools/clang/test/DXC/dumpPSV_PS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_PS.hlsl
@@ -19,6 +19,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 3
 // CHECK-NEXT:  PSVResourceBindInfo:
 // CHECK-NEXT:   Space: 0

--- a/tools/clang/test/DXC/dumpPSV_VS.hlsl
+++ b/tools/clang/test/DXC/dumpPSV_VS.hlsl
@@ -18,6 +18,7 @@
 // CHECK-NEXT:  SigOutputVectors[2]: 0
 // CHECK-NEXT:  SigOutputVectors[3]: 0
 // CHECK-NEXT:  EntryFunctionName: main
+// CHECK-NEXT:  LinAlgRuntimeInfoPresent: false
 // CHECK-NEXT: ResourceCount : 1
 // CHECK-NEXT:  PSVResourceBindInfo:
 // CHECK-NEXT:   Space: 0

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -109,6 +109,7 @@ public:
   TEST_METHOD(Compile_CheckPSV0_EntryFunctionName)
   TEST_METHOD(CompileCSWaveSize_CheckPSV0)
   TEST_METHOD(CompileCSWaveSizeRange_CheckPSV0)
+  TEST_METHOD(PSVLinAlgRuntimeInfoRoundTripAndPrint)
   TEST_METHOD(CompileWhenOkThenCheckRDAT)
   TEST_METHOD(CompileWhenOkThenCheckRDAT2)
   TEST_METHOD(CompileWhenOkThenCheckRDATSM69)
@@ -1448,6 +1449,178 @@ TEST_F(DxilContainerTest, CompileCSWaveSizeRange_CheckPSV0) {
   // Same range, whether preferred is set or not.
   TestCompile(L"-DPREFERRED=");
   TestCompile(L"-DPREFERRED=,32");
+}
+
+TEST_F(DxilContainerTest, PSVLinAlgRuntimeInfoRoundTripAndPrint) {
+  const PSVLinAlgMatrixOperationShape0 Shapes[] = {
+      {8, 16, 4},
+      {16, 8, 2},
+      {32, 32, 16},
+  };
+  const uint32_t ShapeIndexes[] = {0, 2, 1, 2, 0};
+  const PSVLinAlgMatrixConstruction0 Constructions[] = {
+      {{0, 2}, 4, {0, 0, 0}},
+  };
+  const PSVLinAlgThreadMatrixVectorMultiply0 ThreadMatrixVectorMultiplies[] = {
+      {1, 2, 3, 3},
+  };
+  const PSVLinAlgWaveMatrixMultiply0 WaveMatrixMultiplies[] = {
+      {{2, 2}, 5, 6, 7, 0},
+  };
+  const PSVLinAlgThreadGroupMatrixMultiply0 ThreadGroupMatrixMultiplies[] = {
+      {{4, 1}, 8, 9, 10, 0},
+  };
+  const PSVLinAlgOuterProduct0 OuterProducts[] = {
+      {11, 12, {0, 0}},
+  };
+  const PSVLinAlgAccumulateStore0 AccumulateStores[] = {
+      {13, 3, {0, 0}},
+  };
+  const char StringTable[] = {'\0'};
+
+  PSVInitInfo InitInfo(MAX_PSV_VERSION);
+  InitInfo.ShaderStage = PSVShaderKind::Compute;
+  InitInfo.StringTable = PSVStringTable(StringTable, sizeof(StringTable));
+  InitInfo.SemanticIndexTable =
+      PSVSemanticIndexTable(ShapeIndexes, std::size(ShapeIndexes));
+  InitInfo.LinAlgMatrixOperationShapes = Shapes;
+  InitInfo.LinAlgMatrixOperationShapeCount = std::size(Shapes);
+  InitInfo.LinAlgMatrixConstructions = Constructions;
+  InitInfo.LinAlgMatrixConstructionCount = std::size(Constructions);
+  InitInfo.LinAlgThreadMatrixVectorMultiplies = ThreadMatrixVectorMultiplies;
+  InitInfo.LinAlgThreadMatrixVectorMultiplyCount =
+      std::size(ThreadMatrixVectorMultiplies);
+  InitInfo.LinAlgWaveMatrixMultiplies = WaveMatrixMultiplies;
+  InitInfo.LinAlgWaveMatrixMultiplyCount = std::size(WaveMatrixMultiplies);
+  InitInfo.LinAlgThreadGroupMatrixMultiplies = ThreadGroupMatrixMultiplies;
+  InitInfo.LinAlgThreadGroupMatrixMultiplyCount =
+      std::size(ThreadGroupMatrixMultiplies);
+  InitInfo.LinAlgOuterProducts = OuterProducts;
+  InitInfo.LinAlgOuterProductCount = std::size(OuterProducts);
+  InitInfo.LinAlgAccumulateStores = AccumulateStores;
+  InitInfo.LinAlgAccumulateStoreCount = std::size(AccumulateStores);
+
+  DxilPipelineStateValidation Writer;
+  uint32_t PSVSize = 0;
+  VERIFY_IS_TRUE(Writer.InitNew(InitInfo, nullptr, &PSVSize));
+  std::vector<uint8_t> PSVBuffer(PSVSize);
+  VERIFY_IS_TRUE(Writer.InitNew(InitInfo, PSVBuffer.data(), &PSVSize));
+
+  DxilPipelineStateValidation Reader;
+  VERIFY_IS_TRUE(Reader.InitFromPSV0(PSVBuffer.data(), PSVSize));
+
+  PSVRuntimeInfo4 *RuntimeInfo = Reader.GetPSVRuntimeInfo4();
+  VERIFY_IS_NOT_NULL(RuntimeInfo);
+  VERIFY_ARE_EQUAL(
+      static_cast<uint32_t>(PSVRuntimeInfo4Flag::LinAlgRuntimeInfoPresent),
+      RuntimeInfo->Flags);
+
+  VERIFY_ARE_EQUAL(3u, Reader.GetPSVLinAlgMatrixOperationShapeCount());
+  VERIFY_ARE_EQUAL(1u, Reader.GetPSVLinAlgMatrixConstructionCount());
+  VERIFY_ARE_EQUAL(1u, Reader.GetPSVLinAlgThreadMatrixVectorMultiplyCount());
+  VERIFY_ARE_EQUAL(1u, Reader.GetPSVLinAlgWaveMatrixMultiplyCount());
+  VERIFY_ARE_EQUAL(1u, Reader.GetPSVLinAlgThreadGroupMatrixMultiplyCount());
+  VERIFY_ARE_EQUAL(1u, Reader.GetPSVLinAlgOuterProductCount());
+  VERIFY_ARE_EQUAL(1u, Reader.GetPSVLinAlgAccumulateStoreCount());
+
+  PSVLinAlgMatrixOperationShape0 *Shape =
+      Reader.GetPSVLinAlgMatrixOperationShape(2);
+  VERIFY_IS_NOT_NULL(Shape);
+  VERIFY_ARE_EQUAL(32u, Shape->M);
+  VERIFY_ARE_EQUAL(32u, Shape->N);
+  VERIFY_ARE_EQUAL(16u, Shape->K);
+  VERIFY_IS_NULL(Reader.GetPSVLinAlgMatrixOperationShape(3));
+
+  PSVLinAlgMatrixConstruction0 *Construction =
+      Reader.GetPSVLinAlgMatrixConstruction(0);
+  VERIFY_IS_NOT_NULL(Construction);
+  VERIFY_ARE_EQUAL(0u, Construction->OperationShapes.ShapesIndex);
+  VERIFY_ARE_EQUAL(2u, Construction->OperationShapes.Count);
+  VERIFY_ARE_EQUAL(4u, static_cast<uint32_t>(Construction->MatrixType));
+
+  PSVLinAlgThreadMatrixVectorMultiply0 *ThreadMatrixVectorMultiply =
+      Reader.GetPSVLinAlgThreadMatrixVectorMultiply(0);
+  VERIFY_IS_NOT_NULL(ThreadMatrixVectorMultiply);
+  VERIFY_ARE_EQUAL(
+      1u, static_cast<uint32_t>(ThreadMatrixVectorMultiply->ResultType));
+  VERIFY_ARE_EQUAL(
+      2u, static_cast<uint32_t>(ThreadMatrixVectorMultiply->MatrixType));
+  VERIFY_ARE_EQUAL(
+      3u, static_cast<uint32_t>(ThreadMatrixVectorMultiply->VectorInputType));
+  VERIFY_ARE_EQUAL(3u,
+                   static_cast<uint32_t>(ThreadMatrixVectorMultiply->Flags));
+
+  PSVLinAlgWaveMatrixMultiply0 *WaveMatrixMultiply =
+      Reader.GetPSVLinAlgWaveMatrixMultiply(0);
+  VERIFY_IS_NOT_NULL(WaveMatrixMultiply);
+  VERIFY_ARE_EQUAL(2u, WaveMatrixMultiply->OperationShapes.ShapesIndex);
+  VERIFY_ARE_EQUAL(2u, WaveMatrixMultiply->OperationShapes.Count);
+  VERIFY_ARE_EQUAL(5u,
+                   static_cast<uint32_t>(WaveMatrixMultiply->AccumulatorType));
+  VERIFY_ARE_EQUAL(6u, static_cast<uint32_t>(WaveMatrixMultiply->MatrixAType));
+  VERIFY_ARE_EQUAL(7u, static_cast<uint32_t>(WaveMatrixMultiply->MatrixBType));
+
+  PSVLinAlgThreadGroupMatrixMultiply0 *ThreadGroupMatrixMultiply =
+      Reader.GetPSVLinAlgThreadGroupMatrixMultiply(0);
+  VERIFY_IS_NOT_NULL(ThreadGroupMatrixMultiply);
+  VERIFY_ARE_EQUAL(4u, ThreadGroupMatrixMultiply->OperationShapes.ShapesIndex);
+  VERIFY_ARE_EQUAL(1u, ThreadGroupMatrixMultiply->OperationShapes.Count);
+  VERIFY_ARE_EQUAL(
+      8u, static_cast<uint32_t>(ThreadGroupMatrixMultiply->AccumulatorType));
+  VERIFY_ARE_EQUAL(
+      9u, static_cast<uint32_t>(ThreadGroupMatrixMultiply->MatrixAType));
+  VERIFY_ARE_EQUAL(
+      10u, static_cast<uint32_t>(ThreadGroupMatrixMultiply->MatrixBType));
+
+  PSVLinAlgOuterProduct0 *OuterProduct = Reader.GetPSVLinAlgOuterProduct(0);
+  VERIFY_IS_NOT_NULL(OuterProduct);
+  VERIFY_ARE_EQUAL(11u, static_cast<uint32_t>(OuterProduct->ResultType));
+  VERIFY_ARE_EQUAL(12u, static_cast<uint32_t>(OuterProduct->VectorInputType));
+
+  PSVLinAlgAccumulateStore0 *AccumulateStore =
+      Reader.GetPSVLinAlgAccumulateStore(0);
+  VERIFY_IS_NOT_NULL(AccumulateStore);
+  VERIFY_ARE_EQUAL(13u,
+                   static_cast<uint32_t>(AccumulateStore->AccumulatorType));
+  VERIFY_ARE_EQUAL(3u, static_cast<uint32_t>(AccumulateStore->Flags));
+
+  std::string Dump;
+  llvm::raw_string_ostream OS(Dump);
+  Reader.Print(OS, static_cast<uint8_t>(PSVShaderKind::Compute));
+  OS.flush();
+
+  const char *ExpectedDumpLines[] = {
+      " LinAlgRuntimeInfoPresent: true\n",
+      "PSVLinAlgRuntimeInfo:\n",
+      " MatrixOperationShapeCount: 3\n",
+      " MatrixConstructionCount: 1\n",
+      " ThreadMatrixVectorMultiplyCount: 1\n",
+      " WaveMatrixMultiplyCount: 1\n",
+      " ThreadGroupMatrixMultiplyCount: 1\n",
+      " OuterProductCount: 1\n",
+      " AccumulateStoreCount: 1\n",
+      " MatrixConstruction[0]: MatrixType=4, Shapes=[(8,16,4), "
+      "(32,32,16)]\n",
+      " ThreadMatrixVectorMultiply[0]: ResultType=1, MatrixType=2, "
+      "VectorInputType=3, Flags=3\n",
+      " WaveMatrixMultiply[0]: AccumulatorType=5, MatrixAType=6, "
+      "MatrixBType=7, Shapes=[(16,8,2), (32,32,16)]\n",
+      " ThreadGroupMatrixMultiply[0]: AccumulatorType=8, MatrixAType=9, "
+      "MatrixBType=10, Shapes=[(8,16,4)]\n",
+      " OuterProduct[0]: ResultType=11, VectorInputType=12\n",
+      " AccumulateStore[0]: AccumulatorType=13, Flags=3\n",
+  };
+  for (const char *Expected : ExpectedDumpLines)
+    VERIFY_IS_TRUE(Dump.find(Expected) != std::string::npos);
+
+  Construction->OperationShapes.ShapesIndex =
+      static_cast<uint32_t>(std::size(ShapeIndexes) + 1);
+  Dump.clear();
+  Reader.Print(OS, static_cast<uint8_t>(PSVShaderKind::Compute));
+  OS.flush();
+  VERIFY_IS_TRUE(
+      Dump.find(" MatrixConstruction[0]: MatrixType=4, Shapes=[invalid]\n") !=
+      std::string::npos);
 }
 
 TEST_F(DxilContainerTest, CompileWhenOkThenCheckRDAT) {


### PR DESCRIPTION
- Adds the PSV0 LinAlg runtime record layout definitions
- Serializes/Deserializes the types to/from the container
- Prints a deserialized type as a string header for the shader dump

Part of #7843 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>